### PR TITLE
Fix detection of parent-relative paths in playlist saving

### DIFF
--- a/src/playlistparsers/parserbase.cpp
+++ b/src/playlistparsers/parserbase.cpp
@@ -91,7 +91,7 @@ QString ParserBase::URLOrRelativeFilename(const QUrl& url,
   if (QDir::isAbsolutePath(filename)) {
     const QString relative = dir.relativeFilePath(filename);
 
-    if (!relative.contains("..")) return relative;
+    if (!relative.startsWith("../")) return relative;
   }
   return filename;
 }


### PR DESCRIPTION
File or directory names containing `..` caused saved playlists to contain
absolute paths instead of relative paths even when the relative path was
"safe".  This changes the detection to be more strict.

Potentially related to #4463.
