### PR TITLE
Fix M3U Hyphen Parse Bug

### DIFF
--- a/src/playlistparsers/m3uparser.cpp
+++ b/src/playlistparsers/m3uparser.cpp
@@ -94,7 +94,7 @@ bool M3UParser::ParseMetadata(const QString& line,
   metadata->length = length * kNsecPerSec;
 
   QString track_info = info.section(',', 1);
-  QStringList list = track_info.split('-');
+  QStringList list = track_info.split(" - ");
   if (list.size() <= 1) {
     metadata->title = track_info;
     return true;


### PR DESCRIPTION
The M3U parser had a bug that when an artist's name had a hyphen, like Michael-Leon Wooley on the Princess and the Frog soundtrack, it would assume that the artist's name stopped there and that the rest was the title of the song.
Since titles are separated from the artist by " - ", I changed it to that.
And I already ran make format this time.
