### PR TITLE
 Add dummy bands to avoid #695. Change frecuencies to be ISO 266 compliant

### DIFF
--- a/src/engines/gstenginepipeline.h
+++ b/src/engines/gstenginepipeline.h
@@ -171,7 +171,7 @@ signals:
   static const int kGstStateTimeoutNanosecs;
   static const int kFaderFudgeMsec;
   static const int kEqBandCount;
-  static const int kEqBandFrequencies[];
+  static const float kEqBandFrequencies[];
 
   static GstElementDeleter* sElementDeleter;
 

--- a/src/ui/equalizer.cpp
+++ b/src/ui/equalizer.cpp
@@ -28,8 +28,8 @@
 #include "widgets/equalizerslider.h"
 
 // We probably don't need to translate these, right?
-const char* Equalizer::kGainText[] = {"60", "170", "310", "600", "1k",
-                                      "3k", "6k",  "12k", "14k", "16k"};
+const char* Equalizer::kGainText[] = {"31.5", "63", "125", "250", "500",
+                                      "1k",   "2k", "4k",  "8k",  "16k"};
 
 const char* Equalizer::kSettingsGroup = "Equalizer";
 
@@ -39,7 +39,8 @@ Equalizer::Equalizer(QWidget* parent)
 
   // Icons
   ui_->preset_del->setIcon(IconLoader::Load("list-remove", IconLoader::Base));
-  ui_->preset_save->setIcon(IconLoader::Load("document-save", IconLoader::Base));
+  ui_->preset_save->setIcon(
+      IconLoader::Load("document-save", IconLoader::Base));
 
   preamp_ = AddSlider(tr("Pre-amp"));
 


### PR DESCRIPTION
Assuming there is a bug in GStreamer's implementation of the first and last bands of the equalizer, we now set up two dummy bands, cutting from 20Hz and 20KHz, and with a bandwidth of 0 (what makes them dummies). That forces all actual bands to be implemented with band-pass filters, avoiding GStreamer's possibly-buggy shelve-filters implementation and preventing #695.

Also, we make bands compliant with ISO standard 266.