### PR TITLE
Fix setting album artist tag for FLAC files if it already exists

### DIFF
--- a/ext/libclementine-tagreader/tagreader.cpp
+++ b/ext/libclementine-tagreader/tagreader.cpp
@@ -537,8 +537,10 @@ void TagReader::SetVorbisComments(
       "COMPILATION", StdStringToTaglibString(song.compilation() ? "1" : "0"),
       true);
 
-  vorbis_comments->addField("ALBUM ARTIST",
+  // Try to be coherent, the two forms are used but the first one is preferred
+  vorbis_comments->addField("ALBUMARTIST",
                             StdStringToTaglibString(song.albumartist()), true);
+  vorbis_comments->removeField("ALBUM ARTIST");
 }
 
 void TagReader::SetFMPSStatisticsVorbisComments(


### PR DESCRIPTION
Try to be more coherent when we set the album artist tag with vorbis comments. 

Fix an issue when the "ALBUMARTIST" tag was already set and modified with Clementine.