### PR TITLE
deleting track/disc/year in the spinbox should correct as expected

### DIFF
--- a/src/ui/edittagdialog.ui
+++ b/src/ui/edittagdialog.ui
@@ -641,6 +641,9 @@
         </item>
         <item row="0" column="3">
          <widget class="SpinBox" name="track">
+          <property name="correctionMode">
+           <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+          </property>
           <property name="maximum">
            <number>9999</number>
           </property>
@@ -684,6 +687,9 @@
         </item>
         <item row="1" column="3">
          <widget class="SpinBox" name="disc">
+          <property name="correctionMode">
+           <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+          </property>
           <property name="maximum">
            <number>9999</number>
           </property>
@@ -727,6 +733,9 @@
         </item>
         <item row="2" column="3">
          <widget class="SpinBox" name="year">
+          <property name="correctionMode">
+           <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+          </property>
           <property name="maximum">
            <number>9999</number>
           </property>


### PR DESCRIPTION
Hitting backspace on track/disc/year will just result in setting the value of the spinbox to the first digit of the previous value.

It is more reasonable to assume people want to remove these fields. Changing the default behaviour to correct to nearest seems to be better.
