### PR TITLE
Fix context menu for the NowPlayingWidget in Windows

### DIFF
--- a/src/widgets/nowplayingwidget.cpp
+++ b/src/widgets/nowplayingwidget.cpp
@@ -562,9 +562,9 @@ void NowPlayingWidget::contextMenuEvent(QContextMenuEvent* e) {
   menu_->popup(mapToGlobal(e->pos()));
 }
 
-void NowPlayingWidget::mouseReleaseEvent(QMouseEvent*) {
+void NowPlayingWidget::mouseReleaseEvent(QMouseEvent* e) {
   // Same behaviour as right-click > Show Fullsize
-  if (!aww_ && !hypnotoad_.get()) {
+  if (e->button() == Qt::LeftButton && !aww_ && !hypnotoad_.get()) {
     ShowCover();
   }
 }


### PR DESCRIPTION
Introduced in #4416, clicking the cover will show the large art. In Windows, it seems that the click release event that triggers this is also associated with the right mouse button, so the art comes up when you bring up the context menu. This just checks if it was the left button released.