### PR TITLE
Use "title" field for name if "text" is empty in OPML when importing podcast list.

### DIFF
--- a/src/internet/podcasts/podcastparser.cpp
+++ b/src/internet/podcasts/podcastparser.cpp
@@ -291,7 +291,13 @@ void PodcastParser::ParseOutline(QXmlStreamReader* reader,
           // Parse the feed and add it to this container
           Podcast podcast;
           podcast.set_description(attributes.value("description").toString());
-          podcast.set_title(attributes.value("text").toString());
+          QString title = attributes.value("text").toString();
+          // The OPML 2.0 specification requires a "text" attribute. Some
+          // applications, however, will leave this empty if "title" exists.
+          if (title.isEmpty()) {
+             title = attributes.value("title").toString();
+          }
+          podcast.set_title(title);
           podcast.set_image_url_large(QUrl::fromEncoded(
               attributes.value("imageHref").toString().toAscii()));
           podcast.set_url(QUrl::fromEncoded(


### PR DESCRIPTION
Some applications (example: gpodder) omit the "text" attribute if "title" exists when exporting OPML. If the "text" attribute does not exist, then try "title".