### PR TITLE
macOS: Clear stale native notifications on 10.9+.

### DIFF
--- a/src/widgets/osd_mac.mm
+++ b/src/widgets/osd_mac.mm
@@ -17,6 +17,7 @@
 
 #include "osd.h"
 
+#import <Foundation/NSProcessInfo.h>
 #import <Foundation/NSUserNotification.h>
 
 #include <QBuffer>
@@ -36,6 +37,13 @@ void SendNotificationCenterMessage(NSString* title, NSString* subtitle) {
   [notification setTitle:title];
   [notification setSubtitle:subtitle];
 
+  if ([[NSProcessInfo processInfo]
+          isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){
+                                              .majorVersion = 10,
+                                              .minorVersion = 9,
+                                              .patchVersion = 0}]) {
+    [notification_center removeAllDeliveredNotifications];
+  }
   [notification_center deliverNotification:notification];
 }
 


### PR DESCRIPTION
Currently, Clementine notifications pile up on macOS. This clears all notifications before creating a new one, matching the behavior of iTunes.

It appears that this API was [introduced in 10.9](https://developer.apple.com/library/content/releasenotes/Foundation/RN-Foundation-older-but-post-10.8/index.html), so I've got a guard around it.