### PR TITLE
Construct filenames with correct paths on all platforms

### DIFF
--- a/src/ripper/ripcddialog.cpp
+++ b/src/ripper/ripcddialog.cpp
@@ -20,6 +20,7 @@
 #include <cdio/cdio.h>
 #include <QCheckBox>
 #include <QFileDialog>
+#include <QFileInfo>
 #include <QLineEdit>
 #include <QMessageBox>
 #include <QSettings>
@@ -274,12 +275,12 @@ void RipCDDialog::BuildTrackListTable() {
 }
 
 QString RipCDDialog::GetOutputFileName(const QString& basename) const {
-  QString path =
-      ui_->destination->itemData(ui_->destination->currentIndex()).toString();
+  QFileInfo path(
+      ui_->destination->itemData(ui_->destination->currentIndex()).toString());
   QString extension = ui_->format->itemData(ui_->format->currentIndex())
                           .value<TranscoderPreset>()
                           .extension_;
-  return path + '/' + basename + '.' + extension;
+  return path.filePath() + '/' + basename + '.' + extension;
 }
 
 QString RipCDDialog::ParseFileFormatString(const QString& file_format,

--- a/src/transcoder/transcodedialog.cpp
+++ b/src/transcoder/transcodedialog.cpp
@@ -143,9 +143,10 @@ void TranscodeDialog::Start() {
 
   // Add jobs to the transcoder
   for (int i = 0; i < file_model->rowCount(); ++i) {
-    QString filename = file_model->index(i, 0).data(Qt::UserRole).toString();
-    QString outfilename = GetOutputFileName(filename, preset);
-    transcoder_->AddJob(filename, preset, outfilename);
+    QFileInfo input_fileinfo(
+        file_model->index(i, 0).data(Qt::UserRole).toString());
+    QString output_filename = GetOutputFileName(input_fileinfo, preset);
+    transcoder_->AddJob(input_fileinfo.filePath(), preset, output_filename);
   }
 
   // Set up the progressbar
@@ -307,7 +308,7 @@ void TranscodeDialog::AddDestination() {
   if (!dir.isEmpty()) {
     // Keep only a finite number of items in the box.
     while (ui_->destination->count() >= kMaxDestinationItems) {
-      ui_->destination->removeItem(1);  // The oldest folder item.
+      ui_->destination->removeItem(1);  // Remove the oldest folder item.
     }
 
     QIcon icon = IconLoader::Load("folder");
@@ -323,21 +324,16 @@ void TranscodeDialog::AddDestination() {
   }
 }
 
-// Returns the rightmost non-empty part of 'path'.
-QString TranscodeDialog::TrimPath(const QString& path) const {
-  return path.section('/', -1, -1, QString::SectionSkipEmpty);
-}
-
 QString TranscodeDialog::GetOutputFileName(
-    const QString& input, const TranscoderPreset& preset) const {
-  QString path =
-      ui_->destination->itemData(ui_->destination->currentIndex()).toString();
-  if (path.isEmpty()) {
-    // Keep the original path.
-    return input.section('.', 0, -2) + '.' + preset.extension_;
+    const QFileInfo& input, const TranscoderPreset& preset) const {
+  QFileInfo path(
+      ui_->destination->itemData(ui_->destination->currentIndex()).toString());
+  QString output_path;
+  if (path.isDir()) {
+    output_path = path.filePath();
   } else {
-    QString file_name = TrimPath(input);
-    file_name = file_name.section('.', 0, -2);
-    return path + '/' + file_name + '.' + preset.extension_;
+    // Keep the original path.
+    output_path = input.path();
   }
+  return output_path + '/' + input.completeBaseName() + '.' + preset.extension_;
 }

--- a/src/transcoder/transcodedialog.h
+++ b/src/transcoder/transcodedialog.h
@@ -20,6 +20,7 @@
 
 #include <QBasicTimer>
 #include <QDialog>
+#include <QFileInfo>
 
 class Transcoder;
 class Ui_TranscodeDialog;
@@ -59,8 +60,7 @@ class TranscodeDialog : public QDialog {
   void SetWorking(bool working);
   void UpdateStatusText();
   void UpdateProgress();
-  QString TrimPath(const QString& path) const;
-  QString GetOutputFileName(const QString& input,
+  QString GetOutputFileName(const QFileInfo& input,
                             const TranscoderPreset& preset) const;
 
  private:


### PR DESCRIPTION
The transcoder currently produces incorrect paths when specifying a destination directory on Windows.

This implementation fixes this by using QFileInfo to obtain system-independent file information.

Fixes #4579.