### PR TITLE
Add an option to disable inline song metadata editing through click

### DIFF
--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -1109,6 +1109,11 @@ void PlaylistView::ReloadSettings() {
     emit BackgroundPropertyChanged();
     force_background_redraw_ = true;
   }
+
+  if(!s.value("click_edit_inline", true).toBool())
+      setEditTriggers(editTriggers() & ~QAbstractItemView::SelectedClicked);
+  else
+      setEditTriggers(editTriggers() | QAbstractItemView::SelectedClicked);
 }
 
 void PlaylistView::SaveSettings() {

--- a/src/ui/behavioursettingspage.cpp
+++ b/src/ui/behavioursettingspage.cpp
@@ -131,6 +131,8 @@ void BehaviourSettingsPage::Load() {
   s.beginGroup(Playlist::kSettingsGroup);
   ui_->b_grey_out_deleted_->setChecked(
       s.value("greyoutdeleted", false).toBool());
+  ui_->b_click_edit_inline_->setChecked(
+      s.value("click_edit_inline", true).toBool());
   s.endGroup();
 
   s.beginGroup(PlaylistTabBar::kSettingsGroup);
@@ -179,6 +181,7 @@ void BehaviourSettingsPage::Save() {
 
   s.beginGroup(Playlist::kSettingsGroup);
   s.setValue("greyoutdeleted", ui_->b_grey_out_deleted_->isChecked());
+  s.setValue("click_edit_inline", ui_->b_click_edit_inline_->isChecked());
   s.endGroup();
 
   s.beginGroup(PlaylistTabBar::kSettingsGroup);

--- a/src/ui/behavioursettingspage.ui
+++ b/src/ui/behavioursettingspage.ui
@@ -133,6 +133,13 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QCheckBox" name="b_click_edit_inline_">
+        <property name="text">
+         <string>Enable song metadata inline edition with click</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
It's too easy to edit song metadata by mistake simply by clicking on the tune, and it's been annoying me lately . Some albums in my library are also loaded in a peer-to-peer client, and modifying the on-disk files would mean "corrupting" them.
This commit adds an option that allows the user to disable inline editing through simple click.
