### PR TITLE
Send album artist to Last.fm

### DIFF
--- a/src/core/song.cpp
+++ b/src/core/song.cpp
@@ -998,6 +998,9 @@ void Song::ToLastFM(lastfm::Track* track, bool prefer_album_artist) const {
   } else {
     mtrack.setArtist(d->artist_);
   }
+#if LASTFM_MAJOR_VERSION >= 1
+  mtrack.setAlbumArtist(d->albumartist_);
+#endif
   mtrack.setAlbum(d->album_);
   mtrack.setTitle(d->title_);
   mtrack.setDuration(length_nanosec() / kNsecPerSec);


### PR DESCRIPTION
Previous attempt: #4934

Older versions of liblastfm do not support this, so it is only enabled
when compiling with liblastfm >= 1.0.0.

I checked the source of [liblastfm 0.4.0~really0.3.3-0ubuntu1](https://launchpad.net/ubuntu/+archive/primary/+files/liblastfm_0.4.0~really0.3.3.orig.tar.gz) and it does have
```C
#define LASTFM_MAJOR_VERSION 0
```
so this time everything should work properly.