### PR TITLE
Try to make Seafile implementation more robust

### DIFF
--- a/src/internet/core/cloudfileservice.h
+++ b/src/internet/core/cloudfileservice.h
@@ -52,7 +52,7 @@ class CloudFileService : public InternetService {
   virtual bool has_credentials() const = 0;
   bool is_indexing() const { return indexing_task_id_ != -1; }
 
- signals:
+signals:
   void AllIndexingTasksFinished();
 
  public slots:
@@ -67,6 +67,7 @@ class CloudFileService : public InternetService {
                                       const QString& authorisation);
   virtual bool IsSupportedMimeType(const QString& mime_type) const;
   QString GuessMimeTypeForFile(const QString& filename) const;
+  void AbortReadTagsReplies();
 
  protected slots:
   void ShowCoverManager();
@@ -86,6 +87,7 @@ class CloudFileService : public InternetService {
   std::unique_ptr<AlbumCoverManager> cover_manager_;
   PlaylistManager* playlist_manager_;
   TaskManager* task_manager_;
+  QList<TagReaderClient::ReplyType*> pending_tagreader_replies_;
 
  private:
   QIcon icon_;

--- a/src/internet/seafile/seafileservice.cpp
+++ b/src/internet/seafile/seafileservice.cpp
@@ -178,17 +178,12 @@ void SeafileService::GetLibrariesFinished(QNetworkReply* reply) {
   emit GetLibrariesFinishedSignal(libraries);
 }
 
-void SeafileService::ChangeLibrary(const QString& new_library,
-                                   bool have_to_disconnect) {
-  if (have_to_disconnect) {
-    disconnect(this, SIGNAL(UpdatingLibrariesFinishedSignal()));
-  }
-
+void SeafileService::ChangeLibrary(const QString& new_library) {
   if (indexing_task_id_ != -1) {
     qLog(Debug) << "Want to change the Seafile library, but Clementine waits "
                    "the previous indexing...";
     NewClosure(this, SIGNAL(UpdatingLibrariesFinishedSignal()), this,
-               SLOT(ChangeLibrary(QString, bool)), new_library, true);
+               SLOT(ChangeLibrary(QString)), new_library);
     return;
   }
 

--- a/src/internet/seafile/seafileservice.cpp
+++ b/src/internet/seafile/seafileservice.cpp
@@ -217,14 +217,13 @@ void SeafileService::Connect() {
 }
 
 void SeafileService::UpdateLibraries() {
-  if (indexing_task_id_ == -1) {
-    indexing_task_id_ =
-        app_->task_manager()->StartTask(tr("Build index of Seafile"));
-  }
   // Quit if we are already updating the libraries
-  else {
+  if (indexing_task_id_ != -1) {
     return;
   }
+
+  indexing_task_id_ =
+      app_->task_manager()->StartTask(tr("Building Seafile index..."));
 
   connect(this, SIGNAL(GetLibrariesFinishedSignal(QMap<QString, QString>)),
           this, SLOT(UpdateLibrariesInProgress(QMap<QString, QString>)));

--- a/src/internet/seafile/seafileservice.h
+++ b/src/internet/seafile/seafileservice.h
@@ -76,16 +76,18 @@ class SeafileService : public CloudFileService {
                 const QString& server);
   // Get all the libraries available for the user. Will emit a signal
   void GetLibraries();
-  void ChangeLibrary(const QString& new_library);
 
  public slots:
   void Connect();
   void ForgetCredentials();
+  void ChangeLibrary(const QString& new_library,
+                     bool have_to_disconnect = false);
 
- signals:
+signals:
   void Connected();
   // QMap, key : library's id, value : library's name
   void GetLibrariesFinishedSignal(QMap<QString, QString>);
+  void UpdatingLibrariesFinishedSignal();
 
  private slots:
   // Will emit the signal
@@ -143,10 +145,17 @@ class SeafileService : public CloudFileService {
   // argument
   bool CheckReply(QNetworkReply** reply, int tries = 1);
 
+  void StartTaskInProgress();
+  void FinishedTaskInProgress();
+
   SeafileTree tree_;
   QString access_token_;
   QString server_;
   QString library_updated_;
+
+  int indexing_task_id_;
+  int indexing_task_max_;
+  int indexing_task_progress_;
 };
 
 #endif  // INTERNET_SEAFILE_SEAFILESERVICE_H_

--- a/src/internet/seafile/seafileservice.h
+++ b/src/internet/seafile/seafileservice.h
@@ -155,6 +155,8 @@ signals:
   int indexing_task_id_;
   int indexing_task_max_;
   int indexing_task_progress_;
+
+  bool changing_libary_;
 };
 
 #endif  // INTERNET_SEAFILE_SEAFILESERVICE_H_

--- a/src/internet/seafile/seafileservice.h
+++ b/src/internet/seafile/seafileservice.h
@@ -80,8 +80,7 @@ class SeafileService : public CloudFileService {
  public slots:
   void Connect();
   void ForgetCredentials();
-  void ChangeLibrary(const QString& new_library,
-                     bool have_to_disconnect = false);
+  void ChangeLibrary(const QString& new_library);
 
 signals:
   void Connected();

--- a/src/internet/seafile/seafilesettingspage.cpp
+++ b/src/internet/seafile/seafilesettingspage.cpp
@@ -134,6 +134,8 @@ void SeafileSettingsPage::Login() {
 }
 
 void SeafileSettingsPage::Logout() {
+  // Forget the songs added
+  service_->ChangeLibrary("none");
   service_->ForgetCredentials();
 
   // We choose to keep the server


### PR DESCRIPTION
Just added informations via the taskmanager because the build of the Seafile index could be pretty long if the library have many directories

Now Clementine waits the previous index build if the user wants to change the library, it's cleaner.

Finally ReadTagsFinished ignore replies of a previous indexing which was cancelled. It's not the best solution since the tagreaders still download informations about the tracks but I didn't find a better one.