### PR TITLE
Fix bug in edit tag dialog when fetching (2)

### DIFF
--- a/src/ui/edittagdialog.cpp
+++ b/src/ui/edittagdialog.cpp
@@ -365,7 +365,6 @@ bool EditTagDialog::IsValueModified(const QModelIndexList& sel,
 void EditTagDialog::InitFieldValue(const FieldData& field,
                                    const QModelIndexList& sel) {
   const bool varies = DoesValueVary(sel, field.id_);
-  const bool modified = IsValueModified(sel, field.id_);
 
   if (ExtendedEditor* editor = dynamic_cast<ExtendedEditor*>(field.editor_)) {
     editor->clear();
@@ -377,10 +376,7 @@ void EditTagDialog::InitFieldValue(const FieldData& field,
     }
   }
 
-  QFont new_font(font());
-  new_font.setBold(modified);
-  field.label_->setFont(new_font);
-  field.editor_->setFont(new_font);
+  UpdateModifiedField(field, sel);
 }
 
 void EditTagDialog::UpdateFieldValue(const FieldData& field,
@@ -401,9 +397,13 @@ void EditTagDialog::UpdateFieldValue(const FieldData& field,
     data_[i.row()].set_value(field.id_, value);
   }
 
-  // Update the boldness
+  UpdateModifiedField(field, sel);
+}
+
+void EditTagDialog::UpdateModifiedField(const FieldData& field, const QModelIndexList& sel) {
   const bool modified = IsValueModified(sel, field.id_);
 
+  // Update the boldness
   QFont new_font(font());
   new_font.setBold(modified);
   field.label_->setFont(new_font);
@@ -855,12 +855,12 @@ void EditTagDialog::FetchTagSongChosen(const Song& original_song,
   // Is it currently being displayed in the UI?
   if (ui_->song_list->currentRow() == id) {
     // Yes! Additionally update UI
+    const QModelIndexList sel =
+      ui_->song_list->selectionModel()->selectedIndexes();
     ignore_edits_ = true;
-    ui_->title->set_text(new_metadata.title());
-    ui_->artist->set_text(new_metadata.artist());
-    ui_->album->set_text(new_metadata.album());
-    ui_->track->setValue(new_metadata.track());
-    ui_->year->setValue(new_metadata.year());
+    for (const FieldData& field : fields_) {
+      InitFieldValue(field, sel);
+    }
     ignore_edits_ = false;
   }
 }

--- a/src/ui/edittagdialog.cpp
+++ b/src/ui/edittagdialog.cpp
@@ -838,29 +838,27 @@ void EditTagDialog::FetchTagSongChosen(const Song& original_song,
   const QString filename = original_song.url().toLocalFile();
 
   // Find the song with this filename
-  int id;
-  for (id = 0; id < data_.count(); ++id) {
-    if (data_[id].original_.url().toLocalFile() == filename)
-      break;
-  }
-
-  if(id == data_.count()) {
-    qLog(Warning) << "Could not find song for filename: " << filename;
-      return;
+  auto data_it =
+      std::find_if(data_.begin(), data_.end(), [&filename](const Data& d) {
+        return d.original_.url().toLocalFile() == filename;
+      });
+  if (data_it == data_.end()) {
+    qLog(Warning) << "Could not find song to filename: " << filename;
+    return;
   }
 
   // Update song data
-  data_[id].current_.set_title(new_metadata.title());
-  data_[id].current_.set_artist(new_metadata.artist());
-  data_[id].current_.set_album(new_metadata.album());
-  data_[id].current_.set_track(new_metadata.track());
-  data_[id].current_.set_year(new_metadata.year());
+  data_it->current_.set_title(new_metadata.title());
+  data_it->current_.set_artist(new_metadata.artist());
+  data_it->current_.set_album(new_metadata.album());
+  data_it->current_.set_track(new_metadata.track());
+  data_it->current_.set_year(new_metadata.year());
 
   // Is it currently being displayed in the UI?
-  if (ui_->song_list->currentRow() == id) {
+  if (ui_->song_list->currentRow() == std::distance(data_.begin(), data_it)) {
     // Yes! Additionally update UI
     const QModelIndexList sel =
-      ui_->song_list->selectionModel()->selectedIndexes();
+        ui_->song_list->selectionModel()->selectedIndexes();
     UpdateUI(sel);
   }
 }

--- a/src/ui/edittagdialog.cpp
+++ b/src/ui/edittagdialog.cpp
@@ -428,11 +428,7 @@ void EditTagDialog::SelectionChanged() {
   if (sel.isEmpty()) return;
 
   // Set the editable fields
-  ignore_edits_ = true;
-  for (const FieldData& field : fields_) {
-    InitFieldValue(field, sel);
-  }
-  ignore_edits_ = false;
+  UpdateUI(sel);
 
   // If we're editing multiple songs then we have to disable certain tabs
   const bool multiple = sel.count() > 1;
@@ -444,6 +440,14 @@ void EditTagDialog::SelectionChanged() {
     UpdateSummaryTab(song);
     UpdateStatisticsTab(song);
   }
+}
+
+void EditTagDialog::UpdateUI(const QModelIndexList& sel){
+  ignore_edits_ = true;
+  for (const FieldData& field : fields_) {
+    InitFieldValue(field, sel);
+  }
+  ignore_edits_ = false;
 }
 
 static void SetText(QLabel* label, int value, const QString& suffix,
@@ -857,10 +861,6 @@ void EditTagDialog::FetchTagSongChosen(const Song& original_song,
     // Yes! Additionally update UI
     const QModelIndexList sel =
       ui_->song_list->selectionModel()->selectedIndexes();
-    ignore_edits_ = true;
-    for (const FieldData& field : fields_) {
-      InitFieldValue(field, sel);
-    }
-    ignore_edits_ = false;
+    UpdateUI(sel);
   }
 }

--- a/src/ui/edittagdialog.h
+++ b/src/ui/edittagdialog.h
@@ -133,6 +133,8 @@ signals:
   void UpdateSummaryTab(const Song& song);
   void UpdateStatisticsTab(const Song& song);
 
+  void UpdateUI(const QModelIndexList& sel);
+
   bool SetLoading(const QString& message);
   void SetSongListVisibility(bool visible);
 

--- a/src/ui/edittagdialog.h
+++ b/src/ui/edittagdialog.h
@@ -127,6 +127,7 @@ signals:
 
   void InitFieldValue(const FieldData& field, const QModelIndexList& sel);
   void UpdateFieldValue(const FieldData& field, const QModelIndexList& sel);
+  void UpdateModifiedField(const FieldData& field, const QModelIndexList& sel);
   void ResetFieldValue(const FieldData& field, const QModelIndexList& sel);
 
   void UpdateSummaryTab(const Song& song);


### PR DESCRIPTION
A fix for old tag values getting erased (instead of overwritten) in the edit tag dialog when fetching tags with MusicBrainz.

Replacement for pull request #5131 ; issue #3355 is still fixed.

[Maybe the `textEdited` signal can be connected instead of `textChanged` but I didn't want to break anything else. Specially for the next stable release.]