### PR TITLE
Add 'Delete selected playlist files' global shortcut.

### DIFF
--- a/src/core/globalshortcuts.cpp
+++ b/src/core/globalshortcuts.cpp
@@ -71,6 +71,8 @@ GlobalShortcuts::GlobalShortcuts(QWidget* parent)
   AddShortcut("toggle_last_fm_scrobbling",
               tr("Enable/disable Last.fm scrobbling"),
               SIGNAL(ToggleScrobbling()));
+  AddShortcut("delete_selected_playlist_files", tr("Delete selected playlist files"),
+      SIGNAL(DeletePlaylistSelected()));
 
   AddRatingShortcut("rate_zero_star", tr("Rate the current song 0 stars"),
                     rating_signals_mapper_, 0);

--- a/src/core/globalshortcuts.h
+++ b/src/core/globalshortcuts.h
@@ -75,6 +75,7 @@ signals:
   void CycleShuffleMode();
   void CycleRepeatMode();
   void ToggleScrobbling();
+  void DeletePlaylistSelected();
 
  private:
   void AddShortcut(const QString& id, const QString& name, const char* signal,

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -751,6 +751,8 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
           SLOT(ShowOSD()));
   connect(global_shortcuts_, SIGNAL(TogglePrettyOSD()), app_->player(),
           SLOT(TogglePrettyOSD()));
+  connect(global_shortcuts_, SIGNAL(DeletePlaylistSelected()),
+          SLOT(PlaylistDelete()));
 #ifdef HAVE_LIBLASTFM
   connect(global_shortcuts_, SIGNAL(ToggleScrobbling()), app_->scrobbler(),
           SLOT(ToggleScrobbling()));


### PR DESCRIPTION
Relates to issue #2218

Hook a global shortcut to the MainWindow::PlaylistDelete to delete currently selected files.

A feature I've been badly wanting - would it be suitable and anything that would need to be added that I missed?
