### PR TITLE
Add Now Playing widget option: No Song Details

### DIFF
--- a/src/widgets/nowplayingwidget.h
+++ b/src/widgets/nowplayingwidget.h
@@ -58,6 +58,7 @@ class NowPlayingWidget : public QWidget {
     SmallSongDetails = 0,
     LargeSongDetails = 1,
     LargeSongDetailsBelow = 2,
+    LargeNoSongDetails = 3,
   };
 
   void SetApplication(Application* app);


### PR DESCRIPTION
This is simply another option in the Now Playing widget's drop-down box, which says "Large album cover (no details)". It shows the album cover alone, without the song information, for those who prefer this clean look.
![d3985ba4-d605-11e3-9abd-eb83252bee30](https://cloud.githubusercontent.com/assets/4236749/5905513/90bb9958-a55e-11e4-959b-92091f6685e0.png)