### PR TITLE
add file .gitattributes and remove -j8 from make-parameters

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+* text=auto
+
+*.cpp text diff=cpp
+*.h text diff=cpp
+*.in text
+*.txt text
+*.pem text
+*.css text diff=css
+*.md text
+*.sh text
+*.py text
+*.conf text
+*.README text
+*.js text
+
+*.png binary
+*.ttf binary
+*.icns binary
+*.ico binary

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Compile and install:
 
     cd bin
     cmake ..
-    make -j8
+    make 
     sudo make install
 
 See the Wiki for more instructions and a list of dependencies:


### PR DESCRIPTION
The commits of this pull-request do two things:

- Adding a .gitattributes-file, to ensure correct tracking and diffing for different filetypes. (see commit 019dddc for details)
- Removing of the parameter -j8 from make-command in README.md. (see commit 1b729ad for reasons)