### PR TITLE
Added iPod-like behavior to previous button (closes #4638)

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -29,10 +29,10 @@
 
 #include <memory>
 
+#include <QSettings>
 #include <QSortFilterProxyModel>
 #include <QtDebug>
 #include <QtConcurrentRun>
-#include <QSettings>
 
 #include "config.h"
 #include "core/application.h"
@@ -62,7 +62,8 @@ Player::Player(Application* app, QObject* parent)
       last_state_(Engine::Empty),
       nb_errors_received_(0),
       volume_before_mute_(50),
-      last_pressed_previous_(QDateTime::currentDateTime()) {
+      last_pressed_previous_(QDateTime::currentDateTime()),
+      menu_previousmode_(PreviousBehaviour_DontRestart) {
   settings_.beginGroup("Player");
 
   SetVolume(settings_.value("volume", 50).toInt());
@@ -88,6 +89,8 @@ void Player::Init() {
           SLOT(EngineMetadataReceived(Engine::SimpleMetaBundle)));
 
   engine_->SetVolume(settings_.value("volume", 50).toInt());
+
+  ReloadSettings();
 
 #ifdef HAVE_LIBLASTFM
   lastfm_ = app_->scrobbler();

--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -32,6 +32,7 @@
 #include <QSortFilterProxyModel>
 #include <QtDebug>
 #include <QtConcurrentRun>
+#include <QSettings>
 
 #include "config.h"
 #include "core/application.h"
@@ -50,6 +51,8 @@
 
 using std::shared_ptr;
 
+const char* Player::kSettingsGroup = "Player";
+
 Player::Player(Application* app, QObject* parent)
     : PlayerInterface(parent),
       app_(app),
@@ -58,7 +61,8 @@ Player::Player(Application* app, QObject* parent)
       stream_change_type_(Engine::First),
       last_state_(Engine::Empty),
       nb_errors_received_(0),
-      volume_before_mute_(50) {
+      volume_before_mute_(50),
+      last_pressed_previous_(QDateTime::currentDateTime()) {
   settings_.beginGroup("Player");
 
   SetVolume(settings_.value("volume", 50).toInt());
@@ -90,7 +94,16 @@ void Player::Init() {
 #endif
 }
 
-void Player::ReloadSettings() { engine_->ReloadSettings(); }
+void Player::ReloadSettings() {
+  QSettings s;
+  s.beginGroup(kSettingsGroup);
+
+  menu_previousmode_ = PreviousBehaviour(
+      s.value("menu_previousmode", PreviousBehaviour_DontRestart).toInt());
+  s.endGroup();
+
+  engine_->ReloadSettings();
+}
 
 void Player::HandleLoadResult(const UrlHandler::LoadResult& result) {
   switch (result.type_) {
@@ -289,6 +302,18 @@ void Player::Previous() { PreviousItem(Engine::Manual); }
 
 void Player::PreviousItem(Engine::TrackChangeFlags change) {
   const bool ignore_repeat_track = change & Engine::Manual;
+
+  if (menu_previousmode_ == PreviousBehaviour_Restart) {
+    // Check if it has been over two seconds since previous button was pressed
+    QDateTime now = QDateTime::currentDateTime();
+    if (last_pressed_previous_.isValid() &&
+        last_pressed_previous_.secsTo(now) >= 2) {
+      last_pressed_previous_ = now;
+      PlayAt(app_->playlist_manager()->active()->current_row(), change, false);
+      return;
+    }
+    last_pressed_previous_ = now;
+  }
 
   int i = app_->playlist_manager()->active()->previous_row(ignore_repeat_track);
   app_->playlist_manager()->active()->set_current_row(i);

--- a/src/core/player.h
+++ b/src/core/player.h
@@ -29,9 +29,9 @@
 
 #include <memory>
 
+#include <QDateTime>
 #include <QObject>
 #include <QSettings>
-#include <QDateTime>
 
 #include "config.h"
 #include "core/song.h"

--- a/src/core/player.h
+++ b/src/core/player.h
@@ -31,6 +31,7 @@
 
 #include <QObject>
 #include <QSettings>
+#include <QDateTime>
 
 #include "config.h"
 #include "core/song.h"
@@ -91,7 +92,7 @@ class PlayerInterface : public QObject {
   virtual void Play() = 0;
   virtual void ShowOSD() = 0;
 
- signals:
+signals:
   void Playing();
   void Paused();
   void Stopped();
@@ -118,6 +119,14 @@ class Player : public PlayerInterface {
  public:
   explicit Player(Application* app, QObject* parent = nullptr);
   ~Player();
+
+  static const char* kSettingsGroup;
+
+  // Don't change the values
+  enum PreviousBehaviour {
+    PreviousBehaviour_DontRestart = 1,
+    PreviousBehaviour_Restart = 2
+  };
 
   void Init();
 
@@ -197,6 +206,9 @@ class Player : public PlayerInterface {
   QUrl loading_async_;
 
   int volume_before_mute_;
+
+  QDateTime last_pressed_previous_;
+  PreviousBehaviour menu_previousmode_;
 };
 
 #endif  // CORE_PLAYER_H_

--- a/src/ui/behavioursettingspage.cpp
+++ b/src/ui/behavioursettingspage.cpp
@@ -17,6 +17,7 @@
 
 #include "behavioursettingspage.h"
 #include "mainwindow.h"
+#include "core/player.h"
 #include "ui_behavioursettingspage.h"
 #include "playlist/playlist.h"
 #include "playlist/playlisttabbar.h"
@@ -49,6 +50,9 @@ BehaviourSettingsPage::BehaviourSettingsPage(SettingsDialog* dialog)
   ui_->menu_playmode->setItemData(0, MainWindow::PlayBehaviour_Never);
   ui_->menu_playmode->setItemData(1, MainWindow::PlayBehaviour_IfStopped);
   ui_->menu_playmode->setItemData(2, MainWindow::PlayBehaviour_Always);
+
+  ui_->menu_previousmode->setItemData(0, Player::PreviousBehaviour_DontRestart);
+  ui_->menu_previousmode->setItemData(1, Player::PreviousBehaviour_Restart);
 
   // Populate the language combo box.  We do this by looking at all the
   // compiled in translations.
@@ -180,6 +184,10 @@ void BehaviourSettingsPage::Save() {
   MainWindow::PlayBehaviour menu_playmode = MainWindow::PlayBehaviour(
       ui_->menu_playmode->itemData(ui_->menu_playmode->currentIndex()).toInt());
 
+  Player::PreviousBehaviour menu_previousmode = Player::PreviousBehaviour(
+      ui_->menu_previousmode->itemData(ui_->menu_previousmode->currentIndex())
+          .toInt());
+
   Playlist::Path path = Playlist::Path_Automatic;
   if (ui_->b_automatic_path->isChecked()) {
     path = Playlist::Path_Automatic;
@@ -200,6 +208,10 @@ void BehaviourSettingsPage::Save() {
   s.setValue("menu_playmode", menu_playmode);
   s.setValue("resume_playback_after_start",
              ui_->resume_after_start_->isChecked());
+  s.endGroup();
+
+  s.beginGroup(Player::kSettingsGroup);
+  s.setValue("menu_previousmode", menu_previousmode);
   s.endGroup();
 
   s.beginGroup("General");

--- a/src/ui/behavioursettingspage.ui
+++ b/src/ui/behavioursettingspage.ui
@@ -178,6 +178,32 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="groupBox_previous">
+     <property name="title">
+      <string>Pressing "Previous" in player will...</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_18">
+      <item>
+       <widget class="QComboBox" name="menu_previousmode">
+        <property name="currentIndex">
+         <number>0</number>
+        </property>
+        <item>
+         <property name="text">
+          <string>Jump to previous song right away</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Restart song, then jump to previous if pressed again (iPod behavior)</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="groupBox_7">
      <property name="title">
       <string>Double clicking a song will...</string>

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -216,6 +216,7 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
   int volume = app_->player()->GetVolume();
   ui_->volume->setValue(volume);
   VolumeChanged(volume);
+  app_->player()->ReloadSettings();
 
   // Initialise the global search widget
   StyleHelper::setBaseColor(palette().color(QPalette::Highlight).darker());

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -216,7 +216,6 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
   int volume = app_->player()->GetVolume();
   ui_->volume->setValue(volume);
   VolumeChanged(volume);
-  app_->player()->ReloadSettings();
 
   // Initialise the global search widget
   StyleHelper::setBaseColor(palette().color(QPalette::Highlight).darker());


### PR DESCRIPTION
Hey guys, @corco requested in #4638 that the previous button restarted the song if it were pressed, like the iPod behavior, so I added that option in Clementine's behavior page. I kept the 2 seconds mentioned by him as I don't own an iPod myself.