### PR TITLE
Fix pipeline with direct output to ALSA

### DIFF
--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -418,7 +418,7 @@ bool GstEnginePipeline::Init() {
 
   // Ensure that the audio output of the tee does not autonegotiate to 16 bit
   GstCaps* caps = gst_caps_new_simple("audio/x-raw", "format", G_TYPE_STRING,
-                                      "F32LE", NULL);
+                                      "S32LE", NULL);
 
   // Add caps for fixed sample rate and mono, but only if requested
   if (sample_rate_ != GstEngine::kAutoSampleRate && sample_rate_ > 0) {


### PR DESCRIPTION
In the new version of gstreamer, alsasink now supports floating samples, so it seems to be bypassing audioconvert. If the sound card does not support float samples, the pipeline will not link.
Integer samples make downmixing work correctly on all the sound cards I tested with ALSA.