### PR TITLE
Check if there is a current icon item in the device manager. Fixes #4604 #4555 

### DIFF
--- a/src/devices/deviceproperties.cpp
+++ b/src/devices/deviceproperties.cpp
@@ -254,12 +254,12 @@ void DeviceProperties::accept() {
 
   // By default no icon is selected and thus no current item is selected
   QString icon_name;
-  if(ui_->icon->currentItem() != nullptr) {
+  if (ui_->icon->currentItem() != nullptr) {
     icon_name = ui_->icon->currentItem()->data(Qt::UserRole).toString();
   }
 
-  manager_->SetDeviceOptions(
-        index_.row(), ui_->name->text(), icon_name, mode,format);
+  manager_->SetDeviceOptions(index_.row(), ui_->name->text(), icon_name, mode,
+                             format);
 }
 
 void DeviceProperties::OpenDevice() { manager_->Connect(index_.row()); }


### PR DESCRIPTION
When we open the device properties dialog for the first time there is no selected icon so this segfault when we just click on OK. I just added a condition to be sure that _icon->currentItem_ is not _null_.

(#4604 was a duplicate of #4555).
