### PR TITLE
Fix time labels blinking when playing streams without known duration

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1317,8 +1317,6 @@ void MainWindow::UpdateTrackPosition() {
 
   if (length <= 0) {
     // Probably a stream that we don't know the length of
-    ui_->track_slider->SetStopped();
-    tray_icon_->SetProgress(0);
     return;
   }
 #ifdef HAVE_LIBLASTFM

--- a/src/widgets/trackslider.cpp
+++ b/src/widgets/trackslider.cpp
@@ -111,7 +111,8 @@ void TrackSlider::UpdateTimes(int elapsed) {
                                     elapsed));
   } else {
     // check if slider maximum value is changed before updating
-    if (slider_maximum_value_ != ui_->slider->maximum()) {
+    if (slider_maximum_value_ != ui_->slider->maximum() ||
+        !ui_->slider->isEnabled()) {
       slider_maximum_value_ = ui_->slider->maximum();
       ui_->remaining->setText(
           Utilities::PrettyTime((ui_->slider->maximum() / kMsecPerSec)));


### PR DESCRIPTION
Removed two extra lines from ui/mainwindow.cpp which actually causes the blinking.

The additional condition in widgets/trackslider.cpp is for preventing initially displaying the
"0:00:00" text on the "remaining time" label when you start to play streams without known duration
from the "Stop" player's state.
Closes #4990.