### PR TITLE
Fix bug in edit tag dialog when fetching

### DIFF
--- a/src/musicbrainz/tagfetcher.cpp
+++ b/src/musicbrainz/tagfetcher.cpp
@@ -27,6 +27,9 @@
 #include <QUrl>
 #include <QtConcurrentMap>
 
+const std::array<QString, 5> TagFetcher::kFetchedFields{
+    {"title", "artist", "album", "track", "year"}};
+
 TagFetcher::TagFetcher(QObject* parent)
     : QObject(parent),
       fingerprint_watcher_(nullptr),

--- a/src/musicbrainz/tagfetcher.h
+++ b/src/musicbrainz/tagfetcher.h
@@ -24,6 +24,8 @@
 #include <QFutureWatcher>
 #include <QObject>
 
+#include <array>
+
 class AcoustidClient;
 
 class TagFetcher : public QObject {
@@ -33,6 +35,7 @@ class TagFetcher : public QObject {
   // MusicBrainzClient.
 
  public:
+  static const std::array<QString, 5> kFetchedFields;
   TagFetcher(QObject* parent = nullptr);
 
   void StartFetch(const SongList& songs);

--- a/src/ui/edittagdialog.cpp
+++ b/src/ui/edittagdialog.cpp
@@ -372,15 +372,11 @@ void EditTagDialog::InitFieldValue(const FieldData& field,
     editor->clear();
     editor->clear_hint();
     if (varies) {
-      qLog(Debug) << "set hint";
       editor->set_hint(tr(EditTagDialog::kHintText));
     } else {
-      qLog(Debug) << "Set " << field.id_ << " to "
-                  << data_[sel[0].row()].current_value(field.id_).toString();
       editor->set_text(data_[sel[0].row()].current_value(field.id_).toString());
     }
   }
-  if (modified) qLog(Debug) << "Bold font";
   QFont new_font(font());
   new_font.setBold(modified);
   field.label_->setFont(new_font);


### PR DESCRIPTION
Before: When only one song is selected and the tag fetcher returns the value a field already has, the value of the field gets erased. The reason for this became not 100% clear to me. This bug was introduced in #5094 

The changes prevent that a field gets updated when the value did not change. Furthermore the fields changed by the tag fetcher are no longer hard coded to allow easy extending and more readable code.