### PR TITLE
Fix Pretty OSD positioning on Windows

### DIFF
--- a/src/widgets/osdpretty.cpp
+++ b/src/widgets/osdpretty.cpp
@@ -317,8 +317,14 @@ void OSDPretty::Reposition() {
   int y = popup_pos_.y() < 0 ? geometry.bottom() - height()
                              : geometry.top() + popup_pos_.y();
 
-  move(qBound(0, x, geometry.right() - width()),
-       qBound(0, y, geometry.bottom() - height()));
+#ifndef Q_OS_WIN32
+  // windows needs negative coordinates for monitors
+  // to the left or above the primary
+  x = qBound(0, x, geometry.right() - width());
+  y = qBound(0, y, geometry.bottom() - height());
+#endif
+
+  move(x, y);
 
   // Create a mask for the actual area of the OSD
   QBitmap mask(size());


### PR DESCRIPTION
Fixes #1218
Windows uses the primary monitor as the origin for coordinates, so any monitor to the left or above the primary uses negative coordinates. This would cause the OSD to always be displayed on the primary as the negative values would be set to 0.