### PR TITLE
Removed gradient & text from large album cover (Issue #853)

### DIFF
--- a/src/widgets/nowplayingwidget.cpp
+++ b/src/widgets/nowplayingwidget.cpp
@@ -44,11 +44,6 @@ const char* NowPlayingWidget::kHypnotoadPath = ":/hypnotoad.gif";
 // Space between the cover and the details in small mode
 const int NowPlayingWidget::kPadding = 2;
 
-// Width of the transparent to black gradient above and below the text in large
-// mode
-const int NowPlayingWidget::kGradientHead = 40;
-const int NowPlayingWidget::kGradientTail = 20;
-
 // Maximum height of the cover in large mode, and offset between the
 // bottom of the cover and bottom of the widget
 const int NowPlayingWidget::kMaxCoverSize = 260;
@@ -354,23 +349,6 @@ void NowPlayingWidget::DrawContents(QPainter* p) {
         }
       }
 
-      // Work out how high the text is going to be
-      const int text_height = details_->size().height();
-      const int gradient_mid = height() - qMax(text_height, kBottomOffset);
-
-      // Draw the black fade
-      QLinearGradient gradient(0, gradient_mid - kGradientHead, 0,
-                               gradient_mid + kGradientTail);
-      gradient.setColorAt(0, QColor(0, 0, 0, 0));
-      gradient.setColorAt(1, QColor(0, 0, 0, 255));
-
-      p->fillRect(0, gradient_mid - kGradientHead, width(),
-                  height() - (gradient_mid - kGradientHead), gradient);
-
-      // Draw the text on top
-      p->translate(x_offset, height() - text_height);
-      details_->drawContents(p);
-      p->translate(-x_offset, -height() + text_height);
       break;
   }
 }

--- a/src/widgets/nowplayingwidget.h
+++ b/src/widgets/nowplayingwidget.h
@@ -47,8 +47,6 @@ class NowPlayingWidget : public QWidget {
 
   static const char* kSettingsGroup;
   static const int kPadding;
-  static const int kGradientHead;
-  static const int kGradientTail;
   static const int kMaxCoverSize;
   static const int kBottomOffset;
   static const int kTopBorder;


### PR DESCRIPTION
Hello, this is my attempt to address issue #853 and make the large album art widget better. This simply removes the black gradient and text over the large album cover to give a cleaner interface and show off the album art better. If the user wants the song information next to the album art, they can still switch to the small album art. Thank you!
![tv6yjgl](https://cloud.githubusercontent.com/assets/4236749/2905509/d3985ba4-d605-11e3-9abd-eb83252bee30.png)
