### PR TITLE
Scroll to last played track when switching playlists

### DIFF
--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -272,6 +272,7 @@ void PlaylistView::SetPlaylist(Playlist* playlist) {
   DynamicModeChanged(playlist->is_dynamic());
   setFocus();
   read_only_settings_ = false;
+  JumpToLastPlayedTrack();
 
   connect(playlist_, SIGNAL(RestoreFinished()), SLOT(JumpToLastPlayedTrack()));
   connect(playlist_, SIGNAL(CurrentSongChanged(Song)), SLOT(MaybeAutoscroll()));


### PR DESCRIPTION
Currently we just scroll to the current index of the last playlist in the new one. This makes no sense and leads to the scrollbars acting like they are "linked" together. This is frustrating when switching between long and short playlists.
This change scrolls to the last played track in each playlist on transition.