### PR TITLE
Scale cover art to the current monitor, not the entire virtual screen

### DIFF
--- a/src/ui/albumcoverchoicecontroller.cpp
+++ b/src/ui/albumcoverchoicecontroller.cpp
@@ -217,8 +217,9 @@ void AlbumCoverChoiceController::ShowCover(const Song& song) {
   // if the cover is larger than the screen, resize the window
   // 85% seems to be enough to account for title bar and taskbar etc.
   QDesktopWidget desktop;
-  int desktop_height = desktop.geometry().height();
-  int desktop_width = desktop.geometry().width();
+  int current_screen = desktop.screenNumber(this);
+  int desktop_height = desktop.screenGeometry(current_screen).height();
+  int desktop_width = desktop.screenGeometry(current_screen).width();
 
   // resize differently if monitor is in portrait mode
   if (desktop_width < desktop_height) {


### PR DESCRIPTION
When showing the album cover from the now playing widget, the cover is scaled to fit the screen. However if the screen is made up of 2 or more monitors of different resolutions, it will always be scaled to the largest one.

This change ensures that the cover is scaled to the size of the monitor Clementine's main window is on, or the primary if indeterminate.