### PR TITLE
Sonogram should stop scrolling when paused

### DIFF
--- a/src/analyzers/sonogram.cpp
+++ b/src/analyzers/sonogram.cpp
@@ -55,7 +55,7 @@ void Sonogram::psychedelicModeChanged(bool enabled) {
 }
 
 void Sonogram::analyze(QPainter& p, const Scope& s, bool new_frame) {
-  if (!new_frame) {
+  if (!new_frame || engine_->state() == Engine::Paused) {
     p.drawPixmap(0, 0, canvas_);
     return;
   }

--- a/src/analyzers/sonogram.h
+++ b/src/analyzers/sonogram.h
@@ -26,6 +26,7 @@
 #define ANALYZERS_SONOGRAM_H_
 
 #include "analyzerbase.h"
+#include "engines/enginebase.h"
 
 class Sonogram : public Analyzer::Base {
   Q_OBJECT


### PR DESCRIPTION
Fixes #755

All the other analysers stop, including nyan and rainbow, so sonogram should too.