### PR TITLE
Translation, typos and mac build fixes for Vk.com plugin.

### DIFF
--- a/src/internet/vkmusiccache.cpp
+++ b/src/internet/vkmusiccache.cpp
@@ -14,10 +14,10 @@
    You should have received a copy of the GNU General Public License
    along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
 */
-
 #include "vkmusiccache.h"
 #include "vkservice.h"
 
+#include <qmath.h>
 #include <QDir>
 
 #include "core/application.h"
@@ -130,7 +130,7 @@ void VkMusicCache::DownloadNext() {
 
 void VkMusicCache::DownloadProgress(qint64 bytesReceived, qint64 bytesTotal) {
   if (bytesTotal) {
-    int progress = round(100 * bytesReceived / bytesTotal);
+    int progress = qRound(100 * bytesReceived / bytesTotal);
     app_->task_manager()->SetTaskProgress(task_id, progress, 100);
   }
 }

--- a/src/internet/vksearchdialog.cpp
+++ b/src/internet/vksearchdialog.cpp
@@ -91,7 +91,7 @@ void VkSearchDialog::ReceiveResults(const SearchID& id, const MusicOwnerList& ow
         popup->addTopLevelItem(createItem(own));
       }
     } else {
-      popup->addTopLevelItem(new QTreeWidgetItem(QStringList(tr("Nothig found"))));
+      popup->addTopLevelItem(new QTreeWidgetItem(QStringList(tr("Nothing found"))));
     }
 
     popup->setCurrentItem(popup->topLevelItem(0));

--- a/src/internet/vkservice.cpp
+++ b/src/internet/vkservice.cpp
@@ -148,7 +148,7 @@ Song MusicOwner::toOwnerRadio() const {
                         .arg(songs_count_)
                         .arg(screen_name_)
                         .arg(QString(name_).replace('/', '_'))));
-  song.set_artist(" " + QObject::tr("Group radio"));
+  song.set_artist(" " + QObject::tr("Community Radio"));
   song.set_valid(true);
   return song;
 }

--- a/src/internet/vksettingspage.ui
+++ b/src/internet/vksettingspage.ui
@@ -150,7 +150,7 @@
            <item>
             <widget class="QToolButton" name="choose_path">
              <property name="text">
-              <string>...</string>
+              <string notr="true">...</string>
              </property>
             </widget>
            </item>
@@ -171,7 +171,7 @@
            <item>
             <widget class="QLineEdit" name="cache_filename">
              <property name="text">
-              <string>%artist - %title</string>
+              <string notr="true">%artist - %title</string>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
Fixed:
- Mac build (I guess)
- Typo
- Mark "..." and "%artist - %title" as untranslatable.

To fix:
-  "(%0 songs)" can not be translated in transifex. (What requirements must be satisfied for transifex?)
