### PR TITLE
moodbar: check QSlider max/min before using them in division

### DIFF
--- a/src/moodbar/moodbarproxystyle.cpp
+++ b/src/moodbar/moodbarproxystyle.cpp
@@ -270,10 +270,15 @@ QRect MoodbarProxyStyle::subControlRect(ComplexControl cc,
         case SC_SliderHandle: {
           const QStyleOptionSlider* slider_opt =
               qstyleoption_cast<const QStyleOptionSlider*>(opt);
+          int x = 0;
 
-          const int x = (slider_opt->sliderValue - slider_opt->minimum) *
-                        (opt->rect.width() - kArrowWidth) /
-                        (slider_opt->maximum - slider_opt->minimum);
+          /* slider_opt->{maximum,minimum} can have the value 0 (their default
+             values), so this check avoids a division by 0. */
+          if (slider_opt->maximum > slider_opt->minimum) {
+            x = (slider_opt->sliderValue - slider_opt->minimum) *
+                (opt->rect.width() - kArrowWidth) /
+				(slider_opt->maximum - slider_opt->minimum);
+          }
 
           return QRect(QPoint(opt->rect.left() + x, opt->rect.top()),
                        QSize(kArrowWidth, kArrowHeight));


### PR DESCRIPTION
When switching playback from an item for which the moodbar is not
displayed (e.g. an internet stream), to an item for which it is
displayed (e.g. a local mp3 file), Clementine sometimes crashes.

This happens because the slider_opt->maximum and slider_opt->minimum
have the value 0 (their default value), and the difference is used as a
divisor.  This gives a division by 0, and a SIGFPE.

This problem has been fixed in commit af42cce.  However, when a9f9b0e
reverted 3f79fa5, a little to much was reverted and we lost what af42cce
did.  This patch re-introduces the fix.

Fixes #5261