### PR TITLE
Fix Russian translation of the term "opacity"

### DIFF
--- a/src/translations/ru.po
+++ b/src/translations/ru.po
@@ -920,7 +920,7 @@ msgstr "Фоновое изображение"
 
 #: ../bin/src/ui_notificationssettingspage.h:452
 msgid "Background opacity"
-msgstr "Прозрачность фона"
+msgstr "Непрозрачность фона"
 
 #: core/database.cpp:640
 msgid "Backing up database"
@@ -3494,7 +3494,7 @@ msgstr "Показывать только первый"
 
 #: ../bin/src/ui_appearancesettingspage.h:290
 msgid "Opacity"
-msgstr "Прозрачность"
+msgstr "Непрозрачность"
 
 #: internet/digitallyimportedservicebase.cpp:172
 #: internet/groovesharkservice.cpp:554 internet/icecastservice.cpp:297


### PR DESCRIPTION
Russian word "прозрачность" means "transparency". "Opacity" is the opposite of that. When a user sets "прозрачность" to 90%, he expects the picture to become less discernible, not the other way around.

Correct Russian translation of this term is "непрозрачность".
