### PR TITLE
Add missing <functional> includes

### DIFF
--- a/src/core/mergedproxymodel.cpp
+++ b/src/core/mergedproxymodel.cpp
@@ -23,6 +23,7 @@
 
 #include <QStringList>
 
+#include <functional>
 #include <limits>
 
 // boost::multi_index still relies on these being in the global namespace.

--- a/src/devices/giolister.cpp
+++ b/src/devices/giolister.cpp
@@ -17,6 +17,7 @@
 
 #include "config.h"
 
+#include <functional>
 #include <memory>
 
 #include <QFile>

--- a/src/library/groupbydialog.cpp
+++ b/src/library/groupbydialog.cpp
@@ -20,6 +20,8 @@
 
 #include <QPushButton>
 
+#include <functional>
+
 // boost::multi_index still relies on these being in the global namespace.
 using std::placeholders::_1;
 using std::placeholders::_2;


### PR DESCRIPTION
This PR simply adds missing `<functional>` includes everywhere `std::placeholders` are used (previously reported in issue #4279, see also [cppreference](http://en.cppreference.com/w/cpp/utility/functional/placeholders)).

This is required to build Clementine on the current gcc 7.0 trunk.