### PR TITLE
Fixes for songinfo/lyrics

### DIFF
--- a/src/songinfo/songinfotextview.cpp
+++ b/src/songinfo/songinfotextview.cpp
@@ -79,9 +79,12 @@ void SongInfoTextView::contextMenuEvent(QContextMenuEvent* e) {
 void SongInfoTextView::SetHtml(const QString& html) {
   QString copy(html.trimmed());
 
-  // Simplify newlines, and convert them to <p>
-  copy.replace(QRegExp("[\\r\\n]+"), "\n");
-  copy.replace(QRegExp("([^>])[\\t ]*\\n"), "\\1<p>");
+  // Simplify newlines
+  copy.replace(QRegExp("\\r\\n?"), "\n");
+
+  // Convert two or more newlines to <p>, convert single newlines to <br>
+  copy.replace(QRegExp("([^>])([\\t ]*\\n){2,}"), "\\1<p>");
+  copy.replace(QRegExp("([^>])[\\t ]*\\n"), "\\1<br>");
 
   // Strip any newlines from the end
   copy.replace(QRegExp("((<\\s*br\\s*/?\\s*>)|(<\\s*/?\\s*p\\s*/?\\s*>))+$"),

--- a/src/songinfo/ultimatelyricslyric.cpp
+++ b/src/songinfo/ultimatelyricslyric.cpp
@@ -25,9 +25,12 @@ UltimateLyricsLyric::UltimateLyricsLyric(QObject* parent)
 void UltimateLyricsLyric::SetHtml(const QString& html) {
   QString copy(html.trimmed());
 
-  // Simplify newlines, and convert them to <p>
-  copy.replace(QRegExp("[\\r\\n]+"), "\n");
-  copy.replace(QRegExp("([^>])[\\t ]*\\n"), "\\1<p>");
+  // Simplify newlines
+  copy.replace(QRegExp("\\r\\n?"), "\n");
+
+  // Convert two or more newlines to <p>, convert single newlines to <br>
+  copy.replace(QRegExp("([^>])([\\t ]*\\n){2,}"), "\\1<p>");
+  copy.replace(QRegExp("([^>])[\\t ]*\\n"), "\\1<br>");
 
   // Strip any newlines from the end
   copy.replace(QRegExp("((<\\s*br\\s*/?\\s*>)|(<\\s*/?\\s*p\\s*/?\\s*>))+$"),

--- a/src/songinfo/ultimatelyricsprovider.cpp
+++ b/src/songinfo/ultimatelyricsprovider.cpp
@@ -223,7 +223,7 @@ QString UltimateLyricsProvider::Extract(const QString& source,
   int end_idx = source.indexOf(end, begin_idx);
   if (end_idx == -1) return QString();
 
-  return source.mid(begin_idx, end_idx - begin_idx - 1);
+  return source.mid(begin_idx, end_idx - begin_idx);
 }
 
 void UltimateLyricsProvider::ApplyExcludeRule(const Rule& rule,


### PR DESCRIPTION
This changes the way we try to intelligently convert `\n` to `<p>` in song/artist info views (see [discussion](https://github.com/clementine-player/Clementine/commit/c35ba55e750a0824bd3f32da8c22b4c380dfffbd#commitcomment-13451549)):
Two or more newlines are converted to `<p>`, a single newline is converted to `<br>`.

Also an indexing error is fixed that cut the last character of the extracted content.