### PR TITLE
Improve the handling of colons in library search

### DIFF
--- a/src/library/libraryquery.cpp
+++ b/src/library/libraryquery.cpp
@@ -39,9 +39,11 @@ LibraryQuery::LibraryQuery(const QueryOptions& options)
     // expected with sqlite's FTS3:
     //  1) Append * to all tokens.
     //  2) Prefix "fts" to column names.
+    //  3) Remove colons which don't correspond to column names.
 
     // Split on whitespace
-    QStringList tokens(options.filter().split(QRegExp("\\s+")));
+    QStringList tokens(options.filter().split(
+        QRegExp("\\s+"), QString::SkipEmptyParts));
     QString query;
     foreach (QString token, tokens) {
       token.remove('(');
@@ -57,9 +59,11 @@ LibraryQuery::LibraryQuery(const QueryOptions& options)
               ':', 0, 0, QString::SectionIncludeTrailingSep);
           QString subtoken = token.section(':', 1, -1);
           subtoken.replace(":", " ");
+          subtoken = subtoken.trimmed();
           query += "fts" + columntoken + subtoken + "* ";
         } else {
-          token.replace(':', 1, ' ');
+          token.replace(":", " ");
+          token = token.trimmed();
           query += token + "* ";
         }
       } else {


### PR DESCRIPTION
Currently when searching the library, you can limit your search to a specific field by prefixing "field:" to your search term, e.g artist:Queen.

The way clementine handles this is to prefix fts to each token which contains a colon. In the sql query, this translates to searching the specific column in the fts table. However, no check is made if the token is a valid column in this table. As documented in issue #925, searching for items that contain colons will therefore fail.

When searching manually in the library this is not much of a problem since you probably find the result before you have to type in the colon. However, if you use the recently merged "Show in library" feature (#4107), this sends a complete string at once to the search form. If this string contain colons, the search will fail.

The proposed solution is to prefix fts" only to tokens which are valid column names. All other colons are replaced with spaces.
