### PR TITLE
Fix auto download podcasts

### DIFF
--- a/src/podcasts/podcastdownloader.h
+++ b/src/podcasts/podcastdownloader.h
@@ -71,7 +71,7 @@ private slots:
   void ReloadSettings();
 
   void SubscriptionAdded(const Podcast& podcast);
-  void EpisodesAdded(const QList<PodcastEpisode>& episodes);
+  void EpisodesAdded(const PodcastEpisodeList& episodes);
 
   void ReplyReadyRead();
   void ReplyFinished();


### PR DESCRIPTION
Fix a broken slot, should take care of problems with automatic download of podcast episodes.
