### PR TITLE
Check for error when getting the number of cd tracks

### DIFF
--- a/src/ui/ripcd.cpp
+++ b/src/ui/ripcd.cpp
@@ -492,7 +492,12 @@ void RipCD::RemoveTemporaryDirectory() {
 void RipCD::BuildTrackListTable() {
   checkboxes_.clear();
   track_names_.clear();
+
   i_tracks_ = cdio_get_num_tracks(cdio_);
+  // Build an empty table if there is an error, e.g. no medium found.
+  if (i_tracks_ == CDIO_INVALID_TRACK)
+    i_tracks_ = 0;
+
   ui_->tableWidget->setRowCount(i_tracks_);
   for (int i = 1; i <= i_tracks_; i++) {
     QCheckBox* checkbox_i = new QCheckBox(ui_->tableWidget);


### PR DESCRIPTION
In the CD ripper, when `cdio_get_num_tracks` returns an error code, you currently get 255 ghost tracks. This pull request changes this so that an an empty table is built instead.
