### PR TITLE
Spinboxes for year/disc/track now show if multiple different values are selected

### DIFF
--- a/src/widgets/lineedit.cpp
+++ b/src/widgets/lineedit.cpp
@@ -189,9 +189,40 @@ void TextEdit::resizeEvent(QResizeEvent* e) {
   Resize();
 }
 
+const char* SpinBox::sboxstylesheet = "QSpinBox { color:gray; }";
+const char* SpinBox::sboxhinttext = "-";
+
 SpinBox::SpinBox(QWidget* parent)
     : QSpinBox(parent), ExtendedEditor(this, 14, false) {
   connect(reset_button_, SIGNAL(clicked()), SIGNAL(Reset()));
+  connect(this, SIGNAL(valueChanged(int)), this, SLOT(value_changed(int)));
+}
+
+void SpinBox::set_hint(const QString& hint) {
+  //Spinboxes don't have a good hint so we need to use SpecialValueText
+  QSpinBox* sbox = static_cast<QSpinBox*>(widget_);
+  if( hint.isEmpty()) {
+    draw_hint_ = false;
+    sbox->setSpecialValueText("");
+    sbox->setMinimum(0);
+    widget_->setStyleSheet("");
+  } else {
+    draw_hint_ = true;
+    sbox->setSpecialValueText(sboxhinttext);
+    sbox->setMinimum(-1);
+    sbox->setValue(-1);
+    widget_->setStyleSheet(sboxstylesheet);
+  }
+}
+
+void SpinBox::value_changed(int value) {
+  if (draw_hint_) {
+    if (value == -1) {
+      set_hint(sboxhinttext);
+    } else {
+      set_hint(""); //this sets the minimum to 0 making it is only possible to get to the original state with reset
+    }
+  }
 }
 
 void SpinBox::paintEvent(QPaintEvent* e) {

--- a/src/widgets/lineedit.h
+++ b/src/widgets/lineedit.h
@@ -164,6 +164,7 @@ class SpinBox : public QSpinBox, public ExtendedEditor {
   QString textFromValue(int val) const;
 
   // ExtendedEditor
+  void set_hint(const QString& hint);
   bool is_empty() const { return text().isEmpty() || text() == "0"; }
   void set_focus() { QSpinBox::setFocus(); }
   QString text() const { return QSpinBox::text(); }
@@ -173,6 +174,13 @@ class SpinBox : public QSpinBox, public ExtendedEditor {
  protected:
   void paintEvent(QPaintEvent*);
   void resizeEvent(QResizeEvent*);
+
+ private slots:
+  void value_changed(int value);
+
+ private:
+  static const char* sboxstylesheet;
+  static const char* sboxhinttext;
 
 signals:
   void Reset();


### PR DESCRIPTION
The original code didn't do this and with modification to call ExtendedEditor::set_hint + ExtendedEditor::Paint gave a very inconsistent hint.

This code uses SpecialValueText and a StyleSheet.
