### PR TITLE
Fix issues related to "AutoExpandingTreeView" and some enhacements

### DIFF
--- a/src/internet/core/internetview.cpp
+++ b/src/internet/core/internetview.cpp
@@ -47,11 +47,6 @@ void InternetView::contextMenuEvent(QContextMenuEvent* e) {
                                   e->globalPos());
 }
 
-void InternetView::currentChanged(const QModelIndex& current,
-                                  const QModelIndex&) {
-  emit CurrentIndexChanged(current);
-}
-
 void InternetView::setModel(QAbstractItemModel* model) {
   AutoExpandingTreeView::setModel(model);
 

--- a/src/internet/core/internetview.cpp
+++ b/src/internet/core/internetview.cpp
@@ -32,7 +32,6 @@ InternetView::InternetView(QWidget* parent) : AutoExpandingTreeView(parent) {
   SetExpandOnReset(false);
   setAttribute(Qt::WA_MacShowFocusRect, false);
   setSelectionMode(QAbstractItemView::ExtendedSelection);
-  setAnimated(true);
 }
 
 void InternetView::contextMenuEvent(QContextMenuEvent* e) {

--- a/src/internet/core/internetview.h
+++ b/src/internet/core/internetview.h
@@ -33,11 +33,7 @@ class InternetView : public AutoExpandingTreeView {
   void contextMenuEvent(QContextMenuEvent* e);
 
   // QTreeView
-  void currentChanged(const QModelIndex& current, const QModelIndex& previous);
   void setModel(QAbstractItemModel* model);
-
- signals:
-  void CurrentIndexChanged(const QModelIndex& index);
 };
 
 #endif  // INTERNET_CORE_INTERNETVIEW_H_

--- a/src/library/libraryview.cpp
+++ b/src/library/libraryview.cpp
@@ -185,7 +185,6 @@ LibraryView::LibraryView(QWidget* parent)
   setSelectionMode(QAbstractItemView::ExtendedSelection);
 
   setStyleSheet("QTreeView::item{padding-top:1px;}");
-  setAnimated(true);
 }
 
 LibraryView::~LibraryView() {}

--- a/src/widgets/autoexpandingtreeview.cpp
+++ b/src/widgets/autoexpandingtreeview.cpp
@@ -128,6 +128,18 @@ void AutoExpandingTreeView::keyPressEvent(QKeyEvent* e) {
       emit FocusOnFilterSignal(e);
       e->accept();
       break;
+
+    case Qt::Key_Left:
+      QModelIndex index = currentIndex();
+
+      // Set focus on the root of the current branch
+      if (index.isValid() && index.parent() != rootIndex() &&
+          (!isExpanded(index) || model()->rowCount(index) == 0)) {
+        setCurrentIndex(index.parent());
+        setFocus();
+        e->accept();
+      }
+      break;
   }
 
   QTreeView::keyPressEvent(e);

--- a/src/widgets/autoexpandingtreeview.cpp
+++ b/src/widgets/autoexpandingtreeview.cpp
@@ -33,8 +33,6 @@ AutoExpandingTreeView::AutoExpandingTreeView(QWidget* parent)
 
   connect(this, SIGNAL(expanded(QModelIndex)), SLOT(ItemExpanded(QModelIndex)));
   connect(this, SIGNAL(clicked(QModelIndex)), SLOT(ItemClicked(QModelIndex)));
-  connect(this, SIGNAL(doubleClicked(QModelIndex)),
-          SLOT(ItemDoubleClicked(QModelIndex)));
 }
 
 void AutoExpandingTreeView::reset() {
@@ -84,7 +82,10 @@ void AutoExpandingTreeView::ItemClicked(const QModelIndex& index) {
   setExpanded(index, !isExpanded(index));
 }
 
-void AutoExpandingTreeView::ItemDoubleClicked(const QModelIndex& index) {
+void AutoExpandingTreeView::mouseDoubleClickEvent(QMouseEvent* event) {
+  QTreeView::mouseDoubleClickEvent(event);
+
+  QModelIndex index = indexAt(event->pos());
   ignore_next_click_ = true;
 
   if (add_on_double_click_) {

--- a/src/widgets/autoexpandingtreeview.cpp
+++ b/src/widgets/autoexpandingtreeview.cpp
@@ -83,10 +83,7 @@ void AutoExpandingTreeView::ItemClicked(const QModelIndex& index) {
   setExpanded(index, !isExpanded(index));
 }
 
-void AutoExpandingTreeView::mouseDoubleClickEvent(QMouseEvent* event) {
-  QTreeView::mouseDoubleClickEvent(event);
-
-  QModelIndex index = indexAt(event->pos());
+void AutoExpandingTreeView::ItemDoubleClicked(const QModelIndex& index) {
   ignore_next_click_ = true;
 
   if (add_on_double_click_) {
@@ -97,6 +94,13 @@ void AutoExpandingTreeView::mouseDoubleClickEvent(QMouseEvent* event) {
     emit AddToPlaylistSignal(data);
   }
 }
+
+void AutoExpandingTreeView::mouseDoubleClickEvent(QMouseEvent* event) {
+  QTreeView::mouseDoubleClickEvent(event);
+
+  ItemDoubleClicked(indexAt(event->pos()));
+}
+
 
 void AutoExpandingTreeView::mousePressEvent(QMouseEvent* event) {
   if (event->modifiers() != Qt::NoModifier) {
@@ -119,7 +123,7 @@ void AutoExpandingTreeView::keyPressEvent(QKeyEvent* e) {
   switch (e->key()) {
     case Qt::Key_Enter:
     case Qt::Key_Return:
-      if (currentIndex().isValid()) emit doubleClicked(currentIndex());
+      if (currentIndex().isValid()) ItemDoubleClicked(currentIndex());
       e->accept();
       break;
 

--- a/src/widgets/autoexpandingtreeview.cpp
+++ b/src/widgets/autoexpandingtreeview.cpp
@@ -30,6 +30,7 @@ AutoExpandingTreeView::AutoExpandingTreeView(QWidget* parent)
       add_on_double_click_(true),
       ignore_next_click_(false) {
   setExpandsOnDoubleClick(false);
+  setAnimated(true);
 
   connect(this, SIGNAL(expanded(QModelIndex)), SLOT(ItemExpanded(QModelIndex)));
   connect(this, SIGNAL(clicked(QModelIndex)), SLOT(ItemClicked(QModelIndex)));

--- a/src/widgets/autoexpandingtreeview.h
+++ b/src/widgets/autoexpandingtreeview.h
@@ -57,6 +57,7 @@ signals:
  private slots:
   void ItemExpanded(const QModelIndex& index);
   void ItemClicked(const QModelIndex& index);
+  void ItemDoubleClicked(const QModelIndex& index);
 
  private:
   bool RecursivelyExpand(const QModelIndex& index, int* count);

--- a/src/widgets/autoexpandingtreeview.h
+++ b/src/widgets/autoexpandingtreeview.h
@@ -48,6 +48,7 @@ signals:
   // QWidget
   void mousePressEvent(QMouseEvent* event);
   void keyPressEvent(QKeyEvent* event);
+  void mouseDoubleClickEvent(QMouseEvent* event);
 
   virtual bool CanRecursivelyExpand(const QModelIndex& index) const {
     return true;
@@ -56,7 +57,6 @@ signals:
  private slots:
   void ItemExpanded(const QModelIndex& index);
   void ItemClicked(const QModelIndex& index);
-  void ItemDoubleClicked(const QModelIndex& index);
 
  private:
   bool RecursivelyExpand(const QModelIndex& index, int* count);


### PR DESCRIPTION
Changes made by this PR:
 - Fixes issue #4485
 - Fix misbehavior when you double click after a single/double click on a song item in library or internet views
 - Make "AutoExpandingTreeView" animated by default
 - Collapse current branch in "AutoExpandingTreeView" by pressing "Left" key on items under its root