### PR TITLE
Re-read FMPS_Rating from file when changed

### DIFF
--- a/src/core/song.cpp
+++ b/src/core/song.cpp
@@ -1058,6 +1058,7 @@ bool Song::IsMetadataEqual(const Song& other) const {
          d->samplerate_ == other.d->samplerate_ &&
          d->art_automatic_ == other.d->art_automatic_ &&
          d->art_manual_ == other.d->art_manual_ &&
+         d->rating_ == other.d->rating_ &&
          d->cue_path_ == other.d->cue_path_;
 }
 
@@ -1133,7 +1134,6 @@ void Song::MergeUserSetData(const Song& other) {
   set_playcount(other.playcount());
   set_skipcount(other.skipcount());
   set_lastplayed(other.lastplayed());
-  set_rating(other.rating());
   set_score(other.score());
   set_art_manual(other.art_manual());
 }


### PR DESCRIPTION
When the FMPS_Rating changes in a file, Clementine will now re-read it
and change the rating in the library database.  This lets you modify
song ratings outside of Clementine and then load the new ratings into
Clementine.  Previously Clementine would ignore changed ratings in a
file's metadata after a song had been scanned into the library.

This is consistent with the handling of other standardized tags (e.g. artist, album, title).  It's especially useful if a user has a shared music library which he accesses from multiple systems.