### PR TITLE
Fix playlist not deselecting playing track when stopping

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -292,6 +292,7 @@ void Player::RestartOrPrevious() {
 
 void Player::Stop(bool stop_after) {
   engine_->Stop(stop_after);
+  app_->playlist_manager()->active()->set_current_row(-1);
   current_item_.reset();
 }
 


### PR DESCRIPTION
Regression from #4866 

I don't know why this line was removed. It is required to tell the playlist manager to stop the glow on the playing track once it has stopped. Without it, the track will always show as playing, and the moodbars stop working.

Adding it back in doesn't seem to break the stop after every track feature from my testing.