### PR TITLE
Switch to the library tab when using the 'Show in library' feature

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1040,8 +1040,7 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
 
   CommandlineOptionsReceived(options);
 
-  if (!options.contains_play_options())
-    LoadPlaybackStatus();
+  if (!options.contains_play_options()) LoadPlaybackStatus();
 
   qLog(Debug) << "Started";
 }
@@ -2078,6 +2077,7 @@ void MainWindow::ShowInLibrary() {
         "artist:" + songs.first().artist() + " album:" + songs.first().album();
   }
   library_view_->filter()->ShowInLibrary(search);
+  FocusLibraryTab();
 }
 
 void MainWindow::PlaylistRemoveCurrent() {
@@ -2784,6 +2784,10 @@ void MainWindow::ScrollToInternetIndex(const QModelIndex& index) {
 
 void MainWindow::AddPodcast() {
   app_->internet_model()->Service<PodcastService>()->AddPodcast();
+}
+
+void MainWindow::FocusLibraryTab() {
+  ui_->tabs->SetCurrentWidget(library_view_);
 }
 
 void MainWindow::FocusGlobalSearchField() {

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -273,6 +273,7 @@ signals:
                                  QString line2);
 
   void ScrollToInternetIndex(const QModelIndex& index);
+  void FocusLibraryTab();
   void FocusGlobalSearchField();
   void DoGlobalSearch(const QString& query);
 


### PR DESCRIPTION
Always switch to the library tab when clicking on 'Show in library' in the playlist context menu. This was proposed in the comments of #4107.