### PR TITLE
[Qt5] Fix compilation error and adapt spotify part to Qt5

### DIFF
--- a/ext/clementine-spotifyblob/spotifyclient.cpp
+++ b/ext/clementine-spotifyblob/spotifyclient.cpp
@@ -697,7 +697,7 @@ void SpotifyClient::ConvertTrack(sp_track* track, pb::spotify::Track* pb) {
   const QByteArray art_id(reinterpret_cast<const char*>(sp_album_cover(
                               sp_track_album(track), SP_IMAGE_SIZE_LARGE)),
                           kSpotifyImageIDSize);
-  const QString art_id_b64 = QString::fromAscii(art_id.toBase64());
+  const QString art_id_b64 = QString::fromLatin1(art_id.toBase64());
   pb->set_album_art_id(DataCommaSizeFromQString(art_id_b64));
 
   // Artists
@@ -732,7 +732,7 @@ void SpotifyClient::ConvertAlbum(sp_album* album, pb::spotify::Track* pb) {
   const QByteArray art_id(
       reinterpret_cast<const char*>(sp_album_cover(album, SP_IMAGE_SIZE_LARGE)),
       kSpotifyImageIDSize);
-  const QString art_id_b64 = QString::fromAscii(art_id.toBase64());
+  const QString art_id_b64 = QString::fromLatin1(art_id.toBase64());
   pb->set_album_art_id(DataCommaSizeFromQString(art_id_b64));
 
   // URI - Blugh
@@ -979,7 +979,7 @@ void SpotifyClient::SendPlaybackError(const QString& error) {
 }
 
 void SpotifyClient::LoadImage(const QString& id_b64) {
-  QByteArray id = QByteArray::fromBase64(id_b64.toAscii());
+  QByteArray id = QByteArray::fromBase64(id_b64.toLatin1());
   if (id.length() != kSpotifyImageIDSize) {
     qLog(Warning) << "Invalid image ID (did not decode to"
                   << kSpotifyImageIDSize << "bytes):" << id_b64;

--- a/ext/libclementine-common/core/logging.cpp
+++ b/ext/libclementine-common/core/logging.cpp
@@ -267,4 +267,21 @@ void DumpStackTrace() {
 #endif
 }
 
+QDebug CreateLoggerFatal() { return qCreateLogger(Fatal); }
+QDebug CreateLoggerError() { return qCreateLogger(Error); }
+
+#ifdef QT_NO_WARNING_OUTPUT
+QNoDebug CreateLoggerWarning() { return QNoDebug(); }
+#else
+QDebug CreateLoggerWarning() { return qCreateLogger(Warning); }
+#endif // QT_NO_WARNING_OUTPUT
+
+#ifdef QT_NO_DEBUG_OUTPUT
+QNoDebug CreateLoggerInfo() { return QNoDebug(); }
+QNoDebug CreateLoggerDebug() { return QNoDebug(); }
+#else
+QDebug CreateLoggerInfo() { return qCreateLogger(Info); }
+QDebug CreateLoggerDebug() { return qCreateLogger(Debug); }
+#endif // QT_NO_DEBUG_OUTPUT
+
 }  // namespace logging

--- a/ext/libclementine-common/core/logging.h
+++ b/ext/libclementine-common/core/logging.h
@@ -61,21 +61,21 @@ void DumpStackTrace();
 QString ParsePrettyFunction(const char* pretty_function);
 QDebug CreateLogger(Level level, const QString& class_name, int line);
 
-QDebug CreateLoggerFatal() { return qCreateLogger(Fatal); }
-QDebug CreateLoggerError() { return qCreateLogger(Error); }
+QDebug CreateLoggerFatal();
+QDebug CreateLoggerError();
 
 #ifdef QT_NO_WARNING_OUTPUT
-QNoDebug CreateLoggerWarning() { return QNoDebug(); }
+QNoDebug CreateLoggerWarning();
 #else
-QDebug CreateLoggerWarning() { return qCreateLogger(Warning); }
+QDebug CreateLoggerWarning();
 #endif // QT_NO_WARNING_OUTPUT
 
 #ifdef QT_NO_DEBUG_OUTPUT
-QNoDebug CreateLoggerInfo() { return QNoDebug(); }
-QNoDebug CreateLoggerDebug() { return QNoDebug(); }
+QNoDebug CreateLoggerInfo();
+QNoDebug CreateLoggerDebug();
 #else
-QDebug CreateLoggerInfo() { return qCreateLogger(Info); }
-QDebug CreateLoggerDebug() { return qCreateLogger(Debug); }
+QDebug CreateLoggerInfo();
+QDebug CreateLoggerDebug();
 #endif // QT_NO_DEBUG_OUTPUT
 
 


### PR DESCRIPTION
I adapted the spotify codes to qt5 (just some ascii things).

The second part is more complicated since I don't understand why it didn't work (and why I didn't notice compilations failed with the new system of logging in the last qt5 PR). 

I had these kind of errors:
    
    CMakeFiles/clementine-tagreader.dir/tagreaderworker.cpp.o: in function « logging::CreateLoggerFatal() »:
    tagreaderworker.cpp:(.text+0x0): multiple definitions of « logging::CreateLoggerFatal() »
    CMakeFiles/clementine-tagreader.dir/main.cpp.o:main.cpp:(.text+0x0): defined here

It seems the *qLog* macro defined a new function each time it was called (replacing itself with `QDebug CreateLoggerFatal() { return qCreateLogger(Fatal); }` instead of `return qCreateLogger(Fatal);`.
I moved the definitions of the functions in the *.cpp* and now it works as expected. 

I simply don't understand, is it because the functions was defined in the *.h* ? Or a CMakeList issue ? If you have an idea...

Anyway, with this PR it seems to compile as expected.