### PR TITLE
Moodbar-Trackslider uses the full available height

### DIFF
--- a/src/moodbar/moodbarproxystyle.cpp
+++ b/src/moodbar/moodbarproxystyle.cpp
@@ -98,6 +98,12 @@ void MoodbarProxyStyle::SetMoodbarEnabled(bool enabled) {
 void MoodbarProxyStyle::NextState() {
   const bool visible = enabled_ && !data_.isEmpty();
 
+  // While the regular slider should stay at the standard size (Fixed),
+  // moodbars should use all available space (MinimumExpanding).
+  slider_->setSizePolicy(QSizePolicy::Expanding,
+      visible ? QSizePolicy::MinimumExpanding : QSizePolicy::Fixed);
+  slider_->updateGeometry();
+
   if (show_moodbar_action_) {
     show_moodbar_action_->setChecked(enabled_);
   }


### PR DESCRIPTION
When determining the next state (for rendering the change), the slider widgets vertical SizePolicy is changed from Fixed to MinimumExpanding (same thing works the other way around).
