### PR TITLE
"Stop after current" as command-line option

### DIFF
--- a/dist/clementine.desktop
+++ b/dist/clementine.desktop
@@ -33,7 +33,7 @@ Terminal=false
 Categories=AudioVideo;Player;Qt;Audio;
 StartupNotify=false
 MimeType=application/ogg;application/x-ogg;application/x-ogm-audio;audio/aac;audio/mp4;audio/mpeg;audio/mpegurl;audio/ogg;audio/vnd.rn-realaudio;audio/vorbis;audio/x-flac;audio/x-mp3;audio/x-mpeg;audio/x-mpegurl;audio/x-ms-wma;audio/x-musepack;audio/x-oggflac;audio/x-pn-realaudio;audio/x-scpls;audio/x-speex;audio/x-vorbis;audio/x-vorbis+ogg;audio/x-wav;video/x-ms-asf;x-content/audio-player;x-scheme-handler/zune;x-scheme-handler/itpc;x-scheme-handler/itms;x-scheme-handler/feed;
-Actions=Play;Pause;Stop;Previous;Next;
+Actions=Play;Pause;Stop;StopAfterCurrent;Previous;Next;
 
 [Desktop Action Play]
 Name=Play
@@ -180,6 +180,54 @@ Name[uk]=Зупинити
 Name[vi]=Dừng
 Name[zh_CN]=停止
 Name[zh_TW]=停止
+
+[Desktop Action StopAfterCurrent]
+Name=Stop after this track
+Exec=clementine --stop-after-current
+OnlyShowIn=Unity;
+Name[be]=Спыніць пасьля гэтага трэку
+Name[bg]=Спри след тази песен
+Name[br]=Paouez goude ar roud-mañ
+Name[ca]=Atura després d’aquesta peça
+Name[cs]=Zastavit po této skladbě
+Name[da]=Stop efter dette spor
+Name[de]=Wiedergabe nach diesem Titel anhalten
+Name[el]=Σταμάτημα μετά από αυτό το κομμάτι
+Name[es]=Detener reproducción al finalizar la pista
+Name[eu]=Gelditu pista honen ondoren
+Name[fa]=ایست پس از این آهنگ
+Name[fi]=Pysäytä toistettavan kappaleen jälkeen
+Name[fr]=Arrêter la lecture après cette piste
+Name[ga]=Stad i ndiaidh an rian seo
+Name[gl]=Deter a reprodución despois da pista actual
+Name[he]=הפסקה אחרי רצועה זו
+Name[hr]=Zaustavi reprodukciju nakon ove pjesme
+Name[hu]=Leállítás az aktuális szám után
+Name[it]=Ferma dopo questa traccia
+Name[ja]=このトラック後に停止
+Name[ko]=이번 트랙 이후 정지
+Name[lt]=Sustabdyti po šio takelio
+Name[lv]=Apturēt pēc šīs dziesmas
+Name[ms]=Henti selepas trek ini
+Name[nb]=Stopp etter denne sangen
+Name[nl]=Na dit nummer stoppen
+Name[pl]=Zatrzymaj po tym utworze
+Name[pt]=Parar após esta faixa
+Name[pt_BR]=Parar depois desta música
+Name[ro]=Oprește după această piesă
+Name[ru]=Остановить после этого трека
+Name[sk]=Zastaviť po tejto skladbe
+Name[sl]=Zaustavi po tej skladbi
+Name[sr]=Заустави после ове нумере
+Name[sr@ijekavian]=
+Name[sr@ijekavianlatin]=
+Name[sr@latin]=Zaustavi posle ove numere
+Name[sv]=Stoppa efter detta spår
+Name[tr]=Bu parçadan sonra durdur
+Name[uk]=Зупинити після цієї доріжки
+Name[vi]=Dừng sau khi phát xong bài này
+Name[zh_CN]=在此曲目后停止
+Name[zh_TW]=在這首歌之後停止
 
 [Desktop Action Previous]
 Name=Previous

--- a/src/core/commandlineoptions.cpp
+++ b/src/core/commandlineoptions.cpp
@@ -42,30 +42,31 @@ const char* CommandlineOptions::kHelpText =
     "  -t, --play-pause          %6\n"
     "  -u, --pause               %7\n"
     "  -s, --stop                %8\n"
-    "  -r, --previous            %9\n"
-    "  -f, --next                %10\n"
-    "  -v, --volume <value>      %11\n"
-    "  --volume-up               %12\n"
-    "  --volume-down             %13\n"
-    "  --volume-increase-by      %14\n"
-    "  --volume-decrease-by      %15\n"
-    "  --seek-to <seconds>       %16\n"
-    "  --seek-by <seconds>       %17\n"
-    "  --restart-or-previous     %18\n"
+    "  -q, --stop-after-current  %9\n"
+    "  -r, --previous            %10\n"
+    "  -f, --next                %11\n"
+    "  -v, --volume <value>      %12\n"
+    "  --volume-up               %13\n"
+    "  --volume-down             %14\n"
+    "  --volume-increase-by      %15\n"
+    "  --volume-decrease-by      %16\n"
+    "  --seek-to <seconds>       %17\n"
+    "  --seek-by <seconds>       %18\n"
+    "  --restart-or-previous     %19\n"
     "\n"
-    "%19:\n"
-    "  -a, --append              %20\n"
-    "  -l, --load                %21\n"
-    "  -k, --play-track <n>      %22\n"
+    "%20:\n"
+    "  -a, --append              %21\n"
+    "  -l, --load                %22\n"
+    "  -k, --play-track <n>      %23\n"
     "\n"
-    "%23:\n"
-    "  -o, --show-osd            %24\n"
-    "  -y, --toggle-pretty-osd   %25\n"
-    "  -g, --language <lang>     %26\n"
-    "      --quiet               %27\n"
-    "      --verbose             %28\n"
-    "      --log-levels <levels> %29\n"
-    "      --version             %30\n";
+    "%24:\n"
+    "  -o, --show-osd            %25\n"
+    "  -y, --toggle-pretty-osd   %26\n"
+    "  -g, --language <lang>     %27\n"
+    "      --quiet               %28\n"
+    "      --verbose             %29\n"
+    "      --log-levels <levels> %30\n"
+    "      --version             %31\n";
 
 const char* CommandlineOptions::kVersionText = "Clementine %1";
 
@@ -111,6 +112,7 @@ bool CommandlineOptions::Parse() {
       {"play-pause", no_argument, 0, 't'},
       {"pause", no_argument, 0, 'u'},
       {"stop", no_argument, 0, 's'},
+      {"stop-after-current", no_argument, 0, 'q'},
       {"previous", no_argument, 0, 'r'},
       {"next", no_argument, 0, 'f'},
       {"volume", required_argument, 0, 'v'},
@@ -136,7 +138,7 @@ bool CommandlineOptions::Parse() {
   // Parse the arguments
   bool ok = false;
   forever {
-    int c = getopt_long(argc_, argv_, "hptusrfv:alk:oyg:", kOptions, nullptr);
+    int c = getopt_long(argc_, argv_, "hptusqrfv:alk:oyg:", kOptions, nullptr);
 
     // End of the options
     if (c == -1) break;
@@ -150,8 +152,9 @@ bool CommandlineOptions::Parse() {
                      tr("Start the playlist currently playing"),
                      tr("Play if stopped, pause if playing"),
                      tr("Pause playback"), tr("Stop playback"),
-                     tr("Skip backwards in playlist"))
-                .arg(tr("Skip forwards in playlist"),
+                     tr("Stop playback after current track"))
+                .arg(tr("Skip backwards in playlist"),
+                     tr("Skip forwards in playlist"),
                      tr("Set the volume to <value> percent"),
                      tr("Increase the volume by 4%"),
                      tr("Decrease the volume by 4%"),
@@ -190,6 +193,9 @@ bool CommandlineOptions::Parse() {
         break;
       case 's':
         player_action_ = Player_Stop;
+        break;
+      case 'q':
+        player_action_ = Player_StopAfterCurrent;
         break;
       case 'r':
         player_action_ = Player_Previous;

--- a/src/core/commandlineoptions.h
+++ b/src/core/commandlineoptions.h
@@ -54,6 +54,7 @@ class CommandlineOptions {
     Player_Previous = 5,
     Player_Next = 6,
     Player_RestartOrPrevious = 7,
+    Player_StopAfterCurrent = 8,
   };
 
   bool Parse();

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2116,6 +2116,9 @@ void MainWindow::CommandlineOptionsReceived(const CommandlineOptions& options) {
     case CommandlineOptions::Player_Stop:
       app_->player()->Stop();
       break;
+    case CommandlineOptions::Player_StopAfterCurrent:
+      app_->player()->StopAfterCurrent();
+      break;
     case CommandlineOptions::Player_Previous:
       app_->player()->Previous();
       break;


### PR DESCRIPTION
As suggested in #5304 I have added support for the command-line flag `-q, --stop-after-current` and added this option to the Unity launcher icon.

I have no previous experience with C/C++, so I might have made some rookie mistakes. However, this change seemed pretty straight-forward, the code compiles without errors and everything seems to work as intended.