### PR TITLE
Don't translate field names in the library search filter tool tip

### DIFF
--- a/src/library/libraryfilterwidget.cpp
+++ b/src/library/libraryfilterwidget.cpp
@@ -20,12 +20,14 @@
 #include "libraryquery.h"
 #include "groupbydialog.h"
 #include "ui_libraryfilterwidget.h"
+#include "core/song.h"
 #include "ui/iconloader.h"
 #include "ui/settingsdialog.h"
 
 #include <QActionGroup>
 #include <QKeyEvent>
 #include <QMenu>
+#include <QRegExp>
 #include <QSettings>
 #include <QSignalMapper>
 #include <QTimer>
@@ -39,6 +41,13 @@ LibraryFilterWidget::LibraryFilterWidget(QWidget* parent)
       filter_applies_to_model_(true),
       delay_behaviour_(DelayedOnLargeLibraries) {
   ui_->setupUi(this);
+
+  // Add the available fields to the tooltip here instead of the ui
+  // file to prevent that they get translated by mistake.
+  QString available_fields =
+      Song::kFtsColumns.join(", ").replace(QRegExp("\\bfts"), "");
+  ui_->filter->setToolTip(ui_->filter->toolTip().arg(available_fields));
+
   connect(ui_->filter, SIGNAL(returnPressed()), SIGNAL(ReturnPressed()));
   connect(filter_delay_, SIGNAL(timeout()), SLOT(FilterDelayTimeout()));
 

--- a/src/library/libraryfilterwidget.ui
+++ b/src/library/libraryfilterwidget.ui
@@ -23,7 +23,7 @@
    <item>
     <widget class="QSearchField" name="filter" native="true">
      <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Prefix a word with a field name to limit the search to that field, e.g. &lt;span style=&quot; font-weight:600;&quot;&gt;artist:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Bode&lt;/span&gt; searches the library for all artists that contain the word Bode.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Available fields: &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;title, album, artist, albumartist, composer, performer, grouping, genre, comment&lt;/span&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Prefix a word with a field name to limit the search to that field, e.g. &lt;span style=&quot; font-weight:600;&quot;&gt;artist:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Bode&lt;/span&gt; searches the library for all artists that contain the word Bode.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Available fields: &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;%1&lt;/span&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="placeholderText" stdset="0">
       <string>Enter search terms here</string>


### PR DESCRIPTION
The names of the available fields in the tool tip for the library search filter should not be translated, since only the original names will work in an actual search.

This pull request adjusts the tool tip for the library search filter so that the names of the available fields are taken directly from Song::kFtsColumns.
