### PR TITLE
Request to merge a fix to "Seek instead of navigation with arrow keys #5550".

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2856,12 +2856,6 @@ void MainWindow::keyPressEvent(QKeyEvent* event) {
   if (event->key() == Qt::Key_Space) {
     app_->player()->PlayPause();
     event->accept();
-  } else if (event->key() == Qt::Key_Left) {
-    app_->player()->SeekBackward();
-    event->accept();
-  } else if (event->key() == Qt::Key_Right) {
-    app_->player()->SeekForward();
-    event->accept();
   } else {
     QMainWindow::keyPressEvent(event);
   }


### PR DESCRIPTION
Hello, my team for a Software Development class has figured out a possible fix to issue #5550. It seems that there has been a possible overlap of key functions between [mainwindow.cpp](https://github.com/clementine-player/Clementine/blob/c7b8aacad8179ea2a7fe3857833a8c01c70104da/src/ui/mainwindow.cpp#L2859-L2864) and [playlistview.cpp](https://github.com/clementine-player/Clementine/blob/e5ab3e786f9adde12cec3cc90cfe8c1cc6b06320/src/playlist/playlistview.cpp#L621-L626). By getting rid of the left and right key functions in mainwindow.cpp, the left, right, and down keys are now used solely for browsing through the library hierarchy when the library is in focus; when the playlist is in focus, the left and right keys properly seek, and the up key starts the song over from the beginning as usual. I hope you will consider this into Clementine, thank you.