### PR TITLE
Fix moodbar segfault when playing broken mp3

### DIFF
--- a/src/moodbar/moodbarbuilder.cpp
+++ b/src/moodbar/moodbarbuilder.cpp
@@ -158,13 +158,15 @@ void MoodbarBuilder::Normalize(QList<Rgb>* vals, double Rgb::*member) {
 }
 
 QByteArray MoodbarBuilder::Finish(int width) {
-  Normalize(&frames_, &Rgb::r);
-  Normalize(&frames_, &Rgb::g);
-  Normalize(&frames_, &Rgb::b);
-
   QByteArray ret;
   ret.resize(width * 3);
   char* data = ret.data();
+  if (frames_.count() == 0)
+    return ret;
+
+  Normalize(&frames_, &Rgb::r);
+  Normalize(&frames_, &Rgb::g);
+  Normalize(&frames_, &Rgb::b);
 
   for (int i = 0; i < width; ++i) {
     Rgb rgb;

--- a/src/moodbar/moodbarpipeline.cpp
+++ b/src/moodbar/moodbarpipeline.cpp
@@ -181,8 +181,10 @@ GstBusSyncReply MoodbarPipeline::BusCallbackSync(GstBus*, GstMessage* msg,
 
 void MoodbarPipeline::Stop(bool success) {
   success_ = success;
-  data_ = builder_->Finish(1000);
-  builder_.reset();
+  if (builder_ != nullptr) {
+    data_ = builder_->Finish(1000);
+    builder_.reset();
+  }
 
   emit Finished(success);
 }


### PR DESCRIPTION
When playing a broken mp3 (eg empty file) clementine crashed if moodbar
was enabled.

Didn't dive into the workings of the moodbar, this just solves the issue without
analyzing what caused the problem.
