### PR TITLE
Uses effective fields for album hashing and comparison

### DIFF
--- a/src/core/song.cpp
+++ b/src/core/song.cpp
@@ -1127,12 +1127,13 @@ bool Song::IsOnSameAlbum(const Song& other) const {
 
   if (is_compilation() && album() == other.album()) return true;
 
-  return album() == other.album() && artist() == other.artist();
+  return effective_album() == other.effective_album() && 
+    effective_albumartist() == other.effective_albumartist();
 }
 
 QString Song::AlbumKey() const {
-  return QString("%1|%2|%3").arg(is_compilation() ? "_compilation" : artist(),
-                                 has_cue() ? cue_path() : "", album());
+  return QString("%1|%2|%3").arg(is_compilation() ? "_compilation" : effective_albumartist(),
+                                 has_cue() ? cue_path() : "", effective_album());
 }
 
 void Song::ToXesam(QVariantMap* map) const {


### PR DESCRIPTION
Using artist and album as a means for comparing and hashing albums will lead to situations where an track on the same album but having different artist fields (most commonly occurring on songs with features) will not register as being part of the same album