### PR TITLE
Small fixes for podcasts

### DIFF
--- a/src/internet/podcasts/podcastdeleter.cpp
+++ b/src/internet/podcasts/podcastdeleter.cpp
@@ -103,6 +103,7 @@ void PodcastDeleter::AutoDelete() {
   timeout_ms = QDateTime::currentDateTime().toMSecsSinceEpoch();
   timeout_ms -= oldest_episode_time.toMSecsSinceEpoch();
   timeout_ms = (delete_after_secs_ * kMsecPerSec) - timeout_ms;
+  qLog(Info) << "Timeout for autodelete set to:" << timeout_ms <<"ms";
   if (timeout_ms >= 0) {
     auto_delete_timer_->setInterval(timeout_ms);
   } else {

--- a/src/internet/podcasts/podcastdownloader.cpp
+++ b/src/internet/podcasts/podcastdownloader.cpp
@@ -49,7 +49,7 @@ Task::Task(PodcastEpisode episode, QFile* file, PodcastBackend* backend)
   connect(repl.get(), SIGNAL(finished()), SLOT(finishedInternal()));
   connect(repl.get(), SIGNAL(downloadProgress(qint64, qint64)),
           SLOT(downloadProgressInternal(qint64, qint64)));
-  emit ProgressChanged(episode_, PodcastDownload::Downloading, 0);
+  emit ProgressChanged(episode_, PodcastDownload::Queued, 0);
 }
 
 PodcastEpisode Task::episode() const { return episode_; }


### PR DESCRIPTION
A small patch to allow me to debug autodeleter and use PodcastDownload::Queued for a first step of a download