### PR TITLE
Roll back to the cache naming conventions for covers

### DIFF
--- a/src/ui/albumcovermanager.cpp
+++ b/src/ui/albumcovermanager.cpp
@@ -753,8 +753,8 @@ void AlbumCoverManager::SaveAndSetCover(QListWidgetItem* item,
   const QString albumartist = item->data(Role_ArtistName).toString();
   const QString album = item->data(Role_AlbumName).toString();
 
-  QString path = album_cover_choice_controller_->SaveCoverInCache(
-      EffectiveAlbumArtistName(*item), album, image);
+  QString path =
+      album_cover_choice_controller_->SaveCoverInCache(artist, album, image);
 
   // Save the image in the database
   library_backend_->UpdateManualAlbumArtAsync(artist, albumartist, album, path);


### PR DESCRIPTION
Starting from 82f0d261fa8039af4d90761abc2384bdcb74af96, we started searching covers using the tuple `(effective_albumartist, effective_album)`. That tuple was also used to save the image in cache, but that is not consistent with the rest of the code.

In order to not introduce more changes than necessary, we keep using the previous convention of caching images with the tuple `(artist, album)`.