### PR TITLE
Add ampache=1 to getAlbum for playcounts

### DIFF
--- a/src/internet/subsonic/subsonicdynamicplaylist.cpp
+++ b/src/internet/subsonic/subsonicdynamicplaylist.cpp
@@ -158,6 +158,9 @@ void SubsonicDynamicPlaylist::GetAlbum(SubsonicService* service,
                                        const bool usesslv3) {
   QUrl url = service->BuildRequestUrl("getAlbum");
   url.addQueryItem("id", id);
+  if (service->IsAmpache()) {
+    url.addQueryItem("ampache", "1");
+  }
   QNetworkReply* reply = Send(network, url, usesslv3);
   WaitForSignal(reply, SIGNAL(finished()));
   reply->deleteLater();
@@ -220,6 +223,11 @@ void SubsonicDynamicPlaylist::GetAlbum(SubsonicService* service,
     song.set_directory_id(0);
     song.set_mtime(0);
     song.set_ctime(0);
+
+    if (reader.attributes().hasAttribute("playCount")) {
+      song.set_playcount(
+          reader.attributes().value("playCount").toString().toInt());
+    }
 
     list << std::shared_ptr<PlaylistItem>(
         new InternetPlaylistItem(service, song));

--- a/src/internet/subsonic/subsonicservice.h
+++ b/src/internet/subsonic/subsonicservice.h
@@ -87,6 +87,7 @@ class SubsonicService : public InternetService {
   typedef QMap<QString, QString> RequestOptions;
 
   bool IsConfigured() const;
+  bool IsAmpache() const;
 
   QStandardItem* CreateRootItem();
   void LazyPopulate(QStandardItem* item);
@@ -155,6 +156,7 @@ signals:
   LoginState login_state_;
   QString working_server_;  // The actual server, possibly post-redirect
   int redirect_count_;
+  bool is_ampache_;
 
  private slots:
   void UpdateTotalSongCount(int count);


### PR DESCRIPTION
- Ampache recently added support for returning playcounts, if the client
  reports that it knows it's talking to an ampache server:
  https://github.com/ampache/ampache/commit/1aaf01ae98de9fb92e3d46e2e94497830ac9740b

- This checks the type attribute on the ping request to see if
  Clementine is talking to an Ampache server, and if so, it adds
  ampache=1 to getAlbum requests, and uses the returned playcounts.