### PR TITLE
Add support for displaying lyrics from a Vorbis comment

### DIFF
--- a/ext/libclementine-tagreader/tagreader.cpp
+++ b/ext/libclementine-tagreader/tagreader.cpp
@@ -520,7 +520,7 @@ void TagReader::ParseFMPSFrame(const QString& name, const QString& value,
 void TagReader::ParseOggTag(const TagLib::Ogg::FieldListMap& map,
                             const QTextCodec* codec, QString* disc,
                             QString* compilation,
-                            pb::tagreader::SongMetadata* song) const {
+                            pb::tagreader::SongMetadata* song) const {                                                     
   if (!map["COMPOSER"].isEmpty())
     Decode(map["COMPOSER"].front(), codec, song->mutable_composer());
   if (!map["PERFORMER"].isEmpty())
@@ -568,6 +568,12 @@ void TagReader::ParseOggTag(const TagLib::Ogg::FieldListMap& map,
                         .trimmed()
                         .toFloat() *
                     100);
+
+  if (!map["LYRICS"].isEmpty()) {
+    Decode(map["LYRICS"].front(), codec, song->mutable_lyrics());
+  } else if (!map["UNSYNCEDLYRICS"].isEmpty()) {
+    Decode(map["UNSYNCEDLYRICS"].front(), codec, song->mutable_lyrics());
+  }
 }
 
 void TagReader::SetVorbisComments(
@@ -593,9 +599,15 @@ void TagReader::SetVorbisComments(
       true);
 
   // Try to be coherent, the two forms are used but the first one is preferred
+  
   vorbis_comments->addField("ALBUMARTIST",
                             StdStringToTaglibString(song.albumartist()), true);
   vorbis_comments->removeField("ALBUM ARTIST");
+
+  vorbis_comments->addField("LYRICS",
+                            StdStringToTaglibString(song.lyrics()), true);
+  vorbis_comments->removeField("UNSYNCEDLYRICS");
+
 }
 
 void TagReader::SetFMPSStatisticsVorbisComments(

--- a/ext/libclementine-tagreader/tagreader.cpp
+++ b/ext/libclementine-tagreader/tagreader.cpp
@@ -520,7 +520,7 @@ void TagReader::ParseFMPSFrame(const QString& name, const QString& value,
 void TagReader::ParseOggTag(const TagLib::Ogg::FieldListMap& map,
                             const QTextCodec* codec, QString* disc,
                             QString* compilation,
-                            pb::tagreader::SongMetadata* song) const {                                                     
+                            pb::tagreader::SongMetadata* song) const {
   if (!map["COMPOSER"].isEmpty())
     Decode(map["COMPOSER"].front(), codec, song->mutable_composer());
   if (!map["PERFORMER"].isEmpty())
@@ -569,11 +569,10 @@ void TagReader::ParseOggTag(const TagLib::Ogg::FieldListMap& map,
                         .toFloat() *
                     100);
 
-  if (!map["LYRICS"].isEmpty()) {
+  if (!map["LYRICS"].isEmpty())
     Decode(map["LYRICS"].front(), codec, song->mutable_lyrics());
-  } else if (!map["UNSYNCEDLYRICS"].isEmpty()) {
+  else if (!map["UNSYNCEDLYRICS"].isEmpty())
     Decode(map["UNSYNCEDLYRICS"].front(), codec, song->mutable_lyrics());
-  }
 }
 
 void TagReader::SetVorbisComments(
@@ -599,7 +598,7 @@ void TagReader::SetVorbisComments(
       true);
 
   // Try to be coherent, the two forms are used but the first one is preferred
-  
+
   vorbis_comments->addField("ALBUMARTIST",
                             StdStringToTaglibString(song.albumartist()), true);
   vorbis_comments->removeField("ALBUM ARTIST");

--- a/src/songinfo/taglyricsinfoprovider.cpp
+++ b/src/songinfo/taglyricsinfoprovider.cpp
@@ -26,7 +26,7 @@ void TagLyricsInfoProvider::FetchInfo(int id, const Song& metadata) {
   if (!lyrics.isEmpty()) {
     CollapsibleInfoPane::Data data;
     data.id_ = "tag/lyrics";
-    data.title_ = tr("Lyrics from the ID3v2 tag");
+    data.title_ = tr("Lyrics from the tag");
     data.type_ = CollapsibleInfoPane::Data::Type_Lyrics;
 
     SongInfoTextView* editor = new SongInfoTextView;


### PR DESCRIPTION
This adds support for displaying lyrics from a Vorbis comment in the same way Clementine displays lyrics from ID3v2 tags.