### PR TITLE
Added option to hide cover art in now playing widget (closes #4574)

### DIFF
--- a/src/widgets/nowplayingwidget.h
+++ b/src/widgets/nowplayingwidget.h
@@ -58,6 +58,7 @@ class NowPlayingWidget : public QWidget {
     SmallSongDetails = 0,
     LargeSongDetails = 1,
     LargeSongDetailsBelow = 2,
+    NoCoverDetails = 3
   };
 
   void SetApplication(Application* app);


### PR DESCRIPTION
@mkoniecz suggested an option to hide the cover art in the now playing widget in #4574, so I've added that option which draws only the text with a black background.
