### PR TITLE
Remove arrow indicators from mainwindow repeat & shuffle QToolButtons

### DIFF
--- a/src/playlist/playlistsequence.cpp
+++ b/src/playlist/playlistsequence.cpp
@@ -45,6 +45,10 @@ PlaylistSequence::PlaylistSequence(QWidget* parent, SettingsProvider* settings)
   ui_->shuffle->setIcon(
       AddDesaturatedIcon(IconLoader::Load("media-playlist-shuffle", IconLoader::Base)));
 
+  // Remove arrow indicators
+  ui_->repeat->setStyleSheet("QToolButton::menu-indicator { image: none; }");
+  ui_->shuffle->setStyleSheet("QToolButton::menu-indicator { image: none; }");
+
   settings_->set_group(kSettingsGroup);
 
   QActionGroup* repeat_group = new QActionGroup(this);


### PR DESCRIPTION
before 
![snapshot39](https://cloud.githubusercontent.com/assets/11949260/11237535/3352d5d4-8da6-11e5-9847-680625f8ddf7.png)
![screenshot_2015_11_18_03_38_42](https://cloud.githubusercontent.com/assets/11949260/11237541/39b05f6e-8da6-11e5-9657-d8721b0ce368.png)
(some indicators are even worse)

after
![snapshot38](https://cloud.githubusercontent.com/assets/11949260/11237560/4eb2e544-8da6-11e5-9592-5fbcc659473a.png)
