### PR TITLE
Fix for pull request #4170

### DIFF
--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -1222,7 +1222,7 @@ QString Playlist::column_name(Column column) {
     case Column_Rating:       return tr("Rating");
     case Column_PlayCount:    return tr("Play count");
     case Column_SkipCount:    return tr("Skip count");
-    case Column_LastPlayed:   return tr("Last played");
+    case Column_LastPlayed:   return tr("Last played", "A playlist's tag.");
     case Column_Score:        return tr("Score");
 
     case Column_BPM:          return tr("BPM");

--- a/src/ui/edittagdialog.ui
+++ b/src/ui/edittagdialog.ui
@@ -336,7 +336,7 @@
              </sizepolicy>
             </property>
             <property name="text">
-             <string comment="Refers to a smart playlist's name in Library.">Last played</string>
+             <string comment="A playlist's tag.">Last played</string>
             </property>
             <property name="field_label" stdset="0">
              <bool>true</bool>


### PR DESCRIPTION
The right string for this is [here](https://github.com/clementine-player/Clementine/blob/master/src/library/library.cpp#L71). But It seems to me there is no way to add contextual message if the string is wrapped inside QT_TRANSLATE_NOOP, so use the other two strings used for a song's tag.
