### PR TITLE
Workaround to spotify loading playlist issue

### DIFF
--- a/ext/clementine-spotifyblob/spotifyclient.cpp
+++ b/ext/clementine-spotifyblob/spotifyclient.cpp
@@ -433,8 +433,8 @@ void SpotifyClient::SendPlaylistList() {
                 << sp_playlist_name(playlist);
 
     if (!is_loaded) {
-      qLog(Info) << "Playlist is not loaded yet, waiting...";
-      return;
+      qLog(Info) << "Playlist is not loaded yet, jump to the next one...";
+      continue;
     }
 
     if (type != SP_PLAYLIST_TYPE_PLAYLIST) {


### PR DESCRIPTION
Some Spotify playlists never load (libspotify/spotify server bug I guess). This is a workaround in order that Clementine does not stuck on unloaded playlists.

Fixes https://github.com/clementine-player/Clementine/issues/5574