### PR TITLE
Show track durations in the CD ripper dialog.

### DIFF
--- a/src/ripper/ripcddialog.cpp
+++ b/src/ripper/ripcddialog.cpp
@@ -17,7 +17,6 @@
 
 #include "ripper/ripcddialog.h"
 
-#include <cdio/cdio.h>
 #include <QCheckBox>
 #include <QFileDialog>
 #include <QFileInfo>
@@ -44,6 +43,7 @@ bool ComparePresetsByName(const TranscoderPreset& left,
 const int kCheckboxColumn = 0;
 const int kTrackNumberColumn = 1;
 const int kTrackTitleColumn = 2;
+const int kTrackDurationColumn = 3;
 }
 
 const char* RipCDDialog::kSettingsGroup = "Transcoder";
@@ -271,6 +271,10 @@ void RipCDDialog::BuildTrackListTable() {
     track_names_.append(line_edit_track_title_i);
     ui_->tableWidget->setCellWidget(i - 1, kTrackTitleColumn,
                                     line_edit_track_title_i);
+    QString track_duration =
+        Utilities::PrettyTime(ripper_->TrackDurationSecs(i));
+    ui_->tableWidget->setCellWidget(i - 1, kTrackDurationColumn,
+                                    new QLabel(track_duration));
   }
 }
 

--- a/src/ripper/ripper.cpp
+++ b/src/ripper/ripper.cpp
@@ -86,6 +86,19 @@ int Ripper::TracksOnDisc() const {
   return number_of_tracks;
 }
 
+int Ripper::TrackDurationSecs(int track) const {
+  Q_ASSERT(track <= TracksOnDisc());
+
+  int first_frame = cdio_get_track_lsn(cdio_, track);
+  int last_frame = cdio_get_track_last_lsn(cdio_, track);
+  if (first_frame != CDIO_INVALID_LSN && last_frame != CDIO_INVALID_LSN) {
+    return (last_frame - first_frame + 1) / CDIO_CD_FRAMES_PER_SEC;
+  } else {
+    qLog(Error) << "Could not compute duration of track" << track;
+    return 0;
+  }
+}
+
 int Ripper::AddedTracks() const { return tracks_.length(); }
 
 void Ripper::ClearTracks() { tracks_.clear(); }

--- a/src/ripper/ripper.h
+++ b/src/ripper/ripper.h
@@ -55,6 +55,8 @@ class Ripper : public QObject {
                            Song::FileType type);
   // Returns the number of audio tracks on the disc.
   int TracksOnDisc() const;
+  // Returns the duration of the track or 0 on error.
+  int TrackDurationSecs(int track) const;
   // Returns the number of tracks added to the rip list.
   int AddedTracks() const;
   // Clears the rip list.


### PR DESCRIPTION
The duration in seconds is computed using integer division which should be close enough.