### PR TITLE
Fix playlist behaviour

### DIFF
--- a/src/core/commandlineoptions.cpp
+++ b/src/core/commandlineoptions.cpp
@@ -299,6 +299,11 @@ bool CommandlineOptions::is_empty() const {
          toggle_pretty_osd_ == false && urls_.isEmpty();
 }
 
+bool CommandlineOptions::contains_play_options() const {
+  return player_action_ != Player_None || play_track_at_ != -1 ||
+         !urls_.isEmpty();
+}
+
 QByteArray CommandlineOptions::Serialize() const {
   QBuffer buf;
   buf.open(QIODevice::WriteOnly);

--- a/src/core/commandlineoptions.h
+++ b/src/core/commandlineoptions.h
@@ -60,6 +60,7 @@ class CommandlineOptions {
   bool Parse();
 
   bool is_empty() const;
+  bool contains_play_options() const;
 
   UrlListAction url_list_action() const { return url_list_action_; }
   PlayerAction player_action() const { return player_action_; }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -462,7 +462,7 @@ int main(int argc, char* argv[]) {
 #endif
 
   // Window
-  MainWindow w(&app, tray_icon.get(), &osd);
+  MainWindow w(&app, tray_icon.get(), &osd, options);
 #ifdef Q_OS_DARWIN
   mac::EnableFullScreen(w);
 #endif  // Q_OS_DARWIN
@@ -474,7 +474,6 @@ int main(int argc, char* argv[]) {
 #endif
   QObject::connect(&a, SIGNAL(messageReceived(QByteArray)), &w,
                    SLOT(CommandlineOptionsReceived(QByteArray)));
-  w.CommandlineOptionsReceived(options);
 
   int ret = a.exec();
 

--- a/src/playlist/playlist.h
+++ b/src/playlist/playlist.h
@@ -443,6 +443,9 @@ signals:
   QList<SongInsertVetoListener*> veto_listeners_;
 
   QString special_type_;
+
+  // Cancel async restore if songs are already replaced
+  bool cancel_restore_;
 };
 
 // QDataStream& operator <<(QDataStream&, const Playlist*);

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -165,7 +165,7 @@ const int kTrackPositionUpdateTimeMs = 1000;
 }
 
 MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
-                       QWidget* parent)
+                       const CommandlineOptions& options, QWidget* parent)
     : QMainWindow(parent),
       ui_(new Ui_MainWindow),
       thumbbar_(new Windows7ThumbBar(this)),
@@ -1038,7 +1038,10 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
 
   CheckFullRescanRevisions();
 
-  LoadPlaybackStatus();
+  CommandlineOptionsReceived(options);
+
+  if (!options.contains_play_options())
+    LoadPlaybackStatus();
 
   qLog(Debug) << "Started";
 }

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -89,7 +89,7 @@ class MainWindow : public QMainWindow, public PlatformInterface {
 
  public:
   MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
-             QWidget* parent = nullptr);
+             const CommandlineOptions& options, QWidget* parent = nullptr);
   ~MainWindow();
 
   static const char* kSettingsGroup;


### PR DESCRIPTION
This fixes at least two problems of unwanted behaviour when starting clementine with commandline parameters which contradict with other settings (restoring playback status and doubleclick behaviour).

Hope everything is clear, as always I'll explain more if needed.