### PR TITLE
[Qt5] Fix log messages (lines and classname)

### DIFF
--- a/ext/libclementine-common/core/logging.cpp
+++ b/ext/libclementine-common/core/logging.cpp
@@ -267,21 +267,21 @@ void DumpStackTrace() {
 #endif
 }
 
-QDebug CreateLoggerFatal() { return qCreateLogger(Fatal); }
-QDebug CreateLoggerError() { return qCreateLogger(Error); }
+QDebug CreateLoggerFatal(int line, const char *class_name) { return qCreateLogger(line, class_name, Fatal); }
+QDebug CreateLoggerError(int line, const char *class_name) { return qCreateLogger(line, class_name, Error); }
 
 #ifdef QT_NO_WARNING_OUTPUT
-QNoDebug CreateLoggerWarning() { return QNoDebug(); }
+QNoDebug CreateLoggerWarning(int, const char*) { return QNoDebug(); }
 #else
-QDebug CreateLoggerWarning() { return qCreateLogger(Warning); }
+QDebug CreateLoggerWarning(int line, const char *class_name) { return qCreateLogger(line, class_name, Warning); }
 #endif // QT_NO_WARNING_OUTPUT
 
 #ifdef QT_NO_DEBUG_OUTPUT
-QNoDebug CreateLoggerInfo() { return QNoDebug(); }
-QNoDebug CreateLoggerDebug() { return QNoDebug(); }
+QNoDebug CreateLoggerInfo(int, const char*) { return QNoDebug(); }
+QNoDebug CreateLoggerDebug(int, const char*) { return QNoDebug(); }
 #else
-QDebug CreateLoggerInfo() { return qCreateLogger(Info); }
-QDebug CreateLoggerDebug() { return qCreateLogger(Debug); }
+QDebug CreateLoggerInfo(int line, const char *class_name) { return qCreateLogger(line, class_name, Info); }
+QDebug CreateLoggerDebug(int line, const char *class_name) { return qCreateLogger(line, class_name, Debug); }
 #endif // QT_NO_DEBUG_OUTPUT
 
 }  // namespace logging

--- a/ext/libclementine-common/core/logging.h
+++ b/ext/libclementine-common/core/logging.h
@@ -29,12 +29,12 @@
 #else
 
 #define qLog(level) \
-  logging::CreateLogger##level()
+  logging::CreateLogger##level(__LINE__, __PRETTY_FUNCTION__)
 
-#define qCreateLogger(level) \
+#define qCreateLogger(line, class_name, level) \
   logging::CreateLogger(logging::Level_##level,                            \
-                        logging::ParsePrettyFunction(__PRETTY_FUNCTION__), \
-                        __LINE__)
+                        logging::ParsePrettyFunction(class_name), \
+                        line)
 
 #endif // QT_NO_DEBUG_STREAM
 
@@ -61,21 +61,21 @@ void DumpStackTrace();
 QString ParsePrettyFunction(const char* pretty_function);
 QDebug CreateLogger(Level level, const QString& class_name, int line);
 
-QDebug CreateLoggerFatal();
-QDebug CreateLoggerError();
+QDebug CreateLoggerFatal(int line, const char* class_name);
+QDebug CreateLoggerError(int line, const char* class_name);
 
 #ifdef QT_NO_WARNING_OUTPUT
-QNoDebug CreateLoggerWarning();
+QNoDebug CreateLoggerWarning(int, const char*);
 #else
-QDebug CreateLoggerWarning();
+QDebug CreateLoggerWarning(int line, const char* class_name);
 #endif // QT_NO_WARNING_OUTPUT
 
 #ifdef QT_NO_DEBUG_OUTPUT
-QNoDebug CreateLoggerInfo();
-QNoDebug CreateLoggerDebug();
+QNoDebug CreateLoggerInfo(int, const char*);
+QNoDebug CreateLoggerDebug(int, const char*);
 #else
-QDebug CreateLoggerInfo();
-QDebug CreateLoggerDebug();
+QDebug CreateLoggerInfo(int line, const char* class_name);
+QDebug CreateLoggerDebug(int line, const char* class_name);
 #endif // QT_NO_DEBUG_OUTPUT
 
 

--- a/src/smartplaylists/searchtermwidget.cpp
+++ b/src/smartplaylists/searchtermwidget.cpp
@@ -363,7 +363,7 @@ void SearchTermWidget::Overlay::Grab() {
   hide();
 
   // Take a "screenshot" of the window
-  QPixmap pixmap = QPixmap::grabWidget(parent_);
+  QPixmap pixmap = parent_->grab();
   QImage image = pixmap.toImage();
 
   // Blur it


### PR DESCRIPTION
Keep in mind the line where the macro is called and we log to print it.