### PR TITLE
Fix "Untitled Window" when playing a stream with no metadata

### DIFF
--- a/src/core/song.cpp
+++ b/src/core/song.cpp
@@ -1035,9 +1035,7 @@ QString Song::PrettyTitle() const {
 }
 
 QString Song::PrettyTitleWithArtist() const {
-  QString title(d->title_);
-
-  if (title.isEmpty()) title = d->basefilename_;
+  QString title(PrettyTitle());
 
   if (!d->artist_.isEmpty()) title = d->artist_ + " - " + title;
 


### PR DESCRIPTION
When playing a stream with no metadata the main window's title is set to an empty string. This is inconvenient because it can cause the minimized window to be shown as "Untitled Window" in the desktop's taskbar. (I have observed it in XFCE).

This modification makes the stream's URL to be set as the title. That is not only useful, but consistent with the current behavior for local files: when lacking a title, their path is displayed.