### PR TITLE
Reduce some CPU load by disabling/fixing some UI stuff

### DIFF
--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -120,7 +120,7 @@ PlaylistView::PlaylistView(QWidget* parent)
       last_height_(-1),
       last_width_(-1),
       force_background_redraw_(false),
-      glow_enabled_(true),
+      glow_enabled_(false),
       currently_glowing_(false),
       glow_intensity_step_(0),
       rating_delegate_(nullptr),
@@ -1068,7 +1068,7 @@ void PlaylistView::PlaylistDestroyed() {
 void PlaylistView::ReloadSettings() {
   QSettings s;
   s.beginGroup(Playlist::kSettingsGroup);
-  glow_enabled_ = s.value("glow_effect", true).toBool();
+  glow_enabled_ = s.value("glow_effect", false).toBool();
 
   if (setting_initial_header_layout_ || upgrading_from_qheaderview_) {
     header_->SetStretchEnabled(s.value("stretch", true).toBool());

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -160,7 +160,7 @@ const char* MainWindow::kSettingsGroup = "MainWindow";
 const char* MainWindow::kAllFilesFilterSpec = QT_TR_NOOP("All Files (*)");
 
 namespace {
-const int kTrackSliderUpdateTimeMs = 40;
+const int kTrackSliderUpdateTimeMs = 500;
 const int kTrackPositionUpdateTimeMs = 1000;
 }
 

--- a/src/widgets/tracksliderslider.cpp
+++ b/src/widgets/tracksliderslider.cpp
@@ -32,6 +32,7 @@ TrackSliderSlider::TrackSliderSlider(QWidget* parent)
       mouse_hover_seconds_(0) {
   setMouseTracking(true);
 
+  popup_->hide();
   connect(this, SIGNAL(valueChanged(int)), SLOT(UpdateDeltaTime()));
 }
 


### PR DESCRIPTION
- Disabling playlist row glow by default
- Track slider popup visible by default, add hide()
  to ensure not visible by default (no more repaints)
- Set kTrackSliderUpdateTimeMs to 500. IMO 40 is too low

This should partially fix issue #1079
