### PR TITLE
Fix memory leak in networkremote.

### DIFF
--- a/src/networkremote/networkremote.cpp
+++ b/src/networkremote/networkremote.cpp
@@ -175,6 +175,7 @@ void NetworkRemote::AcceptConnection() {
     qLog(Info) << "Got a connection from public ip"
                << client_socket->peerAddress().toString();
     client_socket->close();
+    client_socket->deleteLater();
   } else {
     CreateRemoteClient(client_socket);
   }

--- a/src/networkremote/remoteclient.cpp
+++ b/src/networkremote/remoteclient.cpp
@@ -56,6 +56,7 @@ RemoteClient::~RemoteClient() {
     client_->waitForDisconnected(2000);
 
   song_sender_->deleteLater();
+  client_->deleteLater();
 }
 
 void RemoteClient::setDownloader(bool downloader) { downloader_ = downloader; }


### PR DESCRIPTION
Memory leak happened when Android-Remote tries to reconnect to Clementine. This is the cause of the problem mentioned in issue #4737.