### PR TITLE
Bound the Block Analyzer's column count

### DIFF
--- a/src/analyzers/blockanalyzer.cpp
+++ b/src/analyzers/blockanalyzer.cpp
@@ -76,7 +76,7 @@ void BlockAnalyzer::resizeEvent(QResizeEvent* e) {
 
   // all is explained in analyze()..
   // +1 to counter -1 in maxSizes, trust me we need this!
-  m_columns = qMax(static_cast<uint>(static_cast<double>(width() + 1) / (WIDTH + 1)), MAX_COLUMNS);
+  m_columns = qMin(static_cast<uint>(static_cast<double>(width() + 1) / (WIDTH + 1)) + 1, MAX_COLUMNS);
   m_rows = static_cast<uint>(static_cast<double>(height() + 1) / (HEIGHT + 1));
 
   // this is the y-offset for drawing from the top of the widget


### PR DESCRIPTION
As it stands, the block analyzer just chops off columns to the right if the window is too small and always internally runs off 256 columns. Since the analyzer is bounded to 256 columns, this qMax bound is totally pointless.
It also makes the demo asymmetrical which trips up my OCD whenever Clementine is idling...