### PR TITLE
Enable Enter key shortcut in file view

### DIFF
--- a/src/widgets/fileview.cpp
+++ b/src/widgets/fileview.cpp
@@ -227,7 +227,10 @@ void FileView::keyPressEvent(QKeyEvent* e) {
     case Qt::Key_Backspace:
       ui_->up->click();
       break;
+    case Qt::Key_Enter:
+    case Qt::Key_Return:
+      ItemDoubleClick(ui_->list->currentIndex());
+      break;
   }
-
   QWidget::keyPressEvent(e);
 }


### PR DESCRIPTION
When selecting a file from the file browser, pressing Enter now has the same effect than double-clicking it. (#5178)