### PR TITLE
Target the active playlist when setting 'Stop after this track' via glob...

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1062,8 +1062,8 @@ void MainWindow::ToggleShowHide() {
 }
 
 void MainWindow::StopAfterCurrent() {
-  app_->playlist_manager()->current()->StopAfter(app_->playlist_manager()->current()->current_row());
-  emit StopAfterToggled(app_->playlist_manager()->current()->stop_after_current());
+  app_->playlist_manager()->active()->StopAfter(app_->playlist_manager()->active()->current_row());
+  emit StopAfterToggled(app_->playlist_manager()->active()->stop_after_current());
 }
 
 void MainWindow::closeEvent(QCloseEvent* event) {


### PR DESCRIPTION
Target the active instead of the current playlist in MainWindow::StopAfterCurrent. This way, the global shortcut for 'Stop after this track' works even if a playlist other than the currently playing one is shown in the main window.
