### PR TITLE
Fix Subsonic endpoint

### DIFF
--- a/src/internet/subsonic/subsonicdynamicplaylist.cpp
+++ b/src/internet/subsonic/subsonicdynamicplaylist.cpp
@@ -93,7 +93,7 @@ PlaylistItemList SubsonicDynamicPlaylist::GenerateMore(int count) {
   }
   BOOST_SCOPE_EXIT_END
 
-  QUrl url = service->BuildRequestUrl("GetAlbumList");
+  QUrl url = service->BuildRequestUrl("getAlbumList");
   QNetworkAccessManager network;
 
   if (count > kMaxCount) count = kMaxCount;


### PR DESCRIPTION
According to the documentation, the endpoint is `getArtistInfo`, not
`GetArtistInfo`. This typo makes the complete feature not working at
all.

Source: http://www.subsonic.org/pages/api.jsp#getArtistInfo