### PR TITLE
Use double click settings as default behaviour for new files added as command line arguments

### DIFF
--- a/src/core/commandlineoptions.cpp
+++ b/src/core/commandlineoptions.cpp
@@ -66,7 +66,7 @@ const char* CommandlineOptions::kVersionText = "Clementine %1";
 CommandlineOptions::CommandlineOptions(int argc, char** argv)
     : argc_(argc),
       argv_(argv),
-      url_list_action_(UrlList_Append),
+      url_list_action_(UrlList_None),
       player_action_(Player_None),
       set_volume_(-1),
       volume_modifier_(0),

--- a/src/core/commandlineoptions.h
+++ b/src/core/commandlineoptions.h
@@ -34,7 +34,11 @@ class CommandlineOptions {
 
   // Don't change the values or order, these get serialised and sent to
   // possibly a different version of Clementine
-  enum UrlListAction { UrlList_Append = 0, UrlList_Load = 1, };
+  enum UrlListAction {
+    UrlList_Append = 0,
+    UrlList_Load = 1,
+    UrlList_None = 2,
+  };
   enum PlayerAction {
     Player_None = 0,
     Player_Play = 1,

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1929,7 +1929,9 @@ void MainWindow::CommandlineOptionsReceived(
 void MainWindow::CommandlineOptionsReceived(const CommandlineOptions& options) {
   switch (options.player_action()) {
     case CommandlineOptions::Player_Play:
-      app_->player()->Play();
+      if (options.urls().empty()) {
+        app_->player()->Play();
+      }
       break;
     case CommandlineOptions::Player_PlayPause:
       app_->player()->PlayPause();
@@ -1954,17 +1956,30 @@ void MainWindow::CommandlineOptionsReceived(const CommandlineOptions& options) {
       break;
   }
 
-  switch (options.url_list_action()) {
-    case CommandlineOptions::UrlList_Load:
-      app_->playlist_manager()->ClearCurrent();
+  if (!options.urls().empty()) {
+    MimeData* data = new MimeData;
+    data->setUrls(options.urls());
+    // Behaviour depends on command line options, so set it here
+    data->override_user_settings_ = true;
 
-    // fallthrough
-    case CommandlineOptions::UrlList_Append: {
-      MimeData* data = new MimeData;
-      data->setUrls(options.urls());
-      AddToPlaylist(data);
-      break;
+    if (options.player_action() == CommandlineOptions::Player_Play)
+      data->play_now_ = true;
+    else
+      ApplyPlayBehaviour(doubleclick_playmode_, data);
+
+    switch (options.url_list_action()) {
+      case CommandlineOptions::UrlList_Load:
+        data->clear_first_ = true;
+        break;
+      case CommandlineOptions::UrlList_Append:
+        // Nothing to do
+        break;
+      case CommandlineOptions::UrlList_None:
+        ApplyAddBehaviour(doubleclick_addmode_, data);
+        break;
     }
+
+    AddToPlaylist(data);
   }
 
   if (options.set_volume() != -1)


### PR DESCRIPTION
.. and the '--play' option plays the new added files now.
See #4183.
