### PR TITLE
Fixed lastfm scrobbling workflow.

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -296,6 +296,10 @@ void Player::RestartOrPrevious() {
 }
 
 void Player::Stop(bool stop_after) {
+#ifdef HAVE_LIBLASTFM
+  lastfm_->Scrobble();
+#endif
+
   engine_->Stop(stop_after);
   app_->playlist_manager()->active()->set_current_row(-1);
   current_item_.reset();
@@ -432,6 +436,7 @@ void Player::CurrentMetadataChanged(const Song& metadata) {
   engine_->RefreshMarkers(metadata.beginning_nanosec(), metadata.end_nanosec());
 
 #ifdef HAVE_LIBLASTFM
+  lastfm_->Scrobble();
   lastfm_->NowPlaying(metadata);
 #endif
 }

--- a/src/internet/core/scrobbler.h
+++ b/src/internet/core/scrobbler.h
@@ -41,6 +41,7 @@ class Scrobbler : public QObject {
   virtual void Love() = 0;
   virtual void ToggleScrobbling() = 0;
   virtual void ShowConfig() = 0;
+  virtual void CacheSong(int scrobble_point) = 0;
 
  signals:
   void AuthenticationComplete(bool success, const QString& error_message);

--- a/src/internet/lastfm/lastfmservice.h
+++ b/src/internet/lastfm/lastfmservice.h
@@ -75,6 +75,7 @@ class LastFMService : public Scrobbler {
 
  public slots:
   void NowPlaying(const Song& song);
+  void CacheSong(int scrobble_point);
   void Scrobble();
   void Love();
   void Ban();
@@ -87,7 +88,7 @@ signals:
   void ButtonVisibilityChanged(bool value);
   void ScrobbleButtonVisibilityChanged(bool value);
   void PreferAlbumArtistChanged(bool value);
-  void ScrobbleSubmitted();
+  void CachedToScrobble();
   void ScrobbleError(int value);
   void UpdatedSubscriberStatus(bool is_subscriber);
   void ScrobbledRadioStream();
@@ -111,7 +112,7 @@ signals:
   std::unique_ptr<lastfm::Audioscrobbler> scrobbler_;
   lastfm::Track last_track_;
   lastfm::Track next_metadata_;
-  bool already_scrobbled_;
+  bool already_cached_to_scrobble_{false};
 
   QUrl last_url_;
 

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -955,8 +955,8 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
           SLOT(ShuffleModeChanged(PlaylistSequence::ShuffleMode)));
 
 #ifdef HAVE_LIBLASTFM
-  connect(app_->scrobbler(), SIGNAL(ScrobbleSubmitted()),
-          SLOT(ScrobbleSubmitted()));
+  connect(app_->scrobbler(), SIGNAL(CachedToScrobble()),
+          SLOT(CachedToScrobble()));
   connect(app_->scrobbler(), SIGNAL(ScrobbleError(int)),
           SLOT(ScrobbleError(int)));
 
@@ -1512,8 +1512,7 @@ void MainWindow::UpdateTrackPosition() {
     if (playlist->get_lastfm_status() == Playlist::LastFM_New) {
       if (app_->scrobbler()->IsScrobblingEnabled() &&
           app_->scrobbler()->IsAuthenticated()) {
-        qLog(Info) << "Scrobbling at" << scrobble_point;
-        app_->scrobbler()->Scrobble();
+        app_->scrobbler()->CacheSong(scrobble_point);
       }
     }
   }
@@ -2913,7 +2912,7 @@ void MainWindow::SetToggleScrobblingIcon(bool value) {
 }
 
 #ifdef HAVE_LIBLASTFM
-void MainWindow::ScrobbleSubmitted() {
+void MainWindow::CachedToScrobble() {
   const bool last_fm_enabled = ui_->action_toggle_scrobbling->isVisible() &&
                                app_->scrobbler()->IsScrobblingEnabled() &&
                                app_->scrobbler()->IsAuthenticated();

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -252,7 +252,7 @@ signals:
 
   void ShowCoverManager();
 #ifdef HAVE_LIBLASTFM
-  void ScrobbleSubmitted();
+  void CachedToScrobble();
   void ScrobbleError(int value);
 #endif
   void ShowAboutDialog();


### PR DESCRIPTION
Fixed lastfm workflow with "now playing" and scrobbling feature(Maybe Issue #2672). After scrobble request song was displayed on "just listened" and "listening now", that was wrong. Now listeting request sends after starting song. Scrobble works through cache. Cache send tracks on stop, next, prev, change song events. I think that it is correct algorithm for scrobbling. 
I have a couple ideas to improve working with lastfm. I'll try realize them later.

Changed logic of love track action and fix Issue #3515.

I'll be glad to find my code in my favorite player source code.
Thanks.
