### PR TITLE
Fix podcast episodes forgotten

### DIFF
--- a/src/internet/podcasts/podcastbackend.cpp
+++ b/src/internet/podcasts/podcastbackend.cpp
@@ -228,7 +228,7 @@ PodcastEpisodeList PodcastBackend::GetEpisodes(int podcast_id) {
                   " WHERE podcast_id = :id"
                   " ORDER BY publication_date DESC",
               db);
-  q.bindValue(":db", podcast_id);
+  q.bindValue(":id", podcast_id);
   q.exec();
   if (db_->CheckErrors(q)) return ret;
 
@@ -251,7 +251,7 @@ PodcastEpisode PodcastBackend::GetEpisodeById(int id) {
                   " FROM podcast_episodes"
                   " WHERE ROWID = :id",
               db);
-  q.bindValue(":db", id);
+  q.bindValue(":id", id);
   q.exec();
   if (!db_->CheckErrors(q) && q.next()) {
     ret.InitFromQuery(q);


### PR DESCRIPTION
This is strange, on the master branch without this patch everything is okay and the podcasts are not forgotten. 

But this causes issues on the Qt5 branch.