### PR TITLE
Fix block analyzer framerate

### DIFF
--- a/src/analyzers/analyzerbase.h
+++ b/src/analyzers/analyzerbase.h
@@ -50,6 +50,8 @@ class Base : public QWidget {
     }
   }
 
+  virtual void framerateChanged() {}
+
  protected:
   Base(QWidget*, uint scopeSize = 7);
 

--- a/src/analyzers/analyzercontainer.cpp
+++ b/src/analyzers/analyzercontainer.cpp
@@ -166,10 +166,8 @@ void AnalyzerContainer::ChangeFramerate(int new_framerate) {
     new_framerate = new_framerate == 0 ? kMediumFramerate : new_framerate;
     current_analyzer_->changeTimeout(1000 / new_framerate);
 
-    // the BlockAnalyzer needs to know when the framerate changes
-    if (strcmp(current_analyzer_->metaObject()->className(), "BlockAnalyzer") == 0) {
-      qobject_cast<BlockAnalyzer*>(current_analyzer_)->determineStep();
-    }
+    // notify the current analyzer that the framerate has changed
+    current_analyzer_->framerateChanged();
   }
   SaveFramerate(new_framerate);
 }

--- a/src/analyzers/blockanalyzer.cpp
+++ b/src/analyzers/blockanalyzer.cpp
@@ -106,6 +106,10 @@ void BlockAnalyzer::determineStep() {
   m_step = double(m_rows * timeout()) / fallTime;
 }
 
+void BlockAnalyzer::framerateChanged() {  // virtual
+  determineStep();
+}
+
 void BlockAnalyzer::transform(Analyzer::Scope& s)  // pure virtual
 {
   for (uint x = 0; x < s.size(); ++x) s[x] *= 2;

--- a/src/analyzers/blockanalyzer.h
+++ b/src/analyzers/blockanalyzer.h
@@ -31,15 +31,15 @@ class BlockAnalyzer : public Analyzer::Base {
 
   static const char* kName;
 
-  void determineStep();
-
  protected:
   virtual void transform(Scope&);
   virtual void analyze(QPainter& p, const Scope&, bool new_frame);
   virtual void resizeEvent(QResizeEvent*);
   virtual void paletteChange(const QPalette&);
+  virtual void framerateChanged();
 
   void drawBackground();
+  void determineStep();
 
  private:
   QPixmap* bar() { return &m_barPixmap; }


### PR DESCRIPTION
Block analyzer uses an internal variable m_step to determine how
long to hold a bar up. This is dependant on framerate, however it is
only set on creation or resize of the analyzer. This patch changes
this value whenever the framerate is changed, preventing the analyzer
from appearing wildly fast or extremely slow until a restart.
