### PR TITLE
Produce a proper url for date parse error

### DIFF
--- a/src/podcasts/podcastparser.cpp
+++ b/src/podcasts/podcastparser.cpp
@@ -215,9 +215,8 @@ void PodcastParser::ParseItem(QXmlStreamReader* reader, Podcast* ret) const {
           if (!episode.publication_date().isValid()) {
             qLog(Error) << "Unable to parse date:" << date
                         << "Please submit it to "
-                        << QUrl::toPercentEncoding(QString("https://github.com/clementine-player/Clementine/"
-                                                           "issues/new?title=[podcast]"
-                                                           " Unable to parse date: %1").arg(date));
+                        << "https://github.com/clementine-player/Clementine/issues/new?title="
+                         + QUrl::toPercentEncoding(QString("[podcast] Unable to parse date: %1").arg(date));
           }
         } else if (name == "duration" && lower_namespace == kItunesNamespace) {
           // http://www.apple.com/itunes/podcasts/specs.html


### PR DESCRIPTION
Needs to be included otherwise url will look like this: https%3a%2f%2fgithub.com%2
not very useful
