### PR TITLE
Fix random artifacting on nyanalyzer on startup

### DIFF
--- a/src/analyzers/nyancatanalyzer.cpp
+++ b/src/analyzers/nyancatanalyzer.cpp
@@ -40,7 +40,7 @@ NyanCatAnalyzer::NyanCatAnalyzer(QWidget* parent)
       px_per_frame_(0),
       x_offset_(0),
       background_brush_(QColor(0x0f, 0x43, 0x73)) {
-  memset(history_, 0, arraysize(history_));
+  memset(history_, 0, arraysize(history_) * sizeof(*history_));
 
   for (int i = 0; i < kRainbowBands; ++i) {
     colors_[i] = QPen(QColor::fromHsv(i * 255 / kRainbowBands, 255, 255),


### PR DESCRIPTION
memset works on bytes, not the source datatype width

...unless getting NaNs in the paths are related to <i>NyaN</i> cat...
![screenshot from 2014-05-21 233002](https://cloud.githubusercontent.com/assets/4623333/3066056/abd5bcb0-e26c-11e3-9973-22f000d6af7c.png)
