### PR TITLE
OPML imports should prefer title to text attributes for podcast names

### DIFF
--- a/src/internet/podcasts/podcastparser.cpp
+++ b/src/internet/podcasts/podcastparser.cpp
@@ -291,7 +291,12 @@ void PodcastParser::ParseOutline(QXmlStreamReader* reader,
           // Parse the feed and add it to this container
           Podcast podcast;
           podcast.set_description(attributes.value("description").toString());
-          podcast.set_title(attributes.value("text").toString());
+
+          QString title = attributes.value("title").toString();
+          if (title.isEmpty()) {
+            title = attributes.value("text").toString();
+          }
+          podcast.set_title(title);
           podcast.set_image_url_large(QUrl::fromEncoded(
               attributes.value("imageHref").toString().toAscii()));
           podcast.set_url(QUrl::fromEncoded(


### PR DESCRIPTION
There was a pull request back in September to implement something like this that never got merged: https://github.com/clementine-player/Clementine/pull/5036

I was toying with the qt5 branch today, and realized that importing / exporting podcasts with gpodder was kind of completely broken.

This is both a fix for gpodder not conforming to OPML standards and a general best practice. According to the spec, title is an optional attribute but if there is a title we should be... titling our podcasts based off of it, since text can be user modifiable in exporters. This is an amendment to jbroadus' work since we should be using title attributes in priority over text anyway, and this fixes both the empty title and description as title problems.

I'm also[ pushing changes to mygpo to fix their OPML exporter](https://github.com/gpodder/mygpo/pull/35) so its generating OPML 2 compliant tags (currently they are using their description fields for text, when by spec it should be the top level units title, which is why when you export OPML from their website and add it to Clementine all the podcast names are their descriptions). But regardless of that being fixed, we should still use title attributes over text when available.