### PR TITLE
Add contexts to some translation strings, v2. Closes #4163

### DIFF
--- a/src/globalsearch/searchproviderstatuswidget.cpp
+++ b/src/globalsearch/searchproviderstatuswidget.cpp
@@ -44,7 +44,7 @@ SearchProviderStatusWidget::SearchProviderStatusWidget(
   if (enabled && logged_in) {
     ui_->disabled_group->hide();
   } else {
-    const QString disabled_text = tr("Disabled");
+    const QString disabled_text = tr("Disabled", "Refers to search provider's status.");
     const QString not_logged_in_text = tr("Not logged in");
     const int disabled_width = fontMetrics().width("    ") + qMax(
           fontMetrics().width(disabled_text),

--- a/src/playlist/playlistlistcontainer.cpp
+++ b/src/playlist/playlistlistcontainer.cpp
@@ -71,7 +71,7 @@ PlaylistListContainer::PlaylistListContainer(QWidget* parent)
 
   action_new_folder_->setText(tr("New folder"));
   action_remove_->setText(tr("Delete"));
-  action_save_playlist_->setText(tr("Save playlist"));
+  action_save_playlist_->setText(tr("Save playlist", "Save playlist menu action."));
 
   ui_->new_folder->setDefaultAction(action_new_folder_);
   ui_->remove->setDefaultAction(action_remove_);

--- a/src/playlist/playlistmanager.cpp
+++ b/src/playlist/playlistmanager.cpp
@@ -237,7 +237,7 @@ void PlaylistManager::SaveWithUI(int id, const QString& suggested_filename) {
   QString default_filter = parser()->default_filter();
 
   filename = QFileDialog::getSaveFileName(
-      NULL, tr("Save playlist"), filename,
+      NULL, tr("Save playlist", "Title of the playlist save dialog."), filename,
       parser()->filters(), &default_filter);
 
   if (filename.isNull())

--- a/src/ui/behavioursettingspage.ui
+++ b/src/ui/behavioursettingspage.ui
@@ -190,7 +190,7 @@
         </item>
         <item>
          <property name="text">
-          <string>Open in new playlist</string>
+          <string comment="Refers to behavior settings in Clementine settings page.">Open in new playlist</string>
          </property>
         </item>
         <item>

--- a/src/ui/edittagdialog.ui
+++ b/src/ui/edittagdialog.ui
@@ -336,7 +336,7 @@
              </sizepolicy>
             </property>
             <property name="text">
-             <string>Last played</string>
+             <string comment="Refers to a smart playlist's name in Library.">Last played</string>
             </property>
             <property name="field_label" stdset="0">
              <bool>true</bool>

--- a/src/ui/notificationssettingspage.ui
+++ b/src/ui/notificationssettingspage.ui
@@ -30,7 +30,7 @@
       <item>
        <widget class="QRadioButton" name="notifications_none">
         <property name="text">
-         <string>Disabled</string>
+         <string comment="Refers to a disabled notification type in Notification settings.">Disabled</string>
         </property>
        </widget>
       </item>

--- a/src/ui/organisedialog.cpp
+++ b/src/ui/organisedialog.cpp
@@ -67,7 +67,7 @@ OrganiseDialog::OrganiseDialog(TaskManager* task_manager, QWidget *parent)
   tags[tr("Genre")] = "genre";
   tags[tr("Comment")] = "comment";
   tags[tr("Length")] = "length";
-  tags[tr("Bitrate")] = "bitrate";
+  tags[tr("Bitrate", "Refers to bitrate in file organise dialog.")] = "bitrate";
   tags[tr("Samplerate")] = "samplerate";
   tags[tr("File extension")] = "extension";
 


### PR DESCRIPTION
Presumably, the language update scripts will take care the rest.
