### PR TITLE
mpris: Fix track not restarting when playing the first track on the…

### DIFF
--- a/src/core/mpris1.cpp
+++ b/src/core/mpris1.cpp
@@ -244,7 +244,8 @@ int Mpris1Player::GetCaps(Engine::State state) const {
     if (playlists->active()->next_row() != -1) {
       caps |= CAN_GO_NEXT;
     }
-    if (playlists->active()->previous_row() != -1) {
+    if (playlists->active()->previous_row() != -1 ||
+        app_->player()->PreviousWouldRestartTrack()) {
       caps |= CAN_GO_PREV;
     }
   }

--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -305,6 +305,13 @@ void Player::StopAfterCurrent() {
       app_->playlist_manager()->active()->current_row());
 }
 
+bool Player::PreviousWouldRestartTrack() const {
+  // Check if it has been over two seconds since previous button was pressed
+  return menu_previousmode_ == PreviousBehaviour_Restart &&
+         last_pressed_previous_.isValid() &&
+         last_pressed_previous_.secsTo(QDateTime::currentDateTime()) >= 2;
+}
+
 void Player::Previous() { PreviousItem(Engine::Manual); }
 
 void Player::PreviousItem(Engine::TrackChangeFlags change) {

--- a/src/core/player.h
+++ b/src/core/player.h
@@ -142,6 +142,8 @@ class Player : public PlayerInterface {
 
   const UrlHandler* HandlerForUrl(const QUrl& url) const;
 
+  bool PreviousWouldRestartTrack() const;
+
  public slots:
   void ReloadSettings();
 


### PR DESCRIPTION
…playlist and menu_previousmode setting is PreviousBehaviour_Restart.