### PR TITLE
Fix for queue ordering issue in the playlist view when using c-d to dequeue a track (issue #4015)

### DIFF
--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -1984,6 +1984,7 @@ void Playlist::TracksDequeued() {
     emit dataChanged(index, index);
   }
   temp_dequeue_change_indexes_.clear();
+  emit QueueChanged();
 }
 
 void Playlist::TracksEnqueued(const QModelIndex&, int begin, int end) {

--- a/src/playlist/playlist.h
+++ b/src/playlist/playlist.h
@@ -333,6 +333,10 @@ signals:
 
   void LoadTracksError(const QString& message);
 
+  // Signals that the queue has changed, meaning that the remaining queued
+  // items should update their position.
+  void QueueChanged();
+
  private:
   void SetCurrentIsPaused(bool paused);
   void UpdateScrobblePoint();

--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -256,6 +256,7 @@ void PlaylistView::SetPlaylist(Playlist* playlist) {
     disconnect(playlist_, SIGNAL(DynamicModeChanged(bool)), this,
                SLOT(DynamicModeChanged(bool)));
     disconnect(playlist_, SIGNAL(destroyed()), this, SLOT(PlaylistDestroyed()));
+    disconnect(playlist_, SIGNAL(QueueChanged()), this, SLOT(UpdateView()));
 
     disconnect(dynamic_controls_, SIGNAL(Expand()), playlist_,
                SLOT(ExpandDynamicPlaylist()));
@@ -273,11 +274,12 @@ void PlaylistView::SetPlaylist(Playlist* playlist) {
   read_only_settings_ = false;
 
   connect(playlist_, SIGNAL(RestoreFinished()), SLOT(JumpToLastPlayedTrack()));
-
   connect(playlist_, SIGNAL(CurrentSongChanged(Song)), SLOT(MaybeAutoscroll()));
   connect(playlist_, SIGNAL(DynamicModeChanged(bool)),
           SLOT(DynamicModeChanged(bool)));
   connect(playlist_, SIGNAL(destroyed()), SLOT(PlaylistDestroyed()));
+  connect(playlist_, SIGNAL(QueueChanged()), SLOT(UpdateView()));
+
   connect(dynamic_controls_, SIGNAL(Expand()), playlist_,
           SLOT(ExpandDynamicPlaylist()));
   connect(dynamic_controls_, SIGNAL(Repopulate()), playlist_,
@@ -1318,4 +1320,8 @@ void PlaylistView::focusInEvent(QFocusEvent* event) {
       selectionModel()->select(new_selection, QItemSelectionModel::Select);
     }
   }
+}
+
+void PlaylistView::UpdateView() {
+  update();
 }

--- a/src/playlist/playlistview.h
+++ b/src/playlist/playlistview.h
@@ -105,6 +105,9 @@ class PlaylistView : public QTreeView {
                           const QImage& cover_art);
   void PlayerStopped();
 
+  // General slot to update the whole playlistview
+  void UpdateView();
+
 signals:
   void PlayItem(const QModelIndex& index);
   void PlayPause();


### PR DESCRIPTION
Fix for the queue order problem referred in issue #4015.
When dequeuing a track the executing function wouldn't update the remaining tracks in queue. Now it updates the queuing position of the remaining tracks instantly.
To do that I created a signal that allows to announce the change in the queue (QueueChange).

In the playlist view created a slot that updates the whole view (as qt optimizes it) as discussed in [1], which may be used by other procedures or events if necessary.

That's it. Waiting for feedback.
Thanks!

[1] - [Forum link](https://groups.google.com/forum/?hl=en#!topic/clementine-player/XMLstJKP0rk)
