### PR TITLE
Add error message if editing tag from playlist fails

### DIFF
--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -415,9 +415,15 @@ bool Playlist::setData(const QModelIndex& index, const QVariant& value,
 void Playlist::SongSaveComplete(TagReaderReply* reply,
                                 const QPersistentModelIndex& index) {
   if (reply->is_successful() && index.isValid()) {
-    QFuture<void> future = item_at(index.row())->BackgroundReload();
-    NewClosure(future, this, SLOT(ItemReloadComplete(QPersistentModelIndex)),
-               index);
+    if (reply->message().save_file_response().success()) {
+      QFuture<void> future = item_at(index.row())->BackgroundReload();
+      NewClosure(future, this, SLOT(ItemReloadComplete(QPersistentModelIndex)),
+                 index);
+    } else {
+      emit Error(tr("An error occurred writing metadata to '%1'").arg(
+          QString::fromStdString(
+              reply->request_message().save_file_request().filename())));
+    }
   }
   reply->deleteLater();
 }
@@ -692,7 +698,7 @@ void Playlist::set_current_row(int i, bool is_stopping) {
 void Playlist::InsertDynamicItems(int count) {
   GeneratorInserter* inserter =
       new GeneratorInserter(task_manager_, library_, this);
-  connect(inserter, SIGNAL(Error(QString)), SIGNAL(LoadTracksError(QString)));
+  connect(inserter, SIGNAL(Error(QString)), SIGNAL(Error(QString)));
   connect(inserter, SIGNAL(PlayRequested(QModelIndex)),
           SIGNAL(PlayRequested(QModelIndex)));
 
@@ -820,7 +826,7 @@ bool Playlist::dropMimeData(const QMimeData* data, Qt::DropAction action,
   } else if (data->hasFormat(kCddaMimeType)) {
     SongLoaderInserter* inserter = new SongLoaderInserter(
         task_manager_, library_, backend_->app()->player());
-    connect(inserter, SIGNAL(Error(QString)), SIGNAL(LoadTracksError(QString)));
+    connect(inserter, SIGNAL(Error(QString)), SIGNAL(Error(QString)));
     inserter->LoadAudioCD(this, row, play_now, enqueue_now);
   } else if (data->hasUrls()) {
     // URL list dragged from the file list or some other app
@@ -834,7 +840,7 @@ void Playlist::InsertUrls(const QList<QUrl>& urls, int pos, bool play_now,
                           bool enqueue) {
   SongLoaderInserter* inserter = new SongLoaderInserter(
       task_manager_, library_, backend_->app()->player());
-  connect(inserter, SIGNAL(Error(QString)), SIGNAL(LoadTracksError(QString)));
+  connect(inserter, SIGNAL(Error(QString)), SIGNAL(Error(QString)));
 
   inserter->Load(this, pos, play_now, enqueue, urls);
 }
@@ -848,7 +854,7 @@ void Playlist::InsertSmartPlaylist(GeneratorPtr generator, int pos,
 
   GeneratorInserter* inserter =
       new GeneratorInserter(task_manager_, library_, this);
-  connect(inserter, SIGNAL(Error(QString)), SIGNAL(LoadTracksError(QString)));
+  connect(inserter, SIGNAL(Error(QString)), SIGNAL(Error(QString)));
 
   inserter->Load(this, pos, play_now, enqueue, generator);
 

--- a/src/playlist/playlist.h
+++ b/src/playlist/playlist.h
@@ -348,7 +348,7 @@ signals:
   void PlaylistChanged();
   void DynamicModeChanged(bool dynamic);
 
-  void LoadTracksError(const QString& message);
+  void Error(const QString& message);
 
   // Signals that the queue has changed, meaning that the remaining queued
   // items should update their position.

--- a/src/playlist/playlistmanager.cpp
+++ b/src/playlist/playlistmanager.cpp
@@ -117,7 +117,7 @@ Playlist* PlaylistManager::AddPlaylist(int id, const QString& name,
   connect(ret, SIGNAL(PlaylistChanged()), SLOT(UpdateSummaryText()));
   connect(ret, SIGNAL(EditingFinished(QModelIndex)),
           SIGNAL(EditingFinished(QModelIndex)));
-  connect(ret, SIGNAL(LoadTracksError(QString)), SIGNAL(Error(QString)));
+  connect(ret, SIGNAL(Error(QString)), SIGNAL(Error(QString)));
   connect(ret, SIGNAL(PlayRequested(QModelIndex)),
           SIGNAL(PlayRequested(QModelIndex)));
   connect(playlist_container_->view(),

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -230,23 +230,31 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
           SLOT(AddToPlaylist(QMimeData*)));
 
   // Add tabs to the fancy tab widget
-  ui_->tabs->AddTab(global_search_view_, IconLoader::Load("search", IconLoader::Base),
+  ui_->tabs->AddTab(global_search_view_,
+                    IconLoader::Load("search", IconLoader::Base),
                     tr("Search", "Global search settings dialog title."));
-  ui_->tabs->AddTab(library_view_, IconLoader::Load("folder-sound", IconLoader::Base),
+  ui_->tabs->AddTab(library_view_,
+                    IconLoader::Load("folder-sound", IconLoader::Base),
                     tr("Library"));
-  ui_->tabs->AddTab(file_view_, IconLoader::Load("document-open", IconLoader::Base), 
+  ui_->tabs->AddTab(file_view_,
+                    IconLoader::Load("document-open", IconLoader::Base),
                     tr("Files"));
-  ui_->tabs->AddTab(playlist_list_, IconLoader::Load("view-media-playlist", IconLoader::Base),
+  ui_->tabs->AddTab(playlist_list_,
+                    IconLoader::Load("view-media-playlist", IconLoader::Base),
                     tr("Playlists"));
-  ui_->tabs->AddTab(internet_view_, IconLoader::Load("applications-internet", IconLoader::Base),
+  ui_->tabs->AddTab(internet_view_,
+                    IconLoader::Load("applications-internet", IconLoader::Base),
                     tr("Internet"));
-  ui_->tabs->AddTab(device_view_container_,
-                    IconLoader::Load("multimedia-player-ipod-mini-blue", IconLoader::Base),
-                    tr("Devices"));
+  ui_->tabs->AddTab(
+      device_view_container_,
+      IconLoader::Load("multimedia-player-ipod-mini-blue", IconLoader::Base),
+      tr("Devices"));
   ui_->tabs->AddSpacer();
-  ui_->tabs->AddTab(song_info_view_, IconLoader::Load("view-media-lyrics", IconLoader::Base),
+  ui_->tabs->AddTab(song_info_view_,
+                    IconLoader::Load("view-media-lyrics", IconLoader::Base),
                     tr("Song info"));
-  ui_->tabs->AddTab(artist_info_view_, IconLoader::Load("x-clementine-artist", IconLoader::Base),
+  ui_->tabs->AddTab(artist_info_view_,
+                    IconLoader::Load("x-clementine-artist", IconLoader::Base),
                     tr("Artist info"));
 
   // Add the now playing widget to the fancy tab widget
@@ -293,39 +301,68 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
   qLog(Debug) << "Creating UI";
   ui_->action_about->setIcon(IconLoader::Load("help-about", IconLoader::Base));
   ui_->action_about_qt->setIcon(IconLoader::Load("qtlogo", IconLoader::Base));
-  ui_->action_add_file->setIcon(IconLoader::Load("document-open", IconLoader::Base));
-  ui_->action_add_folder->setIcon(IconLoader::Load("document-open-folder", IconLoader::Base));
-  ui_->action_add_stream->setIcon(IconLoader::Load("document-open-remote", IconLoader::Base));
-  ui_->action_add_podcast->setIcon(IconLoader::Load("podcast", IconLoader::Provider));
-  ui_->action_clear_playlist->setIcon(IconLoader::Load("edit-clear-list", IconLoader::Base));
-  ui_->action_configure->setIcon(IconLoader::Load("configure", IconLoader::Base));
-  ui_->action_cover_manager->setIcon(IconLoader::Load("download", IconLoader::Base));
-  ui_->action_edit_track->setIcon(IconLoader::Load("edit-rename", IconLoader::Base));
-  ui_->action_equalizer->setIcon(IconLoader::Load("view-media-equalizer", IconLoader::Base));
+  ui_->action_add_file->setIcon(
+      IconLoader::Load("document-open", IconLoader::Base));
+  ui_->action_add_folder->setIcon(
+      IconLoader::Load("document-open-folder", IconLoader::Base));
+  ui_->action_add_stream->setIcon(
+      IconLoader::Load("document-open-remote", IconLoader::Base));
+  ui_->action_add_podcast->setIcon(
+      IconLoader::Load("podcast", IconLoader::Provider));
+  ui_->action_clear_playlist->setIcon(
+      IconLoader::Load("edit-clear-list", IconLoader::Base));
+  ui_->action_configure->setIcon(
+      IconLoader::Load("configure", IconLoader::Base));
+  ui_->action_cover_manager->setIcon(
+      IconLoader::Load("download", IconLoader::Base));
+  ui_->action_edit_track->setIcon(
+      IconLoader::Load("edit-rename", IconLoader::Base));
+  ui_->action_equalizer->setIcon(
+      IconLoader::Load("view-media-equalizer", IconLoader::Base));
   ui_->action_jump->setIcon(IconLoader::Load("go-jump", IconLoader::Base));
-  ui_->action_next_track->setIcon(IconLoader::Load("media-skip-forward", IconLoader::Base));
-  ui_->action_open_media->setIcon(IconLoader::Load("document-open", IconLoader::Base));
-  ui_->action_open_cd->setIcon(IconLoader::Load("media-optical", IconLoader::Base));
-  ui_->action_play_pause->setIcon(IconLoader::Load("media-playback-start", IconLoader::Base));
-  ui_->action_previous_track->setIcon(IconLoader::Load("media-skip-backward", IconLoader::Base));
-  ui_->action_mute->setIcon(IconLoader::Load("audio-volume-muted", IconLoader::Base));
-  ui_->action_quit->setIcon(IconLoader::Load("application-exit", IconLoader::Base));
-  ui_->action_remove_from_playlist->setIcon(IconLoader::Load("list-remove", IconLoader::Base));
-  ui_->action_repeat_mode->setIcon(IconLoader::Load("media-playlist-repeat", IconLoader::Base));
-  ui_->action_rip_audio_cd->setIcon(IconLoader::Load("media-optical", IconLoader::Base));
-  ui_->action_shuffle->setIcon(IconLoader::Load("x-clementine-shuffle", IconLoader::Base));
-  ui_->action_shuffle_mode->setIcon(IconLoader::Load("media-playlist-shuffle", IconLoader::Base));
-  ui_->action_stop->setIcon(IconLoader::Load("media-playback-stop", IconLoader::Base));
+  ui_->action_next_track->setIcon(
+      IconLoader::Load("media-skip-forward", IconLoader::Base));
+  ui_->action_open_media->setIcon(
+      IconLoader::Load("document-open", IconLoader::Base));
+  ui_->action_open_cd->setIcon(
+      IconLoader::Load("media-optical", IconLoader::Base));
+  ui_->action_play_pause->setIcon(
+      IconLoader::Load("media-playback-start", IconLoader::Base));
+  ui_->action_previous_track->setIcon(
+      IconLoader::Load("media-skip-backward", IconLoader::Base));
+  ui_->action_mute->setIcon(
+      IconLoader::Load("audio-volume-muted", IconLoader::Base));
+  ui_->action_quit->setIcon(
+      IconLoader::Load("application-exit", IconLoader::Base));
+  ui_->action_remove_from_playlist->setIcon(
+      IconLoader::Load("list-remove", IconLoader::Base));
+  ui_->action_repeat_mode->setIcon(
+      IconLoader::Load("media-playlist-repeat", IconLoader::Base));
+  ui_->action_rip_audio_cd->setIcon(
+      IconLoader::Load("media-optical", IconLoader::Base));
+  ui_->action_shuffle->setIcon(
+      IconLoader::Load("x-clementine-shuffle", IconLoader::Base));
+  ui_->action_shuffle_mode->setIcon(
+      IconLoader::Load("media-playlist-shuffle", IconLoader::Base));
+  ui_->action_stop->setIcon(
+      IconLoader::Load("media-playback-stop", IconLoader::Base));
   ui_->action_stop_after_this_track->setIcon(
       IconLoader::Load("media-playback-stop", IconLoader::Base));
-  ui_->action_new_playlist->setIcon(IconLoader::Load("document-new", IconLoader::Base));
-  ui_->action_load_playlist->setIcon(IconLoader::Load("document-open", IconLoader::Base));
-  ui_->action_save_playlist->setIcon(IconLoader::Load("document-save", IconLoader::Base));
-  ui_->action_full_library_scan->setIcon(IconLoader::Load("view-refresh", IconLoader::Base));
-  ui_->action_rain->setIcon(IconLoader::Load("weather-showers-scattered", IconLoader::Base));
-  ui_->action_hypnotoad->setIcon(IconLoader::Load("hypnotoad", IconLoader::Base));
+  ui_->action_new_playlist->setIcon(
+      IconLoader::Load("document-new", IconLoader::Base));
+  ui_->action_load_playlist->setIcon(
+      IconLoader::Load("document-open", IconLoader::Base));
+  ui_->action_save_playlist->setIcon(
+      IconLoader::Load("document-save", IconLoader::Base));
+  ui_->action_full_library_scan->setIcon(
+      IconLoader::Load("view-refresh", IconLoader::Base));
+  ui_->action_rain->setIcon(
+      IconLoader::Load("weather-showers-scattered", IconLoader::Base));
+  ui_->action_hypnotoad->setIcon(
+      IconLoader::Load("hypnotoad", IconLoader::Base));
   ui_->action_kittens->setIcon(IconLoader::Load("kittens", IconLoader::Base));
-  ui_->action_enterprise->setIcon(IconLoader::Load("enterprise", IconLoader::Base));
+  ui_->action_enterprise->setIcon(
+      IconLoader::Load("enterprise", IconLoader::Base));
   ui_->action_love->setIcon(IconLoader::Load("love", IconLoader::Lastfm));
 
   // File view connections
@@ -589,9 +626,9 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
   connect(library_view_group, SIGNAL(triggered(QAction*)),
           SLOT(ChangeLibraryQueryMode(QAction*)));
 
-  QAction* library_config_action = new QAction(
-      IconLoader::Load("configure", IconLoader::Base), 
-                       tr("Configure library..."), this);
+  QAction* library_config_action =
+      new QAction(IconLoader::Load("configure", IconLoader::Base),
+                  tr("Configure library..."), this);
   connect(library_config_action, SIGNAL(triggered()),
           SLOT(ShowLibraryConfig()));
   library_view_->filter()->SetSettingsGroup(kSettingsGroup);
@@ -611,7 +648,7 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
       playlist_menu_->addAction(tr("Play"), this, SLOT(PlaylistPlay()));
   playlist_menu_->addAction(ui_->action_stop);
   playlist_stop_after_ = playlist_menu_->addAction(
-      IconLoader::Load("media-playback-stop", IconLoader::Base), 
+      IconLoader::Load("media-playback-stop", IconLoader::Base),
       tr("Stop after this track"), this, SLOT(PlaylistStopAfter()));
   playlist_queue_ = playlist_menu_->addAction("", this, SLOT(PlaylistQueue()));
   playlist_queue_->setShortcut(QKeySequence("Ctrl+D"));
@@ -630,29 +667,26 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
   playlist_menu_->addAction(ui_->action_add_files_to_transcoder);
   playlist_menu_->addSeparator();
   playlist_copy_to_library_ = playlist_menu_->addAction(
-      IconLoader::Load("edit-copy", IconLoader::Base), 
-      tr("Copy to library..."), this, SLOT(PlaylistCopyToLibrary()));
+      IconLoader::Load("edit-copy", IconLoader::Base), tr("Copy to library..."),
+      this, SLOT(PlaylistCopyToLibrary()));
   playlist_move_to_library_ = playlist_menu_->addAction(
-      IconLoader::Load("go-jump", IconLoader::Base), 
-      tr("Move to library..."), this, SLOT(PlaylistMoveToLibrary()));
-  playlist_organise_ = playlist_menu_->addAction(IconLoader::Load("edit-copy", 
-                                                 IconLoader::Base),
-                                                 tr("Organise files..."), this,
-                                                 SLOT(PlaylistMoveToLibrary()));
+      IconLoader::Load("go-jump", IconLoader::Base), tr("Move to library..."),
+      this, SLOT(PlaylistMoveToLibrary()));
+  playlist_organise_ = playlist_menu_->addAction(
+      IconLoader::Load("edit-copy", IconLoader::Base), tr("Organise files..."),
+      this, SLOT(PlaylistMoveToLibrary()));
   playlist_copy_to_device_ = playlist_menu_->addAction(
       IconLoader::Load("multimedia-player-ipod-mini-blue", IconLoader::Base),
       tr("Copy to device..."), this, SLOT(PlaylistCopyToDevice()));
-  playlist_delete_ = playlist_menu_->addAction(IconLoader::Load("edit-delete", 
-                                               IconLoader::Base),
-                                               tr("Delete from disk..."), this,
-                                               SLOT(PlaylistDelete()));
+  playlist_delete_ = playlist_menu_->addAction(
+      IconLoader::Load("edit-delete", IconLoader::Base),
+      tr("Delete from disk..."), this, SLOT(PlaylistDelete()));
   playlist_open_in_browser_ = playlist_menu_->addAction(
-      IconLoader::Load("document-open-folder", IconLoader::Base), 
-                       tr("Show in file browser..."),
-      this, SLOT(PlaylistOpenInBrowser()));
+      IconLoader::Load("document-open-folder", IconLoader::Base),
+      tr("Show in file browser..."), this, SLOT(PlaylistOpenInBrowser()));
   playlist_show_in_library_ = playlist_menu_->addAction(
-      IconLoader::Load("edit-find", IconLoader::Base), 
-      tr("Show in library..."), this, SLOT(ShowInLibrary()));
+      IconLoader::Load("edit-find", IconLoader::Base), tr("Show in library..."),
+      this, SLOT(ShowInLibrary()));
   playlist_menu_->addSeparator();
   playlistitem_actions_separator_ = playlist_menu_->addSeparator();
   playlist_menu_->addAction(ui_->action_clear_playlist);
@@ -1034,7 +1068,8 @@ void MainWindow::MediaStopped() {
 
   ui_->action_stop->setEnabled(false);
   ui_->action_stop_after_this_track->setEnabled(false);
-  ui_->action_play_pause->setIcon(IconLoader::Load("media-playback-start", IconLoader::Base));
+  ui_->action_play_pause->setIcon(
+      IconLoader::Load("media-playback-start", IconLoader::Base));
   ui_->action_play_pause->setText(tr("Play"));
 
   ui_->action_play_pause->setEnabled(true);
@@ -1052,7 +1087,8 @@ void MainWindow::MediaStopped() {
 void MainWindow::MediaPaused() {
   ui_->action_stop->setEnabled(true);
   ui_->action_stop_after_this_track->setEnabled(true);
-  ui_->action_play_pause->setIcon(IconLoader::Load("media-playback-start", IconLoader::Base));
+  ui_->action_play_pause->setIcon(
+      IconLoader::Load("media-playback-start", IconLoader::Base));
   ui_->action_play_pause->setText(tr("Play"));
 
   ui_->action_play_pause->setEnabled(true);
@@ -1066,7 +1102,8 @@ void MainWindow::MediaPaused() {
 void MainWindow::MediaPlaying() {
   ui_->action_stop->setEnabled(true);
   ui_->action_stop_after_this_track->setEnabled(true);
-  ui_->action_play_pause->setIcon(IconLoader::Load("media-playback-pause", IconLoader::Base));
+  ui_->action_play_pause->setIcon(
+      IconLoader::Load("media-playback-pause", IconLoader::Base));
   ui_->action_play_pause->setText(tr("Pause"));
 
   bool enable_play_pause = !(app_->player()->GetCurrentItem()->options() &
@@ -1166,7 +1203,8 @@ void MainWindow::ScrobbleButtonVisibilityChanged(bool value) {
     // check if the song was scrobbled
     if (app_->playlist_manager()->active()->get_lastfm_status() ==
         Playlist::LastFM_Scrobbled) {
-      ui_->action_toggle_scrobbling->setIcon(IconLoader::Load("as", IconLoader::Lastfm));
+      ui_->action_toggle_scrobbling->setIcon(
+          IconLoader::Load("as", IconLoader::Lastfm));
     } else {
 #ifdef HAVE_LIBLASTFM
       SetToggleScrobblingIcon(app_->scrobbler()->IsScrobblingEnabled());
@@ -1563,10 +1601,12 @@ void MainWindow::PlaylistRightClick(const QPoint& global_pos,
           source_index.row() &&
       app_->player()->GetState() == Engine::Playing) {
     playlist_play_pause_->setText(tr("Pause"));
-    playlist_play_pause_->setIcon(IconLoader::Load("media-playback-pause", IconLoader::Base));
+    playlist_play_pause_->setIcon(
+        IconLoader::Load("media-playback-pause", IconLoader::Base));
   } else {
     playlist_play_pause_->setText(tr("Play"));
-    playlist_play_pause_->setIcon(IconLoader::Load("media-playback-start", IconLoader::Base));
+    playlist_play_pause_->setIcon(
+        IconLoader::Load("media-playback-start", IconLoader::Base));
   }
 
   // Are we allowed to pause?
@@ -2619,6 +2659,8 @@ void MainWindow::AutoCompleteTags() {
             SLOT(AutoCompleteTagsAccepted()));
     connect(track_selection_dialog_.get(), SIGNAL(finished(int)),
             tag_fetcher_.get(), SLOT(Cancel()));
+    connect(track_selection_dialog_.get(), SIGNAL(Error(QString)),
+            SLOT(ShowErrorDialog(QString)));
   }
 
   // Get the selected songs and start fetching tags for them
@@ -2654,7 +2696,8 @@ void MainWindow::AutoCompleteTagsAccepted() {
 }
 
 QPixmap MainWindow::CreateOverlayedIcon(int position, int scrobble_point) {
-  QPixmap normal_icon = IconLoader::Load("as_light", IconLoader::Lastfm).pixmap(16);
+  QPixmap normal_icon =
+      IconLoader::Load("as_light", IconLoader::Lastfm).pixmap(16);
   QPixmap light_icon = IconLoader::Load("as", IconLoader::Lastfm).pixmap(16);
   QRect rect(normal_icon.rect());
 
@@ -2682,9 +2725,11 @@ QPixmap MainWindow::CreateOverlayedIcon(int position, int scrobble_point) {
 
 void MainWindow::SetToggleScrobblingIcon(bool value) {
   if (!value) {
-    ui_->action_toggle_scrobbling->setIcon(IconLoader::Load("as_disabled", IconLoader::Lastfm));
+    ui_->action_toggle_scrobbling->setIcon(
+        IconLoader::Load("as_disabled", IconLoader::Lastfm));
   } else {
-    ui_->action_toggle_scrobbling->setIcon(IconLoader::Load("as_light", IconLoader::Lastfm));
+    ui_->action_toggle_scrobbling->setIcon(
+        IconLoader::Load("as_light", IconLoader::Lastfm));
   }
 }
 
@@ -2699,7 +2744,8 @@ void MainWindow::ScrobbleSubmitted() {
 
   // update the button icon
   if (last_fm_enabled)
-    ui_->action_toggle_scrobbling->setIcon(IconLoader::Load("as", IconLoader::Lastfm));
+    ui_->action_toggle_scrobbling->setIcon(
+        IconLoader::Load("as", IconLoader::Lastfm));
 }
 
 void MainWindow::ScrobbleError(int value) {

--- a/src/ui/trackselectiondialog.cpp
+++ b/src/ui/trackselectiondialog.cpp
@@ -244,8 +244,8 @@ void TrackSelectionDialog::SaveData(const QList<Data>& data) {
 
     if (!TagReaderClient::Instance()->SaveFileBlocking(copy.url().toLocalFile(),
                                                        copy)) {
-      qLog(Warning) << "Failed to write new auto-tags to"
-                    << copy.url().toLocalFile();
+      emit Error(tr("Failed to write new auto-tags to '%1'")
+                     .arg(copy.url().toLocalFile()));
     }
   }
 }
@@ -256,7 +256,7 @@ void TrackSelectionDialog::accept() {
 
     // Save tags in the background
     QFuture<void> future =
-        QtConcurrent::run(&TrackSelectionDialog::SaveData, data_);
+        QtConcurrent::run(this, &TrackSelectionDialog::SaveData, data_);
     NewClosure(future, this, SLOT(AcceptFinished()));
     return;
   }

--- a/src/ui/trackselectiondialog.h
+++ b/src/ui/trackselectiondialog.h
@@ -47,6 +47,7 @@ class TrackSelectionDialog : public QDialog {
   void accept();
 
 signals:
+  void Error(const QString& error);
   void SongChosen(const Song& original_song, const Song& new_metadata);
 
  private slots:
@@ -75,7 +76,7 @@ signals:
   void AddSong(const Song& song, int result_index, QTreeWidget* parent) const;
 
   void SetLoading(const QString& message);
-  static void SaveData(const QList<Data>& data);
+  void SaveData(const QList<Data>& data);
 
  private:
   QList<Data> data_;


### PR DESCRIPTION
Closes https://github.com/clementine-player/Clementine/issues/5133

When the auto tagger fails for a song I made the choice (suggested in the issue) to display the error in a popup because people generally don't have/read the logs.