### PR TITLE
Fix some warnings shown on start-up

### DIFF
--- a/src/analyzers/analyzerbase.cpp
+++ b/src/analyzers/analyzerbase.cpp
@@ -241,9 +241,9 @@ QColor Analyzer::Base::getPsychedelicColor(const Scope& scope,
   rgb[1] = sqrt(rgb[1]) * ampFactor + bias;
   rgb[2] = sqrt(rgb[2]) * ampFactor + bias;
 
-  const int r = qMax(0, qMin(255, static_cast<int>(rgb[0])));
-  const int g = qMax(0, qMin(255, static_cast<int>(rgb[1])));
-  const int b = qMax(0, qMin(255, static_cast<int>(rgb[2])));
+  const int r = qBound(0, static_cast<int>(rgb[0]), 255);
+  const int g = qBound(0, static_cast<int>(rgb[1]), 255);
+  const int b = qBound(0, static_cast<int>(rgb[2]), 255);
 
   return QColor::fromRgb(r, g, b);
 }

--- a/src/analyzers/analyzerbase.cpp
+++ b/src/analyzers/analyzerbase.cpp
@@ -236,12 +236,16 @@ QColor Analyzer::Base::getPsychedelicColor(const Scope& scope,
     rgb[(i * 3) / sBarkBandCount] += pow(bands[i], 2);
   }
 
-  for (int i = 0; i < 3; ++i) {
-    // bias colours for a threshold around normally amplified audio
-    rgb[i] = qMin(255, (int)((sqrt(rgb[i]) * ampFactor) + bias));
-  }
+  // bias colours for a threshold around normally amplified audio
+  rgb[0] = sqrt(rgb[0]) * ampFactor + bias;
+  rgb[1] = sqrt(rgb[1]) * ampFactor + bias;
+  rgb[2] = sqrt(rgb[2]) * ampFactor + bias;
 
-  return QColor::fromRgb(rgb[0], rgb[1], rgb[2]);
+  const int r = qMax(0, qMin(255, static_cast<int>(rgb[0])));
+  const int g = qMax(0, qMin(255, static_cast<int>(rgb[1])));
+  const int b = qMax(0, qMin(255, static_cast<int>(rgb[2])));
+
+  return QColor::fromRgb(r, g, b);
 }
 
 void Analyzer::Base::polishEvent() {

--- a/src/analyzers/blockanalyzer.cpp
+++ b/src/analyzers/blockanalyzer.cpp
@@ -398,6 +398,10 @@ void BlockAnalyzer::paletteChange(const QPalette&) {
 }
 
 void BlockAnalyzer::drawBackground() {
+  if (background_.isNull()) {
+    return;
+  }
+
   const QColor bg = palette().color(QPalette::Background);
   const QColor bgdark = bg.dark(112);
 

--- a/src/ui/albumcoverchoicecontroller.cpp
+++ b/src/ui/albumcoverchoicecontroller.cpp
@@ -64,15 +64,15 @@ AlbumCoverChoiceController::AlbumCoverChoiceController(QWidget* parent)
                   tr("Save cover to disk..."), this);
   cover_from_url_ = new QAction(IconLoader::Load("download", IconLoader::Base),
                                 tr("Load cover from URL..."), this);
-  search_for_cover_ = new QAction(IconLoader::Load("find", IconLoader::Base),
-                                  tr("Search for album covers..."), this);
+  search_for_cover_ =
+      new QAction(IconLoader::Load("edit-find", IconLoader::Base),
+                  tr("Search for album covers..."), this);
   unset_cover_ = new QAction(IconLoader::Load("list-remove", IconLoader::Base),
                              tr("Unset cover"), this);
   show_cover_ = new QAction(IconLoader::Load("zoom-in", IconLoader::Base),
                             tr("Show fullsize..."), this);
 
-  search_cover_auto_ = new QAction(IconLoader::Load("find", IconLoader::Base),
-                                   tr("Search automatically"), this);
+  search_cover_auto_ = new QAction(tr("Search automatically"), this);
   search_cover_auto_->setCheckable(true);
   search_cover_auto_->setChecked(false);
 


### PR DESCRIPTION
> QColor::fromRgb: RGB parameters out of range 

> Couldn't load icon "find"

> QPainter::begin: Paint device returned engine == 0, type: 2 

