### PR TITLE
multiple select in tag editor for spinbox fixed

### DIFF
--- a/src/ui/edittagdialog.cpp
+++ b/src/ui/edittagdialog.cpp
@@ -48,6 +48,8 @@
 const char* EditTagDialog::kHintText =
     QT_TR_NOOP("(different across multiple songs)");
 const char* EditTagDialog::kSettingsGroup = "EditTagDialog";
+const char* EditTagDialog::multipleSpinbBoxStyle = "QSpinBox { color: gray; }";
+const char* EditTagDialog::multipleSpinBoxText = "--";
 
 EditTagDialog::EditTagDialog(Application* app, QWidget* parent)
     : QDialog(parent),
@@ -349,6 +351,7 @@ void EditTagDialog::InitFieldValue(const FieldData& field,
                                    const QModelIndexList& sel) {
   const bool varies = DoesValueVary(sel, field.id_);
   const bool modified = IsValueModified(sel, field.id_);
+  const bool multiple = sel.count() > 1;
 
   if (ExtendedEditor* editor = dynamic_cast<ExtendedEditor*>(field.editor_)) {
     editor->clear();
@@ -357,6 +360,20 @@ void EditTagDialog::InitFieldValue(const FieldData& field,
       editor->set_hint(tr(EditTagDialog::kHintText));
     } else {
       editor->set_text(data_[sel[0].row()].current_value(field.id_).toString());
+    }
+    //if we are a spinbox (disc,track,year) set_hint does not work so
+    //we need some trick to show multiple select
+    if (QSpinBox* sbox = dynamic_cast<QSpinBox*>(field.editor_)) {
+      if (multiple && varies) {
+          sbox->setMinimum(-1);
+          sbox->setSpecialValueText(multipleSpinBoxText);
+          sbox->setStyleSheet(multipleSpinbBoxStyle);
+          sbox->setValue(-1);
+      } else {
+          sbox->setMinimum(0);
+          sbox->setSpecialValueText("");
+          sbox->setStyleSheet("");
+      }
     }
   }
 

--- a/src/ui/edittagdialog.h
+++ b/src/ui/edittagdialog.h
@@ -48,6 +48,8 @@ class EditTagDialog : public QDialog {
 
   static const char* kHintText;
   static const char* kSettingsGroup;
+  static const char* multipleSpinbBoxStyle;
+  static const char* multipleSpinBoxText;
 
   void SetSongs(const SongList& songs,
                 const PlaylistItemList& items = PlaylistItemList());


### PR DESCRIPTION
Spinboxes (track, year, disc) now use specialvaluetext and stylesheet to give a hint that
multiple selected values are different.

The current text is -- and the color is gray.
