### PR TITLE
Adding some fixer scripts in dist, formating is src/dbus and fix for mtime in podcasts

### DIFF
--- a/src/dbus/metatypes.h
+++ b/src/dbus/metatypes.h
@@ -1,8 +1,25 @@
-#ifndef DBUSMETATYPES_H
-#define DBUSMETATYPES_H
+/* This file is part of Clementine.
+   Copyright 2011, John Maguire <john.maguire@gmail.com>
+
+   Clementine is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Clementine is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DBUS_METATYPES_H_
+#define DBUS_METATYPES_H_
 
 #include <QMetaType>
 
 Q_DECLARE_METATYPE(QList<QByteArray>);
 
-#endif  // DBUSMETATYPES_H
+#endif  // DBUS_METATYPES_H_

--- a/src/internet/podcasts/podcastservice.cpp
+++ b/src/internet/podcasts/podcastservice.cpp
@@ -512,7 +512,7 @@ void PodcastService::ShowContextMenu(const QPoint& global_pos) {
 
     if (explicitly_selected_podcasts_.isEmpty()) {
       set_new_action_->setEnabled(listened);
-      set_listened_action_->setEnabled(!listened);
+      set_listened_action_->setEnabled(!listened || !episode.listened_date().isValid());
     }
   } else {
     download_selected_action_->setEnabled(episodes);
@@ -719,7 +719,7 @@ void PodcastService::UpdatePodcastListenedStateAsync(const Song& metadata) {
   if (!episode.is_valid()) return;
 
   // Mark it as listened if it's not already
-  if (!episode.listened()) {
+  if (!episode.listened() || !episode.listened_date().isValid()) {
     episode.set_listened(true);
     episode.set_listened_date(QDateTime::currentDateTime());
     backend_->UpdateEpisodes(PodcastEpisodeList() << episode);


### PR DESCRIPTION
This fixer scripts are really ugly, but I use them and it's pain to move the commits out of the way for each pr
Formatting in src/dbus, I just couldn't help myself
mtime was broken after change in PodcastDeleter that set an invalid listened date after deleting episode.