### PR TITLE
Avoiding usage of pixelMetric because it breaks on non-Oxygen styling

### DIFF
--- a/src/moodbar/moodbarproxystyle.h
+++ b/src/moodbar/moodbarproxystyle.h
@@ -79,10 +79,6 @@ class MoodbarProxyStyle : public QProxyStyle {
   void ChangeStyle(QAction* action);
 
  private:
-  // The slider "groove" is smaller than the actual slider: this convenient
-  // function returns the difference between groove width and slider width.
-  int GetExtraSpace(const QStyleOptionComplex* opt) const;
-
   Application* app_;
   QSlider* slider_;
 


### PR DESCRIPTION
Partial revertion for commit "3f79fa5c651f23e48faf1af6ca56dbff9e5660ab" because of
https://github.com/clementine-player/Clementine/issues/4770