### PR TITLE
Update Boom and Turbine analyzers

### DIFF
--- a/src/analyzers/boomanalyzer.h
+++ b/src/analyzers/boomanalyzer.h
@@ -1,7 +1,7 @@
 /* This file is part of Clementine.
    Copyright 2004, Max Howell <max.howell@methylblue.com>
    Copyright 2009-2010, David Sansome <davidsansome@gmail.com>
-   Copyright 2014, Mark Furneaux <mark@romaco.ca>
+   Copyright 2014-2015, Mark Furneaux <mark@furneaux.ca>
    Copyright 2014, Krzysztof Sobiecki <sobkas@gmail.com>
    Copyright 2014, John Maguire <john.maguire@gmail.com>
 
@@ -27,10 +27,6 @@
 
 #include "analyzerbase.h"
 
-/**
-@author Max Howell
-*/
-
 class BoomAnalyzer : public Analyzer::Base {
   Q_OBJECT
 
@@ -39,7 +35,6 @@ class BoomAnalyzer : public Analyzer::Base {
 
   static const char* kName;
 
-  virtual void init();
   virtual void transform(Analyzer::Scope& s);
   virtual void analyze(QPainter& p, const Analyzer::Scope&, bool new_frame);
 
@@ -49,9 +44,15 @@ class BoomAnalyzer : public Analyzer::Base {
 
  protected:
   void resizeEvent(QResizeEvent* e);
+  void paletteChange(const QPalette&);
 
-  static const uint COLUMN_WIDTH = 4;
-  static const uint BAND_COUNT = 32;
+  static const uint COLUMN_WIDTH;
+  static const uint MAX_BAND_COUNT;
+  static const uint MIN_BAND_COUNT;
+
+  uint m_bands;
+  Analyzer::Scope m_scope;
+  QColor m_fg;
 
   double K_barHeight, F_peakSpeed, F;
 

--- a/src/analyzers/boomanalyzer.h
+++ b/src/analyzers/boomanalyzer.h
@@ -46,21 +46,21 @@ class BoomAnalyzer : public Analyzer::Base {
   void resizeEvent(QResizeEvent* e);
   void paletteChange(const QPalette&);
 
-  static const uint COLUMN_WIDTH;
-  static const uint MAX_BAND_COUNT;
-  static const uint MIN_BAND_COUNT;
+  static const uint kColumnWidth;
+  static const uint kMaxBandCount;
+  static const uint kMinBandCount;
 
-  uint m_bands;
-  Analyzer::Scope m_scope;
-  QColor m_fg;
+  uint bands_;
+  Analyzer::Scope scope_;
+  QColor fg_;
 
-  double K_barHeight, F_peakSpeed, F;
+  double K_barHeight_, F_peakSpeed_, F_;
 
-  std::vector<float> bar_height;
-  std::vector<float> peak_height;
-  std::vector<float> peak_speed;
+  std::vector<float> bar_height_;
+  std::vector<float> peak_height_;
+  std::vector<float> peak_speed_;
 
-  QPixmap barPixmap;
+  QPixmap barPixmap_;
   QPixmap canvas_;
 };
 

--- a/src/analyzers/turbine.cpp
+++ b/src/analyzers/turbine.cpp
@@ -2,7 +2,7 @@
    Copyright 2003, Stanislav Karchebny <berkus@users.sf.net>
    Copyright 2003, Max Howell <max.howell@methylblue.com>
    Copyright 2009-2010, David Sansome <davidsansome@gmail.com>
-   Copyright 2014, Mark Furneaux <mark@romaco.ca>
+   Copyright 2014-2015, Mark Furneaux <mark@furneaux.ca>
    Copyright 2014, Krzysztof Sobiecki <sobkas@gmail.com>
    Copyright 2014, John Maguire <john.maguire@gmail.com>
 
@@ -21,7 +21,7 @@
 */
 
 /* Original Author:  Stanislav Karchebny  <berkus@users.sf.net>   2003
- * Original Author:  Max Howell  <max.howell@methylblue.com>  2003 
+ * Original Author:  Max Howell  <max.howell@methylblue.com>  2003
  */
 
 #include <cmath>
@@ -47,8 +47,10 @@ void TurbineAnalyzer::analyze(QPainter& p, const Scope& scope, bool new_frame) {
   QPainter canvas_painter(&canvas_);
   canvas_.fill(palette().color(QPalette::Background));
 
-  for (uint i = 0, x = 0, y; i < BAND_COUNT; ++i, x += COLUMN_WIDTH + 1) {
-    h = log10(scope[i] * 256.0) * F * 0.5;
+  Analyzer::interpolate(scope, m_scope);
+
+  for (uint i = 0, x = 0, y; i < m_bands; ++i, x += COLUMN_WIDTH + 1) {
+    h = log10(m_scope[i] * 256.0) * F * 0.5;
 
     if (h > MAX_HEIGHT) h = MAX_HEIGHT;
 
@@ -81,16 +83,15 @@ void TurbineAnalyzer::analyze(QPainter& p, const Scope& scope, bool new_frame) {
     y = hd2 - static_cast<uint>(bar_height[i]);
     canvas_painter.drawPixmap(x + 1, y, barPixmap, 0, y, -1, -1);
     canvas_painter.drawPixmap(x + 1, hd2, barPixmap, 0,
-                              static_cast<int>(bar_height[i]),
-                              -1, -1);
+                              static_cast<int>(bar_height[i]), -1, -1);
 
-    canvas_painter.setPen(palette().color(QPalette::Highlight));
+    canvas_painter.setPen(m_fg);
     if (bar_height[i] > 0)
       canvas_painter.drawRect(x, y, COLUMN_WIDTH - 1,
                               static_cast<int>(bar_height[i]) * 2 - 1);
 
     const uint x2 = x + COLUMN_WIDTH - 1;
-    canvas_painter.setPen(palette().color(QPalette::Base));
+    canvas_painter.setPen(palette().color(QPalette::Midlight));
     y = hd2 - uint(peak_height[i]);
     canvas_painter.drawLine(x, y, x2, y);
     y = hd2 + uint(peak_height[i]);

--- a/src/analyzers/turbine.cpp
+++ b/src/analyzers/turbine.cpp
@@ -42,59 +42,59 @@ void TurbineAnalyzer::analyze(QPainter& p, const Scope& scope, bool new_frame) {
 
   float h;
   const uint hd2 = height() / 2;
-  const uint MAX_HEIGHT = hd2 - 1;
+  const uint kMaxHeight = hd2 - 1;
 
   QPainter canvas_painter(&canvas_);
   canvas_.fill(palette().color(QPalette::Background));
 
-  Analyzer::interpolate(scope, m_scope);
+  Analyzer::interpolate(scope, scope_);
 
-  for (uint i = 0, x = 0, y; i < m_bands; ++i, x += COLUMN_WIDTH + 1) {
-    h = log10(m_scope[i] * 256.0) * F * 0.5;
+  for (uint i = 0, x = 0, y; i < bands_; ++i, x += kColumnWidth + 1) {
+    h = log10(scope_[i] * 256.0) * F_ * 0.5;
 
-    if (h > MAX_HEIGHT) h = MAX_HEIGHT;
+    if (h > kMaxHeight) h = kMaxHeight;
 
-    if (h > bar_height[i]) {
-      bar_height[i] = h;
+    if (h > bar_height_[i]) {
+      bar_height_[i] = h;
 
-      if (h > peak_height[i]) {
-        peak_height[i] = h;
-        peak_speed[i] = 0.01;
+      if (h > peak_height_[i]) {
+        peak_height_[i] = h;
+        peak_speed_[i] = 0.01;
       } else {
         goto peak_handling;
       }
     } else {
-      if (bar_height[i] > 0.0) {
-        bar_height[i] -= K_barHeight;  // 1.4
-        if (bar_height[i] < 0.0) bar_height[i] = 0.0;
+      if (bar_height_[i] > 0.0) {
+        bar_height_[i] -= K_barHeight_;  // 1.4
+        if (bar_height_[i] < 0.0) bar_height_[i] = 0.0;
       }
 
     peak_handling:
 
-      if (peak_height[i] > 0.0) {
-        peak_height[i] -= peak_speed[i];
-        peak_speed[i] *= F_peakSpeed;  // 1.12
+      if (peak_height_[i] > 0.0) {
+        peak_height_[i] -= peak_speed_[i];
+        peak_speed_[i] *= F_peakSpeed_;  // 1.12
 
-        if (peak_height[i] < bar_height[i]) peak_height[i] = bar_height[i];
-        if (peak_height[i] < 0.0) peak_height[i] = 0.0;
+        if (peak_height_[i] < bar_height_[i]) peak_height_[i] = bar_height_[i];
+        if (peak_height_[i] < 0.0) peak_height_[i] = 0.0;
       }
     }
 
-    y = hd2 - static_cast<uint>(bar_height[i]);
-    canvas_painter.drawPixmap(x + 1, y, barPixmap, 0, y, -1, -1);
-    canvas_painter.drawPixmap(x + 1, hd2, barPixmap, 0,
-                              static_cast<int>(bar_height[i]), -1, -1);
+    y = hd2 - static_cast<uint>(bar_height_[i]);
+    canvas_painter.drawPixmap(x + 1, y, barPixmap_, 0, y, -1, -1);
+    canvas_painter.drawPixmap(x + 1, hd2, barPixmap_, 0,
+                              static_cast<int>(bar_height_[i]), -1, -1);
 
-    canvas_painter.setPen(m_fg);
-    if (bar_height[i] > 0)
-      canvas_painter.drawRect(x, y, COLUMN_WIDTH - 1,
-                              static_cast<int>(bar_height[i]) * 2 - 1);
+    canvas_painter.setPen(fg_);
+    if (bar_height_[i] > 0)
+      canvas_painter.drawRect(x, y, kColumnWidth - 1,
+                              static_cast<int>(bar_height_[i]) * 2 - 1);
 
-    const uint x2 = x + COLUMN_WIDTH - 1;
+    const uint x2 = x + kColumnWidth - 1;
     canvas_painter.setPen(palette().color(QPalette::Midlight));
-    y = hd2 - uint(peak_height[i]);
+    y = hd2 - uint(peak_height_[i]);
     canvas_painter.drawLine(x, y, x2, y);
-    y = hd2 + uint(peak_height[i]);
+    y = hd2 + uint(peak_height_[i]);
     canvas_painter.drawLine(x, y, x2, y);
   }
 


### PR DESCRIPTION
Boom and Turbine remain small fixed-size analyzers with a few issues with regards to colours.
This update attempts to remedy these issues.
Changes:
-Both analyzers now resize to fit the size of their container, and scale to the lower frequencies if in a small window
-The colour now does not change as the main window gains/loses focus
-The peak bars now use a colour which is actually visible (I didn't even know they existed before!)