### PR TITLE
Fix album shuffle issue

### DIFF
--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -1915,7 +1915,7 @@ void Playlist::ReshuffleIndices() {
                           shuffled_album_keys.end());
 
       // If the user is currently playing a song, force its album to be first
-      // Or if the song was not playing but it is selected, force its album
+      // Or if the song was not playing but it was selected, force its album
       // to be first.
       if (current_virtual_index_ != -1 || current_row() != -1) {
         const QString key = items_[current_row()]->Metadata().AlbumKey();


### PR DESCRIPTION
Hi,

This pull request addresses issue #4402 where after restarting Clementine in shuffle album mode, the current album was skipped after playing one track.

The change tests if a track is selected (despite being paused or stopped) and the user simply hits play, it will prioritize that music's album and won't skip the album after playing one track. The difference is that it doesn't only check if the track is **currently** playing, but as in account if it also selected.

Thanks!
Waiting feedback.
