### PR TITLE
Update AZLyrics parsing rule

### DIFF
--- a/data/lyrics/ultimate_providers.xml
+++ b/data/lyrics/ultimate_providers.xml
@@ -3,13 +3,14 @@
   <provider name="azlyrics.com" title="{artist} LYRICS - {title}" charset="utf-8" url="http://www.azlyrics.com/lyrics/{artist}/{title}.html">
     <urlFormat replace=" ._@,;&amp;\/()'&quot;-" with=""/>
     <extract>
-      <item begin="&lt;!-- start of lyrics --&gt;" end="&lt;!-- end of lyrics --&gt;"/>
+      <item begin="&lt;!-- Usage of azlyrics.com content by any third-party lyrics provider is prohibited by our licensing agreement. Sorry about that. --&gt;" end="&lt;/div&gt;"/>
     </extract>
     <exclude>
       <item tag="&lt;B&gt;"/>
       <item begin="&lt;i&gt;[" end="]&lt;/i&gt;"/>
       <item begin="[" end="]"/>
     </exclude>
+    <invalidIndicator value="&lt;h1&gt;Welcome to AZLyrics!&lt;/h1&gt;"/>
   </provider>
   <provider name="bollywoodlyrics.com (Bollywood songs)" title="{title} Song Lyrics - BollywoodLyrics.com" charset="utf-8" url="http://www.bollywoodlyrics.com/lyric/{Title}">
     <urlFormat replace=" _@;\/&quot;'()[]" with="-"/>


### PR DESCRIPTION
AZLyrics breaks old rule - the site always returns:
```html
<!-- start of lyrics -->
<div class="hidden">Visit www.azlyrics.com for these lyrics.</div>
<!-- end of lyrics -->
```