### PR TITLE
volume text color palette

### DIFF
--- a/src/widgets/sliderwidget.cpp
+++ b/src/widgets/sliderwidget.cpp
@@ -309,9 +309,9 @@ void Amarok::VolumeSlider::paintEvent(QPaintEvent*) {
   // Draw percentage number
   QStyleOptionViewItem opt;
   p.setPen(opt.palette.color(QPalette::Disabled, QPalette::Text));
-  QFont font;
-  font.setPixelSize(9);
-  p.setFont(font);
+  QFont vol_font(opt.font);
+  vol_font.setPixelSize(9);
+  p.setFont(vol_font);
   const QRect rect(0, 0, 34, 15);
   p.drawText(rect, Qt::AlignRight | Qt::AlignVCenter,
              QString::number(value()) + '%');

--- a/src/widgets/sliderwidget.cpp
+++ b/src/widgets/sliderwidget.cpp
@@ -307,7 +307,8 @@ void Amarok::VolumeSlider::paintEvent(QPaintEvent*) {
                m_handlePixmaps[m_animCount]);
 
   // Draw percentage number
-  p.setPen(palette().color(QPalette::Disabled, QPalette::Text).dark());
+  QStyleOptionViewItem opt;
+  p.setPen(opt.palette.color(QPalette::Disabled, QPalette::Text));
   QFont font;
   font.setPixelSize(9);
   p.setFont(font);


### PR DESCRIPTION
This modification makes the volume percentage text color match general text color.
![untitled](https://cloud.githubusercontent.com/assets/11949260/9793829/28977bf6-57ad-11e5-9324-abb96f15be9d.png)
