### PR TITLE
Fix compilation with Clang

### DIFF
--- a/3rdparty/vreen/vreen/cmake/CommonUtils.cmake
+++ b/3rdparty/vreen/vreen/cmake/CommonUtils.cmake
@@ -92,7 +92,7 @@ macro(UPDATE_COMPILER_FLAGS target)
 
     if(FLAGS_CXX11)
         update_cxx_compiler_flag(${target} "-std=c++0x" CXX_11)
-	update_cxx_compiler_flag(${target} "-stdlib=libc++" STD_LIBCXX)
+        #update_cxx_compiler_flag(${target} "-stdlib=libc++" STD_LIBCXX)
         #add check for c++11 support
     endif()
 

--- a/ext/clementine-spotifyblob/CMakeLists.txt
+++ b/ext/clementine-spotifyblob/CMakeLists.txt
@@ -7,7 +7,7 @@ include_directories(${CMAKE_SOURCE_DIR}/ext/libclementine-spotifyblob)
 include_directories(${CMAKE_SOURCE_DIR}/ext/libclementine-common)
 include_directories(${CMAKE_SOURCE_DIR}/src)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Woverloaded-virtual -Wall -Wno-sign-compare -Wno-deprecated-declarations -Wno-unused-local-typedefs -Wno-unused-private-field -Wno-unknown-warning-option --std=c++0x -U__STRICT_ANSI__")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Woverloaded-virtual -Wall -Wno-sign-compare -Wno-deprecated-declarations -Wno-unused-local-typedefs -Wno-unused-private-field -Wno-unknown-warning-option --std=c++0x")
 
 link_directories(${SPOTIFY_LIBRARY_DIRS})
 

--- a/ext/clementine-tagreader/CMakeLists.txt
+++ b/ext/clementine-tagreader/CMakeLists.txt
@@ -7,7 +7,7 @@ include_directories(${CMAKE_BINARY_DIR}/ext/libclementine-tagreader)
 include_directories(${CMAKE_SOURCE_DIR}/src)
 include_directories(${CMAKE_BINARY_DIR}/src)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --std=c++0x -U__STRICT_ANSI__")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --std=c++0x")
 
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Woverloaded-virtual -Wall -Wno-sign-compare -Wno-deprecated-declarations -Wno-unused-local-typedefs -Wno-unused-private-field -Wno-unknown-warning-option --std=c++0x -U__STRICT_ANSI__")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Woverloaded-virtual -Wall -Wno-sign-compare -Wno-deprecated-declarations -Wno-unused-local-typedefs -Wno-unused-private-field -Wno-unknown-warning-option --std=c++0x")
 
 option(BUILD_WERROR "Build with -Werror" ON)
 

--- a/src/globalsearch/digitallyimportedsearchprovider.h
+++ b/src/globalsearch/digitallyimportedsearchprovider.h
@@ -31,7 +31,7 @@ class DigitallyImportedSearchProvider : public SimpleSearchProvider {
   InternetService* internet_service() override { return service_; }
 
  protected:
-  void RecreateItems();
+  void RecreateItems() override;
 
  private:
   DigitallyImportedServiceBase* service_;

--- a/src/globalsearch/intergalacticfmsearchprovider.h
+++ b/src/globalsearch/intergalacticfmsearchprovider.h
@@ -28,10 +28,10 @@ class IntergalacticFMSearchProvider : public SimpleSearchProvider {
   // SearchProvider
   InternetService* internet_service() override { return service_; }
 
-  void LoadArtAsync(int id, const Result& result);
+  void LoadArtAsync(int id, const Result& result) override;
 
  protected:
-  void RecreateItems();
+  void RecreateItems() override;
 
  private:
   IntergalacticFMServiceBase* service_;

--- a/src/globalsearch/savedradiosearchprovider.h
+++ b/src/globalsearch/savedradiosearchprovider.h
@@ -30,7 +30,7 @@ class SavedRadioSearchProvider : public SimpleSearchProvider {
   InternetService* internet_service() override { return service_; }
 
  protected:
-  void RecreateItems();
+  void RecreateItems() override;
 
  private:
   SavedRadio* service_;

--- a/src/globalsearch/somafmsearchprovider.h
+++ b/src/globalsearch/somafmsearchprovider.h
@@ -28,10 +28,10 @@ class SomaFMSearchProvider : public SimpleSearchProvider {
   // SearchProvider
   InternetService* internet_service() override { return service_; }
 
-  void LoadArtAsync(int id, const Result& result);
+  void LoadArtAsync(int id, const Result& result) override;
 
  protected:
-  void RecreateItems();
+  void RecreateItems() override;
 
  private:
   SomaFMServiceBase* service_;

--- a/src/globalsearch/spotifysearchprovider.h
+++ b/src/globalsearch/spotifysearchprovider.h
@@ -30,9 +30,9 @@ class SpotifySearchProvider : public SearchProvider {
  public:
   SpotifySearchProvider(Application* app, QObject* parent = nullptr);
 
-  void SearchAsync(int id, const QString& query);
-  void LoadArtAsync(int id, const Result& result);
-  QStringList GetSuggestions(int count);
+  void SearchAsync(int id, const QString& query) override;
+  void LoadArtAsync(int id, const Result& result) override;
+  QStringList GetSuggestions(int count) override;
 
   // SearchProvider
   bool IsLoggedIn() override;

--- a/src/internet/dropbox/dropboxsettingspage.h
+++ b/src/internet/dropbox/dropboxsettingspage.h
@@ -34,8 +34,8 @@ class DropboxSettingsPage : public SettingsPage {
   explicit DropboxSettingsPage(SettingsDialog* parent = nullptr);
   ~DropboxSettingsPage();
 
-  void Load();
-  void Save();
+  void Load() override;
+  void Save() override;
 
   // QObject
   bool eventFilter(QObject* object, QEvent* event) override;

--- a/src/internet/spotify/spotifyservice.h
+++ b/src/internet/spotify/spotifyservice.h
@@ -102,7 +102,7 @@ signals:
 
  public slots:
   void Search(const QString& text, bool now = false);
-  void ShowConfig();
+  void ShowConfig() override;
   void RemoveCurrentFromPlaylist();
 
  private:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.6)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -fpermissive -Wno-c++11-narrowing -U__STRICT_ANSI__")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -fpermissive -Wno-c++11-narrowing")
 
 if(USE_SYSTEM_GMOCK)
   include_directories(${GMOCK_INCLUDE_DIRS} ${GTEST_INCLUDE_DIRS})

--- a/tests/mock_networkaccessmanager.h
+++ b/tests/mock_networkaccessmanager.h
@@ -15,7 +15,7 @@
    along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef MOCK_NETWORKACCESSAMANGER_H
+#ifndef MOCK_NETWORKACCESSMANAGER_H
 #define MOCK_NETWORKACCESSMANAGER_H
 
 #include <QByteArray>


### PR DESCRIPTION
Another try to fix  #4227
Also this fixes several warnings about missing overrides. And a messed up include guard.

Previous PR had troubled building chromaprint which is currently removed.
I've test myself that it builds fine with both clang-3.7.1 and gcc-4.9.3 on gentoo linux. But this one still requires some additional testing.
