### PR TITLE
Add lyrics field to device databases.

### DIFF
--- a/data/schema/device-schema.sql
+++ b/data/schema/device-schema.sql
@@ -58,7 +58,8 @@ CREATE TABLE device_%deviceid_songs (
   etag TEXT,
 
   performer TEXT,
-  grouping TEXT
+  grouping TEXT,
+  lyrics TEXT
 );
 
 CREATE INDEX idx_device_%deviceid_songs_album ON device_%deviceid_songs (album);


### PR DESCRIPTION
Connecting and scanning of a new device failed due to the missing lyrics
field. This fixes it.