### PR TITLE
Fixed default settings for double clicking a playlist

### DIFF
--- a/src/ui/behavioursettingspage.cpp
+++ b/src/ui/behavioursettingspage.cpp
@@ -132,7 +132,7 @@ void BehaviourSettingsPage::Load() {
   ui_->doubleclick_playlist_playmode->setCurrentIndex(
       ui_->doubleclick_playlist_playmode->findData(
           s.value("doubleclick_playlist_playmode",
-                  MainWindow::PlaylistPlayBehaviour_IfStopped).toInt()));
+                  MainWindow::PlaylistPlayBehaviour_Always).toInt()));
   ui_->menu_playmode->setCurrentIndex(ui_->menu_playmode->findData(
       s.value("menu_playmode", MainWindow::PlayBehaviour_IfStopped).toInt()));
 


### PR DESCRIPTION
This is a very small change that should fix the unexpectedly changed default settings as pointed out [in the prior pull request](https://github.com/clementine-player/Clementine/pull/4991#issuecomment-136908074).