### PR TITLE
Send album artist to Last.fm

### DIFF
--- a/src/core/song.cpp
+++ b/src/core/song.cpp
@@ -998,6 +998,7 @@ void Song::ToLastFM(lastfm::Track* track, bool prefer_album_artist) const {
   } else {
     mtrack.setArtist(d->artist_);
   }
+  mtrack.setAlbumArtist(d->albumartist_);
   mtrack.setAlbum(d->album_);
   mtrack.setTitle(d->title_);
   mtrack.setDuration(length_nanosec() / kNsecPerSec);


### PR DESCRIPTION
This was reverted in 1f97406171eb82027fd2bec73514e497f3df7eee, but like I commented there, MutableTrack::setAlbumArtist is supported by the latest version of liblastfm, as well as all versions since at least 1.0.0, released Jun 11, 2012.

My guess is that @hatstand was using an old version of liblastfm.

Issue: #4354
Original PR: #4363