### PR TITLE
Ignore case in path comparison (#5445)

### DIFF
--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -1284,7 +1284,8 @@ bool Playlist::CompareItems(int column, Qt::SortOrder order,
     case Column_Samplerate:
       cmp(samplerate);
     case Column_Filename:
-      cmp(url);
+      return (QString::localeAwareCompare(a->Url().path().toLower(),
+                                          b->Url().path().toLower()) < 0);
     case Column_BaseFilename:
       cmp(basefilename);
     case Column_Filesize:


### PR DESCRIPTION
This makes sorting by `filename` (path) return the expected result.

For example:
* /Music/a.mp3
* /Music/c.mp3
* /Music/Brooklyn/b.mp3
* /Music/Brooklyn/z.mp3
* /Music/Charlie/a.mp3
* /Music/Charlie/e.mp3
* /Music/Brooklyn/X/l.mp3