### PR TITLE
Remove OnlyShowIn=Unity from clementine.desktop's action sections

### DIFF
--- a/dist/clementine.desktop
+++ b/dist/clementine.desktop
@@ -38,7 +38,6 @@ Actions=Play;Pause;Stop;StopAfterCurrent;Previous;Next;
 [Desktop Action Play]
 Name=Play
 Exec=clementine --play
-OnlyShowIn=Unity;
 Name[af]=Speel
 Name[be]=Прайграць
 Name[bg]=Възпроизвеждане
@@ -89,7 +88,6 @@ Name[zh_TW]=播放
 [Desktop Action Pause]
 Name=Pause
 Exec=clementine --pause
-OnlyShowIn=Unity;
 Name[be]=Прыпыніць
 Name[bg]=Пауза
 Name[br]=Ehan
@@ -135,7 +133,6 @@ Name[zh_TW]=暫停
 [Desktop Action Stop]
 Name=Stop
 Exec=clementine --stop
-OnlyShowIn=Unity;
 Name[be]=Спыніць
 Name[bg]=Спиране
 Name[br]=Paouez
@@ -184,7 +181,6 @@ Name[zh_TW]=停止
 [Desktop Action StopAfterCurrent]
 Name=Stop after this track
 Exec=clementine --stop-after-current
-OnlyShowIn=Unity;
 Name[be]=Спыніць пасьля гэтага трэку
 Name[bg]=Спри след тази песен
 Name[br]=Paouez goude ar roud-mañ
@@ -232,7 +228,6 @@ Name[zh_TW]=在這首歌之後停止
 [Desktop Action Previous]
 Name=Previous
 Exec=clementine --previous
-OnlyShowIn=Unity;
 Name[af]=Vorige
 Name[be]=Папярэдні
 Name[bg]=Предишна
@@ -280,7 +275,6 @@ Name[zh_TW]=往前
 [Desktop Action Next]
 Name=Next
 Exec=clementine --next
-OnlyShowIn=Unity;
 Name[af]=Volgende
 Name[be]=Далей
 Name[bg]=Следваща


### PR DESCRIPTION
fix the desktop-file-validate (part of [desktop-file-utils](https://freedesktop.org/wiki/Software/desktop-file-utils/)) complains about the clementine.desktop:
```
dist/clementine.desktop: warning: key "OnlyShowIn" in group "Desktop Action Play" is deprecated
dist/clementine.desktop: warning: key "OnlyShowIn" in group "Desktop Action Pause" is deprecated
dist/clementine.desktop: warning: key "OnlyShowIn" in group "Desktop Action Stop" is deprecated
dist/clementine.desktop: warning: key "OnlyShowIn" in group "Desktop Action StopAfterCurrent" is deprecated
dist/clementine.desktop: warning: key "OnlyShowIn" in group "Desktop Action Previous" is deprecated
dist/clementine.desktop: warning: key "OnlyShowIn" in group "Desktop Action Next" is deprecated
```
Some info why it is deprecated may be found on the [maillist](https://lists.freedesktop.org/archives/xdg/2013-July/012835.html)