### PR TITLE
Add custom hosts scrobbling support with libscrobbler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,9 +81,18 @@ if (WIN32)
   find_library(QTSPARKLE_LIBRARIES qtsparkle)
 endif (WIN32)
 
-find_library(LASTFM_LIBRARIES lastfm)
-find_path(LASTFM_INCLUDE_DIRS lastfm/ws.h)
-find_path(LASTFM1_INCLUDE_DIRS lastfm/Track.h)
+find_library(SCROBBLER_LIBRARIES scrobbler)
+
+if (NOT SCROBBLER_LIBRARIES)
+  find_library(LASTFM_LIBRARIES lastfm)
+  find_path(LASTFM_INCLUDE_DIRS lastfm/ws.h)
+  find_path(LASTFM1_INCLUDE_DIRS lastfm/Track.h)
+else()
+  set(LASTFM_LIBRARIES scrobbler)
+  find_path(LASTFM_INCLUDE_DIRS scrobbler/ws.h)
+  find_path(LASTFM1_INCLUDE_DIRS scrobbler/Track.h)
+  set(HAVE_LIBSCROBBLER ON)
+endif()
 
 find_path(SPARSEHASH_INCLUDE_DIRS google/sparsetable)
 
@@ -239,6 +248,10 @@ optional_component(LIBMTP ON "Devices: MTP support"
 
 optional_component(LIBLASTFM ON "Last.fm support"
   DEPENDS "liblastfm" LASTFM_LIBRARIES LASTFM_INCLUDE_DIRS
+)
+
+optional_component(LIBSCROBBLER ON "Custom scrobbling support"
+  DEPENDS "libscrobbler" SCROBBLER_LIBRARIES LASTFM_INCLUDE_DIRS
 )
 
 optional_component(DBUS ON "D-Bus support"

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -36,6 +36,7 @@
 #cmakedefine HAVE_LIBLASTFM1
 #cmakedefine HAVE_LIBMTP
 #cmakedefine HAVE_LIBPULSE
+#cmakedefine HAVE_LIBSCROBBLER
 #cmakedefine HAVE_MOODBAR
 #cmakedefine HAVE_SEAFILE
 #cmakedefine HAVE_SKYDRIVE

--- a/src/core/song.cpp
+++ b/src/core/song.cpp
@@ -44,11 +44,6 @@
 
 #ifdef HAVE_LIBLASTFM
 #include "internet/lastfm/fixlastfm.h"
-#ifdef HAVE_LIBLASTFM1
-#include <lastfm/Track.h>
-#else
-#include <lastfm/Track>
-#endif
 #endif
 
 #include <id3v1genres.h>
@@ -574,7 +569,7 @@ void Song::ToProtobuf(pb::tagreader::SongMetadata* pb) const {
   pb->set_filesize(d->filesize_);
   pb->set_suspicious_tags(d->suspicious_tags_);
   pb->set_art_automatic(DataCommaSizeFromQString(d->art_automatic_));
-  pb->set_type(static_cast< ::pb::tagreader::SongMetadata_Type>(d->filetype_));
+  pb->set_type(static_cast<::pb::tagreader::SongMetadata_Type>(d->filetype_));
 }
 
 void Song::InitFromQuery(const SqlRow& q, bool reliable_metadata, int col) {
@@ -970,7 +965,8 @@ void Song::BindToQuery(QSqlQuery* query) const {
   query->bindValue(":grouping", strval(d->grouping_));
   query->bindValue(":lyrics", strval(d->lyrics_));
   query->bindValue(":originalyear", intval(d->originalyear_));
-  query->bindValue(":effective_originalyear", intval(this->effective_originalyear()));
+  query->bindValue(":effective_originalyear",
+                   intval(this->effective_originalyear()));
 
 #undef intval
 #undef notnullintval
@@ -1073,9 +1069,9 @@ bool Song::IsMetadataEqual(const Song& other) const {
          d->performer_ == other.d->performer_ &&
          d->grouping_ == other.d->grouping_ && d->track_ == other.d->track_ &&
          d->disc_ == other.d->disc_ && qFuzzyCompare(d->bpm_, other.d->bpm_) &&
-         d->year_ == other.d->year_ && d->originalyear_ == other.d->originalyear_ &&
-         d->genre_ == other.d->genre_ &&
-         d->comment_ == other.d->comment_ &&
+         d->year_ == other.d->year_ &&
+         d->originalyear_ == other.d->originalyear_ &&
+         d->genre_ == other.d->genre_ && d->comment_ == other.d->comment_ &&
          d->compilation_ == other.d->compilation_ &&
          d->beginning_ == other.d->beginning_ &&
          length_nanosec() == other.length_nanosec() &&
@@ -1083,8 +1079,7 @@ bool Song::IsMetadataEqual(const Song& other) const {
          d->samplerate_ == other.d->samplerate_ &&
          d->art_automatic_ == other.d->art_automatic_ &&
          d->art_manual_ == other.d->art_manual_ &&
-         d->rating_ == other.d->rating_ &&
-         d->cue_path_ == other.d->cue_path_ &&
+         d->rating_ == other.d->rating_ && d->cue_path_ == other.d->cue_path_ &&
          d->lyrics_ == other.d->lyrics_;
 }
 

--- a/src/core/song.h
+++ b/src/core/song.h
@@ -38,6 +38,18 @@
 #include "config.h"
 #include "engines/engine_fwd.h"
 
+#ifdef HAVE_LIBLASTFM
+#ifdef HAVE_LIBSCROBBLER
+#include <scrobbler/Track.h>
+#else  // DO NOT HAVE LIBSCROBBLER
+#ifdef HAVE_LIBLASTFM1
+#include <lastfm/Track.h>
+#else  // DO NOT HAVE LIBLASTFM1
+#include <lastfm/Track>
+#endif
+#endif
+#endif
+
 namespace pb {
 namespace tagreader {
 class SongMetadata;
@@ -55,9 +67,9 @@ struct _Itdb_Track;
 struct LIBMTP_track_struct;
 #endif
 
-#ifdef HAVE_LIBLASTFM
+#ifdef HAVE_LIBSCROBBLER
 namespace lastfm {
-class Track;
+using namespace scrobbler;
 }
 #endif
 

--- a/src/internet/lastfm/lastfmcompat.h
+++ b/src/internet/lastfm/lastfmcompat.h
@@ -23,6 +23,15 @@
 #include "config.h"
 #include "fixlastfm.h"
 
+#ifdef HAVE_LIBSCROBBLER
+#include <scrobbler/Audioscrobbler.h>
+#include <scrobbler/misc.h>
+#include <scrobbler/ScrobbleCache.h>
+#include <scrobbler/ScrobblePoint.h>
+#include <scrobbler/User.h>
+#include <scrobbler/ws.h>
+#include <scrobbler/XmlQuery.h>
+#else  // DO NOT HAVE_LIBSCROBBLER
 #ifdef HAVE_LIBLASTFM1
 #include <lastfm/Audioscrobbler.h>
 #include <lastfm/misc.h>
@@ -31,7 +40,7 @@
 #include <lastfm/User.h>
 #include <lastfm/ws.h>
 #include <lastfm/XmlQuery.h>
-#else
+#else  // DO NOT HAVE_LIBLASTFM1
 #include <lastfm/Audioscrobbler>
 #include <lastfm/misc.h>
 #include <lastfm/ScrobbleCache>
@@ -39,9 +48,19 @@
 #include <lastfm/User>
 #include <lastfm/ws.h>
 #include <lastfm/XmlQuery>
-#endif
+#endif  // HAVE_LIBALASTFM1
+#endif  // HAVE_LIBSCROBBLER
 
 namespace lastfm {
+
+#ifdef HAVE_LIBSCROBBLER
+using namespace scrobbler;
+
+namespace ws {
+using namespace scrobbler::ws;
+}
+#endif
+
 namespace compat {
 
 lastfm::XmlQuery EmptyXmlQuery();

--- a/src/internet/lastfm/lastfmsettingspage.h
+++ b/src/internet/lastfm/lastfmsettingspage.h
@@ -40,6 +40,10 @@ class LastFMSettingsPage : public SettingsPage {
   void Login();
   void AuthenticationComplete(bool success, const QString& error_message);
   void Logout();
+#ifdef HAVE_LIBSCROBBLER
+  void AdvancedOptionsChanged(int state);
+  void AddHttpServer();
+#endif
 
  private:
   LastFMService* service_;

--- a/src/internet/lastfm/lastfmsettingspage.ui
+++ b/src/internet/lastfm/lastfmsettingspage.ui
@@ -26,10 +26,17 @@
       <property name="fieldGrowthPolicy">
        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
       </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_server">
+        <property name="text">
+         <string>Server</string>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
-         <string>Last.fm username</string>
+         <string>Username</string>
         </property>
        </widget>
       </item>
@@ -50,7 +57,7 @@
       <item row="2" column="0">
        <widget class="QLabel" name="label_3">
         <property name="text">
-         <string>Last.fm password</string>
+         <string>Password</string>
         </property>
        </widget>
       </item>
@@ -58,6 +65,20 @@
        <widget class="QLineEdit" name="password">
         <property name="echoMode">
          <enum>QLineEdit::Password</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="server">
+        <property name="placeholderText">
+         <string>Lastfm server if empty</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QCheckBox" name="advanced_options">
+        <property name="text">
+         <string>Show advanced options</string>
         </property>
        </widget>
       </item>
@@ -131,13 +152,17 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>server</tabstop>
   <tabstop>username</tabstop>
   <tabstop>password</tabstop>
-  <tabstop>login</tabstop>
+  <tabstop>advanced_options</tabstop>
   <tabstop>scrobble</tabstop>
   <tabstop>love_ban_</tabstop>
   <tabstop>scrobble_button</tabstop>
+  <tabstop>prefer_albumartist</tabstop>
+  <tabstop>login</tabstop>
  </tabstops>
  <resources/>
  <connections/>
 </ui>
+

--- a/src/songinfo/lastfmtrackinfoprovider.h
+++ b/src/songinfo/lastfmtrackinfoprovider.h
@@ -20,9 +20,16 @@
 
 #include "songinfoprovider.h"
 
+#ifdef HAVE_LIBSCROBBLER
+#include <scrobbler/XmlQuery.h>
+namespace lastfm {
+using scrobbler::XmlQuery;
+}
+#else
 namespace lastfm {
 class XmlQuery;
 }
+#endif
 
 class QNetworkReply;
 


### PR DESCRIPTION
Liblastfm doesn't seem to want to merge my PR which add the ability to customize the host and thus use libre.fm. I emailed them but nothing changed. So I forked the library and renamed lastfm to scrobbler (https://github.com/Chocobozzz/libscrobbler). I added this library to the AUR. This is now the choice of packagers/users to compile with liblastfm or libscrobbler. 

This PR adds support of libscrobbler. If Clementine compiles with liblastfm it doesn't allow to modify the scrobbler host. If it compiles with libscrobbler the user can edit the host (by default it always use lastfm host).

