### PR TITLE
Remove non-allowed characters in playlist filename when saving

### DIFF
--- a/src/playlist/playlistmanager.cpp
+++ b/src/playlist/playlistmanager.cpp
@@ -196,7 +196,7 @@ void PlaylistManager::ItemsLoadedForSavePlaylist(QFuture<SongList> future,
   parser_->Save(future.result(), filename, path_type);
 }
 
-void PlaylistManager::SaveWithUI(int id, const QString& suggested_filename) {
+void PlaylistManager::SaveWithUI(int id, const QString& playlist_name) {
   QSettings settings;
   settings.beginGroup(Playlist::kSettingsGroup);
   QString filename = settings.value("last_save_playlist").toString();
@@ -205,10 +205,13 @@ void PlaylistManager::SaveWithUI(int id, const QString& suggested_filename) {
   QString filter =
       settings.value("last_save_filter", parser()->default_filter()).toString();
 
+  QString suggested_filename = playlist_name;
+  suggested_filename.replace(QRegExp("\\W"), "");
+
   qLog(Debug) << "Using extension:" << extension;
 
-  // We want to use the playlist tab name as a default filename, but in the
-  // same directory as the last saved file.
+  // We want to use the playlist tab name (with disallowed characters removed)
+  // as a default filename, but in the same directory as the last saved file.
 
   // Strip off filename components until we find something that's a folder
   forever {
@@ -237,11 +240,11 @@ void PlaylistManager::SaveWithUI(int id, const QString& suggested_filename) {
   QFileInfo info(filename);
   ParserBase* parser = parser_->ParserForExtension(info.suffix());
   if (!parser) {
-      qLog(Warning) << "Unknown file extension:" << info.suffix();
-      filename = info.absolutePath() + "/" + info.fileName()
-        + "." + parser_->default_extension();
-      info.setFile(filename);
-      filter = info.suffix();
+    qLog(Warning) << "Unknown file extension:" << info.suffix();
+    filename = info.absolutePath() + "/" + info.fileName() + "." +
+               parser_->default_extension();
+    info.setFile(filename);
+    filter = info.suffix();
   }
 
   int p = settings.value(Playlist::kPathType, Playlist::Path_Automatic).toInt();

--- a/src/playlist/playlistmanager.h
+++ b/src/playlist/playlistmanager.h
@@ -184,7 +184,7 @@ class PlaylistManager : public PlaylistManagerInterface {
   void Load(const QString& filename);
   void Save(int id, const QString& filename, Playlist::Path path_type);
   // Display a file dialog to let user choose a file before saving the file
-  void SaveWithUI(int id, const QString& suggested_filename);
+  void SaveWithUI(int id, const QString& playlist_name);
   void Rename(int id, const QString& new_name);
   void Favorite(int id, bool favorite);
   void Delete(int id);


### PR DESCRIPTION
This fixes the bug described in #5460 for Windows and also avoids the same problem in other systems (for example: Unix-based ones and forward slashes).