### PR TITLE
Restore to changes made in pull request #4102

### DIFF
--- a/src/widgets/lineedit.cpp
+++ b/src/widgets/lineedit.cpp
@@ -119,6 +119,7 @@ void ExtendedEditor::Paint(QPaintDevice* device) {
     }
   } else {
     clear_button_->setVisible(has_clear_button_);
+    Resize();
   }
 }
 
@@ -142,19 +143,16 @@ LineEdit::LineEdit(QWidget* parent)
     ExtendedEditor(this)
 {
   connect(reset_button_, SIGNAL(clicked()), SIGNAL(Reset()));
-  connect(this, SIGNAL(textChanged(QString)), SLOT(text_changed(QString)));
 }
 
-void LineEdit::text_changed(const QString& text) {
-  if (text.isEmpty()) {
-    // Consider empty string as LTR
-    set_rtl(false);
-  } else {
-    // For some reason Qt will detect any text with LTR at the end as LTR, so instead
-    // compare only the first character
+void LineEdit::set_text(const QString& text) {
+  QLineEdit::setText(text);
+
+  // For some reason Qt will detect any text with LTR at the end as LTR, so instead
+  // compare only the first character
+  if (!text.isEmpty()) {
     set_rtl(QString(text.at(0)).isRightToLeft());
   }
-  Resize();
 }
 
 void LineEdit::paintEvent(QPaintEvent* e) {

--- a/src/widgets/lineedit.h
+++ b/src/widgets/lineedit.h
@@ -103,7 +103,7 @@ public:
   // ExtendedEditor
   void set_focus() { QLineEdit::setFocus(); }
   QString text() const { return QLineEdit::text(); }
-  void set_text(const QString& text) { QLineEdit::setText(text); }
+  void set_text(const QString& text);
   void set_enabled(bool enabled) { QLineEdit::setEnabled(enabled); }
 
 protected:
@@ -113,9 +113,6 @@ protected:
 private:
   bool is_rtl() const { return is_rtl_; }
   void set_rtl(bool rtl) { is_rtl_ = rtl; }
-
-private slots:
-  void text_changed(const QString& text);
 
 signals:
   void Reset();


### PR DESCRIPTION
This reverts the experimental changes made on the master branch which virtually reset #4102. The changes made break the editor badly when RTL tags are already set (same behaviour as before the original pull request as demonstrated in screen shots).

If changes are to be made that can break the UI for those of us running off HEAD of master, they should be done in another branch.
