### PR TITLE
Playlist sort by album considers disc and track numbers

### DIFF
--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -1402,8 +1402,18 @@ void Playlist::sort(int column, Qt::SortOrder order) {
   if (dynamic_playlist_ && current_item_index_.isValid())
     begin += current_item_index_.row() + 1;
 
-  qStableSort(begin, new_items.end(),
+  if (column == Column_Album) {
+    // When sorting by album, also take into account discs and tracks.
+      qStableSort(begin, new_items.end(),
+            std::bind(&Playlist::CompareItems, Column_Track, order, _1, _2));
+      qStableSort(begin, new_items.end(),
+            std::bind(&Playlist::CompareItems, Column_Disc, order, _1, _2));
+      qStableSort(begin, new_items.end(),
+            std::bind(&Playlist::CompareItems, Column_Album, order, _1, _2));
+  } else {
+        qStableSort(begin, new_items.end(),
               std::bind(&Playlist::CompareItems, column, order, _1, _2));
+  }
 
   undo_stack_->push(
       new PlaylistUndoCommands::SortItems(this, column, order, new_items));

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -1404,15 +1404,15 @@ void Playlist::sort(int column, Qt::SortOrder order) {
 
   if (column == Column_Album) {
     // When sorting by album, also take into account discs and tracks.
-      qStableSort(begin, new_items.end(),
-            std::bind(&Playlist::CompareItems, Column_Track, order, _1, _2));
-      qStableSort(begin, new_items.end(),
-            std::bind(&Playlist::CompareItems, Column_Disc, order, _1, _2));
-      qStableSort(begin, new_items.end(),
-            std::bind(&Playlist::CompareItems, Column_Album, order, _1, _2));
+    qStableSort(begin, new_items.end(), std::bind(&Playlist::CompareItems,
+                                                  Column_Track, order, _1, _2));
+    qStableSort(begin, new_items.end(),
+                std::bind(&Playlist::CompareItems, Column_Disc, order, _1, _2));
+    qStableSort(begin, new_items.end(), std::bind(&Playlist::CompareItems,
+                                                  Column_Album, order, _1, _2));
   } else {
-        qStableSort(begin, new_items.end(),
-              std::bind(&Playlist::CompareItems, column, order, _1, _2));
+    qStableSort(begin, new_items.end(),
+                std::bind(&Playlist::CompareItems, column, order, _1, _2));
   }
 
   undo_stack_->push(


### PR DESCRIPTION
When sorting the playlist by album, it also sorts by disc number and track number. That way multi-disk albums get their proper playing order.

This was requested in isues #2315 and #2317.

