### PR TITLE
BugFix: clementine cannot delete directories in file tab #858

### DIFF
--- a/src/core/filesystemmusicstorage.cpp
+++ b/src/core/filesystemmusicstorage.cpp
@@ -17,6 +17,7 @@
 
 #include "filesystemmusicstorage.h"
 #include "core/logging.h"
+#include "core/utilities.h"
 
 #include <QDir>
 #include <QFile>
@@ -50,44 +51,10 @@ bool FilesystemMusicStorage::CopyToStorage(const CopyJob& job) {
 }
 
 bool FilesystemMusicStorage::DeleteFromStorage(const DeleteJob& job) {
-  bool result = false;
-  
-  QString path = job.metadata_.url().toLocalFile();  
+  QString path = job.metadata_.url().toLocalFile();
   QFileInfo fileInfo(path);
   if (fileInfo.isDir())
-    result = RemoveDirectory(path);
+    return Utilities::RemoveRecursive(path);
   else
-    result = QFile::remove(path);
-    
-  return result;
-}
-
-bool FilesystemMusicStorage::RemoveDirectory(const QString& dirName) {
-  bool result = true;
-  QDir dir(dirName);
-
-  if (dir.exists(dirName)) {    
-    auto fileInfoList = dir.entryInfoList(QDir::NoDotAndDotDot
-                                        | QDir::System
-                                        | QDir::Hidden
-                                        | QDir::AllDirs
-                                        | QDir::Files
-                                        , QDir::DirsFirst);
-    
-    for (auto info : fileInfoList) {      
-      // remove subdirectories too
-      if (info.isDir()) {
-        result = RemoveDirectory(info.absoluteFilePath());
-      }
-      else { 
-        result = QFile::remove(info.absoluteFilePath());
-      } 
-      
-      if (!result) {
-        return result;
-      }      
-    }
-    result = dir.rmdir(dirName);    
-  }
-    return result;
+    return QFile::remove(path);
 }

--- a/src/core/filesystemmusicstorage.h
+++ b/src/core/filesystemmusicstorage.h
@@ -30,9 +30,6 @@ class FilesystemMusicStorage : public virtual MusicStorage {
   bool CopyToStorage(const CopyJob& job);
   bool DeleteFromStorage(const DeleteJob& job);
 
-private:
-  bool RemoveDirectory(const QString &dirName);
-  
  private:
   QString root_;
 };

--- a/src/core/utilities.cpp
+++ b/src/core/utilities.cpp
@@ -219,17 +219,24 @@ QString GetTemporaryFileName() {
   return file;
 }
 
-void RemoveRecursive(const QString& path) {
+bool RemoveRecursive(const QString& path) {
   QDir dir(path);
   for (const QString& child :
-       dir.entryList(QDir::NoDotAndDotDot | QDir::Dirs | QDir::Hidden))
-    RemoveRecursive(path + "/" + child);
+       dir.entryList(QDir::NoDotAndDotDot | QDir::Dirs | QDir::Hidden)) {
+    if (!RemoveRecursive(path + "/" + child))
+      return false;
+  }
 
   for (const QString& child :
-       dir.entryList(QDir::NoDotAndDotDot | QDir::Files | QDir::Hidden))
-    QFile::remove(path + "/" + child);
+       dir.entryList(QDir::NoDotAndDotDot | QDir::Files | QDir::Hidden)) {
+    if (!QFile::remove(path + "/" + child))
+      return false;
+  }
 
-  dir.rmdir(path);
+  if (!dir.rmdir(path))
+    return false;
+
+  return true;
 }
 
 bool CopyRecursive(const QString& source, const QString& destination) {

--- a/src/core/utilities.h
+++ b/src/core/utilities.h
@@ -51,7 +51,7 @@ quint64 FileSystemFreeSpace(const QString& path);
 
 QString MakeTempDir(const QString template_name = QString());
 QString GetTemporaryFileName();
-void RemoveRecursive(const QString& path);
+bool RemoveRecursive(const QString& path);
 bool CopyRecursive(const QString& source, const QString& destination);
 bool Copy(QIODevice* source, QIODevice* destination);
 


### PR DESCRIPTION
Bugfix for #858.
I Added the method for remove a directories. Now you can delete a directory with all its contents.
Whether we are satisfied with this behavior?

Note that I test it on Ubuntu 14.04 only.
