### PR TITLE
This should fix the issue "Make shuffling more random #5201".

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -395,8 +395,8 @@ void Player::PlayAt(int index, Engine::TrackChangeFlags change,
     change |= Engine::SameAlbum;
   }
 
-  if (reshuffle) app_->playlist_manager()->active()->ReshuffleIndices();
   app_->playlist_manager()->active()->set_current_row(index);
+  if (reshuffle) app_->playlist_manager()->active()->ReshuffleIndices();
 
   if (app_->playlist_manager()->active()->current_row() == -1) {
     // Maybe index didn't exist in the playlist.


### PR DESCRIPTION
Hello again, our Software team has come up with another solution, this time to #5201. 
If one were to open a playlist with several songs, play song a then hit next, you will be listening to song b, if you were to hit next several times, double click song a and hit next, now a different song is played instead of song b.  I hope you will consider this fix into Clementine, thank you for your time. 