### PR TITLE
Fix missing buffers sent to analyzer

### DIFF
--- a/src/engines/gstengine.cpp
+++ b/src/engines/gstengine.cpp
@@ -317,6 +317,11 @@ void GstEngine::UpdateScope(int chunk_length) {
   memcpy(dest, source, bytes);
 
   gst_buffer_unmap(latest_buffer_, &map);
+
+  if (scope_chunk_ == scope_chunks_) {
+    gst_buffer_unref(latest_buffer_);
+    latest_buffer_ = nullptr;
+  }
 }
 
 void GstEngine::StartPreloading(const QUrl& url, bool force_stop_at_end,


### PR DESCRIPTION
This is a regression in the upgrade to gstreamer1.0.
The gst_buffer_unref() is incorrect as it removes the buffer when it is still needed by the chunker.
Forcing the pointer to be null prevents it from segfaulting but causes it to skip all chunks in the buffer, dropping the framerate and causing a worse case of #4321.
Removing these 2 lines restores original functionality.
