### PR TITLE
Remove font customizations

### DIFF
--- a/src/widgets/trackslider.cpp
+++ b/src/widgets/trackslider.cpp
@@ -38,10 +38,6 @@ TrackSlider::TrackSlider(QWidget* parent)
 {
   ui_->setupUi(this);
 
-  QFont font("Courier");
-  ui_->elapsed->setFont(font);
-  ui_->remaining->setFont(font);
-
   UpdateLabelWidth();
 
   // Load settings


### PR DESCRIPTION
- Should respect whatever font the user has set.
  (“Respect the user’s settings by always using the system font, sizes, and colors.” http://msdn.microsoft.com/en-us/library/windows/desktop/aa511282.aspx)
- Courier looks odd and it’s too thin to see (a11y issue #4082).

---

@davidsansome: I’m experimenting with a clockface-like font that I’m creating in FontForge, BTW.
