### PR TITLE
Respawn mainwindow on correct monitor

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -903,14 +903,13 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
   qLog(Debug) << "Loading settings";
   settings_.beginGroup(kSettingsGroup);
 
-  // Set window Geometry if the window was closed in normal mode
-  // else set it to window maximized
+  // Set last used geometry to position window on the correct monitor
+  // Set window state only if the window was last maximized
   was_maximized_ = settings_.value("maximized", false).toBool();
-  if (!was_maximized_) {
-    restoreGeometry(settings_.value("geometry").toByteArray());    
-  } else {
+  restoreGeometry(settings_.value("geometry").toByteArray());
+  if (was_maximized_) {
     setWindowState(windowState() | Qt::WindowMaximized);
-  } 
+  }
 
   if (!ui_->splitter->restoreState(
           settings_.value("splitter_state").toByteArray())) {


### PR DESCRIPTION
PR #5081 created a regression where the mainwindow will always start on the primary monitor regardless of which one it was closed on when maximized. This restores previous functionality.