### PR TITLE
Add condition against nullptr dereferencing to AnalyzerContainer::TogglePsychedelicColors()

### DIFF
--- a/src/analyzers/analyzercontainer.cpp
+++ b/src/analyzers/analyzercontainer.cpp
@@ -153,7 +153,9 @@ void AnalyzerContainer::DisableAnalyzer() {
 
 void AnalyzerContainer::TogglePsychedelicColors() {
   psychedelic_colors_on_ = !psychedelic_colors_on_;
-  current_analyzer_->psychedelicModeChanged(psychedelic_colors_on_);
+  if (current_analyzer_) {
+    current_analyzer_->psychedelicModeChanged(psychedelic_colors_on_);
+  }
   SavePsychedelic();
 }
 


### PR DESCRIPTION
Clementine crashes when you try to toggle psychedelic colors with analyzer disabled.