### PR TITLE
Fix stop after track

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -190,7 +190,6 @@ void Player::NextItem(Engine::TrackChangeFlags change) {
 
 bool Player::HandleStopAfter() {
   if (app_->playlist_manager()->active()->stop_after_current()) {
-    app_->playlist_manager()->active()->StopAfter(-1);
 
     // Find what the next track would've been, and mark that one as current
     // so it plays next time the user presses Play.
@@ -198,6 +197,8 @@ bool Player::HandleStopAfter() {
     if (next_row != -1) {
       app_->playlist_manager()->active()->set_current_row(next_row);
     }
+    
+    app_->playlist_manager()->active()->StopAfter(-1);
 
     Stop();
     return true;


### PR DESCRIPTION
Stop after track would cause now playing widget, OSD, and last.fm 
scrobbler to change to next track after stopping, leaving the interface a mess.
Reordering the handler prevents the wrong signal being broadcast.
