### PR TITLE
Don't load the moodbar if the song was stopped

### DIFF
--- a/src/moodbar/moodbarcontroller.cpp
+++ b/src/moodbar/moodbarcontroller.cpp
@@ -69,6 +69,17 @@ void MoodbarController::AsyncLoadComplete(MoodbarPipeline* pipeline,
   if (current_item && current_item->Url() != url) {
     return;
   }
+  // Did we stop the song?
+  switch(app_->player()->GetState()) {
+    case Engine::Error:
+    case Engine::Empty:
+    case Engine::Idle:
+      return;
+      break;
+
+    default:
+      break;
+  }
 
   emit CurrentMoodbarDataChanged(pipeline->data());
 }


### PR DESCRIPTION
When an async moodbar load completes, it checks to see if the song is still playing and should update the UI.
It however failed to check if the song was stopped, so it would load a moodbar when no song was playing.
It now checks the player state before emitting a change.
