### PR TITLE
Fix dbz possibility with small buffers at end of track

### DIFF
--- a/src/widgets/nowplayingwidget.cpp
+++ b/src/widgets/nowplayingwidget.cpp
@@ -67,6 +67,7 @@ NowPlayingWidget::NowPlayingWidget(QWidget* parent)
       fit_cover_width_action_(nullptr),
       visible_(false),
       small_ideal_height_(0),
+      fit_width_(false),
       show_hide_animation_(new QTimeLine(500, this)),
       fade_animation_(new QTimeLine(1000, this)),
       details_(new QTextDocument(this)),


### PR DESCRIPTION
There was a possibility of a dbz when a buffer sent to the
analyzer was shorter than 1ms long, such as what may happen at the end
of a track when stopping. This patch guards against this.
