### PR TITLE
Fixed compile error for the subsonic module.

### DIFF
--- a/src/internet/subsonic/subsonicservice.cpp
+++ b/src/internet/subsonic/subsonicservice.cpp
@@ -139,7 +139,7 @@ SubsonicService::SubsonicService(Application* app, InternetModel* parent)
                            tr("Refresh catalogue"), this,
                            SLOT(ReloadDatabase()));
   QAction* config_action = context_menu_->addAction(
-      IconLoader::Load("configure", IconLoader::Base), tr("Configure Subsonic..."), 
+      IconLoader::Load("configure", IconLoader::Base), tr("Configure Subsonic..."),
       this, SLOT(ShowConfig()));
   context_menu_->addSeparator();
   context_menu_->addMenu(library_filter_->menu());
@@ -154,7 +154,7 @@ SubsonicService::SubsonicService(Application* app, InternetModel* parent)
 SubsonicService::~SubsonicService() {}
 
 QStandardItem* SubsonicService::CreateRootItem() {
-  root_ = new QStandardItem(IconLoader::Load("subsonic", IconLoader::Provider), 
+  root_ = new QStandardItem(IconLoader::Load("subsonic", IconLoader::Provider),
                             kServiceName);
   root_->setData(true, InternetModel::Role_CanLazyLoad);
   return root_;
@@ -404,6 +404,7 @@ void SubsonicService::UpdateServer(const QString& server) {
 
 const int SubsonicLibraryScanner::kAlbumChunkSize = 500;
 const int SubsonicLibraryScanner::kConcurrentRequests = 8;
+const int SubsonicLibraryScanner::kCoverArtSize = 1024;
 
 SubsonicLibraryScanner::SubsonicLibraryScanner(SubsonicService* service,
                                                QObject* parent)

--- a/src/internet/subsonic/subsonicservice.h
+++ b/src/internet/subsonic/subsonicservice.h
@@ -125,6 +125,8 @@ class SubsonicService : public InternetService {
   static const char* kFtsTable;
 
   static const int kMaxRedirects;
+  static const int kCoverArtSize;
+
 
 signals:
   void LoginStateChanged(SubsonicService::LoginState newstate);
@@ -185,6 +187,7 @@ class SubsonicLibraryScanner : public QObject {
 
   static const int kAlbumChunkSize;
   static const int kConcurrentRequests;
+  static const int kCoverArtSize;
 
   void GetAlbumCover(const QString& id);
 


### PR DESCRIPTION
Fixes the following compiler error:

/home/alex/builds/clementine-git/src/Clementine/src/internet/subsonic/subsonicservice.cpp:62:28: error: ‘const int SubsonicService::kCoverArtSize’ is not a static data member of ‘class SubsonicService’
 const int SubsonicService::kCoverArtSize = 1024;
                            ^
/home/alex/builds/clementine-git/src/Clementine/src/internet/subsonic/subsonicservice.cpp: In member function ‘void SubsonicLibraryScanner::GetAlbumCover(const QString&)’:
/home/alex/builds/clementine-git/src/Clementine/src/internet/subsonic/subsonicservice.cpp:593:44: error: ‘kCoverArtSize’ was not declared in this scope
   url.addQueryItem("size", QString::number(kCoverArtSize));
                                            ^
