### PR TITLE
Small improvements to Cover Manager

### DIFF
--- a/src/ui/albumcovermanager.cpp
+++ b/src/ui/albumcovermanager.cpp
@@ -327,8 +327,9 @@ void AlbumCoverManager::ArtistChanged(QListWidgetItem* current) {
     // Don't show songs without an album, obviously
     if (info.album_name.isEmpty()) continue;
 
+    QIcon no_cover(no_cover_icon_.pixmap(120, 120));
     QListWidgetItem* item =
-        new QListWidgetItem(no_cover_icon_, info.album_name, ui_->albums);
+        new QListWidgetItem(no_cover, info.album_name, ui_->albums);
     item->setData(Role_ArtistName, info.artist);
     item->setData(Role_AlbumName, info.album_name);
     item->setData(Role_FirstUrl, info.first_url);

--- a/src/ui/albumcovermanager.ui
+++ b/src/ui/albumcovermanager.ui
@@ -19,7 +19,16 @@
   </property>
   <widget class="QWidget" name="centralWidget">
    <layout class="QVBoxLayout" name="verticalLayout_2">
-    <property name="margin">
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
      <number>0</number>
     </property>
     <item>
@@ -49,7 +58,16 @@
         <property name="spacing">
          <number>0</number>
         </property>
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
@@ -171,6 +189,18 @@
             <property name="spacing">
              <number>0</number>
             </property>
+            <property name="leftMargin">
+             <number>5</number>
+            </property>
+            <property name="topMargin">
+             <number>5</number>
+            </property>
+            <property name="rightMargin">
+             <number>5</number>
+            </property>
+            <property name="bottomMargin">
+             <number>5</number>
+            </property>
             <item>
              <widget class="QPushButton" name="fetch">
               <property name="text">
@@ -183,6 +213,22 @@
                </size>
               </property>
              </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>5</height>
+               </size>
+              </property>
+             </spacer>
             </item>
             <item>
              <widget class="QPushButton" name="export_covers">


### PR DESCRIPTION
* nocover icon was previously loaded and used with the default size
(24x24), causing the list item without a cover in the QListWidget to be
shorter in height with respect to the others. Now the icon is
initialized to 120x120, which is the default size of the list elements.
* Added some padding between "Fetch Missing Cover" and "Export
Covers" buttons.