### PR TITLE
Remove deprecated X-Ayatana actions

### DIFF
--- a/dist/clementine.desktop
+++ b/dist/clementine.desktop
@@ -7,6 +7,8 @@ Name[sr@ijekavian]=Клементина
 Name[sr@ijekavianlatin]=Klementina
 Name[sr@latin]=Klementina
 GenericName=Clementine Music Player
+GenericName[ca]=Reproductor de música Clementine
+GenericName[es]=Reproductor de música Clementine
 GenericName[pl]=Odtwarzacz muzyki Clementine
 GenericName[pt]=Reprodutor de músicas Clementine
 GenericName[sr]=Клементина музички плејер
@@ -14,6 +16,8 @@ GenericName[sr@ijekavian]=Клементина музички плејер
 GenericName[sr@ijekavianlatin]=Klementina muzički plejer
 GenericName[sr@latin]=Klementina muzički plejer
 Comment=Plays music and last.fm streams
+Comment[ca]=Reproducció de música i fluxos de Last.fm
+Comment[es]=Reproducción de música y flujos de Last.fm
 Comment[pl]=Odtwarzanie muzyki i strumieni last.fm
 Comment[pt]=Reprodução de músicas e emissões last.fm
 Comment[sr]=Репродукује музику и last.fm токове
@@ -27,12 +31,12 @@ Terminal=false
 Categories=AudioVideo;Player;Qt;Audio;
 StartupNotify=false
 MimeType=application/ogg;application/x-ogg;application/x-ogm-audio;audio/aac;audio/mp4;audio/mpeg;audio/mpegurl;audio/ogg;audio/vnd.rn-realaudio;audio/vorbis;audio/x-flac;audio/x-mp3;audio/x-mpeg;audio/x-mpegurl;audio/x-ms-wma;audio/x-musepack;audio/x-oggflac;audio/x-pn-realaudio;audio/x-scpls;audio/x-speex;audio/x-vorbis;audio/x-vorbis+ogg;audio/x-wav;video/x-ms-asf;x-content/audio-player;x-scheme-handler/zune;x-scheme-handler/itpc;x-scheme-handler/itms;x-scheme-handler/feed;
-X-Ayatana-Desktop-Shortcuts=Play;Pause;Stop;Previous;Next;
+Actions=Play;Pause;Stop;Previous;Next;
 
-[Play Shortcut Group]
+[Desktop Action Play]
 Name=Play
 Exec=clementine --play
-TargetEnvironment=Unity
+OnlyShowIn=Unity;
 Name[af]=Speel
 Name[be]=Прайграць
 Name[bg]=Възпроизвеждане
@@ -43,7 +47,6 @@ Name[da]=Afspil
 Name[de]=Wiedergabe
 Name[el]=Αναπαραγωγή
 Name[es]=Reproducir
-Name[es_AR]=Reproducir
 Name[et]=Mängi
 Name[eu]=Erreproduzitu
 Name[fa]=پخش
@@ -81,10 +84,10 @@ Name[vi]=Phát
 Name[zh_CN]=播放
 Name[zh_TW]=播放
 
-[Pause Shortcut Group]
+[Desktop Action Pause]
 Name=Pause
 Exec=clementine --pause
-TargetEnvironment=Unity
+OnlyShowIn=Unity;
 Name[be]=Прыпыніць
 Name[bg]=Пауза
 Name[br]=Ehan
@@ -92,7 +95,6 @@ Name[ca]=Pausa
 Name[cs]=Pozastavit
 Name[el]=Παύση
 Name[es]=Pausar
-Name[es_AR]=Pausar
 Name[et]=Paus
 Name[eu]=Pausarazi
 Name[fa]=ایست
@@ -128,10 +130,10 @@ Name[vi]=Tạm dừng
 Name[zh_CN]=暂停
 Name[zh_TW]=暫停
 
-[Stop Shortcut Group]
+[Desktop Action Stop]
 Name=Stop
 Exec=clementine --stop
-TargetEnvironment=Unity
+OnlyShowIn=Unity;
 Name[be]=Спыніць
 Name[bg]=Спиране
 Name[br]=Paouez
@@ -140,7 +142,6 @@ Name[cs]=Zastavit
 Name[de]=Anhalten
 Name[el]=Σταμάτημα
 Name[es]=Detener
-Name[es_AR]=Detener
 Name[et]=Peata
 Name[eu]=Gelditu
 Name[fa]=ایست
@@ -178,10 +179,10 @@ Name[vi]=Dừng
 Name[zh_CN]=停止
 Name[zh_TW]=停止
 
-[Previous Shortcut Group]
+[Desktop Action Previous]
 Name=Previous
 Exec=clementine --previous
-TargetEnvironment=Unity
+OnlyShowIn=Unity;
 Name[af]=Vorige
 Name[be]=Папярэдні
 Name[bg]=Предишна
@@ -192,7 +193,6 @@ Name[da]=Forrige
 Name[de]=Vorheriger
 Name[el]=Προηγούμενο
 Name[es]=Anterior
-Name[es_AR]=Anterior
 Name[eu]=Aurrekoa
 Name[fa]=پیشین
 Name[fi]=Edellinen
@@ -227,10 +227,10 @@ Name[vi]=Trước
 Name[zh_CN]=上一首
 Name[zh_TW]=往前
 
-[Next Shortcut Group]
+[Desktop Action Next]
 Name=Next
 Exec=clementine --next
-TargetEnvironment=Unity
+OnlyShowIn=Unity;
 Name[af]=Volgende
 Name[be]=Далей
 Name[bg]=Следваща
@@ -241,7 +241,6 @@ Name[da]=Næste
 Name[de]=Weiter
 Name[el]=Επόμενο
 Name[es]=Siguiente
-Name[es_AR]=Siguiente
 Name[eu]=Hurrengoa
 Name[fa]=پسین
 Name[fi]=Seuraava


### PR DESCRIPTION
Replace with Freedesktop Actions which work with newer Unity.

While I’m here, remove old, redundant es_AR and update ca and es.
