### PR TITLE
Fixed VkService with visualisations crash 

### DIFF
--- a/src/internet/vkservice.cpp
+++ b/src/internet/vkservice.cpp
@@ -1145,8 +1145,6 @@ Vreen::AudioItem VkService::GetAudioItemFromUrl(const QUrl& url) {
     Vreen::AudioItemListReply* song_request =
         audio_provider_->getAudiosByIds(song_id);
     emit StopWaiting();  // Stop all previous requests.
-    // To prevent object destruction in nested event loop
-    song_request->deleteLater();
     bool success = WaitForReply(song_request);
 
     if (success && !song_request->result().isEmpty()) {
@@ -1467,6 +1465,8 @@ void VkService::ClearStandardItem(QStandardItem* item) {
 bool VkService::WaitForReply(Vreen::Reply* reply) {
   QEventLoop event_loop;
   QTimer timeout_timer;
+  // To prevent object destruction in nested event loop
+  reply->deleteLater();
   timeout_timer.setSingleShot(true);
   connect(this, SIGNAL(StopWaiting()), &timeout_timer, SLOT(stop()));
   connect(this, SIGNAL(StopWaiting()), &event_loop, SLOT(quit()));


### PR DESCRIPTION
Hey guys, I have faced with the Clementine crash when try to play not cached song(from VkService) with visualisations enabled. Steps to reproduce the bug:
    1. Clear vkcache
    2. Enable visualisations
    3. Add vksongs to playlist and try to press player's Next button(maybe several times).

I have noticed that this happening in the VkService::WaitForReply(): the reply is destructed immediatly after the event_loop exit. To prevent this I've decided to call deleteLater() on reply so that it will be deleted only when the control returns to outer event loop. 

Need your feedback, thanks.
