### PR TITLE
Relative Paths for XSPF File Format

### DIFF
--- a/src/playlistparsers/xspfparser.cpp
+++ b/src/playlistparsers/xspfparser.cpp
@@ -135,11 +135,9 @@ void XSPFParser::Save(const SongList& songs, QIODevice* device,
     if (!art.startsWith(":") && !art.isEmpty()) {
       // Convert local files to URLs.
       QUrl url(art);
-      qDebug() << url.toString() << "\n\n\n";
-      if (!art.contains("http")) {
+      if (!art.contains("://") || url.scheme() == "file") {
         art = dir.relativeFilePath(QFileInfo(url.toLocalFile()).absoluteFilePath());
-      }
-      else {
+      } else {
         art = url.toString();
       }
       writer.writeTextElement("image", art);


### PR DESCRIPTION
These changes move the XSPF save code to using relative file paths. I want this feature because I don't want to have to edit the playlists I create when I move them to a backup server. It would be great if I could use them as is. Relative paths do that, and the XSPF format does allow for them.
The paths are used for both the song and the art.
If you would prefer that a user preference be added, I can do that too. Just let me know.
