### PR TITLE
Register QAbstractSocket::SocketState meta type

### DIFF
--- a/src/core/metatypes.cpp
+++ b/src/core/metatypes.cpp
@@ -80,6 +80,8 @@ void RegisterMetaTypes() {
       "PlaylistSequence::RepeatMode");
   qRegisterMetaType<PlaylistSequence::ShuffleMode>(
       "PlaylistSequence::ShuffleMode");
+  qRegisterMetaType<QAbstractSocket::SocketState>(
+      "QAbstractSocket::SocketState");
   qRegisterMetaType<QList<PodcastEpisode>>("QList<PodcastEpisode>");
   qRegisterMetaType<QList<Podcast>>("QList<Podcast>");
   qRegisterMetaType<QList<QNetworkCookie>>("QList<QNetworkCookie>");


### PR DESCRIPTION
This fixes the following warnings that were shown multiple times during exit:

> DEBUG WorkerPool<HandlerType>:176      Closing worker socket 
WARN  unknown                          QObject::connect: Cannot queue arguments of type '**QAbstractSocket::SocketState**' 
WARN  unknown                          **(Make sure 'QAbstractSocket::SocketState' is registered using qRegisterMetaType().)**