### PR TITLE
Make seeking with keys behaviour consistent.

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -52,6 +52,7 @@
 using std::shared_ptr;
 
 const char* Player::kSettingsGroup = "Player";
+const int kSeekSec = 10;
 
 Player::Player(Application* app, QObject* parent)
     : PlayerInterface(parent),
@@ -444,11 +445,11 @@ void Player::SeekTo(int seconds) {
 }
 
 void Player::SeekForward() {
-  SeekTo(engine()->position_nanosec() / kNsecPerSec + 10);
+  SeekTo(engine()->position_nanosec() / kNsecPerSec + kSeekSec);
 }
 
 void Player::SeekBackward() {
-  SeekTo(engine()->position_nanosec() / kNsecPerSec - 10);
+  SeekTo(engine()->position_nanosec() / kNsecPerSec - kSeekSec);
 }
 
 void Player::EngineMetadataReceived(const Engine::SimpleMetaBundle& bundle) {

--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -52,7 +52,10 @@
 using std::shared_ptr;
 
 const char* Player::kSettingsGroup = "Player";
-const int kSeekSec = 10;
+
+namespace {
+const int kSeekStepSec = 10;
+}
 
 Player::Player(Application* app, QObject* parent)
     : PlayerInterface(parent),
@@ -445,11 +448,11 @@ void Player::SeekTo(int seconds) {
 }
 
 void Player::SeekForward() {
-  SeekTo(engine()->position_nanosec() / kNsecPerSec + kSeekSec);
+  SeekTo(engine()->position_nanosec() / kNsecPerSec + kSeekStepSec);
 }
 
 void Player::SeekBackward() {
-  SeekTo(engine()->position_nanosec() / kNsecPerSec - kSeekSec);
+  SeekTo(engine()->position_nanosec() / kNsecPerSec - kSeekStepSec);
 }
 
 void Player::EngineMetadataReceived(const Engine::SimpleMetaBundle& bundle) {

--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -586,10 +586,10 @@ void PlaylistView::keyPressEvent(QKeyEvent* event) {
     emit PlayPause();
     event->accept();
   } else if (event->key() == Qt::Key_Left) {
-    emit SeekTrack(-1);
+    emit SeekBackward();
     event->accept();
   } else if (event->key() == Qt::Key_Right) {
-    emit SeekTrack(1);
+    emit SeekForward();
     event->accept();
   } else if (event->modifiers() ==
                  Qt::NoModifier  // No modifier keys currently pressed...
@@ -1192,7 +1192,7 @@ ColumnAlignmentMap PlaylistView::DefaultColumnAlignment() {
                       ret[Playlist::Column_PlayCount] =
                           ret[Playlist::Column_SkipCount] =
                               ret[Playlist::Column_OriginalYear] =
-                              (Qt::AlignRight | Qt::AlignVCenter);
+                                  (Qt::AlignRight | Qt::AlignVCenter);
   ret[Playlist::Column_Score] = (Qt::AlignCenter);
 
   return ret;

--- a/src/playlist/playlistview.h
+++ b/src/playlist/playlistview.h
@@ -109,7 +109,8 @@ signals:
   void PlayItem(const QModelIndex& index);
   void PlayPause();
   void RightClicked(const QPoint& global_pos, const QModelIndex& index);
-  void SeekTrack(int gap);
+  void SeekForward();
+  void SeekBackward();
   void FocusOnFilterSignal(QKeyEvent* event);
   void BackgroundPropertyChanged();
   void ColumnAlignmentChanged(const ColumnAlignmentMap& alignment);

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -536,13 +536,19 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
           SLOT(PlayPause()));
   connect(ui_->playlist->view(), SIGNAL(RightClicked(QPoint, QModelIndex)),
           SLOT(PlaylistRightClick(QPoint, QModelIndex)));
-  connect(ui_->playlist->view(), SIGNAL(SeekTrack(int)), ui_->track_slider,
-          SLOT(Seek(int)));
+  connect(ui_->playlist->view(), SIGNAL(SeekForward()), app_->player(),
+          SLOT(SeekForward()));
+  connect(ui_->playlist->view(), SIGNAL(SeekBackward()), app_->player(),
+          SLOT(SeekBackward()));
   connect(ui_->playlist->view(), SIGNAL(BackgroundPropertyChanged()),
           SLOT(RefreshStyleSheet()));
 
   connect(ui_->track_slider, SIGNAL(ValueChangedSeconds(int)), app_->player(),
           SLOT(SeekTo(int)));
+  connect(ui_->track_slider, SIGNAL(SeekForward()), app_->player(),
+          SLOT(SeekForward()));
+  connect(ui_->track_slider, SIGNAL(SeekBackward()), app_->player(),
+          SLOT(SeekBackward()));
 
   // Library connections
   connect(library_view_->view(), SIGNAL(AddToPlaylistSignal(QMimeData*)),
@@ -1342,7 +1348,8 @@ void MainWindow::UpdateTrackPosition() {
     }
   }
 
-  // (just after) the scrobble point is a good point to change tracks in intro mode
+  // (just after) the scrobble point is a good point to change tracks in intro
+  // mode
   if (position >= scrobble_point + 5) {
     if (playlist->sequence()->repeat_mode() == PlaylistSequence::Repeat_Intro) {
       emit IntroPointReached();
@@ -2727,10 +2734,10 @@ void MainWindow::keyPressEvent(QKeyEvent* event) {
     app_->player()->PlayPause();
     event->accept();
   } else if (event->key() == Qt::Key_Left) {
-    ui_->track_slider->Seek(-1);
+    app_->player()->SeekBackward();
     event->accept();
   } else if (event->key() == Qt::Key_Right) {
-    ui_->track_slider->Seek(1);
+    app_->player()->SeekForward();
     event->accept();
   } else {
     QMainWindow::keyPressEvent(event);

--- a/src/widgets/trackslider.cpp
+++ b/src/widgets/trackslider.cpp
@@ -47,6 +47,8 @@ TrackSlider::TrackSlider(QWidget* parent)
 
   connect(ui_->slider, SIGNAL(sliderMoved(int)), SIGNAL(ValueChanged(int)));
   connect(ui_->slider, SIGNAL(valueChanged(int)), SLOT(ValueMaybeChanged(int)));
+  connect(ui_->slider, SIGNAL(SeekForward()), SIGNAL(SeekForward()));
+  connect(ui_->slider, SIGNAL(SeekBackward()), SIGNAL(SeekBackward()));
   connect(ui_->remaining, SIGNAL(Clicked()), SLOT(ToggleTimeDisplay()));
 }
 

--- a/src/widgets/trackslider.h
+++ b/src/widgets/trackslider.h
@@ -55,6 +55,9 @@ signals:
   void ValueChanged(int value);
   void ValueChangedSeconds(int value);
 
+  void SeekForward();
+  void SeekBackward();
+
  private slots:
   void ValueMaybeChanged(int value);
   void ToggleTimeDisplay();

--- a/src/widgets/tracksliderslider.cpp
+++ b/src/widgets/tracksliderslider.cpp
@@ -100,10 +100,10 @@ void TrackSliderSlider::leaveEvent(QEvent* e) {
 
 void TrackSliderSlider::keyPressEvent(QKeyEvent* event) {
   if (event->key() == Qt::Key_Left || event->key() == Qt::Key_Down) {
-    if (isEnabled()) setValue(value() - 1 * kMsecPerSec);
+    emit SeekBackward();
     event->accept();
   } else if (event->key() == Qt::Key_Right || event->key() == Qt::Key_Up) {
-    if (isEnabled()) setValue(value() + 1 * kMsecPerSec);
+    emit SeekForward();
     event->accept();
   } else {
     QSlider::keyPressEvent(event);

--- a/src/widgets/tracksliderslider.cpp
+++ b/src/widgets/tracksliderslider.cpp
@@ -98,6 +98,18 @@ void TrackSliderSlider::leaveEvent(QEvent* e) {
   popup_->hide();
 }
 
+void TrackSliderSlider::keyPressEvent(QKeyEvent* event) {
+  if (event->key() == Qt::Key_Left || event->key() == Qt::Key_Down) {
+    if (isEnabled()) setValue(value() - 1 * kMsecPerSec);
+    event->accept();
+  } else if (event->key() == Qt::Key_Right || event->key() == Qt::Key_Up) {
+    if (isEnabled()) setValue(value() + 1 * kMsecPerSec);
+    event->accept();
+  } else {
+    QSlider::keyPressEvent(event);
+  }
+}
+
 void TrackSliderSlider::UpdateDeltaTime() {
   if (popup_->isVisible()) {
     int delta_seconds = mouse_hover_seconds_ - (value() / kMsecPerSec);

--- a/src/widgets/tracksliderslider.h
+++ b/src/widgets/tracksliderslider.h
@@ -35,6 +35,7 @@ class TrackSliderSlider : public QSlider {
   void mouseMoveEvent(QMouseEvent* e);
   void enterEvent(QEvent*);
   void leaveEvent(QEvent*);
+  void keyPressEvent(QKeyEvent* event);
 
  private slots:
   void UpdateDeltaTime();

--- a/src/widgets/tracksliderslider.h
+++ b/src/widgets/tracksliderslider.h
@@ -29,6 +29,10 @@ class TrackSliderSlider : public QSlider {
  public:
   TrackSliderSlider(QWidget* parent = nullptr);
 
+signals:
+  void SeekForward();
+  void SeekBackward();
+
  protected:
   void mousePressEvent(QMouseEvent* e);
   void mouseReleaseEvent(QMouseEvent* e);


### PR DESCRIPTION
Seeking using arrow keys behaved differently depending on which widget received the keypress event.

It may be a good idea to define a constant with the number of seconds to seek instead of using a hardcoded 1.