### PR TITLE
Fix psychedelic mode on analysers

### DIFF
--- a/src/analyzers/analyzerbase.cpp
+++ b/src/analyzers/analyzerbase.cpp
@@ -235,16 +235,12 @@ QColor Analyzer::Base::getPsychedelicColor(const Scope& scope,
     rgb[(i * 3) / sBarkBandCount] += pow(bands[i], 2);
   }
 
-  // bias colours for a threshold around normally amplified audio
-  rgb[0] = sqrt(rgb[0]) * ampFactor + bias;
-  rgb[1] = sqrt(rgb[1]) * ampFactor + bias;
-  rgb[2] = sqrt(rgb[2]) * ampFactor + bias;
+  for (int i = 0; i < 3; ++i) {
+    // bias colours for a threshold around normally amplified audio
+    rgb[i] = qMin(255, (int)((sqrt(rgb[i]) * ampFactor) + bias));
+  }
 
-  const int r = qBound(0, static_cast<int>(rgb[0]), 255);
-  const int g = qBound(0, static_cast<int>(rgb[1]), 255);
-  const int b = qBound(0, static_cast<int>(rgb[2]), 255);
-
-  return QColor::fromRgb(r, g, b);
+  return QColor::fromRgb(rgb[0], rgb[1], rgb[2]);
 }
 
 void Analyzer::Base::polishEvent() {

--- a/src/analyzers/analyzerbase.cpp
+++ b/src/analyzers/analyzerbase.cpp
@@ -203,7 +203,6 @@ void Analyzer::Base::updateBandSize(const int scopeSize) {
   bands_ = scopeSize;
 
   barkband_table_.clear();
-  barkband_table_.resize(bands_ + 1);
 
   int barkband = 0;
   for (int i = 0; i < bands_ + 1; ++i) {


### PR DESCRIPTION
6c9bc43bbb0b23a1fd8801e2075cef44cc3aae8b broke psychedelic mode because somehow a `QList.reserve()` turned into a `QVector.resize()` which are definitely not equivalent.

There were also bounds added to stop the code spewing errors because of this, but they are not needed now since it's not broken anymore.