### PR TITLE
Scrolling over tray icon support

### DIFF
--- a/src/ui/behavioursettingspage.cpp
+++ b/src/ui/behavioursettingspage.cpp
@@ -106,6 +106,8 @@ void BehaviourSettingsPage::Load() {
 
   s.beginGroup(MainWindow::kSettingsGroup);
   ui_->b_show_tray_icon_->setChecked(s.value("showtray", true).toBool());
+  ui_->b_scroll_tray_icon_->setChecked(
+      s.value("scrolltrayicon", ui_->b_show_tray_icon_->isChecked()).toBool());
   ui_->b_keep_running_->setChecked(
       s.value("keeprunning", ui_->b_show_tray_icon_->isChecked()).toBool());
   ui_->doubleclick_addmode->setCurrentIndex(ui_->doubleclick_addmode->findData(
@@ -227,6 +229,7 @@ void BehaviourSettingsPage::Save() {
 
   s.beginGroup(MainWindow::kSettingsGroup);
   s.setValue("showtray", ui_->b_show_tray_icon_->isChecked());
+  s.setValue("scrolltrayicon", ui_->b_scroll_tray_icon_->isChecked());
   s.setValue("keeprunning", ui_->b_keep_running_->isChecked());
   s.setValue("startupbehaviour", int(behaviour));
   s.setValue("doubleclick_addmode", doubleclick_addmode);
@@ -266,4 +269,5 @@ void BehaviourSettingsPage::ShowTrayIconToggled(bool on) {
     ui_->b_remember_->setChecked(true);
   ui_->b_keep_running_->setEnabled(on);
   ui_->b_keep_running_->setChecked(on);
+  ui_->b_scroll_tray_icon_->setEnabled(on);
 }

--- a/src/ui/behavioursettingspage.ui
+++ b/src/ui/behavioursettingspage.ui
@@ -25,6 +25,16 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="b_scroll_tray_icon_">
+     <property name="text">
+      <string>Scroll over icon to change track</string>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QCheckBox" name="b_keep_running_">
      <property name="text">
       <string>Keep running in the background when the window is closed</string>

--- a/src/ui/qtsystemtrayicon.cpp
+++ b/src/ui/qtsystemtrayicon.cpp
@@ -85,7 +85,18 @@ bool QtSystemTrayIcon::eventFilter(QObject* object, QEvent* event) {
         emit PreviousTrack();
       }
     } else {
+      QSettings s;
+      s.beginGroup(MainWindow::kSettingsGroup);
+      bool prev_next_track = s.value("scrolltrayicon").toBool();
+	  if(prev_next_track) {
+	    if (e->delta() < 0) {
+              emit NextTrack();
+            } else {
+              emit PreviousTrack();
+            }
+	  } else {
       emit ChangeVolume(e->delta());
+      }
     }
     return true;
   }

--- a/src/ui/qtsystemtrayicon.cpp
+++ b/src/ui/qtsystemtrayicon.cpp
@@ -38,7 +38,8 @@ QtSystemTrayIcon::QtSystemTrayIcon(QObject* parent)
       action_mute_(nullptr),
       action_love_(nullptr) {
   QIcon theme_icon = IconLoader::Load("clementine-panel", IconLoader::Base);
-  QIcon theme_icon_grey = IconLoader::Load("clementine-panel-grey", IconLoader::Base);
+  QIcon theme_icon_grey =
+      IconLoader::Load("clementine-panel-grey", IconLoader::Base);
 
   if (theme_icon.isNull() || theme_icon_grey.isNull()) {
     // Load the default icon
@@ -88,14 +89,14 @@ bool QtSystemTrayIcon::eventFilter(QObject* object, QEvent* event) {
       QSettings s;
       s.beginGroup(MainWindow::kSettingsGroup);
       bool prev_next_track = s.value("scrolltrayicon").toBool();
-	  if(prev_next_track) {
-	    if (e->delta() < 0) {
-              emit NextTrack();
-            } else {
-              emit PreviousTrack();
-            }
-	  } else {
-      emit ChangeVolume(e->delta());
+      if (prev_next_track) {
+        if (e->delta() < 0) {
+          emit NextTrack();
+        } else {
+          emit PreviousTrack();
+        }
+      } else {
+        emit ChangeVolume(e->delta());
       }
     }
     return true;
@@ -171,7 +172,8 @@ void QtSystemTrayIcon::SetPaused() {
 
   action_stop_->setEnabled(true);
   action_stop_after_this_track_->setEnabled(true);
-  action_play_pause_->setIcon(IconLoader::Load("media-playback-start", IconLoader::Base));
+  action_play_pause_->setIcon(
+      IconLoader::Load("media-playback-start", IconLoader::Base));
   action_play_pause_->setText(tr("Play"));
 
   action_play_pause_->setEnabled(true);
@@ -182,7 +184,8 @@ void QtSystemTrayIcon::SetPlaying(bool enable_play_pause, bool enable_love) {
 
   action_stop_->setEnabled(true);
   action_stop_after_this_track_->setEnabled(true);
-  action_play_pause_->setIcon(IconLoader::Load("media-playback-pause", IconLoader::Base));
+  action_play_pause_->setIcon(
+      IconLoader::Load("media-playback-pause", IconLoader::Base));
   action_play_pause_->setText(tr("Pause"));
   action_play_pause_->setEnabled(enable_play_pause);
 #ifdef HAVE_LIBLASTFM
@@ -195,7 +198,8 @@ void QtSystemTrayIcon::SetStopped() {
 
   action_stop_->setEnabled(false);
   action_stop_after_this_track_->setEnabled(false);
-  action_play_pause_->setIcon(IconLoader::Load("media-playback-start", IconLoader::Base));
+  action_play_pause_->setIcon(
+      IconLoader::Load("media-playback-start", IconLoader::Base));
   action_play_pause_->setText(tr("Play"));
 
   action_play_pause_->setEnabled(true);

--- a/src/ui/qtsystemtrayicon.h
+++ b/src/ui/qtsystemtrayicon.h
@@ -18,6 +18,7 @@
 #ifndef QTSYSTEMTRAYICON_H
 #define QTSYSTEMTRAYICON_H
 
+#include "mainwindow.h"
 #include "systemtrayicon.h"
 
 #include <QSystemTrayIcon>


### PR DESCRIPTION
This fixes #4918 
Also adds setting for old behavior. I've also found support for Ctrl and Shoft modifiers in source code, but they do not work on Linux (maybe on other OS's too)