### PR TITLE
Restructure edittagdialog layout (corrects #5437)

### DIFF
--- a/src/ui/edittagdialog.ui
+++ b/src/ui/edittagdialog.ui
@@ -2,13 +2,11 @@
 <ui version="4.0">
  <class>EditTagDialog</class>
  <widget class="QDialog" name="EditTagDialog">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>863</width>
-    <height>635</height>
-   </rect>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>Edit track information</string>
@@ -625,6 +623,16 @@
          <layout class="QVBoxLayout" name="verticalLayout_4">
           <item>
            <layout class="QGridLayout" name="gridLayout">
+            <item row="12" column="0">
+             <widget class="QLabel" name="comment_label">
+              <property name="text">
+               <string>Comment</string>
+              </property>
+              <property name="buddy">
+               <cstring>comment</cstring>
+              </property>
+             </widget>
+            </item>
             <item row="0" column="0">
              <widget class="QLabel" name="title_label">
               <property name="text">
@@ -648,7 +656,7 @@
             <item row="0" column="2">
              <widget class="QLabel" name="track_label">
               <property name="text">
-               <string>Track</string>
+               <string>Trac&amp;k</string>
               </property>
               <property name="buddy">
                <cstring>track</cstring>
@@ -740,7 +748,7 @@
             <item row="2" column="2">
              <widget class="QLabel" name="year_label">
               <property name="text">
-               <string>Year</string>
+               <string>&amp;Year</string>
               </property>
               <property name="buddy">
                <cstring>year</cstring>
@@ -786,7 +794,7 @@
             <item row="4" column="0">
              <widget class="QLabel" name="composer_label">
               <property name="text">
-               <string>Composer</string>
+               <string>Co&amp;mposer</string>
               </property>
               <property name="buddy">
                <cstring>composer</cstring>
@@ -826,7 +834,7 @@
             <item row="6" column="0">
              <widget class="QLabel" name="grouping_label">
               <property name="text">
-               <string>Grouping</string>
+               <string>&amp;Grouping</string>
               </property>
               <property name="buddy">
                <cstring>grouping</cstring>
@@ -846,7 +854,7 @@
             <item row="7" column="0">
              <widget class="QLabel" name="genre_label">
               <property name="text">
-               <string>Genre</string>
+               <string>Ge&amp;nre</string>
               </property>
               <property name="buddy">
                <cstring>genre</cstring>
@@ -876,33 +884,17 @@
               </property>
              </widget>
             </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_3">
-            <item>
+            <item row="11" column="0">
              <widget class="QLabel" name="lyrics_label">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>100</width>
-                <height>0</height>
-               </size>
-              </property>
               <property name="text">
-               <string>Lyrics</string>
+               <string>&amp;Lyrics</string>
               </property>
               <property name="buddy">
                <cstring>lyrics</cstring>
               </property>
              </widget>
             </item>
-            <item>
+            <item row="11" column="1" colspan="3">
              <widget class="TextEdit" name="lyrics">
               <property name="has_reset_button" stdset="0">
                <bool>true</bool>
@@ -912,27 +904,7 @@
               </property>
              </widget>
             </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_4">
-            <item>
-             <widget class="QLabel" name="comment_label">
-              <property name="minimumSize">
-               <size>
-                <width>100</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="text">
-               <string>Comment</string>
-              </property>
-              <property name="buddy">
-               <cstring>comment</cstring>
-              </property>
-             </widget>
-            </item>
-            <item>
+            <item row="12" column="1" colspan="3">
              <widget class="TextEdit" name="comment">
               <property name="has_reset_button" stdset="0">
                <bool>true</bool>


### PR DESCRIPTION
Change the layout in `edittagdialog.ui` to correct #5437 .

Now the minimum height is 600px. Also, the last two labels (*Lyrics* and *Comment*) are properly aligned.