### PR TITLE
Fixed #4091 - Reverted letras.mus.br to utf-8

### DIFF
--- a/data/lyrics/ultimate_providers.xml
+++ b/data/lyrics/ultimate_providers.xml
@@ -51,7 +51,7 @@
     <invalidIndicator value="&quot;iTotalRecords&quot;: 0"/>
     <invalidIndicator value="lyrics not available"/>
   </provider>
-  <provider name="letras.mus.br" title="" charset="iso-8859-1" url="http://letras.terra.com.br/winamp.php?musica={title}&amp;artista={artist}">
+  <provider name="letras.mus.br" title="" charset="utf-8" url="http://letras.terra.com.br/winamp.php?musica={title}&amp;artista={artist}">
     <urlFormat replace="_@,;&amp;\/&quot;" with="_"/>
     <urlFormat replace=" " with="+"/>
     <extract>

--- a/tools/ultimate_lyrics_parser/sites.js
+++ b/tools/ultimate_lyrics_parser/sites.js
@@ -377,7 +377,7 @@ const siteDescriptors = {
 		extract: [['</a>?','<div']]
 	},
 	"letras.mus.br": {
-		charset: "iso-8859-1",
+		charset: "utf-8",
 		url: "http://letras.terra.com.br/winamp.php?musica={title}&artista={artist}",
 		urlFormat : [
 			{rep: "_", punct: "_@,;&\\/\"" },


### PR DESCRIPTION
It seems that letras.mus.br is now always enconded in utf-8. For example, see: http://letras.mus.br/winamp.php?musica=non%C3%B4&artista=nara+le%C3%A3o+_+nelson+rufino

Therefore I switched the encodings to utf-8, fixing Issue #4091.