### PR TITLE
QT5: Fix DESTINATION path for protocol files

### DIFF
--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -62,7 +62,7 @@ if (NOT APPLE)
                 clementine-itpc.protocol
                 clementine-feed.protocol
                 clementine-zune.protocol
-    DESTINATION share/kde4/services
+    DESTINATION share/kservices5
   )
 
   install(FILES clementine.appdata.xml

--- a/dist/clementine.spec.in
+++ b/dist/clementine.spec.in
@@ -83,10 +83,10 @@ make clean
 %{_datadir}/appdata/clementine.appdata.xml
 %{_datadir}/applications/clementine.desktop
 %{_datadir}/clementine/projectm-presets
-%{_datadir}/kde4/services/clementine-itms.protocol
-%{_datadir}/kde4/services/clementine-itpc.protocol
-%{_datadir}/kde4/services/clementine-feed.protocol
-%{_datadir}/kde4/services/clementine-zune.protocol
+%{_datadir}/kservices5/clementine-itms.protocol
+%{_datadir}/kservices5/clementine-itpc.protocol
+%{_datadir}/kservices5/clementine-feed.protocol
+%{_datadir}/kservices5/clementine-zune.protocol
 %{_datadir}/icons/hicolor/64x64/apps/clementine.png
 %{_datadir}/icons/hicolor/128x128/apps/clementine.png
 %{_datadir}/icons/hicolor/scalable/apps/clementine.svg


### PR DESCRIPTION
protocol files are stored in `/usr/share/kservices5` PATH in Plasma 5