### PR TITLE
Improve handling of Spotify Top Tracks and compilations

### DIFF
--- a/src/globalsearch/spotifysearchprovider.cpp
+++ b/src/globalsearch/spotifysearchprovider.cpp
@@ -89,6 +89,19 @@ void SpotifySearchProvider::SearchFinishedSlot(
   PendingState state = it.value();
   queries_.erase(it);
 
+  /* Here we clean up Spotify's results for our purposes
+   *
+   * Since Spotify doesn't give us an album artist,
+   * we pick one, so there's a single album artist
+   * per album to use for sorting.
+   *
+   * We also drop any of the single tracks returned
+   * if they are already represented in an album
+   *
+   * This eliminates frequent duplicates from the
+   * "Top Tracks" results that Spotify sometimes
+   * returns
+   */
   QMap<std::string, std::string> album_dedup;
   ResultList ret;
 
@@ -96,13 +109,20 @@ void SpotifySearchProvider::SearchFinishedSlot(
     const pb::spotify::Album& album = response.album(i);
 
     QHash<QString, int> artist_count;
-    QString artist, majority_artist;
+    QString majority_artist;
     int majority_count = 0;
 
-    // Choose an album artist
+    /* We go through and find the artist that is
+     * represented most frequently in the artist
+     *
+     * For most albums this will just be one artist,
+     * but this ensures we have a consistend album artist for
+     * soundtracks, compilations, contributing artists, etc
+     */
     for (int j = 0; j < album.track_size(); ++j) {
+      // Each track can have multiple artists attributed, check them all
       for (int k = 0; k < album.track(j).artist_size(); ++k) {
-        artist = QStringFromStdString(album.track(j).artist(k));
+        QString artist = QStringFromStdString(album.track(j).artist(k));
         if (artist_count.contains(artist)) {
           artist_count[artist]++;
         } else {
@@ -116,6 +136,8 @@ void SpotifySearchProvider::SearchFinishedSlot(
     }
 
     for (int j = 0; j < album.track_size(); ++j) {
+      // Insert the album/track title into the dedup map
+      // so we can check tracks against it below
       album_dedup.insertMulti(album.track(j).album(), album.track(j).title());
 
       Result result(this);
@@ -132,6 +154,8 @@ void SpotifySearchProvider::SearchFinishedSlot(
   for (int i = 0; i < response.result_size(); ++i) {
     const pb::spotify::Track& track = response.result(i);
 
+    // Check this track/album against tracks we've already seen
+    // in the album results, and skip if it's a duplicate
     if (album_dedup.contains(track.album()) &&
         album_dedup.values(track.album()).contains(track.title())) {
       continue;


### PR DESCRIPTION
Currently, Spotify results are problematic for two reasons, which are both demonstrated in this screenshot of the results for a single New Pornographers album:
![2014-10-28-205030_331x546_scrot](https://cloud.githubusercontent.com/assets/479715/4820853/c4399478-5f1e-11e4-9953-abf5fc8be0a2.png)

Firstly, they are not assigned an album artist, so albums with different artists per track that should have a single album artist and therefore show up as one album when sorting by Album Artist are split up into two.  In this case, track 8 (Born With a Sound) features Amber Webber, so even though I am grouping by Album Artist, the album is split up between two artists.  When you add the album under The New Pornographers to your playlist, it is missing track 8, since that is filed under "The New Pornographers, Amber Webber".  My proposed solution here is to choose a "majority artist" by tallying up which artist shows up most often, and assigning that as the album artist.  This should be the "correct" solution in most cases, and even in edge cases (Broadway cast recordings, etc) will at least group the album into a single entry, albeit perhaps with an odd Album Artist entry.

The second issue is that the individual "top tracks" that Spotify provides retain their album title, so when sorted create one or more extra album entries, each of which only have a few songs in them, which is confusing, and not how Spotify presents them.  In the example above, all the top tracks are from one album, so we just end up with two copies of the album, one of which only has the 5 Top Tracks in it.

:Here's an example of the 5 Top Tracks being spread across multiple albums, demonstrating how things can get extra messy:

![2014-10-28-204628_357x793_scrot](https://cloud.githubusercontent.com/assets/479715/4820837/72df444c-5f1e-11e4-8a74-45bf86506dbc.png)

My proposed solution to this is to group these tracks into an artifical "Top Tracks" album, so that they show up in one place, and it is clear what they are.

This pull request implements both of those solutions, and the result looks like this:

![2014-10-28-204950_332x491_scrot](https://cloud.githubusercontent.com/assets/479715/4820873/1cbc0734-5f1f-11e4-8fd1-da6e76fd093d.png)

The duplicate album entries are gone, and the Top Tracks are clearly marked as such.

There are some other ways this could be done, but I implemented the most conservative changes as I saw them.  An option that is more invasive but perhaps more widely helpful would be instead of assigning the Majority Artist to the Album Artist, simply set each track's Artist to the Majority Artist, since the default sort options don't involve Album Artist.  This would be straightforward to implement, and show better results to more people, at the cost of losing accuracy of metadata.  The name for "Top Tracks" is also arbitrary, it could be "[Spotify] Top Tracks" to make clear it's a placeholder album, or whatever makes the most sense.

A note on the patch itself: I have successfully compiled against the 1.2.3 release, and these changes with that base are in the spotify-improvements-1.2 branch.  I have been unable to compile master starting at 56c9498, due to some apparent issues in my build environment with Gstreamer 1.x, but it's a small patch that doesn't touch any GStreamer things, so I can't imagine this patch against master will cause any problems.