### PR TITLE
Resolve some issues related to "AutoExpandingTreeView" 

### DIFF
--- a/src/internet/core/internetview.cpp
+++ b/src/internet/core/internetview.cpp
@@ -47,11 +47,6 @@ void InternetView::contextMenuEvent(QContextMenuEvent* e) {
                                   e->globalPos());
 }
 
-void InternetView::currentChanged(const QModelIndex& current,
-                                  const QModelIndex&) {
-  emit CurrentIndexChanged(current);
-}
-
 void InternetView::setModel(QAbstractItemModel* model) {
   AutoExpandingTreeView::setModel(model);
 

--- a/src/internet/core/internetview.cpp
+++ b/src/internet/core/internetview.cpp
@@ -32,7 +32,6 @@ InternetView::InternetView(QWidget* parent) : AutoExpandingTreeView(parent) {
   SetExpandOnReset(false);
   setAttribute(Qt::WA_MacShowFocusRect, false);
   setSelectionMode(QAbstractItemView::ExtendedSelection);
-  setAnimated(true);
 }
 
 void InternetView::contextMenuEvent(QContextMenuEvent* e) {

--- a/src/internet/core/internetview.h
+++ b/src/internet/core/internetview.h
@@ -33,11 +33,7 @@ class InternetView : public AutoExpandingTreeView {
   void contextMenuEvent(QContextMenuEvent* e);
 
   // QTreeView
-  void currentChanged(const QModelIndex& current, const QModelIndex& previous);
   void setModel(QAbstractItemModel* model);
-
- signals:
-  void CurrentIndexChanged(const QModelIndex& index);
 };
 
 #endif  // INTERNET_CORE_INTERNETVIEW_H_

--- a/src/library/libraryview.cpp
+++ b/src/library/libraryview.cpp
@@ -185,7 +185,6 @@ LibraryView::LibraryView(QWidget* parent)
   setSelectionMode(QAbstractItemView::ExtendedSelection);
 
   setStyleSheet("QTreeView::item{padding-top:1px;}");
-  setAnimated(true);
 }
 
 LibraryView::~LibraryView() {}

--- a/src/widgets/autoexpandingtreeview.cpp
+++ b/src/widgets/autoexpandingtreeview.cpp
@@ -129,10 +129,12 @@ void AutoExpandingTreeView::mouseDoubleClickEvent(QMouseEvent* event) {
 }
 
 void AutoExpandingTreeView::keyPressEvent(QKeyEvent* e) {
+  QModelIndex index = currentIndex();
+
   switch (e->key()) {
     case Qt::Key_Enter:
     case Qt::Key_Return:
-      if (currentIndex().isValid()) emit doubleClicked(currentIndex());
+      if (index.isValid()) emit doubleClicked(index);
       e->accept();
       break;
 
@@ -140,6 +142,16 @@ void AutoExpandingTreeView::keyPressEvent(QKeyEvent* e) {
     case Qt::Key_Escape:
       emit FocusOnFilterSignal(e);
       e->accept();
+      break;
+
+    case Qt::Key_Left:
+      // Set focus on the root of the current branch
+      if (index.isValid() && index.parent() != rootIndex() &&
+          (!isExpanded(index) || model()->rowCount(index) == 0)) {
+        setCurrentIndex(index.parent());
+        setFocus();
+        e->accept();
+      }
       break;
   }
 

--- a/src/widgets/autoexpandingtreeview.cpp
+++ b/src/widgets/autoexpandingtreeview.cpp
@@ -113,6 +113,20 @@ void AutoExpandingTreeView::mousePressEvent(QMouseEvent* event) {
   }
 }
 
+void AutoExpandingTreeView::mouseDoubleClickEvent(QMouseEvent* event) {
+  State p_state = state();
+  QModelIndex index = indexAt(event->pos());
+
+  QTreeView::mouseDoubleClickEvent(event);
+
+  // If the p_state was the "AnimatingState", then the base class's
+  // "mouseDoubleClickEvent" method just did nothing, hence the
+  // "doubleClicked" signal is not emitted. So let's do it ourselves.
+  if (index.isValid() && p_state == AnimatingState) {
+    emit doubleClicked(index);
+  }
+}
+
 void AutoExpandingTreeView::keyPressEvent(QKeyEvent* e) {
   switch (e->key()) {
     case Qt::Key_Enter:

--- a/src/widgets/autoexpandingtreeview.cpp
+++ b/src/widgets/autoexpandingtreeview.cpp
@@ -30,6 +30,7 @@ AutoExpandingTreeView::AutoExpandingTreeView(QWidget* parent)
       add_on_double_click_(true),
       ignore_next_click_(false) {
   setExpandsOnDoubleClick(false);
+  setAnimated(true);
 
   connect(this, SIGNAL(expanded(QModelIndex)), SLOT(ItemExpanded(QModelIndex)));
   connect(this, SIGNAL(clicked(QModelIndex)), SLOT(ItemClicked(QModelIndex)));

--- a/src/widgets/autoexpandingtreeview.h
+++ b/src/widgets/autoexpandingtreeview.h
@@ -47,6 +47,7 @@ signals:
 
   // QWidget
   void mousePressEvent(QMouseEvent* event);
+  void mouseDoubleClickEvent(QMouseEvent* event);
   void keyPressEvent(QKeyEvent* event);
 
   virtual bool CanRecursivelyExpand(const QModelIndex& index) const {


### PR DESCRIPTION
Changes made by this PR:
 - Fixed issue #4485
 - Fixed misbehavior when you double click after a single/double click on a song item in library or internet views
 - Made "AutoExpandingTreeView" animated by default
 - Added ability to collapse current branch in "AutoExpandingTreeView" by pressing "Left" key on items under its root