### PR TITLE
Fix incorrect highlight colour in playlist when the window is inactive

### DIFF
--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -496,6 +496,9 @@ void PlaylistView::drawRow(QPainter* painter,
                         is_paused ? currenttrack_pause_ : currenttrack_play_);
 
     // Set the font
+    opt.palette.setColor(QPalette::Inactive, QPalette::HighlightedText,
+                         QApplication::palette().color(
+                             QPalette::Active, QPalette::HighlightedText));
     opt.palette.setColor(QPalette::Text, QApplication::palette().color(
                                              QPalette::HighlightedText));
     opt.palette.setColor(QPalette::Highlight, Qt::transparent);


### PR DESCRIPTION
When the mainwindow redraws the playlist and the window is not focused, the text colour for the currently playing track changes (usually white to black on the default palette) which is wrong and has poor contrast. This usually happens when changing tracks with keyboard shortcuts, or when the Score column updates at the scrobble point.