### PR TITLE
Update playlist virtual order after sorting (#5436)

### DIFF
--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -1417,6 +1417,8 @@ void Playlist::sort(int column, Qt::SortOrder order) {
 
   undo_stack_->push(
       new PlaylistUndoCommands::SortItems(this, column, order, new_items));
+
+  ReshuffleIndices();
 }
 
 void Playlist::ReOrderWithoutUndo(const PlaylistItemList& new_items) {


### PR DESCRIPTION
List with playback order should be resorted too after sorting playlist view. It will prevent misunderstanding with playback order. 