### PR TITLE
Show an OSD notification when 'Stop after this track' is toggled

### DIFF
--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -1524,11 +1524,6 @@ void Playlist::StopAfter(int row) {
   else
     stop_after_ = index(row, 0);
 
-  // stop_after_.isValid() == true when there is a stop placed
-  // somewhere on the playlist. Emit a StopAfterToggled signal that
-  // reflects this.
-  emit StopAfterToggled(stop_after_.isValid());
-
   if (old_stop_after.isValid())
     emit dataChanged(old_stop_after, old_stop_after.sibling(old_stop_after.row(), ColumnCount-1));
   if (stop_after_.isValid())

--- a/src/playlist/playlist.h
+++ b/src/playlist/playlist.h
@@ -306,9 +306,6 @@ class Playlist : public QAbstractListModel {
   void EditingFinished(const QModelIndex& index);
   void PlayRequested(const QModelIndex& index);
 
-  // Signals that stop playing after track was toggled.
-  void StopAfterToggled(bool stop);
-
   // Signals that the underlying list of items was changed, meaning that
   // something was added to it, removed from it or the ordering changed.
   void PlaylistChanged();

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -690,8 +690,8 @@ MainWindow::MainWindow(Application* app,
   app_->playlist_manager()->Init(app_->library_backend(), app_->playlist_backend(),
                                  ui_->playlist_sequence, ui_->playlist);
 
-  // This connection must be done after the playlist has been initialized.
-  connect(app_->playlist_manager()->current(), SIGNAL(StopAfterToggled(bool)),
+  // This connection must be done after the playlists have been initialized.
+  connect(this, SIGNAL(StopAfterToggled(bool)),
 	  osd_, SLOT(StopAfterToggle(bool)));
 
   // We need to connect these global shortcuts here after the playlist have been initialized
@@ -1063,6 +1063,7 @@ void MainWindow::ToggleShowHide() {
 
 void MainWindow::StopAfterCurrent() {
   app_->playlist_manager()->current()->StopAfter(app_->playlist_manager()->current()->current_row());
+  emit StopAfterToggled(app_->playlist_manager()->current()->stop_after_current());
 }
 
 void MainWindow::closeEvent(QCloseEvent* event) {

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -134,6 +134,10 @@ class MainWindow : public QMainWindow, public PlatformInterface {
   void Activate();
   bool LoadUrl(const QString& url);
 
+ signals:
+  // Signals that stop playing after track was toggled.
+  void StopAfterToggled(bool stop);
+
  private slots:
   void FilePathChanged(const QString& path);
   


### PR DESCRIPTION
Currently when you toggle "Stop after this track" via a global shortcut or via the system tray, the only way to see if you turned it on or off is to bring up the main window to the front. 

I added an OSD notification that will show the current state when you toggle it. This functionality existed in Amarok 1.4.
