### PR TITLE
Fix mpris dbus notifications

### DIFF
--- a/src/core/mpris2.cpp
+++ b/src/core/mpris2.cpp
@@ -171,6 +171,12 @@ void Mpris2::EmitNotification(const QString& name) {
     value = Volume();
   else if (name == "Position")
     value = Position();
+  else if (name == "CanGoNext")
+    value = CanGoNext();
+  else if (name == "CanGoPrevious")
+    value = CanGoPrevious();
+  else if (name == "CanSeek")
+    value = CanSeek();
 
   if (value.isValid()) EmitNotification(name, value);
 }
@@ -402,6 +408,14 @@ bool Mpris2::CanSeek() const {
   } else {
     return true;
   }
+}
+
+bool Mpris2::CanSeek(Engine::State state) const {
+    if (mpris1_->player()) {
+      return mpris1_->player()->GetCaps(state) & CAN_SEEK;
+    } else {
+      return true;
+    }
 }
 
 bool Mpris2::CanControl() const { return true; }

--- a/src/core/mpris2.cpp
+++ b/src/core/mpris2.cpp
@@ -332,7 +332,12 @@ QString Mpris2::current_track_id() const {
 
 // We send Metadata change notification as soon as the process of
 // changing song starts...
-void Mpris2::CurrentSongChanged(const Song& song) { ArtLoaded(song, ""); }
+void Mpris2::CurrentSongChanged(const Song& song) {
+  ArtLoaded(song, "");
+  EmitNotification("CanGoNext", CanGoNext());
+  EmitNotification("CanGoPrevious", CanGoPrevious());
+  EmitNotification("CanSeek", CanSeek());
+}
 
 // ... and we add the cover information later, when it's available.
 void Mpris2::ArtLoaded(const Song& song, const QString& art_uri) {

--- a/src/core/mpris2.cpp
+++ b/src/core/mpris2.cpp
@@ -134,6 +134,8 @@ void Mpris2::EngineStateChanged(Engine::State newState) {
   }
 
   EmitNotification("PlaybackStatus", PlaybackStatus(newState));
+  if (newState == Engine::Playing)
+    EmitNotification("CanSeek", CanSeek(newState));
 }
 
 void Mpris2::VolumeChanged() { EmitNotification("Volume"); }

--- a/src/core/mpris2.cpp
+++ b/src/core/mpris2.cpp
@@ -187,7 +187,7 @@ void Mpris2::EmitNotification(const QString& name) {
   if (value.isValid()) EmitNotification(name, value);
 }
 
-  // ------------------Root Interface--------------- //
+// ------------------Root Interface--------------- //
 
 bool Mpris2::CanQuit() const { return true; }
 
@@ -414,19 +414,12 @@ bool Mpris2::CanPause() const {
 }
 
 bool Mpris2::CanSeek() const {
-  if (mpris1_->player()) {
-    return mpris1_->player()->GetCaps() & CAN_SEEK;
-  } else {
-    return true;
-  }
+  return mpris1_->player() ? mpris1_->player()->GetCaps() & CAN_SEEK : true;
 }
 
 bool Mpris2::CanSeek(Engine::State state) const {
-    if (mpris1_->player()) {
-      return mpris1_->player()->GetCaps(state) & CAN_SEEK;
-    } else {
-      return true;
-    }
+  return mpris1_->player() ? mpris1_->player()->GetCaps(state) & CAN_SEEK
+                           : true;
 }
 
 bool Mpris2::CanControl() const { return true; }

--- a/src/core/mpris2.cpp
+++ b/src/core/mpris2.cpp
@@ -140,7 +140,11 @@ void Mpris2::VolumeChanged() { EmitNotification("Volume"); }
 
 void Mpris2::ShuffleModeChanged() { EmitNotification("Shuffle"); }
 
-void Mpris2::RepeatModeChanged() { EmitNotification("LoopStatus"); }
+void Mpris2::RepeatModeChanged() {
+  EmitNotification("LoopStatus");
+  EmitNotification("CanGoNext", CanGoNext());
+  EmitNotification("CanGoPrevious", CanGoPrevious());
+}
 
 void Mpris2::EmitNotification(const QString& name, const QVariant& val) {
   EmitNotification(name, val, "org.mpris.MediaPlayer2.Player");

--- a/src/core/mpris2.h
+++ b/src/core/mpris2.h
@@ -217,6 +217,8 @@ class Mpris2 : public QObject {
 
   QString current_track_id() const;
 
+  bool CanSeek(Engine::State state) const;
+
   QString DesktopEntryAbsolutePath() const;
 
  private:

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -633,10 +633,6 @@ void Playlist::set_current_row(int i, bool is_stopping) {
                          old_current_item_index.row(), ColumnCount - 1));
   }
 
-  if (current_item_index_.isValid() && !is_stopping) {
-    InformOfCurrentSongChange();
-  }
-
   // Update the virtual index
   if (i == -1) {
     current_virtual_index_ = -1;
@@ -653,6 +649,10 @@ void Playlist::set_current_row(int i, bool is_stopping) {
     current_virtual_index_ = virtual_items_.indexOf(i);
   } else {
     current_virtual_index_ = i;
+  }
+
+  if (current_item_index_.isValid() && !is_stopping) {
+    InformOfCurrentSongChange();
   }
 
   // The structure of a dynamic playlist is as follows:


### PR DESCRIPTION
Clementine does not send the correct signal about the changed properties such as CanGoNext, CanGoPrevious, CanSeek and may cause programs that listen to those changes use the wrong information. 

To check the corect signals are send one can use:

`dbus-monitor --session --monitor "type='signal',interface=org.freedesktop.DBus.Properties,member=PropertiesChanged,path=/org/mpris/MediaPlayer2"`