### PR TITLE
Fix socket leak in moodbarpipeline

### DIFF
--- a/src/moodbar/moodbarpipeline.cpp
+++ b/src/moodbar/moodbarpipeline.cpp
@@ -190,8 +190,10 @@ void MoodbarPipeline::Cleanup() {
   Q_ASSERT(QThread::currentThread() != qApp->thread());
 
   if (pipeline_) {
-    gst_bus_set_sync_handler(gst_pipeline_get_bus(GST_PIPELINE(pipeline_)),
-                             nullptr, nullptr, nullptr);
+    GstBus* bus = gst_pipeline_get_bus(GST_PIPELINE(pipeline_));
+    gst_bus_set_sync_handler(bus, nullptr, nullptr, nullptr);
+    gst_object_unref(bus);
+    
     gst_element_set_state(pipeline_, GST_STATE_NULL);
     gst_object_unref(pipeline_);
     pipeline_ = nullptr;


### PR DESCRIPTION
Fixes #4663
When tearing down the pipeline, there was a leak of a GstBus which holds a socketpair open.
Eventually the OS runs out of file descriptors and terminates Clementine.

Now you can generate ALL THE MOODBARS!
