### PR TITLE
This fixes "First track always the same in shuffle #793".

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -334,6 +334,7 @@ void Player::PreviousItem(Engine::TrackChangeFlags change) {
   app_->playlist_manager()->active()->set_current_row(i);
   if (i == -1) {
     Stop();
+    PlayAt(i, change, true);
     return;
   }
 


### PR DESCRIPTION
Hello, our team again as been able to find a possible solution to a bug, this time to issue #793. By adding this call into the if statement, this allows a reshuffle to happen after the playlist ends so that when the playlist starts again, it will already have a new set location to go to. In order to make sure this did not create any additional bugs, a few checks were made:

- Turning off shuffle album mode to make sure that songs were not starting at random points in the playlist.
- Playlist works with one song (Playlist will end, and song will play again)
- Playlist works with two songs (Playlist will end, and will start with the other song that wasn't played.)

I hope you will consider this into Clementine, thank you for your time.


