### PR TITLE
Set next track as current when removing tracks

### DIFF
--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -1647,7 +1647,11 @@ PlaylistItemList Playlist::RemoveItemsWithoutUndo(int row, int count) {
 
   // Reset current_virtual_index_
   if (current_row() == -1)
-    current_virtual_index_ = -1;
+    if (row - 1 > 0 && row - 1 < items_.size()) {
+      current_virtual_index_ = virtual_items_.indexOf(row - 1);
+    } else {
+      current_virtual_index_ = -1;
+    }
   else
     current_virtual_index_ = virtual_items_.indexOf(current_row());
 


### PR DESCRIPTION
Fixes #5031
Attempt to set the song after the deleted tracks as the current so that they will play next rather than the beginning of the playlist.