### PR TITLE
Fix save state when the song was paused

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -422,24 +422,25 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
 
   // Playlist view actions
   ui_->action_next_playlist->setShortcuts(
-      QList<QKeySequence>() << QKeySequence::fromString("Ctrl+Tab")
+      QList<QKeySequence>()
+      << QKeySequence::fromString("Ctrl+Tab")
 #ifdef Q_OS_DARWIN
-                            // On OS X "Ctrl+Tab" == Cmd + Tab but this shorcut
-                            // is already used by default for switching between
-                            // applications.
-                            // I would have preferred to use Meta+Tab (which
-                            // means Ctrl+Tab on OS X), like in Firefox or
-                            // Chrome, but this doesn't work (probably at Qt bug)
-                            // and some applications (e.g. Qt creator) uses
-                            // Alt+Tab too so I believe it's a good shorcut anyway
-                            << QKeySequence::fromString("Alt+Tab")
-#endif // Q_OS_DARWIN
-                            << QKeySequence::fromString("Ctrl+PgDown"));
+      // On OS X "Ctrl+Tab" == Cmd + Tab but this shorcut
+      // is already used by default for switching between
+      // applications.
+      // I would have preferred to use Meta+Tab (which
+      // means Ctrl+Tab on OS X), like in Firefox or
+      // Chrome, but this doesn't work (probably at Qt bug)
+      // and some applications (e.g. Qt creator) uses
+      // Alt+Tab too so I believe it's a good shorcut anyway
+      << QKeySequence::fromString("Alt+Tab")
+#endif  // Q_OS_DARWIN
+      << QKeySequence::fromString("Ctrl+PgDown"));
   ui_->action_previous_playlist->setShortcuts(
       QList<QKeySequence>() << QKeySequence::fromString("Ctrl+Shift+Tab")
 #ifdef Q_OS_DARWIN
                             << QKeySequence::fromString("Alt+Shift+Tab")
-#endif // Q_OS_DARWIN
+#endif  // Q_OS_DARWIN
                             << QKeySequence::fromString("Ctrl+PgUp"));
   // Actions for switching tabs will be global to the entire window, so adding
   // them here
@@ -1190,13 +1191,15 @@ void MainWindow::LoadPlaybackStatus() {
 
 void MainWindow::ResumePlayback() {
   qLog(Debug) << "Resuming playback";
+
+  if (saved_playback_state_ == Engine::Paused) {
+    NewClosure(app_->player(), SIGNAL(Playing()), app_->player(),
+               SLOT(PlayPause()));
+  }
+
   app_->player()->Play();
 
   app_->player()->SeekTo(saved_playback_position_);
-
-  if (saved_playback_state_ == Engine::Paused) {
-    app_->player()->Pause();
-  }
 }
 
 void MainWindow::PlayIndex(const QModelIndex& index) {


### PR DESCRIPTION
When we want to save the state, Clementine always play the music when we open it even if it was paused at the shutdown.

This is because the `pause()` is skipped because the current pipeline is still not in playing state: we have to wait.
