### PR TITLE
Made m3u playlists relative for real.

### DIFF
--- a/src/playlistparsers/parserbase.cpp
+++ b/src/playlistparsers/parserbase.cpp
@@ -91,7 +91,7 @@ QString ParserBase::URLOrRelativeFilename(const QUrl& url,
   if (QDir::isAbsolutePath(filename)) {
     const QString relative = dir.relativeFilePath(filename);
 
-    if (!relative.contains("..")) return relative;
+    return relative;
   }
   return filename;
 }


### PR DESCRIPTION
Because of the random "if" statement before the return, sometimes Clementine would not write out relative paths. Instead, it would write out absolute paths. This pull request fixes the problem.

I did this because I backup all of my music to a server that I can access from anywhere, and I really want to be able to listen to playlists I make from my server.
