### PR TITLE
Spotify Dialog Shows When Disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,7 +275,7 @@ optional_component(VISUALISATIONS ON "Visualisations")
 if(NOT HAVE_SPOTIFY_BLOB AND NOT QCA_FOUND)
   message(FATAL_ERROR "Either QCA must be available or the non-GPL Spotify "
           "code must be compiled in")
-elseif(QCA_FOUND)
+elseif(QCA_FOUND AND SPOTIFY_BLOB)
   set(HAVE_SPOTIFY_DOWNLOADER ON)
 endif()
 


### PR DESCRIPTION
Spotify has a dialog that pops up asking to download the blog whenever I start music or switch tracks manually. The problem is that I disabled Spotify in the CMake config.

This patch forces CMake to honor the config and not add in an insistent Spotify dialog when I don't want it.
