### PR TITLE
Spinboxes for year/disc/track now show better if multiple different value are selected

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ if (UNIX AND NOT APPLE)
   set(LINUX 1)
 endif (UNIX AND NOT APPLE)
 
-find_package(Qt4 4.5.0 REQUIRED QtCore QtGui QtOpenGL QtSql QtNetwork QtXml)
+find_package(Qt4 4.7.0 REQUIRED QtCore QtGui QtOpenGL QtSql QtNetwork QtXml)
 
 if(NOT APPLE)
   find_package(Qt4 COMPONENTS QtWebKit)

--- a/src/widgets/lineedit.cpp
+++ b/src/widgets/lineedit.cpp
@@ -60,7 +60,7 @@ ExtendedEditor::ExtendedEditor(QWidget* widget, int extra_right_padding,
 
 void ExtendedEditor::set_hint(const QString& hint) {
   hint_ = hint;
-  this->clear();
+  clear();
   this->set_place_holder(hint_);
 }
 

--- a/src/widgets/lineedit.cpp
+++ b/src/widgets/lineedit.cpp
@@ -60,7 +60,6 @@ ExtendedEditor::ExtendedEditor(QWidget* widget, int extra_right_padding,
 
 void ExtendedEditor::set_hint(const QString& hint) {
   hint_ = hint;
-  clear();
   this->set_place_holder(hint_);
 }
 
@@ -144,6 +143,7 @@ void LineEdit::text_changed(const QString& text) {
     set_rtl(QString(text.at(0)).isRightToLeft());
   }
   Resize();
+  clear_hint();
 }
 
 void LineEdit::paintEvent(QPaintEvent* e) {
@@ -159,8 +159,8 @@ void LineEdit::resizeEvent(QResizeEvent* e) {
 TextEdit::TextEdit(QWidget* parent)
     : QPlainTextEdit(parent), ExtendedEditor(this) {
   connect(reset_button_, SIGNAL(clicked()), SIGNAL(Reset()));
-  connect(this, SIGNAL(textChanged()), viewport(),
-          SLOT(update()));  // To clear the hint
+  connect(this, SIGNAL(textChanged()), this,
+          SLOT(text_changed()));  // To clear the hint*/
 }
 
 void TextEdit::paintEvent(QPaintEvent* e) {
@@ -199,11 +199,13 @@ const char* SpinBox::abbrev_hint = "-";
 SpinBox::SpinBox(QWidget* parent)
     : QSpinBox(parent), ExtendedEditor(this, 14, true) {
   connect(reset_button_, SIGNAL(clicked()), SIGNAL(Reset()));
+  connect(this, SIGNAL(valueChanged(QString)), this, SLOT(value_changed()));
 }
 
 void SpinBox::set_hint(const QString& hint) {
   if (hint.isEmpty()) {
     hint_ = "";
+    set_place_holder("");
   } else {
     hint_ = abbrev_hint;
     lineEdit()->clear();

--- a/src/widgets/lineedit.cpp
+++ b/src/widgets/lineedit.cpp
@@ -32,7 +32,6 @@ ExtendedEditor::ExtendedEditor(QWidget* widget, int extra_right_padding,
       reset_button_(new QToolButton(widget)),
       extra_right_padding_(extra_right_padding),
       draw_hint_(draw_hint),
-      font_point_size_(widget->font().pointSizeF() - 1),
       is_rtl_(false) {
   clear_button_->setIcon(IconLoader::Load("edit-clear-locationbar-ltr"));
   clear_button_->setIconSize(QSize(16, 16));
@@ -61,7 +60,8 @@ ExtendedEditor::ExtendedEditor(QWidget* widget, int extra_right_padding,
 
 void ExtendedEditor::set_hint(const QString& hint) {
   hint_ = hint;
-  widget_->update();
+  this->clear();
+  this->set_place_holder(hint_);
 }
 
 void ExtendedEditor::set_clear_button(bool visible) {
@@ -105,25 +105,9 @@ void ExtendedEditor::Paint(QPaintDevice* device) {
   if (!widget_->hasFocus() && is_empty() && !hint_.isEmpty()) {
     clear_button_->hide();
 
-    if (draw_hint_) {
-      QPainter p(device);
-
-      QFont font;
-      font.setBold(false);
-      font.setPointSizeF(font_point_size_);
-
-      QFontMetrics m(font);
-      const int kBorder = (device->height() - m.height()) / 2;
-
-      p.setPen(widget_->palette().color(QPalette::Disabled, QPalette::Text));
-      p.setFont(font);
-
-      QRect r(5, kBorder, device->width() - 10, device->height() - kBorder * 2);
-      p.drawText(r, Qt::AlignLeft | Qt::AlignVCenter,
-                 m.elidedText(hint_, Qt::ElideRight, r.width()));
+    if (!draw_hint_) {
+      clear_button_->setVisible(has_clear_button_);
     }
-  } else {
-    clear_button_->setVisible(has_clear_button_);
   }
 }
 
@@ -182,6 +166,27 @@ TextEdit::TextEdit(QWidget* parent)
 void TextEdit::paintEvent(QPaintEvent* e) {
   QPlainTextEdit::paintEvent(e);
   Paint(viewport());
+
+  if (!widget_->hasFocus() && is_empty() && !hint_.isEmpty() && draw_hint_) {
+    QPainter p(viewport());
+
+    QFont font;
+    font.setBold(false);
+    font.setPointSizeF(widget_->font().pointSizeF());
+
+    QFontMetrics m(font);
+    const int kBorder = (viewport()->height() - m.height()) / 2;
+
+    //the color of PlaceHolderText is hardcoded in Qt to be text color at 128 alpha
+    QColor col = widget_->palette().text().color();
+    col.setAlpha(128);
+    p.setPen(col);
+    p.setFont(font);
+
+    QRect r(5, kBorder, viewport()->width() - 10, viewport()->height() - kBorder * 2);
+    p.drawText(r, Qt::AlignLeft | Qt::AlignVCenter,
+               m.elidedText(hint_, Qt::ElideRight, r.width()));
+  }
 }
 
 void TextEdit::resizeEvent(QResizeEvent* e) {
@@ -189,9 +194,21 @@ void TextEdit::resizeEvent(QResizeEvent* e) {
   Resize();
 }
 
+const char* SpinBox::abbrev_hint = "-";
+
 SpinBox::SpinBox(QWidget* parent)
-    : QSpinBox(parent), ExtendedEditor(this, 14, false) {
+    : QSpinBox(parent), ExtendedEditor(this, 14, true) {
   connect(reset_button_, SIGNAL(clicked()), SIGNAL(Reset()));
+}
+
+void SpinBox::set_hint(const QString& hint) {
+  if (hint.isEmpty()) {
+    hint_ = "";
+  } else {
+    hint_ = abbrev_hint;
+    lineEdit()->clear();
+    set_place_holder(abbrev_hint);
+  }
 }
 
 void SpinBox::paintEvent(QPaintEvent* e) {
@@ -202,6 +219,14 @@ void SpinBox::paintEvent(QPaintEvent* e) {
 void SpinBox::resizeEvent(QResizeEvent* e) {
   QSpinBox::resizeEvent(e);
   Resize();
+}
+
+void SpinBox::focusOutEvent(QFocusEvent* event) {
+  QSpinBox::focusOutEvent(event);
+  if (!hint_.isEmpty() && value() <=0) {
+    lineEdit()->clear();
+    set_place_holder(hint_);
+  }
 }
 
 QString SpinBox::textFromValue(int val) const {

--- a/src/widgets/lineedit.h
+++ b/src/widgets/lineedit.h
@@ -60,7 +60,7 @@ class ExtendedEditor : public LineEditInterface {
 
   QString hint() const { return hint_; }
   void set_hint(const QString& hint);
-  void clear_hint() { set_hint(QString()); }
+  void clear_hint() { if (!hint_.isEmpty()) this->set_hint(QString()); }
   virtual void set_place_holder(const QString& text) = 0;
 
   bool has_clear_button() const { return has_clear_button_; }
@@ -145,6 +145,9 @@ class TextEdit : public QPlainTextEdit, public ExtendedEditor {
   void paintEvent(QPaintEvent*);
   void resizeEvent(QResizeEvent*);
 
+ private slots:
+  void text_changed() { clear_hint(); };
+
 signals:
   void Reset();
 };
@@ -177,7 +180,10 @@ class SpinBox : public QSpinBox, public ExtendedEditor {
   void resizeEvent(QResizeEvent*);
   void focusOutEvent(QFocusEvent* event);
 
-signals:
+ private slots:
+  void value_changed() { clear_hint(); };
+
+ signals:
   void Reset();
 
  private:

--- a/src/widgets/lineedit.h
+++ b/src/widgets/lineedit.h
@@ -42,6 +42,7 @@ class LineEditInterface {
   virtual QString hint() const = 0;
   virtual void set_hint(const QString& hint) = 0;
   virtual void clear_hint() = 0;
+  virtual void set_place_holder(const QString& text) = 0;
 
   virtual void set_enabled(bool enabled) = 0;
 
@@ -60,6 +61,7 @@ class ExtendedEditor : public LineEditInterface {
   QString hint() const { return hint_; }
   void set_hint(const QString& hint);
   void clear_hint() { set_hint(QString()); }
+  virtual void set_place_holder(const QString& text) = 0;
 
   bool has_clear_button() const { return has_clear_button_; }
   void set_clear_button(bool visible);
@@ -67,11 +69,9 @@ class ExtendedEditor : public LineEditInterface {
   bool has_reset_button() const;
   void set_reset_button(bool visible);
 
-  qreal font_point_size() const { return font_point_size_; }
-  void set_font_point_size(qreal size) { font_point_size_ = size; }
-
  protected:
   void Paint(QPaintDevice* device);
+  void PaintHint(QPaintDevice* device);
   void Resize();
 
  private:
@@ -93,8 +93,6 @@ class ExtendedEditor : public LineEditInterface {
 class LineEdit : public QLineEdit, public ExtendedEditor {
   Q_OBJECT
   Q_PROPERTY(QString hint READ hint WRITE set_hint);
-  Q_PROPERTY(qreal font_point_size READ font_point_size WRITE
-                 set_font_point_size);
   Q_PROPERTY(bool has_clear_button READ has_clear_button WRITE
                  set_clear_button);
   Q_PROPERTY(bool has_reset_button READ has_reset_button WRITE
@@ -108,6 +106,7 @@ class LineEdit : public QLineEdit, public ExtendedEditor {
   QString text() const { return QLineEdit::text(); }
   void set_text(const QString& text) { QLineEdit::setText(text); }
   void set_enabled(bool enabled) { QLineEdit::setEnabled(enabled); }
+  void set_place_holder(const QString& text) { setPlaceholderText(text); };
 
  protected:
   void paintEvent(QPaintEvent*);
@@ -140,6 +139,7 @@ class TextEdit : public QPlainTextEdit, public ExtendedEditor {
   QString text() const { return QPlainTextEdit::toPlainText(); }
   void set_text(const QString& text) { QPlainTextEdit::setPlainText(text); }
   void set_enabled(bool enabled) { QPlainTextEdit::setEnabled(enabled); }
+  void set_place_holder(const QString& text) {}; // QT5> give us native placeholder text, at the moment we have do to this with paintevent
 
  protected:
   void paintEvent(QPaintEvent*);
@@ -164,18 +164,24 @@ class SpinBox : public QSpinBox, public ExtendedEditor {
   QString textFromValue(int val) const;
 
   // ExtendedEditor
+  void set_hint(const QString& hint);
   bool is_empty() const { return text().isEmpty() || text() == "0"; }
   void set_focus() { QSpinBox::setFocus(); }
   QString text() const { return QSpinBox::text(); }
   void set_text(const QString& text) { QSpinBox::setValue(text.toInt()); }
   void set_enabled(bool enabled) { QSpinBox::setEnabled(enabled); }
+  void set_place_holder(const QString& text) { lineEdit()->setPlaceholderText(text); };
 
  protected:
   void paintEvent(QPaintEvent*);
   void resizeEvent(QResizeEvent*);
+  void focusOutEvent(QFocusEvent* event);
 
 signals:
   void Reset();
+
+ private:
+  static const char* abbrev_hint;
 };
 
 #endif  // LINEEDIT_H


### PR DESCRIPTION
Update to discussion in #4432.
- This now uses for QLineEdit and QSpinBox setPlaceHolderText which is exactly what we want to do.
- PlaceHolderText was introduced with Qt 4.7 (that is the version bump)
- Only TextEdit needs the complicated paintEvent code and in Qt 5.0 this will get setPlaceHolderText too.

I am still not exactly happy with the code as the introduced setPlaceholder() function is just a weird indirection to call the apropiate setPlaceHolderText() function but if I understand 
C++ multiple inheritance correctly there is no other way. With this setup it saves the repeated code from set_hint for LineEdit and TextEdit.
If somebody has a better idea or anything else should be changed, please tell me.
