### PR TITLE
Add sample rate selection

### DIFF
--- a/src/engines/gstengine.cpp
+++ b/src/engines/gstengine.cpp
@@ -103,6 +103,7 @@ GstEngine::GstEngine(TaskManager* task_manager)
       buffer_duration_nanosec_(1 * kNsecPerSec),  // 1s
       buffer_min_fill_(33),
       mono_playback_(false),
+      sample_rate_(kAutoSampleRate),
       seek_timer_(new QTimer(this)),
       timer_id_(-1),
       next_element_id_(0),
@@ -204,6 +205,7 @@ void GstEngine::ReloadSettings() {
   buffer_min_fill_ = s.value("bufferminfill", 33).toInt();
 
   mono_playback_ = s.value("monoplayback", false).toBool();
+  sample_rate_ = s.value("samplerate", kAutoSampleRate).toInt();
 }
 
 qint64 GstEngine::position_nanosec() const {
@@ -788,6 +790,7 @@ shared_ptr<GstEnginePipeline> GstEngine::CreatePipeline() {
   ret->set_buffer_duration_nanosec(buffer_duration_nanosec_);
   ret->set_buffer_min_fill(buffer_min_fill_);
   ret->set_mono_playback(mono_playback_);
+  ret->set_sample_rate(sample_rate_);
 
   ret->AddBufferConsumer(this);
   for (BufferConsumer* consumer : buffer_consumers_) {

--- a/src/engines/gstengine.h
+++ b/src/engines/gstengine.h
@@ -47,9 +47,8 @@ class TaskManager;
 
 #ifdef Q_OS_DARWIN
 struct _GTlsDatabase;
-typedef struct _GTlsDatabase  GTlsDatabase;
+typedef struct _GTlsDatabase GTlsDatabase;
 #endif
-
 
 /**
  * @class GstEngine
@@ -72,6 +71,7 @@ class GstEngine : public Engine::Base, public BufferConsumer {
   };
   typedef QList<OutputDetails> OutputDetailsList;
 
+  static const int kAutoSampleRate = -1;
   static const char* kSettingsGroup;
   static const char* kAutoSink;
 
@@ -216,6 +216,7 @@ class GstEngine : public Engine::Base, public BufferConsumer {
   int buffer_min_fill_;
 
   bool mono_playback_;
+  int sample_rate_;
 
   mutable bool can_decode_success_;
   mutable bool can_decode_last_;

--- a/src/engines/gstenginepipeline.h
+++ b/src/engines/gstenginepipeline.h
@@ -55,6 +55,7 @@ class GstEnginePipeline : public QObject {
   void set_buffer_duration_nanosec(qint64 duration_nanosec);
   void set_buffer_min_fill(int percent);
   void set_mono_playback(bool enabled);
+  void set_sample_rate(int rate);
 
   // Creates the pipeline, returns false on error
   bool InitFromUrl(const QUrl& url, qint64 end_nanosec);
@@ -220,6 +221,7 @@ signals:
   bool buffering_;
 
   bool mono_playback_;
+  int sample_rate_;
 
   // The URL that is currently playing, and the URL that is to be preloaded
   // when the current track is close to finishing.

--- a/src/ui/playbacksettingspage.cpp
+++ b/src/ui/playbacksettingspage.cpp
@@ -43,6 +43,12 @@ PlaybackSettingsPage::PlaybackSettingsPage(SettingsDialog* dialog)
   ui_->replaygain_preamp_label->setMinimumWidth(
       QFontMetrics(ui_->replaygain_preamp_label->font()).width("-WW.W dB"));
   RgPreampChanged(ui_->replaygain_preamp->value());
+
+  ui_->sample_rate->setItemData(0, GstEngine::kAutoSampleRate);
+  ui_->sample_rate->setItemData(1, 44100);
+  ui_->sample_rate->setItemData(2, 48000);
+  ui_->sample_rate->setItemData(3, 96000);
+  ui_->sample_rate->setItemData(4, 192000);
 }
 
 PlaybackSettingsPage::~PlaybackSettingsPage() { delete ui_; }
@@ -60,8 +66,8 @@ void PlaybackSettingsPage::Load() {
       components.removeLast();
     }
 
-    ui_->gst_output->addItem(
-        icon, output.description, QVariant::fromValue(output));
+    ui_->gst_output->addItem(icon, output.description,
+                             QVariant::fromValue(output));
   }
 
   QSettings s;
@@ -107,6 +113,8 @@ void PlaybackSettingsPage::Load() {
       s.value("rgcompression", true).toBool());
   ui_->buffer_duration->setValue(s.value("bufferduration", 4000).toInt());
   ui_->mono_playback->setChecked(s.value("monoplayback", false).toBool());
+  ui_->sample_rate->setCurrentIndex(ui_->sample_rate->findData(
+      s.value("samplerate", GstEngine::kAutoSampleRate).toInt()));
   ui_->buffer_min_fill->setValue(s.value("bufferminfill", 33).toInt());
   s.endGroup();
 }
@@ -130,7 +138,7 @@ void PlaybackSettingsPage::Save() {
 
   GstEngine::OutputDetails details =
       ui_->gst_output->itemData(ui_->gst_output->currentIndex())
-      .value<GstEngine::OutputDetails>();
+          .value<GstEngine::OutputDetails>();
 
   s.beginGroup(GstEngine::kSettingsGroup);
   s.setValue("sink", details.gstreamer_plugin_name);
@@ -141,6 +149,9 @@ void PlaybackSettingsPage::Save() {
   s.setValue("rgcompression", ui_->replaygain_compression->isChecked());
   s.setValue("bufferduration", ui_->buffer_duration->value());
   s.setValue("monoplayback", ui_->mono_playback->isChecked());
+  s.setValue(
+      "samplerate",
+      ui_->sample_rate->itemData(ui_->sample_rate->currentIndex()).toInt());
   s.setValue("bufferminfill", ui_->buffer_min_fill->value());
   s.endGroup();
 }

--- a/src/ui/playbacksettingspage.ui
+++ b/src/ui/playbacksettingspage.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>596</width>
-    <height>638</height>
+    <height>667</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -300,22 +300,12 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0" colspan="2">
-       <widget class="QCheckBox" name="mono_playback">
-        <property name="toolTip">
-         <string>Changing mono playback preference will be effective for the next playing songs</string>
-        </property>
-        <property name="text">
-         <string>Mono playback</string>
-        </property>
-       </widget>
-      </item>
       <item row="2" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>
          <widget class="QLabel" name="buffer_min_fill_value_label">
           <property name="text">
-           <string> </string>
+           <string/>
           </property>
          </widget>
         </item>
@@ -337,6 +327,87 @@
            <number>1</number>
           </property>
          </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="5" column="0" colspan="2">
+       <widget class="QCheckBox" name="mono_playback">
+        <property name="toolTip">
+         <string>Changing mono playback preference will be effective for the next playing songs</string>
+        </property>
+        <property name="text">
+         <string>Mono playback</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="sample_rate_label">
+        <property name="text">
+         <string>Sample Rate</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
+        <item>
+         <widget class="QComboBox" name="sample_rate">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Changes will take place when the next song starts playing</string>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
+          </property>
+          <item>
+           <property name="text">
+            <string>Auto</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>44,100Hz</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>48,000Hz</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>96,000Hz</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>192,000Hz</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
         </item>
        </layout>
       </item>


### PR DESCRIPTION
This is meant to be a feature, but it also triages #4189, #4748, #4613?

This change provides the ability to set a fixed pipeline sample rate as an alternate to automatically negotiating it (the default). This can be useful on systems with sound cards that work at a fixed rate, as well as it can triage issues where changing tracks hangs due to a problem with gstreamer's caps negotiation.

I've noticed myself that when transitioning between tracks with different sample rates on Windows, the pipeline will always hang on starting the next song. This seems to be gstreamer not negotiating the downstream caps for sample rate. In fact if you disable "exclusive mode" on your sound card in Windows, the pipeline cannot start at all without a set sample rate. I don't want to say this is *the* solution, but it at least stops all the hanging issues. Hopefully someone with more gstreamer experience can find the underlying issue - that is, if this is indeed an issue in Clementine, and not a bug in gstreamer.