### PR TITLE
Add a tool tip to the library search field.

### DIFF
--- a/src/library/libraryfilterwidget.ui
+++ b/src/library/libraryfilterwidget.ui
@@ -21,7 +21,10 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QSearchField" name="filter">
+    <widget class="QSearchField" name="filter" native="true">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Prefix a word with a field name to limit the search to that field, e.g. &lt;span style=&quot; font-weight:600;&quot;&gt;artist:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Bode&lt;/span&gt; searches the library for all artists that contain the word Bode.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Available fields: &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;title, album, artist, albumartist, composer, performer, grouping, genre, comment&lt;/span&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
      <property name="placeholderText" stdset="0">
       <string>Enter search terms here</string>
      </property>


### PR DESCRIPTION
Clementine has been able to search specific fields in the library since 2010. However, this feature seems to be relatively unknown, e.g. issue #3344 and second part of #4197.

This pull request adds a tooltip to the library search field that describe the basic usage of this feature. Fixes #3344.
