### PR TITLE
Use hex in password auth for subsonic. Fixes #4589

### DIFF
--- a/src/internet/subsonicservice.cpp
+++ b/src/internet/subsonicservice.cpp
@@ -190,7 +190,7 @@ QUrl SubsonicService::BuildRequestUrl(const QString& view) const {
   url.addQueryItem("v", kApiVersion);
   url.addQueryItem("c", kApiClientName);
   url.addQueryItem("u", username_);
-  url.addQueryItem("p", QString("enc:" + password_.toAscii().toHex()));
+  url.addQueryItem("p", QString("enc:" + password_.toUtf8().toHex()));
   return url;
 }
 


### PR DESCRIPTION
Use hex-encoded password according to http://www.subsonic.org/pages/api.jsp for subsonic
