### PR TITLE
Spinboxes for year/disc/track now show better if multiple different value are selected (Alternative solution)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ if (UNIX AND NOT APPLE)
   set(LINUX 1)
 endif (UNIX AND NOT APPLE)
 
-find_package(Qt4 4.5.0 REQUIRED QtCore QtGui QtOpenGL QtSql QtNetwork QtXml)
+find_package(Qt4 4.7.0 REQUIRED QtCore QtGui QtOpenGL QtSql QtNetwork QtXml)
 
 if(NOT APPLE)
   find_package(Qt4 COMPONENTS QtWebKit)

--- a/src/widgets/lineedit.cpp
+++ b/src/widgets/lineedit.cpp
@@ -22,7 +22,6 @@
 #include <QStyle>
 #include <QStyleOption>
 #include <QToolButton>
-#include <QtDebug>
 
 ExtendedEditor::ExtendedEditor(QWidget* widget, int extra_right_padding,
                                bool draw_hint)
@@ -32,7 +31,6 @@ ExtendedEditor::ExtendedEditor(QWidget* widget, int extra_right_padding,
       reset_button_(new QToolButton(widget)),
       extra_right_padding_(extra_right_padding),
       draw_hint_(draw_hint),
-      font_point_size_(widget->font().pointSizeF() - 1),
       is_rtl_(false) {
   clear_button_->setIcon(IconLoader::Load("edit-clear-locationbar-ltr"));
   clear_button_->setIconSize(QSize(16, 16));
@@ -57,11 +55,6 @@ ExtendedEditor::ExtendedEditor(QWidget* widget, int extra_right_padding,
   widget->connect(clear_button_, SIGNAL(clicked()), widget, SLOT(setFocus()));
 
   UpdateButtonGeometry();
-}
-
-void ExtendedEditor::set_hint(const QString& hint) {
-  hint_ = hint;
-  widget_->update();
 }
 
 void ExtendedEditor::set_clear_button(bool visible) {
@@ -105,25 +98,9 @@ void ExtendedEditor::Paint(QPaintDevice* device) {
   if (!widget_->hasFocus() && is_empty() && !hint_.isEmpty()) {
     clear_button_->hide();
 
-    if (draw_hint_) {
-      QPainter p(device);
-
-      QFont font;
-      font.setBold(false);
-      font.setPointSizeF(font_point_size_);
-
-      QFontMetrics m(font);
-      const int kBorder = (device->height() - m.height()) / 2;
-
-      p.setPen(widget_->palette().color(QPalette::Disabled, QPalette::Text));
-      p.setFont(font);
-
-      QRect r(5, kBorder, device->width() - 10, device->height() - kBorder * 2);
-      p.drawText(r, Qt::AlignLeft | Qt::AlignVCenter,
-                 m.elidedText(hint_, Qt::ElideRight, r.width()));
+    if (!draw_hint_) {
+      clear_button_->setVisible(has_clear_button_);
     }
-  } else {
-    clear_button_->setVisible(has_clear_button_);
   }
 }
 
@@ -160,6 +137,12 @@ void LineEdit::text_changed(const QString& text) {
     set_rtl(QString(text.at(0)).isRightToLeft());
   }
   Resize();
+  clear_hint();
+}
+
+void LineEdit::set_hint(const QString& text) {
+  hint_ = text;
+  setPlaceholderText(text);
 }
 
 void LineEdit::paintEvent(QPaintEvent* e) {
@@ -175,13 +158,39 @@ void LineEdit::resizeEvent(QResizeEvent* e) {
 TextEdit::TextEdit(QWidget* parent)
     : QPlainTextEdit(parent), ExtendedEditor(this) {
   connect(reset_button_, SIGNAL(clicked()), SIGNAL(Reset()));
-  connect(this, SIGNAL(textChanged()), viewport(),
-          SLOT(update()));  // To clear the hint
+  connect(this, SIGNAL(textChanged()), this,
+          SLOT(text_changed()));  // To clear the hint*/
 }
 
+void TextEdit::set_hint(const QString& hint) {
+  hint_ = hint;
+}
+
+//this can be replaced in qt5 with setPlaceHolderText of qtextedit
 void TextEdit::paintEvent(QPaintEvent* e) {
   QPlainTextEdit::paintEvent(e);
   Paint(viewport());
+
+  if (!widget_->hasFocus() && is_empty() && !hint_.isEmpty() && draw_hint_) {
+    QPainter p(viewport());
+
+    QFont font;
+    font.setBold(false);
+    font.setPointSizeF(widget_->font().pointSizeF());
+
+    QFontMetrics m(font);
+    const int kBorder = (viewport()->height() - m.height()) / 2;
+
+    //the color of PlaceHolderText is hardcoded in Qt to be text color at 128 alpha
+    QColor col = widget_->palette().text().color();
+    col.setAlpha(128);
+    p.setPen(col);
+    p.setFont(font);
+
+    QRect r(5, kBorder, viewport()->width() - 10, viewport()->height() - kBorder * 2);
+    p.drawText(r, Qt::AlignLeft | Qt::AlignVCenter,
+               m.elidedText(hint_, Qt::ElideRight, r.width()));
+  }
 }
 
 void TextEdit::resizeEvent(QResizeEvent* e) {
@@ -189,9 +198,23 @@ void TextEdit::resizeEvent(QResizeEvent* e) {
   Resize();
 }
 
+const char* SpinBox::abbrev_hint = "-";
+
 SpinBox::SpinBox(QWidget* parent)
-    : QSpinBox(parent), ExtendedEditor(this, 14, false) {
+    : QSpinBox(parent), ExtendedEditor(this, 14, true) {
   connect(reset_button_, SIGNAL(clicked()), SIGNAL(Reset()));
+  connect(this, SIGNAL(valueChanged(QString)), this, SLOT(value_changed()));
+}
+
+void SpinBox::set_hint(const QString& hint) {
+  if (hint.isEmpty()) {
+    hint_ = "";
+    lineEdit()->setPlaceholderText("");
+  } else {
+    hint_ = abbrev_hint;
+    lineEdit()->clear();
+    lineEdit()->setPlaceholderText(abbrev_hint);
+  }
 }
 
 void SpinBox::paintEvent(QPaintEvent* e) {
@@ -202,6 +225,14 @@ void SpinBox::paintEvent(QPaintEvent* e) {
 void SpinBox::resizeEvent(QResizeEvent* e) {
   QSpinBox::resizeEvent(e);
   Resize();
+}
+
+void SpinBox::focusOutEvent(QFocusEvent* event) {
+  QSpinBox::focusOutEvent(event);
+  if (!hint_.isEmpty() && value() <=0) {
+    lineEdit()->clear();
+    lineEdit()->setPlaceholderText(hint_);
+  }
 }
 
 QString SpinBox::textFromValue(int val) const {

--- a/src/widgets/lineedit.h
+++ b/src/widgets/lineedit.h
@@ -58,8 +58,8 @@ class ExtendedEditor : public LineEditInterface {
   virtual bool is_empty() const { return text().isEmpty(); }
 
   QString hint() const { return hint_; }
-  void set_hint(const QString& hint);
-  void clear_hint() { set_hint(QString()); }
+  void set_hint(const QString& hint) { hint_ = hint; };
+  void clear_hint() { if (!hint_.isEmpty()) this->set_hint(QString()); }
 
   bool has_clear_button() const { return has_clear_button_; }
   void set_clear_button(bool visible);
@@ -67,11 +67,9 @@ class ExtendedEditor : public LineEditInterface {
   bool has_reset_button() const;
   void set_reset_button(bool visible);
 
-  qreal font_point_size() const { return font_point_size_; }
-  void set_font_point_size(qreal size) { font_point_size_ = size; }
-
  protected:
   void Paint(QPaintDevice* device);
+  void PaintHint(QPaintDevice* device);
   void Resize();
 
  private:
@@ -93,8 +91,6 @@ class ExtendedEditor : public LineEditInterface {
 class LineEdit : public QLineEdit, public ExtendedEditor {
   Q_OBJECT
   Q_PROPERTY(QString hint READ hint WRITE set_hint);
-  Q_PROPERTY(qreal font_point_size READ font_point_size WRITE
-                 set_font_point_size);
   Q_PROPERTY(bool has_clear_button READ has_clear_button WRITE
                  set_clear_button);
   Q_PROPERTY(bool has_reset_button READ has_reset_button WRITE
@@ -107,6 +103,7 @@ class LineEdit : public QLineEdit, public ExtendedEditor {
   void set_focus() { QLineEdit::setFocus(); }
   QString text() const { return QLineEdit::text(); }
   void set_text(const QString& text) { QLineEdit::setText(text); }
+  void set_hint(const QString& text);
   void set_enabled(bool enabled) { QLineEdit::setEnabled(enabled); }
 
  protected:
@@ -139,11 +136,15 @@ class TextEdit : public QPlainTextEdit, public ExtendedEditor {
   void set_focus() { QPlainTextEdit::setFocus(); }
   QString text() const { return QPlainTextEdit::toPlainText(); }
   void set_text(const QString& text) { QPlainTextEdit::setPlainText(text); }
+  void set_hint(const QString& hint);
   void set_enabled(bool enabled) { QPlainTextEdit::setEnabled(enabled); }
 
  protected:
   void paintEvent(QPaintEvent*);
   void resizeEvent(QResizeEvent*);
+
+ private slots:
+  void text_changed() { clear_hint(); };
 
 signals:
   void Reset();
@@ -164,18 +165,27 @@ class SpinBox : public QSpinBox, public ExtendedEditor {
   QString textFromValue(int val) const;
 
   // ExtendedEditor
+
   bool is_empty() const { return text().isEmpty() || text() == "0"; }
   void set_focus() { QSpinBox::setFocus(); }
   QString text() const { return QSpinBox::text(); }
   void set_text(const QString& text) { QSpinBox::setValue(text.toInt()); }
+  void set_hint(const QString& hint);
   void set_enabled(bool enabled) { QSpinBox::setEnabled(enabled); }
 
  protected:
   void paintEvent(QPaintEvent*);
   void resizeEvent(QResizeEvent*);
+  void focusOutEvent(QFocusEvent* event);
 
-signals:
+ private slots:
+  void value_changed() { clear_hint(); };
+
+ signals:
   void Reset();
+
+ private:
+  static const char* abbrev_hint;
 };
 
 #endif  // LINEEDIT_H


### PR DESCRIPTION
Fix hints for multiple year/disc/track select in tageditor.
Alternative solution to #4438 and referencing #4432.

This code doesn't use the indirect calling to call the correct setPlaceholderText function but does this directly in set_hint.
