### PR TITLE
Remove unnecessary string conversion

### DIFF
--- a/src/ui/ripcd.cpp
+++ b/src/ui/ripcd.cpp
@@ -269,7 +269,7 @@ void RipCD::ThreadClickedRipButton() {
                                   .value<TranscoderPreset>();
 
     QString outfilename = GetOutputFileName(filename, preset);
-    transcoder_->AddJob(filename.toUtf8().constData(), preset, outfilename);
+    transcoder_->AddJob(filename, preset, outfilename);
   }
   emit(RippingComplete());
 }


### PR DESCRIPTION
Fix a case where a Qstring was converted to a QByteArray using `QString::toUtf8` and then converted back to a QString using `QString::fromAscii`.

For example, this changed the string "Alfvén" to "AlfvÃ©n".
