### PR TITLE
added popular libraryfiltergroup filter: Album artist/Album

### DIFF
--- a/src/library/libraryfilterwidget.cpp
+++ b/src/library/libraryfilterwidget.cpp
@@ -146,6 +146,10 @@ QActionGroup* LibraryFilterWidget::CreateGroupByActions(QObject* parent) {
       CreateGroupByAction(tr("Group by Artist/Album"), parent,
                           LibraryModel::Grouping(LibraryModel::GroupBy_Artist,
                                                  LibraryModel::GroupBy_Album)));
+  ret->addAction(
+      CreateGroupByAction(tr("Group by Album artist/Album"), parent,
+                          LibraryModel::Grouping(LibraryModel::GroupBy_AlbumArtist,
+                                                 LibraryModel::GroupBy_Album)));
   ret->addAction(CreateGroupByAction(
       tr("Group by Artist/Year - Album"), parent,
       LibraryModel::Grouping(LibraryModel::GroupBy_Artist,


### PR DESCRIPTION
Hi, this is a popular sorting method for those of us who have albums with multiple artists featured. Sorting this way places all the songs in one album, rather than splitting it into 5 albums due to featured artists.

I would argue that having this as a standard option rather than an custom option is something warranted. Right now it looks as though the standard options were chosen because they were all different from one another. Looking at it like that you might disagree with this change at first, but I think it is important have have heavily used things easy to access. :smile: 

As far as naming it "Album artist/Album"... I don't care about the how it is named.

Thank for taking the time to read this