### PR TITLE
Add full rescan reason for original year tag support.

### DIFF
--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -115,6 +115,7 @@ Library::Library(Application* app, QObject* parent)
 
   // full rescan revisions
   full_rescan_revisions_[26] = tr("CUE sheet support");
+  full_rescan_revisions_[50] = tr("Original year tag support");
 
   ReloadSettings();
 }


### PR DESCRIPTION
I hadn't realized that a full rescan would be requiered on existing libraries.