### PR TITLE
Use more random random generator

### DIFF
--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -1097,9 +1097,8 @@ void Playlist::InsertInternetItems(const InternetModel* model,
     switch (item.data(InternetModel::Role_PlayBehaviour).toInt()) {
       case InternetModel::PlayBehaviour_SingleItem:
         playlist_items << shared_ptr<PlaylistItem>(new InternetPlaylistItem(
-                              model->ServiceForIndex(item),
-                              item.data(InternetModel::Role_SongMetadata)
-                                  .value<Song>()));
+            model->ServiceForIndex(item),
+            item.data(InternetModel::Role_SongMetadata).value<Song>()));
         break;
 
       case InternetModel::PlayBehaviour_UseSongLoader:
@@ -1122,7 +1121,7 @@ void Playlist::InsertInternetItems(InternetService* service,
   PlaylistItemList playlist_items;
   for (const Song& song : songs) {
     playlist_items << shared_ptr<PlaylistItem>(
-                          new InternetPlaylistItem(service, song));
+        new InternetPlaylistItem(service, song));
   }
 
   InsertItems(playlist_items, pos, play_now, enqueue);
@@ -1899,8 +1898,8 @@ void Playlist::ReshuffleIndices() {
 
       // Shuffle them
       QStringList shuffled_album_keys = album_key_set.toList();
-      std::random_shuffle(shuffled_album_keys.begin(),
-                          shuffled_album_keys.end());
+      std::shuffle(shuffled_album_keys.begin(), shuffled_album_keys.end(),
+                   std::mt19937());
 
       // If the user is currently playing a song, force its album to be first.
       if (current_virtual_index_ != -1) {


### PR DESCRIPTION
Addresses: #4352

This changes the shuffle feature to use the Mersenne twister algorithm
instead of the default in C++. It also restructures to use std::shuffle
as std::random_shuffle is deprecated in C++14. I still agree with some of the
issue thread in that a better dynamic algorithm needs to be implemented, but
this should help in the meantime.
