### PR TITLE
Back/Forward mouse buttons support (closes #4809)

### DIFF
--- a/src/widgets/fileview.cpp
+++ b/src/widgets/fileview.cpp
@@ -56,6 +56,8 @@ FileView::FileView(QWidget* parent)
   connect(ui_->up, SIGNAL(clicked()), SLOT(FileUp()));
   connect(ui_->path, SIGNAL(textChanged(QString)),
           SLOT(ChangeFilePath(QString)));
+  connect(ui_->list, SIGNAL(Back()), undo_stack_, SLOT(undo()));
+  connect(ui_->list, SIGNAL(Forward()), undo_stack_, SLOT(redo()));
 
   connect(undo_stack_, SIGNAL(canUndoChanged(bool)), ui_->back,
           SLOT(setEnabled(bool)));

--- a/src/widgets/fileviewlist.cpp
+++ b/src/widgets/fileviewlist.cpp
@@ -132,17 +132,29 @@ void FileViewList::DeleteSlot() { emit Delete(FilenamesFromSelection()); }
 void FileViewList::EditTagsSlot() { emit EditTags(UrlListFromSelection()); }
 
 void FileViewList::mousePressEvent(QMouseEvent* e) {
-  QListView::mousePressEvent(e);
+  switch (e->button()) {
+    case Qt::XButton1:
+      emit Back();
+      break;
+    case Qt::XButton2:
+      emit Forward();
+      break;
+    // enqueue to playlist with middleClick
+    case Qt::MidButton: {
+      QListView::mousePressEvent(e);
 
-  // enqueue to playlist with middleClick
-  if (e->button() == Qt::MidButton) {
-    // we need to update the menu selection
-    menu_selection_ = selectionModel()->selection();
+      // we need to update the menu selection
+      menu_selection_ = selectionModel()->selection();
 
-    MimeData* data = new MimeData;
-    data->setUrls(UrlListFromSelection());
-    data->enqueue_now_ = true;
-    emit AddToPlaylist(data);
+      MimeData* data = new MimeData;
+      data->setUrls(UrlListFromSelection());
+      data->enqueue_now_ = true;
+      emit AddToPlaylist(data);
+      break;
+    }
+    default:
+      QListView::mousePressEvent(e);
+      break;
   }
 }
 

--- a/src/widgets/fileviewlist.h
+++ b/src/widgets/fileviewlist.h
@@ -38,6 +38,8 @@ signals:
   void CopyToDevice(const QList<QUrl>& urls);
   void Delete(const QStringList& filenames);
   void EditTags(const QList<QUrl>& urls);
+  void Back();
+  void Forward();
 
  protected:
   void contextMenuEvent(QContextMenuEvent* e);


### PR DESCRIPTION
Allows navigating back and forward through the navigation history in the Files view using not only the UI buttons, but Back and Forward mouse buttons as well.

The switch is constructed this way so that folder selection wouldn't get lost after changing directory using the mouse buttons.

Could you please review it?