### PR TITLE
Fixes lock file removal

### DIFF
--- a/3rdparty/qtsingleapplication/qtlocalpeer.cpp
+++ b/3rdparty/qtsingleapplication/qtlocalpeer.cpp
@@ -107,6 +107,7 @@ QtLocalPeer::QtLocalPeer(QObject* parent, const QString &appId)
                        + QLatin1Char('/') + socketName
                        + QLatin1String("-lockfile");
     lockFile.setFileName(lockName);
+    lockFileCreated = !lockFile.exists();
     lockFile.open(QIODevice::ReadWrite);
 }
 
@@ -212,5 +213,6 @@ void QtLocalPeer::receiveConnection()
 
 QtLocalPeer::~QtLocalPeer ()
 {
-  lockFile.remove();
+  if (lockFileCreated)
+      lockFile.remove();
 }

--- a/3rdparty/qtsingleapplication/qtlocalpeer.h
+++ b/3rdparty/qtsingleapplication/qtlocalpeer.h
@@ -81,4 +81,5 @@ protected:
 
 private:
     static const char* ack;
+    bool lockFileCreated;
 };


### PR DESCRIPTION
This fixes a bug that came with a6ac100 / #4348 .
The problem is obvious: The lock file is removed even when it wasn't created by this instance. Try starting Clementine three times and you'll have two instances running.
