### PR TITLE
Use a single label for the text at the top of the soundcloud settings page

### DIFF
--- a/src/internet/soundcloudsettingspage.ui
+++ b/src/internet/soundcloudsettingspage.ui
@@ -20,15 +20,14 @@
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
     <widget class="QLabel" name="label">
-     <property name="text">
-      <string>You don't need to be logged in to search and to listen to music on SoundCloud.</string>
+     <property name="enabled">
+      <bool>true</bool>
      </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLabel" name="label_3">
      <property name="text">
-      <string>However, you need to login to access your playlists and your stream.</string>
+      <string>You don't need to be logged in to search and to listen to music on SoundCloud. However, you need to login to access your playlists and your stream.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
This pull request puts the two sentences at the top of the soundcloud settings page into the same label. This will give the translators the full context of the paragraph. 
