### PR TITLE
Increase cover size.

### DIFF
--- a/src/internet/soundcloudservice.cpp
+++ b/src/internet/soundcloudservice.cpp
@@ -498,8 +498,7 @@ Song SoundCloudService::ExtractSong(const QVariantMap& result_song) {
       // Increase cover size.
       // See https://developers.soundcloud.com/docs/api/reference#artwork_url
       QString big_cover = cover.toString().replace("large", "t500x500");
-      QUrl cover_url;
-      cover_url.setUrl(big_cover);
+      QUrl cover_url(big_cover, QUrl::StrictMode);
 
       // SoundCloud covers URL are https, but our cover loader doesn't seem to
       // deal well with https URL. Anyway, we don't need a secure connection to


### PR DESCRIPTION
By default soundcloud API returns artwork url with 100x100 size, and cover looks ugly when you set "Large album cover" setting. I replaced url prefix and now it looks very nice.

_Before:_
![cover_before](https://cloud.githubusercontent.com/assets/633363/4149071/8d24ccce-342f-11e4-8c31-5fea022841c6.png)
_After:_
![cover_after](https://cloud.githubusercontent.com/assets/633363/4149072/93d2843a-342f-11e4-9f83-66cba2d6506e.png)
