### PR TITLE
fix Windows build qsqlite

### DIFF
--- a/3rdparty/qsqlite/clementinesqlcachedresult.h
+++ b/3rdparty/qsqlite/clementinesqlcachedresult.h
@@ -53,7 +53,7 @@
 // We mean it.
 //
 
-#include "QtSql/qsqlresult.h"
+#include <QtSql/qsqlresult.h>
 
 QT_BEGIN_NAMESPACE
 
@@ -62,7 +62,7 @@ template <typename T> class QVector;
 
 class ClementineSqlCachedResultPrivate;
 
-class Q_SQL_EXPORT ClementineSqlCachedResult: public QSqlResult
+class ClementineSqlCachedResult: public QSqlResult
 {
 public:
     virtual ~ClementineSqlCachedResult();


### PR DESCRIPTION
Q_SQL_EXPORT is defined in qt5/include/QtSql/qsql.h:
```
#ifndef QT_STATIC
#  if defined(QT_BUILD_SQL_LIB)
#    define Q_SQL_EXPORT Q_DECL_EXPORT
#  else
#    define Q_SQL_EXPORT Q_DECL_IMPORT
#  endif
#else
#  define Q_SQL_EXPORT
#endif
```

qsqlite is static library.
Clementine/3rdparty/qsqlite/CMakeLists.txt:
```
add_library(qsqlite STATIC
   ${SQLITE-SOURCES}
   ${SQLITE-SOURCES-MOC}
   ${SQLITE-WIN32-RESOURCES}
)
```

log: https://gist.github.com/pavelvat/e683a7106b6eca6971d752ad37d52030