### PR TITLE
Fix a typo in a header guard

### DIFF
--- a/tests/mock_networkaccessmanager.h
+++ b/tests/mock_networkaccessmanager.h
@@ -15,7 +15,7 @@
    along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef MOCK_NETWORKACCESSAMANGER_H
+#ifndef MOCK_NETWORKACCESSMANAGER_H
 #define MOCK_NETWORKACCESSMANAGER_H
 
 #include <QByteArray>


### PR DESCRIPTION
Previously reported in #5443 