### PR TITLE
Prioritize album artist in cover search and manager

### DIFF
--- a/src/core/song.cpp
+++ b/src/core/song.cpp
@@ -273,6 +273,10 @@ bool Song::is_unavailable() const { return d->unavailable_; }
 int Song::id() const { return d->id_; }
 const QString& Song::title() const { return d->title_; }
 const QString& Song::album() const { return d->album_; }
+const QString& Song::effective_album() const {
+  // This value is useful for singles, which are one-track albums on their own.
+  return d->album_.isEmpty() ? d->title_ : d->album_;
+}
 const QString& Song::artist() const { return d->artist_; }
 const QString& Song::albumartist() const { return d->albumartist_; }
 const QString& Song::effective_albumartist() const {
@@ -577,7 +581,7 @@ void Song::ToProtobuf(pb::tagreader::SongMetadata* pb) const {
   pb->set_filesize(d->filesize_);
   pb->set_suspicious_tags(d->suspicious_tags_);
   pb->set_art_automatic(DataCommaSizeFromQString(d->art_automatic_));
-  pb->set_type(static_cast< ::pb::tagreader::SongMetadata_Type>(d->filetype_));
+  pb->set_type(static_cast<::pb::tagreader::SongMetadata_Type>(d->filetype_));
 }
 
 void Song::InitFromQuery(const SqlRow& q, bool reliable_metadata, int col) {
@@ -973,7 +977,8 @@ void Song::BindToQuery(QSqlQuery* query) const {
   query->bindValue(":grouping", strval(d->grouping_));
   query->bindValue(":lyrics", strval(d->lyrics_));
   query->bindValue(":originalyear", intval(d->originalyear_));
-  query->bindValue(":effective_originalyear", intval(this->effective_originalyear()));
+  query->bindValue(":effective_originalyear",
+                   intval(this->effective_originalyear()));
 
 #undef intval
 #undef notnullintval
@@ -1074,9 +1079,9 @@ bool Song::IsMetadataEqual(const Song& other) const {
          d->performer_ == other.d->performer_ &&
          d->grouping_ == other.d->grouping_ && d->track_ == other.d->track_ &&
          d->disc_ == other.d->disc_ && qFuzzyCompare(d->bpm_, other.d->bpm_) &&
-         d->year_ == other.d->year_ && d->originalyear_ == other.d->originalyear_ &&
-         d->genre_ == other.d->genre_ &&
-         d->comment_ == other.d->comment_ &&
+         d->year_ == other.d->year_ &&
+         d->originalyear_ == other.d->originalyear_ &&
+         d->genre_ == other.d->genre_ && d->comment_ == other.d->comment_ &&
          d->compilation_ == other.d->compilation_ &&
          d->beginning_ == other.d->beginning_ &&
          length_nanosec() == other.length_nanosec() &&
@@ -1084,8 +1089,7 @@ bool Song::IsMetadataEqual(const Song& other) const {
          d->samplerate_ == other.d->samplerate_ &&
          d->art_automatic_ == other.d->art_automatic_ &&
          d->art_manual_ == other.d->art_manual_ &&
-         d->rating_ == other.d->rating_ &&
-         d->cue_path_ == other.d->cue_path_ &&
+         d->rating_ == other.d->rating_ && d->cue_path_ == other.d->cue_path_ &&
          d->lyrics_ == other.d->lyrics_;
 }
 

--- a/src/core/song.h
+++ b/src/core/song.h
@@ -160,6 +160,7 @@ class Song {
 
   const QString& title() const;
   const QString& album() const;
+  const QString& effective_album() const;
   const QString& artist() const;
   const QString& albumartist() const;
   const QString& effective_albumartist() const;

--- a/src/library/librarybackend.cpp
+++ b/src/library/librarybackend.cpp
@@ -554,12 +554,17 @@ QStringList LibraryBackend::GetAllArtistsWithAlbums(const QueryOptions& opt) {
 
 LibraryBackend::AlbumList LibraryBackend::GetAllAlbums(
     const QueryOptions& opt) {
-  return GetAlbums(QString(), false, opt);
+  return GetAlbums(QString(), QString(), false, opt);
 }
 
 LibraryBackend::AlbumList LibraryBackend::GetAlbumsByArtist(
     const QString& artist, const QueryOptions& opt) {
-  return GetAlbums(artist, false, opt);
+  return GetAlbums(artist, QString(), false, opt);
+}
+
+LibraryBackend::AlbumList LibraryBackend::GetAlbumsByAlbumArtist(
+    const QString& album_artist, const QueryOptions& opt) {
+  return GetAlbums(QString(), album_artist, false, opt);
 }
 
 SongList LibraryBackend::GetSongsByAlbum(const QString& album,
@@ -706,7 +711,7 @@ SongList LibraryBackend::GetSongsByUrl(const QUrl& url) {
 
 LibraryBackend::AlbumList LibraryBackend::GetCompilationAlbums(
     const QueryOptions& opt) {
-  return GetAlbums(QString(), true, opt);
+  return GetAlbums(QString(), QString(), true, opt);
 }
 
 SongList LibraryBackend::GetCompilationSongs(const QString& album,
@@ -844,18 +849,22 @@ void LibraryBackend::UpdateCompilations(QSqlQuery& find_songs,
 }
 
 LibraryBackend::AlbumList LibraryBackend::GetAlbums(const QString& artist,
+                                                    const QString& album_artist,
                                                     bool compilation,
                                                     const QueryOptions& opt) {
   AlbumList ret;
 
   LibraryQuery query(opt);
   query.SetColumnSpec(
-      "album, artist, compilation, sampler, art_automatic, "
+      "album, artist, albumartist, compilation, sampler, art_automatic, "
       "art_manual, filename");
   query.SetOrderBy("album");
 
   if (compilation) {
     query.AddCompilationRequirement(true);
+  } else if (!album_artist.isNull()) {
+    query.AddCompilationRequirement(false);
+    query.AddWhere("albumartist", album_artist);
   } else if (!artist.isNull()) {
     query.AddCompilationRequirement(false);
     query.AddWhere("artist", artist);
@@ -863,39 +872,51 @@ LibraryBackend::AlbumList LibraryBackend::GetAlbums(const QString& artist,
 
   QMutexLocker l(db_->Mutex());
   if (!ExecQuery(&query)) return ret;
+  l.unlock();
 
   QString last_album;
-  QString last_artist;
+  QString last_artist, last_album_artist;
   while (query.Next()) {
-    bool compilation = query.Value(2).toBool() | query.Value(3).toBool();
+    bool compilation = query.Value(3).toBool() | query.Value(4).toBool();
 
     Album info;
     info.artist = compilation ? QString() : query.Value(1).toString();
+    info.album_artist = compilation ? QString() : query.Value(2).toString();
     info.album_name = query.Value(0).toString();
-    info.art_automatic = query.Value(4).toString();
-    info.art_manual = query.Value(5).toString();
-    info.first_url = QUrl::fromEncoded(query.Value(6).toByteArray());
+    info.art_automatic = query.Value(5).toString();
+    info.art_manual = query.Value(6).toString();
+    info.first_url = QUrl::fromEncoded(query.Value(7).toByteArray());
 
-    if (info.artist == last_artist && info.album_name == last_album) continue;
+    if ((info.artist == last_artist ||
+         info.album_artist == last_album_artist) &&
+        info.album_name == last_album)
+      continue;
 
     ret << info;
 
     last_album = info.album_name;
     last_artist = info.artist;
+    last_album_artist = info.album_artist;
   }
 
   return ret;
 }
 
 LibraryBackend::Album LibraryBackend::GetAlbumArt(const QString& artist,
+                                                  const QString& albumartist,
                                                   const QString& album) {
   Album ret;
   ret.album_name = album;
   ret.artist = artist;
+  ret.album_artist = albumartist;
 
   LibraryQuery query = LibraryQuery(QueryOptions());
   query.SetColumnSpec("art_automatic, art_manual, filename");
-  query.AddWhere("artist", artist);
+  if (!albumartist.isEmpty()) {
+    query.AddWhere("albumartist", albumartist);
+  } else if (!artist.isEmpty()) {
+    query.AddWhere("artist", artist);
+  }
   query.AddWhere("album", album);
 
   QMutexLocker l(db_->Mutex());
@@ -911,14 +932,17 @@ LibraryBackend::Album LibraryBackend::GetAlbumArt(const QString& artist,
 }
 
 void LibraryBackend::UpdateManualAlbumArtAsync(const QString& artist,
+                                               const QString& albumartist,
                                                const QString& album,
                                                const QString& art) {
   metaObject()->invokeMethod(this, "UpdateManualAlbumArt", Qt::QueuedConnection,
-                             Q_ARG(QString, artist), Q_ARG(QString, album),
+                             Q_ARG(QString, artist),
+                             Q_ARG(QString, albumartist), Q_ARG(QString, album),
                              Q_ARG(QString, art));
 }
 
 void LibraryBackend::UpdateManualAlbumArt(const QString& artist,
+                                          const QString& albumartist,
                                           const QString& album,
                                           const QString& art) {
   QMutexLocker l(db_->Mutex());
@@ -928,7 +952,12 @@ void LibraryBackend::UpdateManualAlbumArt(const QString& artist,
   LibraryQuery query;
   query.SetColumnSpec("ROWID, " + Song::kColumnSpec);
   query.AddWhere("album", album);
-  if (!artist.isNull()) query.AddWhere("artist", artist);
+
+  if (!albumartist.isNull()) {
+    query.AddWhere("albumartist", albumartist);
+  } else if (!artist.isNull()) {
+    query.AddWhere("artist", artist);
+  }
 
   if (!ExecQuery(&query)) return;
 
@@ -944,12 +973,20 @@ void LibraryBackend::UpdateManualAlbumArt(const QString& artist,
       QString(
           "UPDATE %1 SET art_manual = :art"
           " WHERE album = :album AND unavailable = 0").arg(songs_table_));
-  if (!artist.isNull()) sql += " AND artist = :artist";
+  if (!albumartist.isNull()) {
+    sql += " AND albumartist = :albumartist";
+  } else if (!artist.isNull()) {
+    sql += " AND artist = :artist";
+  }
 
   QSqlQuery q(sql, db);
   q.bindValue(":art", art);
   q.bindValue(":album", album);
-  if (!artist.isNull()) q.bindValue(":artist", artist);
+  if (!albumartist.isNull()) {
+    q.bindValue(":albumartist", albumartist);
+  } else if (!artist.isNull()) {
+    q.bindValue(":artist", artist);
+  }
 
   q.exec();
   db_->CheckErrors(q);

--- a/src/library/librarybackend.h
+++ b/src/library/librarybackend.h
@@ -41,16 +41,22 @@ class LibraryBackendInterface : public QObject {
 
   struct Album {
     Album() {}
-    Album(const QString& _artist, const QString& _album_name,
-          const QString& _art_automatic, const QString& _art_manual,
-          const QUrl& _first_url)
+    Album(const QString& _artist, const QString& _album_artist,
+          const QString& _album_name, const QString& _art_automatic,
+          const QString& _art_manual, const QUrl& _first_url)
         : artist(_artist),
+          album_artist(_album_artist),
           album_name(_album_name),
           art_automatic(_art_automatic),
           art_manual(_art_manual),
           first_url(_first_url) {}
 
+    const QString& effective_albumartist() const {
+      return album_artist.isEmpty() ? artist : album_artist;
+    }
+
     QString artist;
+    QString album_artist;
     QString album_name;
 
     QString art_automatic;
@@ -92,9 +98,11 @@ class LibraryBackendInterface : public QObject {
       const QueryOptions& opt = QueryOptions()) = 0;
 
   virtual void UpdateManualAlbumArtAsync(const QString& artist,
+                                         const QString& albumartist,
                                          const QString& album,
                                          const QString& art) = 0;
-  virtual Album GetAlbumArt(const QString& artist, const QString& album) = 0;
+  virtual Album GetAlbumArt(const QString& artist, const QString& albumartist,
+                            const QString& album) = 0;
 
   virtual Song GetSongById(int id) = 0;
 
@@ -157,11 +165,15 @@ class LibraryBackend : public LibraryBackendInterface {
   AlbumList GetAllAlbums(const QueryOptions& opt = QueryOptions());
   AlbumList GetAlbumsByArtist(const QString& artist,
                               const QueryOptions& opt = QueryOptions());
+  AlbumList GetAlbumsByAlbumArtist(const QString& albumartist,
+                                   const QueryOptions& opt = QueryOptions());
   AlbumList GetCompilationAlbums(const QueryOptions& opt = QueryOptions());
 
-  void UpdateManualAlbumArtAsync(const QString& artist, const QString& album,
-                                 const QString& art);
-  Album GetAlbumArt(const QString& artist, const QString& album);
+  void UpdateManualAlbumArtAsync(const QString& artist,
+                                 const QString& albumartist,
+                                 const QString& album, const QString& art);
+  Album GetAlbumArt(const QString& artist, const QString& albumartist,
+                    const QString& album);
 
   Song GetSongById(int id);
   SongList GetSongsById(const QList<int>& ids);
@@ -197,8 +209,8 @@ class LibraryBackend : public LibraryBackendInterface {
   void MarkSongsUnavailable(const SongList& songs, bool unavailable = true);
   void AddOrUpdateSubdirs(const SubdirectoryList& subdirs);
   void UpdateCompilations();
-  void UpdateManualAlbumArt(const QString& artist, const QString& album,
-                            const QString& art);
+  void UpdateManualAlbumArt(const QString& artist, const QString& albumartist,
+                            const QString& album, const QString& art);
   void ForceCompilation(const QString& album, const QList<QString>& artists,
                         bool on);
   void IncrementPlayCount(int id);
@@ -236,7 +248,8 @@ signals:
   void UpdateCompilations(QSqlQuery& find_songs, QSqlQuery& update,
                           SongList& deleted_songs, SongList& added_songs,
                           const QString& album, int sampler);
-  AlbumList GetAlbums(const QString& artist, bool compilation = false,
+  AlbumList GetAlbums(const QString& artist, const QString& album_artist,
+                      bool compilation = false,
                       const QueryOptions& opt = QueryOptions());
   SubdirectoryList SubdirsInDirectory(int id, QSqlDatabase& db);
 

--- a/src/ui/albumcoverchoicecontroller.cpp
+++ b/src/ui/albumcoverchoicecontroller.cpp
@@ -272,7 +272,7 @@ void AlbumCoverChoiceController::SaveCover(Song* song, const QString& cover) {
   if (song->is_valid() && song->id() != -1) {
     song->set_art_manual(cover);
     app_->library_backend()->UpdateManualAlbumArtAsync(
-        song->effective_albumartist(), song->album(), cover);
+        song->artist(), song->albumartist(), song->album(), cover);
 
     if (song->url() == app_->current_art_loader()->last_song().url()) {
       app_->current_art_loader()->LoadArt(*song);

--- a/src/ui/albumcoverchoicecontroller.cpp
+++ b/src/ui/albumcoverchoicecontroller.cpp
@@ -56,23 +56,23 @@ AlbumCoverChoiceController::AlbumCoverChoiceController(QWidget* parent)
       cover_fetcher_(nullptr),
       save_file_dialog_(nullptr),
       cover_from_url_dialog_(nullptr) {
-  cover_from_file_ = new QAction(IconLoader::Load("document-open", IconLoader::Base),
-                                 tr("Load cover from disk..."), this);
-  cover_to_file_ = new QAction(IconLoader::Load("document-save", IconLoader::Base),
-                               tr("Save cover to disk..."), this);
+  cover_from_file_ =
+      new QAction(IconLoader::Load("document-open", IconLoader::Base),
+                  tr("Load cover from disk..."), this);
+  cover_to_file_ =
+      new QAction(IconLoader::Load("document-save", IconLoader::Base),
+                  tr("Save cover to disk..."), this);
   cover_from_url_ = new QAction(IconLoader::Load("download", IconLoader::Base),
                                 tr("Load cover from URL..."), this);
   search_for_cover_ = new QAction(IconLoader::Load("find", IconLoader::Base),
                                   tr("Search for album covers..."), this);
-  unset_cover_ =
-      new QAction(IconLoader::Load("list-remove", IconLoader::Base), 
-                  tr("Unset cover"), this);
-  show_cover_ =
-      new QAction(IconLoader::Load("zoom-in", IconLoader::Base), 
-                  tr("Show fullsize..."), this);
+  unset_cover_ = new QAction(IconLoader::Load("list-remove", IconLoader::Base),
+                             tr("Unset cover"), this);
+  show_cover_ = new QAction(IconLoader::Load("zoom-in", IconLoader::Base),
+                            tr("Show fullsize..."), this);
 
-  search_cover_auto_ =
-      new QAction(IconLoader::Load("find", IconLoader::Base), tr("Search automatically"), this);
+  search_cover_auto_ = new QAction(IconLoader::Load("find", IconLoader::Base),
+                                   tr("Search automatically"), this);
   search_cover_auto_->setCheckable(true);
   search_cover_auto_->setChecked(false);
 
@@ -168,7 +168,8 @@ QString AlbumCoverChoiceController::LoadCoverFromURL(Song* song) {
   QImage image = cover_from_url_dialog_->Exec();
 
   if (!image.isNull()) {
-    QString cover = SaveCoverInCache(song->artist(), song->album(), image);
+    QString cover =
+        SaveCoverInCache(song->effective_albumartist(), song->album(), image);
     SaveCover(song, cover);
 
     return cover;
@@ -179,10 +180,12 @@ QString AlbumCoverChoiceController::LoadCoverFromURL(Song* song) {
 
 QString AlbumCoverChoiceController::SearchForCover(Song* song) {
   // Get something sensible to stick in the search box
-  QImage image = cover_searcher_->Exec(song->artist(), song->album());
+  QImage image =
+      cover_searcher_->Exec(song->effective_albumartist(), song->album());
 
   if (!image.isNull()) {
-    QString cover = SaveCoverInCache(song->artist(), song->album(), image);
+    QString cover =
+        SaveCoverInCache(song->effective_albumartist(), song->album(), image);
     SaveCover(song, cover);
 
     return cover;
@@ -204,7 +207,7 @@ void AlbumCoverChoiceController::ShowCover(const Song& song) {
 
   // Use Artist - Album as the window title
   QString title_text(song.albumartist());
-  if (title_text.isEmpty()) title_text = song.artist();
+  if (title_text.isEmpty()) title_text = song.effective_albumartist();
 
   if (!song.album().isEmpty()) title_text += " - " + song.album();
 
@@ -244,7 +247,8 @@ void AlbumCoverChoiceController::ShowCover(const Song& song) {
 }
 
 void AlbumCoverChoiceController::SearchCoverAutomatically(const Song& song) {
-  qint64 id = cover_fetcher_->FetchAlbumCover(song.artist(), song.album());
+  qint64 id = cover_fetcher_->FetchAlbumCover(song.effective_albumartist(),
+                                              song.album());
   cover_fetching_tasks_[id] = song;
 }
 
@@ -256,7 +260,8 @@ void AlbumCoverChoiceController::AlbumCoverFetched(
   }
 
   if (!image.isNull()) {
-    QString cover = SaveCoverInCache(song.artist(), song.album(), image);
+    QString cover =
+        SaveCoverInCache(song.effective_albumartist(), song.album(), image);
     SaveCover(&song, cover);
   }
 
@@ -266,8 +271,8 @@ void AlbumCoverChoiceController::AlbumCoverFetched(
 void AlbumCoverChoiceController::SaveCover(Song* song, const QString& cover) {
   if (song->is_valid() && song->id() != -1) {
     song->set_art_manual(cover);
-    app_->library_backend()->UpdateManualAlbumArtAsync(song->artist(),
-                                                       song->album(), cover);
+    app_->library_backend()->UpdateManualAlbumArtAsync(
+        song->effective_albumartist(), song->album(), cover);
 
     if (song->url() == app_->current_art_loader()->last_song().url()) {
       app_->current_art_loader()->LoadArt(*song);
@@ -336,7 +341,7 @@ QString AlbumCoverChoiceController::SaveCover(Song* song, const QDropEvent* e) {
     QImage image = qvariant_cast<QImage>(e->mimeData()->imageData());
     if (!image.isNull()) {
       QString cover_path =
-          SaveCoverInCache(song->artist(), song->album(), image);
+          SaveCoverInCache(song->effective_albumartist(), song->album(), image);
       SaveCover(song, cover_path);
       return cover_path;
     }

--- a/src/ui/albumcoverchoicecontroller.cpp
+++ b/src/ui/albumcoverchoicecontroller.cpp
@@ -180,12 +180,12 @@ QString AlbumCoverChoiceController::LoadCoverFromURL(Song* song) {
 
 QString AlbumCoverChoiceController::SearchForCover(Song* song) {
   // Get something sensible to stick in the search box
-  QImage image =
-      cover_searcher_->Exec(song->effective_albumartist(), song->album());
+  QImage image = cover_searcher_->Exec(song->effective_albumartist(),
+                                       song->effective_album());
 
   if (!image.isNull()) {
-    QString cover =
-        SaveCoverInCache(song->effective_albumartist(), song->album(), image);
+    QString cover = SaveCoverInCache(song->effective_albumartist(),
+                                     song->effective_album(), image);
     SaveCover(song, cover);
 
     return cover;
@@ -248,7 +248,7 @@ void AlbumCoverChoiceController::ShowCover(const Song& song) {
 
 void AlbumCoverChoiceController::SearchCoverAutomatically(const Song& song) {
   qint64 id = cover_fetcher_->FetchAlbumCover(song.effective_albumartist(),
-                                              song.album());
+                                              song.effective_album());
   cover_fetching_tasks_[id] = song;
 }
 

--- a/src/ui/albumcovermanager.cpp
+++ b/src/ui/albumcovermanager.cpp
@@ -424,8 +424,8 @@ bool AlbumCoverManager::ShouldHide(const QListWidgetItem& item,
   QStringList query = filter.split(' ');
   for (const QString& s : query) {
     if (!item.text().contains(s, Qt::CaseInsensitive) &&
-            !item.data(Role_ArtistName).toString().contains(
-                s, Qt::CaseInsensitive),
+        !item.data(Role_ArtistName).toString().contains(
+            s, Qt::CaseInsensitive) &&
         !item.data(Role_AlbumArtistName).toString().contains(
             s, Qt::CaseInsensitive)) {
       return true;
@@ -578,9 +578,8 @@ void AlbumCoverManager::ShowCover() {
 
 void AlbumCoverManager::FetchSingleCover() {
   for (QListWidgetItem* item : context_menu_items_) {
-    QString artist_name = EffectiveAlbumArtistName(item);
     quint64 id = cover_fetcher_->FetchAlbumCover(
-        artist_name, item->data(Role_AlbumName).toString());
+        EffectiveAlbumArtistName(item), item->data(Role_AlbumName).toString());
     cover_fetching_tasks_[id] = item;
     jobs_++;
   }

--- a/src/ui/albumcovermanager.cpp
+++ b/src/ui/albumcovermanager.cpp
@@ -384,7 +384,7 @@ void AlbumCoverManager::UpdateFilter() {
 
     if (!should_hide) {
       total_count++;
-      if (!ItemHasCover(item)) {
+      if (!ItemHasCover(*item)) {
         without_cover++;
       }
     }
@@ -397,7 +397,7 @@ void AlbumCoverManager::UpdateFilter() {
 bool AlbumCoverManager::ShouldHide(const QListWidgetItem& item,
                                    const QString& filter,
                                    HideCovers hide) const {
-  bool has_cover = ItemHasCover(&item);
+  bool has_cover = ItemHasCover(item);
   if (hide == Hide_WithCovers && has_cover) {
     return true;
   } else if (hide == Hide_WithoutCovers && !has_cover) {
@@ -427,7 +427,7 @@ void AlbumCoverManager::FetchAlbumCovers() {
   for (int i = 0; i < ui_->albums->count(); ++i) {
     QListWidgetItem* item = ui_->albums->item(i);
     if (item->isHidden()) continue;
-    if (ItemHasCover(item)) continue;
+    if (ItemHasCover(*item)) continue;
 
     quint64 id = cover_fetcher_->FetchAlbumCover(
         EffectiveAlbumArtistName(item), item->data(Role_AlbumName).toString());
@@ -498,7 +498,7 @@ bool AlbumCoverManager::eventFilter(QObject* obj, QEvent* event) {
     bool some_with_covers = false;
 
     for (QListWidgetItem* item : context_menu_items_) {
-      if (ItemHasCover(item)) some_with_covers = true;
+      if (ItemHasCover(*item)) some_with_covers = true;
     }
 
     album_cover_choice_controller_->cover_from_file_action()->setEnabled(
@@ -781,7 +781,7 @@ void AlbumCoverManager::ExportCovers() {
     QListWidgetItem* item = ui_->albums->item(i);
 
     // skip hidden and coverless albums
-    if (item->isHidden() || !ItemHasCover(item)) {
+    if (item->isHidden() || !ItemHasCover(*item)) {
       continue;
     }
 
@@ -853,6 +853,6 @@ QImage AlbumCoverManager::GenerateNoCoverImage(
   return square_nocover;
 }
 
-bool AlbumCoverManager::ItemHasCover(const QListWidgetItem* item) const {
-  return item->icon().cacheKey() != no_cover_item_icon_.cacheKey();
+bool AlbumCoverManager::ItemHasCover(const QListWidgetItem& item) const {
+  return item.icon().cacheKey() != no_cover_item_icon_.cacheKey();
 }

--- a/src/ui/albumcovermanager.h
+++ b/src/ui/albumcovermanager.h
@@ -170,7 +170,7 @@ signals:
   AlbumCoverExporter* cover_exporter_;
 
   QImage GenerateNoCoverImage(const QIcon& no_cover_icon) const;
-  bool ItemHasCover(const QListWidgetItem* item) const;
+  bool ItemHasCover(const QListWidgetItem& item) const;
 
   QIcon artist_icon_;
   QIcon all_artists_icon_;

--- a/src/ui/albumcovermanager.h
+++ b/src/ui/albumcovermanager.h
@@ -130,7 +130,7 @@ signals:
   QString InitialPathForOpenCoverDialog(const QString& path_automatic,
                                         const QString& first_file_name) const;
 
-  QString EffectiveAlbumArtistName(QListWidgetItem* item) const;
+  QString EffectiveAlbumArtistName(const QListWidgetItem* item) const;
 
   // Returns the selected element in form of a Song ready to be used
   // by AlbumCoverChoiceController or invalid song if there's nothing
@@ -169,10 +169,14 @@ signals:
   AlbumCoverExport* cover_export_;
   AlbumCoverExporter* cover_exporter_;
 
+  QImage GenerateNoCoverImage(const QIcon& no_cover_icon) const;
+  bool ItemHasCover(const QListWidgetItem* item) const;
+
   QIcon artist_icon_;
   QIcon all_artists_icon_;
-  QIcon no_cover_icon_;
-  QImage no_cover_image_;
+  const QIcon no_cover_icon_;
+  const QImage no_cover_image_;
+  const QIcon no_cover_item_icon_;
 
   QMenu* context_menu_;
   QList<QListWidgetItem*> context_menu_items_;

--- a/src/ui/albumcovermanager.h
+++ b/src/ui/albumcovermanager.h
@@ -48,7 +48,8 @@ class AlbumCoverManager : public QMainWindow {
   Q_OBJECT
  public:
   AlbumCoverManager(Application* app, LibraryBackend* library_backend,
-                    QWidget* parent = nullptr, QNetworkAccessManager* network = 0);
+                    QWidget* parent = nullptr,
+                    QNetworkAccessManager* network = 0);
   ~AlbumCoverManager();
 
   static const char* kSettingsGroup;
@@ -105,20 +106,31 @@ signals:
   void UpdateExportStatus(int exported, int bad, int count);
 
  private:
-  enum ArtistItemType { All_Artists, Various_Artists, Specific_Artist, };
+  enum ArtistItemType {
+    All_Artists,
+    Various_Artists,
+    Specific_Artist,
+  };
 
   enum Role {
     Role_ArtistName = Qt::UserRole + 1,
+    Role_AlbumArtistName,
     Role_AlbumName,
     Role_PathAutomatic,
     Role_PathManual,
     Role_FirstUrl,
   };
 
-  enum HideCovers { Hide_None, Hide_WithCovers, Hide_WithoutCovers, };
+  enum HideCovers {
+    Hide_None,
+    Hide_WithCovers,
+    Hide_WithoutCovers,
+  };
 
   QString InitialPathForOpenCoverDialog(const QString& path_automatic,
                                         const QString& first_file_name) const;
+
+  QString EffectiveAlbumArtistName(QListWidgetItem* item) const;
 
   // Returns the selected element in form of a Song ready to be used
   // by AlbumCoverChoiceController or invalid song if there's nothing

--- a/src/ui/albumcovermanager.ui
+++ b/src/ui/albumcovermanager.ui
@@ -277,7 +277,7 @@
            <enum>QListView::IconMode</enum>
           </property>
           <property name="uniformItemSizes">
-           <bool>true</bool>
+           <bool>false</bool>
           </property>
           <property name="wordWrap">
            <bool>true</bool>

--- a/src/widgets/nowplayingwidget.cpp
+++ b/src/widgets/nowplayingwidget.cpp
@@ -683,7 +683,8 @@ bool NowPlayingWidget::GetCoverAutomatically() {
       album_cover_choice_controller_->search_cover_auto_action()->isChecked() &&
       !metadata_.has_manually_unset_cover() &&
       metadata_.art_automatic().isEmpty() && metadata_.art_manual().isEmpty() &&
-      !metadata_.artist().isEmpty() && !metadata_.album().isEmpty();
+      !metadata_.effective_albumartist().isEmpty() &&
+      !metadata_.effective_album().isEmpty();
 
   if (search) {
     qLog(Debug) << "GetCoverAutomatically";


### PR DESCRIPTION
As mentioned in #5623, currently the cover manager and search only take into account an album `artist` field.

These changes make it so that the `effective_albumartist` field is used instead, which is defined as: `albumartist_.isEmpty() ? artist_ : albumartist_`.

Also, the cover manager now shows a list of artists composed by all names that appear in some album as either:
* a) `albumartist`, or
* b) `artist` when `albumartist` is empty.