### PR TITLE
Do not remove currently playing track when repopulating a dynamic playlist

### DIFF
--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -1761,7 +1761,7 @@ void Playlist::ExpandDynamicPlaylist() {
 }
 
 void Playlist::RemoveItemsNotInQueue() {
-  if (queue_->is_empty()) {
+  if (queue_->is_empty() && !current_item_index_.isValid()) {
     RemoveItemsWithoutUndo(0, items_.count());
     return;
   }
@@ -1771,7 +1771,7 @@ void Playlist::RemoveItemsNotInQueue() {
     // Find a place to start - first row that isn't in the queue
     forever {
       if (start >= rowCount()) return;
-      if (!queue_->ContainsSourceRow(start)) break;
+      if (!queue_->ContainsSourceRow(start) && current_row() != start) break;
       start++;
     }
 
@@ -1780,7 +1780,9 @@ void Playlist::RemoveItemsNotInQueue() {
     int count = 1;
     forever {
       if (start + count >= rowCount()) break;
-      if (queue_->ContainsSourceRow(start + count)) break;
+      if (queue_->ContainsSourceRow(start + count) ||
+          current_row() == start + count)
+        break;
       count++;
     }
 


### PR DESCRIPTION
I absolutely love how the queued items are not removed, however I find it odd (and counter-intuitive) that the currently playing track is also removed.
I would personally consider the currently playing item to be "in the queue", so I don't think the modified function loses its meaning. It's also only called in one place, so there is no risk of any regressions.