### PR TITLE
Add ampache compatibility

### DIFF
--- a/src/internet/subsonicservice.cpp
+++ b/src/internet/subsonicservice.cpp
@@ -374,8 +374,18 @@ void SubsonicLibraryScanner::OnGetAlbumListFinished(QNetworkReply* reply,
   reader.readNextStartElement();
   Q_ASSERT(reader.name() == "subsonic-response");
   if (reader.attributes().value("status") != "ok") {
-    // TODO: error handling
-    return;
+    reader.readNextStartElement();
+    int error = reader.attributes().value("code").toString().toInt();
+
+    // Compatibility with Ampache :
+    // When there is no data, Ampache returns NotFound
+    // whereas Subsonic returns empty albumList2 tag
+    switch (error) {
+      case SubsonicService::ApiError_NotFound:
+        break;
+      default:
+        return;
+    }
   }
 
   int albums_added = 0;


### PR DESCRIPTION
Ampache can be accessed through Subsonic API (https://github.com/ampache/ampache/wiki/API#subsonic-api) but there was a small difference that we have to take care.

Maybe it could be interesting to specify that Clementine can use Ampache through the Subsonic service (for example, we could write "Subsonic/Ampache" title for the preference window of  Subsonic).
