### PR TITLE
Update database after tags are edited

### DIFF
--- a/src/core/application.cpp
+++ b/src/core/application.cpp
@@ -75,12 +75,12 @@ Application::Application(QObject* parent)
       network_remote_(nullptr),
       network_remote_helper_(nullptr),
       scrobbler_(nullptr) {
-  tag_reader_client_ = new TagReaderClient(this);
-  MoveToNewThread(tag_reader_client_);
-  tag_reader_client_->Start();
-
   database_ = new Database(this, this);
   MoveToNewThread(database_);
+
+  tag_reader_client_ = new TagReaderClient(this, this);
+  MoveToNewThread(tag_reader_client_);
+  tag_reader_client_->Start();
 
   album_cover_loader_ = new AlbumCoverLoader(this);
   MoveToNewThread(album_cover_loader_);

--- a/src/core/tagreaderclient.h
+++ b/src/core/tagreaderclient.h
@@ -25,6 +25,7 @@
 
 #include <QStringList>
 
+class Application;
 class QLocalServer;
 class QProcess;
 
@@ -32,7 +33,7 @@ class TagReaderClient : public QObject {
   Q_OBJECT
 
  public:
-  TagReaderClient(QObject* parent = nullptr);
+  TagReaderClient(Application* app, QObject* parent = nullptr);
 
   typedef AbstractMessageHandler<pb::tagreader::Message> HandlerType;
   typedef HandlerType::ReplyType ReplyType;
@@ -65,6 +66,7 @@ class TagReaderClient : public QObject {
   static TagReaderClient* Instance() { return sInstance; }
 
  public slots:
+  void SongSaveComplete(TagReaderClient::ReplyType* reply, const QString& filename, const Song& song);
   void UpdateSongsStatistics(const SongList& songs);
   void UpdateSongsRating(const SongList& songs);
 
@@ -74,6 +76,7 @@ class TagReaderClient : public QObject {
  private:
   static TagReaderClient* sInstance;
 
+  Application* app_;
   WorkerPool<HandlerType>* worker_pool_;
   QList<pb::tagreader::Message> message_queue_;
 };


### PR DESCRIPTION
For some reason nobody updated the database when tags where edited.
Problems:
- When editing many songs the Tagedit dialog stays open longer (which I think is ok).
- If there are calls to TagReaderClient::SaveFile (non blocking) which expect to return really fast we might not return as fast. There are some places where this is called and I could only test Inline Editing which is fine with this change.
- I didn't test CDRip.

This might fix: #4419, #221 but I only looked at the description if this might be what the reports mean.
P.S.: Initially I tried to use NewClosure to call the new function but I couldn't make it work. If somebody wants to take a stab at it, be my guest.
