### PR TITLE
Fix echonest qt5 compilation issues with different GNU/Linux distributions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,7 +371,7 @@ else (USE_SYSTEM_QXT)
   endif (NOT APPLE)
 endif (USE_SYSTEM_QXT)
 
-find_path(ECHONEST5_INCLUDE_DIRS echonest5/echonest_export.h)
+find_path(ECHONEST5_INCLUDE_DIRS Artist.h PATH_SUFFIXES echonest5 echonest)
 find_library(ECHONEST5_LIBRARIES echonest5)
 
 # Use system gmock if it's available

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,7 +76,7 @@
 #include <glib.h>
 #include <gst/gst.h>
 
-#include <echonest5/Config.h>
+#include <Config.h>
 
 #ifdef Q_OS_DARWIN
 #include <sys/resource.h>

--- a/src/songinfo/echonestbiographies.cpp
+++ b/src/songinfo/echonestbiographies.cpp
@@ -19,7 +19,7 @@
 
 #include <memory>
 
-#include <echonest5/Artist.h>
+#include <Artist.h>
 
 #include "songinfotextview.h"
 #include "core/logging.h"

--- a/src/songinfo/echonestimages.cpp
+++ b/src/songinfo/echonestimages.cpp
@@ -19,7 +19,7 @@
 
 #include <memory>
 
-#include <echonest5/Artist.h>
+#include <Artist.h>
 
 #include "core/logging.h"
 

--- a/src/songinfo/echonestsimilarartists.cpp
+++ b/src/songinfo/echonestsimilarartists.cpp
@@ -20,7 +20,7 @@
 #include "core/logging.h"
 #include "ui/iconloader.h"
 
-#include <echonest5/Artist.h>
+#include <Artist.h>
 
 Q_DECLARE_METATYPE(QVector<QString>);
 

--- a/src/songinfo/echonesttags.cpp
+++ b/src/songinfo/echonesttags.cpp
@@ -19,7 +19,7 @@
 
 #include <memory>
 
-#include <echonest5/Artist.h>
+#include <Artist.h>
 
 #include "tagwidget.h"
 #include "core/logging.h"

--- a/src/songinfo/songkickconcerts.cpp
+++ b/src/songinfo/songkickconcerts.cpp
@@ -24,7 +24,7 @@
 #include <QJsonObject>
 #include <QJsonArray>
 
-#include <echonest5/Artist.h>
+#include <Artist.h>
 
 #include "core/closure.h"
 #include "core/logging.h"


### PR DESCRIPTION
Unfortunately I didn't find a more elegant solution.

Closes https://github.com/clementine-player/Clementine/issues/4941