### PR TITLE
Fix undefined symbol error conversion from std::string to TagLib::String

### DIFF
--- a/ext/libclementine-tagreader/tagreader.cpp
+++ b/ext/libclementine-tagreader/tagreader.cpp
@@ -695,9 +695,9 @@ bool TagReader::SaveFile(const QString& filename,
         TagLib::MP4::Item(song.disc() <= 0 - 1 ? 0 : song.disc(), 0);
     tag->itemListMap()["tmpo"] = TagLib::StringList(
         song.bpm() <= 0 - 1 ? "0" : TagLib::String::number(song.bpm()));
-    tag->itemListMap()["\251wrt"] = TagLib::StringList(song.composer());
-    tag->itemListMap()["\251grp"] = TagLib::StringList(song.grouping());
-    tag->itemListMap()["aART"] = TagLib::StringList(song.albumartist());
+    tag->itemListMap()["\251wrt"] = TagLib::StringList(song.composer().c_str());
+    tag->itemListMap()["\251grp"] = TagLib::StringList(song.grouping().c_str());
+    tag->itemListMap()["aART"] = TagLib::StringList(song.albumartist().c_str());
     tag->itemListMap()["cpil"] =
         TagLib::StringList(song.compilation() ? "1" : "0");
   }


### PR DESCRIPTION
I had some undefined symbols errors:
```
undefined reference to `TagLib::String::String(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, TagLib::String::Type)'
```
This pr fix it.
I had the same errors on master, might be a good idea to cherry pick ;)