### PR TITLE
Use CaseInsensitive file type checking #5499

### DIFF
--- a/ext/libclementine-tagreader/tagreader.cpp
+++ b/ext/libclementine-tagreader/tagreader.cpp
@@ -1104,19 +1104,21 @@ bool TagReader::ReadCloudFile(const QUrl& download_url, const QString& title,
       download_url, title, size, authorisation_header, network_));
   stream->Precache();
   std::unique_ptr<TagLib::File> tag;
-  if (mime_type == "audio/mpeg" && title.endsWith(".mp3")) {
+  if (mime_type == "audio/mpeg" &&
+      title.endsWith(".mp3", Qt::CaseInsensitive)) {
     tag.reset(new TagLib::MPEG::File(stream.get(),
                                      TagLib::ID3v2::FrameFactory::instance(),
                                      TagLib::AudioProperties::Accurate));
   } else if (mime_type == "audio/mp4" ||
-             (mime_type == "audio/mpeg" && title.endsWith(".m4a"))) {
+             (mime_type == "audio/mpeg" &&
+              title.endsWith(".m4a", Qt::CaseInsensitive))) {
     tag.reset(new TagLib::MP4::File(stream.get(), true,
                                     TagLib::AudioProperties::Accurate));
   }
 #ifdef TAGLIB_HAS_OPUS
   else if ((mime_type == "application/opus" || mime_type == "audio/opus" ||
             mime_type == "application/ogg" || mime_type == "audio/ogg") &&
-           title.endsWith(".opus")) {
+           title.endsWith(".opus", Qt::CaseInsensitive)) {
     tag.reset(new TagLib::Ogg::Opus::File(stream.get(), true,
                                           TagLib::AudioProperties::Accurate));
   }

--- a/src/internet/core/cloudfileservice.cpp
+++ b/src/internet/core/cloudfileservice.cpp
@@ -219,15 +219,17 @@ bool CloudFileService::IsSupportedMimeType(const QString& mime_type) const {
 }
 
 QString CloudFileService::GuessMimeTypeForFile(const QString& filename) const {
-  if (filename.endsWith(".mp3")) {
+  if (filename.endsWith(".mp3", Qt::CaseInsensitive)) {
     return "audio/mpeg";
-  } else if (filename.endsWith(".m4a") || filename.endsWith(".m4b")) {
+  } else if (filename.endsWith(".m4a", Qt::CaseInsensitive) ||
+             filename.endsWith(".m4b", Qt::CaseInsensitive)) {
     return "audio/mpeg";
-  } else if (filename.endsWith(".ogg") || filename.endsWith(".opus")) {
+  } else if (filename.endsWith(".ogg", Qt::CaseInsensitive) ||
+             filename.endsWith(".opus", Qt::CaseInsensitive)) {
     return "application/ogg";
-  } else if (filename.endsWith(".flac")) {
+  } else if (filename.endsWith(".flac", Qt::CaseInsensitive)) {
     return "application/x-flac";
-  } else if (filename.endsWith(".wma")) {
+  } else if (filename.endsWith(".wma", Qt::CaseInsensitive)) {
     return "audio/x-ms-wma";
   }
   return QString::null;

--- a/src/internet/seafile/seafilesettingspage.cpp
+++ b/src/internet/seafile/seafilesettingspage.cpp
@@ -63,7 +63,7 @@ void SeafileSettingsPage::Load() {
   ui_->server->setText(s.value("server").toString());
   ui_->mail->setText(s.value("mail").toString());
 
-  if (!ui_->server->text().isEmpty() && !ui_->mail->text().isEmpty()) {
+  if (service_->has_credentials()) {
     ui_->login_state->SetLoggedIn(LoginStateWidget::LoggedIn,
                                   ui_->mail->text());
 


### PR DESCRIPTION
CloudFileService and TagReader classes use
QString::endWith() method for checking file type.
This method is CaseSensitive by default.