### PR TITLE
Fix moodbars not generating correctly

### DIFF
--- a/gst/moodbar/gstfastspectrum.cpp
+++ b/gst/moodbar/gstfastspectrum.cpp
@@ -138,7 +138,7 @@ gst_fastspectrum_alloc_channel_data (GstFastSpectrum * spectrum)
   spectrum->fft_output =reinterpret_cast<fftw_complex*>(
       fftw_malloc(sizeof(fftw_complex) * (nfft/2+1)));
 
-  spectrum->spect_magnitude = new double[bands]();
+  spectrum->spect_magnitude = new double[bands]{};
 
   GstFastSpectrumClass* klass = reinterpret_cast<GstFastSpectrumClass*>(
       G_OBJECT_GET_CLASS(spectrum));


### PR DESCRIPTION
Fixes #4635

The magnitude output from gstfastspectrum was not initialized for the first FFT.
In some cases, the memory would contain data that upon math operations becomes NaN.
This causes one or more colours of the moodbar to be generated blank, resulting in missing colours or just plain black moodbars.
