### PR TITLE
Fix play bleeding into next track after auto stop

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -199,7 +199,7 @@ bool Player::HandleStopAfter() {
 
     app_->playlist_manager()->active()->StopAfter(-1);
 
-    Stop();
+    Stop(true);
     return true;
   }
   return false;
@@ -264,8 +264,8 @@ void Player::RestartOrPrevious() {
   SeekTo(0);
 }
 
-void Player::Stop() {
-  engine_->Stop();
+void Player::Stop(bool stop_after) {
+  engine_->Stop(stop_after);
   app_->playlist_manager()->active()->set_current_row(-1);
   current_item_.reset();
 }

--- a/src/core/player.h
+++ b/src/core/player.h
@@ -78,7 +78,7 @@ class PlayerInterface : public QObject {
 
   virtual void Mute() = 0;
   virtual void Pause() = 0;
-  virtual void Stop() = 0;
+  virtual void Stop(bool stop_after = false) = 0;
   virtual void Play() = 0;
   virtual void ShowOSD() = 0;
 
@@ -143,7 +143,7 @@ class Player : public PlayerInterface {
 
   void Mute();
   void Pause();
-  void Stop();
+  void Stop(bool stop_after = false);
   void StopAfterCurrent();
   void Play();
   void ShowOSD();

--- a/src/engines/enginebase.h
+++ b/src/engines/enginebase.h
@@ -47,7 +47,7 @@ class Base : public QObject {
 
   virtual void StartPreloading(const QUrl&, bool, qint64, qint64) {}
   virtual bool Play(quint64 offset_nanosec) = 0;
-  virtual void Stop() = 0;
+  virtual void Stop(bool stop_after = false) = 0;
   virtual void Pause() = 0;
   virtual void Unpause() = 0;
   virtual void Seek(quint64 offset_nanosec) = 0;

--- a/src/engines/gstengine.cpp
+++ b/src/engines/gstengine.cpp
@@ -433,13 +433,13 @@ void GstEngine::PlayDone() {
   emit ValidSongRequested(url_);
 }
 
-void GstEngine::Stop() {
+void GstEngine::Stop(bool stop_after) {
   StopTimers();
 
   url_ = QUrl();  // To ensure we return Empty from state()
   beginning_nanosec_ = end_nanosec_ = 0;
 
-  if (fadeout_enabled_ && current_pipeline_) StartFadeout();
+  if (fadeout_enabled_ && current_pipeline_ && !stop_after) StartFadeout();
 
   current_pipeline_.reset();
   BufferingFinished();
@@ -672,8 +672,8 @@ GstElement* GstEngine::CreateElement(const QString& factoryName,
   return element;
 }
 
-GstEngine::PluginDetailsList GstEngine::GetPluginList(const QString& classname)
-    const {
+GstEngine::PluginDetailsList GstEngine::GetPluginList(
+    const QString& classname) const {
   PluginDetailsList ret;
 
   GstRegistry* registry = gst_registry_get_default();

--- a/src/engines/gstengine.h
+++ b/src/engines/gstengine.h
@@ -96,7 +96,7 @@ class GstEngine : public Engine::Base, public BufferConsumer {
             bool force_stop_at_end, quint64 beginning_nanosec,
             qint64 end_nanosec);
   bool Play(quint64 offset_nanosec);
-  void Stop();
+  void Stop(bool stop_after = false);
   void Pause();
   void Unpause();
   void Seek(quint64 offset_nanosec);
@@ -219,7 +219,7 @@ class GstEngine : public Engine::Base, public BufferConsumer {
   int timer_id_;
   int next_element_id_;
 
-  QHash<int, std::shared_ptr<GstEnginePipeline> > background_streams_;
+  QHash<int, std::shared_ptr<GstEnginePipeline>> background_streams_;
 
   bool is_fading_out_to_pause_;
   bool has_faded_out_;


### PR DESCRIPTION
If "fade out on stop" is enabled, the "stop after this track" feature
would not stop the on current track, but instead start playing
the next track and fade out on that immediately. This patch disables
fadeout when the engine is stopped by HandleStopAfter().

This bug has been present since ~1.1 and is unrelated to my last patch.
