### PR TITLE
Updated to implement the feature request asking for a file containing… 

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -411,16 +411,32 @@ void Player::PlayAt(int index, Engine::TrackChangeFlags change,
 
     stream_change_type_ = change;
     HandleLoadResult(url_handlers_[url.scheme()]->StartLoading(url));
-  } else {
-    loading_async_ = QUrl();
-    engine_->Play(current_item_->Url(), change,
-                  current_item_->Metadata().has_cue(),
-                  current_item_->Metadata().beginning_nanosec(),
-                  current_item_->Metadata().end_nanosec());
+  }
+  else {
+      loading_async_ = QUrl();
+
+      if( current_item_->Url().scheme() == "spotify" ) {
+          Engine::SimpleMetaBundle myBundle;
+          current_item_->Metadata().MakeMetaData(myBundle);
+          qLog(Info) << "artist=" << myBundle.artist << " title=" << myBundle.title << " year=" << myBundle.year;
+          engine_->Play(myBundle,
+                        current_item_->Url(),
+                        change,
+                        current_item_->Metadata().has_cue(),
+                        current_item_->Metadata().beginning_nanosec(),
+                        current_item_->Metadata().end_nanosec());
+      }
+      else {
+          engine_->Play(current_item_->Url(),
+                        change,
+                        current_item_->Metadata().has_cue(),
+                        current_item_->Metadata().beginning_nanosec(),
+                        current_item_->Metadata().end_nanosec());
+      }
 
 #ifdef HAVE_LIBLASTFM
-    if (lastfm_->IsScrobblingEnabled())
-      lastfm_->NowPlaying(current_item_->Metadata());
+      if (lastfm_->IsScrobblingEnabled())
+          lastfm_->NowPlaying(current_item_->Metadata());
 #endif
   }
 }

--- a/src/core/song.cpp
+++ b/src/core/song.cpp
@@ -41,6 +41,7 @@
 #include <QTime>
 #include <QVariant>
 #include <QtConcurrentRun>
+#include <QString>
 
 #ifdef HAVE_LIBLASTFM
 #include "internet/lastfm/fixlastfm.h"
@@ -903,6 +904,19 @@ void Song::MergeFromSimpleMetaBundle(const Engine::SimpleMetaBundle& bundle) {
   if (!bundle.length.isEmpty()) set_length_nanosec(bundle.length.toLongLong());
   if (!bundle.year.isEmpty()) d->year_ = bundle.year.toInt();
   if (!bundle.tracknr.isEmpty()) d->track_ = bundle.tracknr.toInt();
+}
+
+void Song::MakeMetaData( Engine::SimpleMetaBundle& bundle ) const {
+    bundle.title = QString( d->title_.data() );
+    bundle.artist = QString(d->artist_.data());
+    bundle.album = QString(d->album_.data());
+    bundle.comment = QString(d->comment_.data());
+    bundle.genre = QString(d->genre_.data());
+    bundle.bitrate = QString::number(d->bitrate_);
+    bundle.samplerate = QString::number(d->samplerate_);
+    bundle.length = QString::number(d->end_-d->beginning_);
+    bundle.year = QString::number(d->year_);
+    bundle.tracknr = QString::number(d->track_);
 }
 
 void Song::BindToQuery(QSqlQuery* query) const {

--- a/src/core/song.h
+++ b/src/core/song.h
@@ -144,6 +144,8 @@ class Song {
 
   static QString Decode(const QString& tag, const QTextCodec* codec = nullptr);
 
+  void MakeMetaData(Engine::SimpleMetaBundle &bundle ) const;
+
   // Save
   void BindToQuery(QSqlQuery* query) const;
   void BindToFtsQuery(QSqlQuery* query) const;

--- a/src/engines/enginebase.cpp
+++ b/src/engines/enginebase.cpp
@@ -100,3 +100,13 @@ bool Engine::Base::Play(const QUrl& u, TrackChangeFlags c,
 
   return Play(0);
 }
+
+bool Engine::Base::Play(const SimpleMetaBundle &bundle, const QUrl& u, TrackChangeFlags c,
+                        bool force_stop_at_end, quint64 beginning_nanosec,
+                        qint64 end_nanosec) {
+
+  if (!Load(u, c, force_stop_at_end, beginning_nanosec, end_nanosec))
+    return false;
+
+  return( Play(bundle, 0) );
+}

--- a/src/engines/enginebase.h
+++ b/src/engines/enginebase.h
@@ -47,6 +47,7 @@ class Base : public QObject {
 
   virtual void StartPreloading(const QUrl&, bool, qint64, qint64) {}
   virtual bool Play(quint64 offset_nanosec) = 0;
+  virtual bool Play(const SimpleMetaBundle &bundle, quint64 offset_nanosec) = 0;
   virtual void Stop(bool stop_after = false) = 0;
   virtual void Pause() = 0;
   virtual void Unpause() = 0;
@@ -79,6 +80,10 @@ class Base : public QObject {
   // should be passed in nanoseconds. 'end' can be negative, indicating that the
   // real length of 'u' stream is unknown.
   bool Play(const QUrl& u, TrackChangeFlags c, bool force_stop_at_end,
+            quint64 beginning_nanosec, qint64 end_nanosec);
+
+  bool Play(const SimpleMetaBundle &bundle,
+            const QUrl& u, TrackChangeFlags c, bool force_stop_at_end,
             quint64 beginning_nanosec, qint64 end_nanosec);
 
   void SetVolume(uint value);

--- a/src/engines/gstengine.cpp
+++ b/src/engines/gstengine.cpp
@@ -469,6 +469,12 @@ bool GstEngine::Play(quint64 offset_nanosec) {
   return true;
 }
 
+bool GstEngine::Play(const Engine::SimpleMetaBundle &bundle,
+                     quint64 offset_nanosec) {
+  this->bundle = bundle;
+  return( this->Play(offset_nanosec) );
+}
+
 void GstEngine::PlayDone(QFuture<GstStateChangeReturn> future,
                          const quint64 offset_nanosec, const int pipeline_id) {
   GstStateChangeReturn ret = future.result();
@@ -574,6 +580,10 @@ void GstEngine::Pause() {
       StopTimers();
     }
   }
+}
+
+const Engine::SimpleMetaBundle& GstEngine::GetMetaDataBundle() const {
+    return( this->bundle );
 }
 
 void GstEngine::Unpause() {

--- a/src/engines/gstengine.h
+++ b/src/engines/gstengine.h
@@ -82,6 +82,8 @@ class GstEngine : public Engine::Base, public BufferConsumer {
   void StopBackgroundStream(int id);
   void SetBackgroundStreamVolume(int id, int volume);
 
+  const Engine::SimpleMetaBundle& GetMetaDataBundle() const;
+
   qint64 position_nanosec() const;
   qint64 length_nanosec() const;
   Engine::State state() const;
@@ -101,6 +103,7 @@ class GstEngine : public Engine::Base, public BufferConsumer {
             bool force_stop_at_end, quint64 beginning_nanosec,
             qint64 end_nanosec);
   bool Play(quint64 offset_nanosec);
+  bool Play(const Engine::SimpleMetaBundle &bundle, quint64 offset_nanosec);
   void Stop(bool stop_after = false);
   void Pause();
   void Unpause();
@@ -234,6 +237,8 @@ class GstEngine : public Engine::Base, public BufferConsumer {
   int scope_chunks_;
 
   QList<DeviceFinder*> device_finders_;
+
+  Engine::SimpleMetaBundle bundle;
 
 #ifdef Q_OS_DARWIN
   GTlsDatabase* tls_database_;

--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -1057,7 +1057,26 @@ QFuture<GstStateChangeReturn> GstEnginePipeline::SetState(GstState state) {
       QMetaObject::invokeMethod(spotify, "SetPaused", Qt::QueuedConnection,
                                 Q_ARG(bool, false));
     }
+
+    // Update the playcount if we are playing again.
+    if (state == GST_STATE_PLAYING && current_state != GST_STATE_PAUSED) {
+        SpotifyService* spotify = InternetModel::Service<SpotifyService>();
+
+        // Invoke the "UpdatePlayCountFile" method in the SpotifyService class (via the
+        // spotify object).
+
+        qLog(Info) << "artist=" << engine_->GetMetaDataBundle().artist
+                   << " title=" << engine_->GetMetaDataBundle().title
+                   << " year=" << engine_->GetMetaDataBundle().year;
+
+        QMetaObject::invokeMethod(spotify, "UpdatePlayCountFile", Qt::QueuedConnection,
+                                  Q_ARG(const QString&, engine_->GetMetaDataBundle().artist),
+                                  Q_ARG(const QString&, engine_->GetMetaDataBundle().title),
+                                  Q_ARG(const QString&, engine_->GetMetaDataBundle().year));
+    }
+
   }
+
   return ConcurrentRun::Run<GstStateChangeReturn, GstElement*, GstState>(
       &set_state_threadpool_, &gst_element_set_state, pipeline_, state);
 }

--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -22,6 +22,7 @@
 #include <QPair>
 #include <QRegExp>
 #include <QUuid>
+#include <QSettings>
 
 #include "bufferconsumer.h"
 #include "config.h"
@@ -1069,10 +1070,15 @@ QFuture<GstStateChangeReturn> GstEnginePipeline::SetState(GstState state) {
                    << " title=" << engine_->GetMetaDataBundle().title
                    << " year=" << engine_->GetMetaDataBundle().year;
 
+        QSettings s;
+        s.beginGroup(SpotifyService::kSettingsGroup);
+
+        if(s.value("spotifySongTracking").toBool()){
         QMetaObject::invokeMethod(spotify, "UpdatePlayCountFile", Qt::QueuedConnection,
                                   Q_ARG(const QString&, engine_->GetMetaDataBundle().artist),
                                   Q_ARG(const QString&, engine_->GetMetaDataBundle().title),
                                   Q_ARG(const QString&, engine_->GetMetaDataBundle().year));
+        }
     }
 
   }

--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -1079,9 +1079,13 @@ QFuture<GstStateChangeReturn> GstEnginePipeline::SetState(GstState state) {
       if (s.value("spotifySongTracking").toBool()) {
         QMetaObject::invokeMethod(
             spotify, "UpdatePlayCountFile", Qt::QueuedConnection,
-            Q_ARG(const QString&, delimChar + (engine_->GetMetaDataBundle().artist) + delimChar),
-            Q_ARG(const QString&, delimChar + (engine_->GetMetaDataBundle().title)+ delimChar),
-            Q_ARG(const QString&, delimChar + (engine_->GetMetaDataBundle().year)+ delimChar));
+            Q_ARG(
+                const QString&,
+                delimChar + (engine_->GetMetaDataBundle().artist) + delimChar),
+            Q_ARG(const QString&,
+                  delimChar + (engine_->GetMetaDataBundle().title) + delimChar),
+            Q_ARG(const QString&,
+                  delimChar + (engine_->GetMetaDataBundle().year) + delimChar));
       }
     }
   }

--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -1074,18 +1074,22 @@ QFuture<GstStateChangeReturn> GstEnginePipeline::SetState(GstState state) {
       QSettings s;
       s.beginGroup(SpotifyService::kSettingsGroup);
 
-      QString delimChar = "\"";
+      QString delimiter = "\"";
+
+      QString artist = engine_->GetMetaDataBundle().artist;
+      QString title = engine_->GetMetaDataBundle().title;
+      QString year = engine_->GetMetaDataBundle().year;
+
+      artist =
+          delimiter + artist.replace(delimiter, QString("\"\"")) + delimiter;
+      title = delimiter + title.replace(delimiter, QString("\"\"")) + delimiter;
+      year = delimiter + year.replace(delimiter, QString("\"\"")) + delimiter;
 
       if (s.value("spotifySongTracking").toBool()) {
         QMetaObject::invokeMethod(
             spotify, "UpdatePlayCountFile", Qt::QueuedConnection,
-            Q_ARG(
-                const QString&,
-                delimChar + (engine_->GetMetaDataBundle().artist) + delimChar),
-            Q_ARG(const QString&,
-                  delimChar + (engine_->GetMetaDataBundle().title) + delimChar),
-            Q_ARG(const QString&,
-                  delimChar + (engine_->GetMetaDataBundle().year) + delimChar));
+            Q_ARG(const QString&, artist), Q_ARG(const QString&, title),
+            Q_ARG(const QString&, year));
       }
     }
   }

--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -1074,12 +1074,14 @@ QFuture<GstStateChangeReturn> GstEnginePipeline::SetState(GstState state) {
       QSettings s;
       s.beginGroup(SpotifyService::kSettingsGroup);
 
+      QString delimChar = "\"";
+
       if (s.value("spotifySongTracking").toBool()) {
         QMetaObject::invokeMethod(
             spotify, "UpdatePlayCountFile", Qt::QueuedConnection,
-            Q_ARG(const QString&, engine_->GetMetaDataBundle().artist),
-            Q_ARG(const QString&, engine_->GetMetaDataBundle().title),
-            Q_ARG(const QString&, engine_->GetMetaDataBundle().year));
+            Q_ARG(const QString&, delimChar + (engine_->GetMetaDataBundle().artist) + delimChar),
+            Q_ARG(const QString&, delimChar + (engine_->GetMetaDataBundle().title)+ delimChar),
+            Q_ARG(const QString&, delimChar + (engine_->GetMetaDataBundle().year)+ delimChar));
       }
     }
   }

--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -1061,26 +1061,27 @@ QFuture<GstStateChangeReturn> GstEnginePipeline::SetState(GstState state) {
 
     // Update the playcount if we are playing again.
     if (state == GST_STATE_PLAYING && current_state != GST_STATE_PAUSED) {
-        SpotifyService* spotify = InternetModel::Service<SpotifyService>();
+      SpotifyService* spotify = InternetModel::Service<SpotifyService>();
 
-        // Invoke the "UpdatePlayCountFile" method in the SpotifyService class (via the
-        // spotify object).
+      // Invoke the "UpdatePlayCountFile" method in the SpotifyService class
+      // (via the
+      // spotify object).
 
-        qLog(Info) << "artist=" << engine_->GetMetaDataBundle().artist
-                   << " title=" << engine_->GetMetaDataBundle().title
-                   << " year=" << engine_->GetMetaDataBundle().year;
+      qLog(Info) << "artist=" << engine_->GetMetaDataBundle().artist
+                 << " title=" << engine_->GetMetaDataBundle().title
+                 << " year=" << engine_->GetMetaDataBundle().year;
 
-        QSettings s;
-        s.beginGroup(SpotifyService::kSettingsGroup);
+      QSettings s;
+      s.beginGroup(SpotifyService::kSettingsGroup);
 
-        if(s.value("spotifySongTracking").toBool()){
-        QMetaObject::invokeMethod(spotify, "UpdatePlayCountFile", Qt::QueuedConnection,
-                                  Q_ARG(const QString&, engine_->GetMetaDataBundle().artist),
-                                  Q_ARG(const QString&, engine_->GetMetaDataBundle().title),
-                                  Q_ARG(const QString&, engine_->GetMetaDataBundle().year));
-        }
+      if (s.value("spotifySongTracking").toBool()) {
+        QMetaObject::invokeMethod(
+            spotify, "UpdatePlayCountFile", Qt::QueuedConnection,
+            Q_ARG(const QString&, engine_->GetMetaDataBundle().artist),
+            Q_ARG(const QString&, engine_->GetMetaDataBundle().title),
+            Q_ARG(const QString&, engine_->GetMetaDataBundle().year));
+      }
     }
-
   }
 
   return ConcurrentRun::Run<GstStateChangeReturn, GstElement*, GstState>(

--- a/src/internet/core/oauthenticator.cpp
+++ b/src/internet/core/oauthenticator.cpp
@@ -80,7 +80,6 @@ void OAuthenticator::StartAuthorisation(const QString& oauth_endpoint,
 void OAuthenticator::RedirectArrived(LocalRedirectServer* server, QUrl url) {
   server->deleteLater();
   QUrl request_url = server->request_url();
-  qLog(Debug) << Q_FUNC_INFO << request_url;
   RequestAccessToken(request_url.queryItemValue("code").toUtf8(), url);
 }
 
@@ -138,8 +137,6 @@ void OAuthenticator::FetchAccessTokenFinished(QNetworkReply* reply) {
     qLog(Error) << "Failed to parse oauth reply";
     return;
   }
-
-  qLog(Debug) << result;
 
   access_token_ = result["access_token"].toString();
   refresh_token_ = result["refresh_token"].toString();

--- a/src/internet/spotify/spotifyservice.cpp
+++ b/src/internet/spotify/spotifyservice.cpp
@@ -408,7 +408,7 @@ int SpotifyService::SongIsInPlayCountFile(std::fstream& ofs,
                                                   // of this line in the file.
         filePosition = numChars;
         songFound = true;
-        const int YEAR_LENGTH_CHARS = 4;
+        const int YEAR_LENGTH_CHARS = 4 + 2; //Length + length of quote at end and begining of year
         playCount = atoi(
             &line[artistLength + 1 + titleLength + 1 + YEAR_LENGTH_CHARS + 1]);
       }
@@ -453,43 +453,41 @@ void SpotifyService::UpdatePlayCountFile(const QString& artist,
   std::fstream ofs(SpotifyPlayCountFileName,
                    std::ios_base::in | std::ios_base::out);
   if (!ofs) {
-    ofs.open(SpotifyPlayCountFileName, std::ios_base::app);
-    ofs << "Artist"
-        << ","
-        << "Title"
-        << ","
-        << "Year"
-        << ","
-        << "Play Count" << std::endl;  // Output headings for the file
-    ofs.flush();
-    ofs << artist.toStdString() << "," << title.toStdString() << ","
-        << year.toStdString() << "," << std::setw(DEFAULT_WIDTH) << std::left
-        << ++playCount << std::endl;
-    ofs.flush();
-    ofs.close();
-  } else {
-    ofs.seekp(0, std::ios_base::beg);
+     ofs.open(SpotifyPlayCountFileName, std::ios_base::app);
+     ofs << "Artist"
+         << ","
+         << "Title"
+         << ","
+         << "Year"
+         << ","
+         << "Play Count" << std::endl;  // Output headings for the file
+     ofs.flush();
+     ofs << artist.toStdString() << "," << title.toStdString() << ","
+         << year.toStdString() << "," << std::setw(DEFAULT_WIDTH) << std::left
+         << ++playCount << std::endl;
+     ofs.flush();
+     ofs.close();
+   } else {
+     ofs.seekp(0, std::ios_base::beg);
 
-    // Try to see if the song is in the "PlayCountFile".
-    int filePosition = this->SongIsInPlayCountFile(
-        ofs, artist.toStdString(), title.toStdString(), year.toStdString(),
-        playCount);
-    if (filePosition > 0) {
-      // Seek to the position in the file where the song is located, or the end
-      // of the file.
-      ofs.seekp(filePosition, std::ios_base::beg);
-    }
-    ofs << artist.toStdString() << "," << title.toStdString() << ","
-        << year.toStdString() << "," << std::setw(DEFAULT_WIDTH) << std::left
-        << ++playCount << std::endl;
+     // Try to see if the song is in the "PlayCountFile".
+     int filePosition = this->SongIsInPlayCountFile(
+         ofs, artist.toStdString(), title.toStdString(), year.toStdString(),
+         playCount);
+     if (filePosition > 0) {
+       // Seek to the position in the file where the song is located, or the end
+       // of the file.
+       ofs.seekp(filePosition, std::ios_base::beg);
+     }
+     ofs << artist.toStdString() << "," << title.toStdString() << ","
+         << year.toStdString() << "," << std::setw(DEFAULT_WIDTH) << std::left
+         << ++playCount << std::endl;
 
-    ofs.seekp(0, std::ios_base::end);
+     ofs.seekp(0, std::ios_base::end);
 
-    ofs.flush();
-    ofs.close();
-  }
-
-  return;
+     ofs.flush();
+     ofs.close();
+   }
 }
 
 void SpotifyService::AddCurrentSongToUserPlaylist(QAction* action) {

--- a/src/internet/spotify/spotifyservice.cpp
+++ b/src/internet/spotify/spotifyservice.cpp
@@ -395,6 +395,7 @@ int SpotifyService::SongIsInPlayCountFile(std::fstream& ofs,
   bool songFound = false;
   size_t artistLength = strlen(songArtist.c_str());
   size_t titleLength = strlen(songTitle.c_str());
+  size_t yearLength = strlen(songTitle.c_str());
   int numChars = 0;
 
   while (!endOfFile && !songFound) {
@@ -408,10 +409,9 @@ int SpotifyService::SongIsInPlayCountFile(std::fstream& ofs,
                                                   // of this line in the file.
         filePosition = numChars;
         songFound = true;
-        const int YEAR_LENGTH_CHARS =
-            4 + 2;  // Length + length of quote at end and begining of year
-        playCount = atoi(
-            &line[artistLength + 1 + titleLength + 1 + YEAR_LENGTH_CHARS + 1]);
+        playCount =
+            strtol(&line[artistLength + 1 + titleLength + 1 + yearLength + 1],
+                   nullptr, 10);
       }
     }
     numChars += (strlen(line) + 1);
@@ -455,13 +455,13 @@ void SpotifyService::UpdatePlayCountFile(const QString& artist,
                    std::ios_base::in | std::ios_base::out);
   if (!ofs) {
     ofs.open(SpotifyPlayCountFileName, std::ios_base::app);
-    ofs << "Artist"
+    ofs << "\"Artist\""
         << ","
-        << "Title"
+        << "\"Title\""
         << ","
-        << "Year"
+        << "\"Year\""
         << ","
-        << "Play Count" << std::endl;  // Output headings for the file
+        << "\"Play Count\"" << std::endl;  // Output headings for the file
     ofs.flush();
   } else {
     ofs.seekp(0, std::ios_base::beg);
@@ -475,14 +475,14 @@ void SpotifyService::UpdatePlayCountFile(const QString& artist,
       // of the file.
       ofs.seekp(filePosition, std::ios_base::beg);
     }
-
-    ofs << artist.toStdString() << "," << title.toStdString() << ","
-        << year.toStdString() << "," << std::setw(DEFAULT_WIDTH) << std::left
-        << ++playCount << std::endl;
-
-    ofs.flush();
-    ofs.close();
   }
+
+  ofs << artist.toStdString() << "," << title.toStdString() << ","
+      << year.toStdString() << "," << std::setw(DEFAULT_WIDTH) << std::left
+      << ++playCount << std::endl;
+
+  ofs.flush();
+  ofs.close();
 }
 
 void SpotifyService::AddCurrentSongToUserPlaylist(QAction* action) {

--- a/src/internet/spotify/spotifyservice.cpp
+++ b/src/internet/spotify/spotifyservice.cpp
@@ -428,7 +428,7 @@ int SpotifyService::SongIsInPlayCountFile(std::fstream &ofs,
 
 void SpotifyService::UpdatePlayCountFile(const QString& artist,
                                          const QString& title,
-                                         const QString& year) { // const Engine::SimpleMetaBundle& bundle) {
+                                         const QString& year) {
     int playCount = 0;
 
     qLog(Info) << "artist=" << artist << " title=" << title << " year=" << year;

--- a/src/internet/spotify/spotifyservice.cpp
+++ b/src/internet/spotify/spotifyservice.cpp
@@ -414,7 +414,6 @@ void SpotifyService::SeekToSongInPlayCountFile(QFile& fileStream,
         fileStream
             .size());  // Seek to the end of the file to add the song there.
   } else {
-    playCount++;
     textStream.seek(seekCount);
   }
 }
@@ -466,7 +465,7 @@ void SpotifyService::UpdatePlayCountFile(const QString& artist,
 
   QString output;
   QTextStream(&output) << artist << "," << title << "," << year << ","
-                       << playCount << '\n';
+                       << playCount+1 << '\n';
 
   qint64 prevPosition = textStream.pos();
 

--- a/src/internet/spotify/spotifyservice.cpp
+++ b/src/internet/spotify/spotifyservice.cpp
@@ -436,7 +436,7 @@ void SpotifyService::UpdatePlayCountFile(const QString& artist,
     char* userHomeDir = std::getenv("HOME");
     char  SpotifyPlayCountFileName[256];
     strncpy( SpotifyPlayCountFileName, userHomeDir, strlen(userHomeDir) );
-    strcat(SpotifyPlayCountFileName,"/SpotifyPlayCount2.csv");
+    strcat(SpotifyPlayCountFileName,"/SpotifyPlayCount.csv");
     const int DEFAULT_WIDTH= 8;
     std::fstream ofs(SpotifyPlayCountFileName, std::ios_base::in | std::ios_base::out);
     if( !ofs ) {

--- a/src/internet/spotify/spotifyservice.cpp
+++ b/src/internet/spotify/spotifyservice.cpp
@@ -472,8 +472,7 @@ void SpotifyService::UpdatePlayCountFile(const QString& artist,
   textStream.readLine();  // Skip to line after to store contents after the
                           // string we want to replace.
 
-  QString tempFile;
-  tempFile = textStream.read(fileStream.size());  // Store the rest of the file
+  QString tempFile = textStream.read(fileStream.size());  // Store the rest of the file
                                                   // so we don't overwrite the
                                                   // next line when replacing
                                                   // the previous line.

--- a/src/internet/spotify/spotifyservice.cpp
+++ b/src/internet/spotify/spotifyservice.cpp
@@ -408,7 +408,8 @@ int SpotifyService::SongIsInPlayCountFile(std::fstream& ofs,
                                                   // of this line in the file.
         filePosition = numChars;
         songFound = true;
-        const int YEAR_LENGTH_CHARS = 4 + 2; //Length + length of quote at end and begining of year
+        const int YEAR_LENGTH_CHARS =
+            4 + 2;  // Length + length of quote at end and begining of year
         playCount = atoi(
             &line[artistLength + 1 + titleLength + 1 + YEAR_LENGTH_CHARS + 1]);
       }
@@ -453,41 +454,41 @@ void SpotifyService::UpdatePlayCountFile(const QString& artist,
   std::fstream ofs(SpotifyPlayCountFileName,
                    std::ios_base::in | std::ios_base::out);
   if (!ofs) {
-     ofs.open(SpotifyPlayCountFileName, std::ios_base::app);
-     ofs << "Artist"
-         << ","
-         << "Title"
-         << ","
-         << "Year"
-         << ","
-         << "Play Count" << std::endl;  // Output headings for the file
-     ofs.flush();
-     ofs << artist.toStdString() << "," << title.toStdString() << ","
-         << year.toStdString() << "," << std::setw(DEFAULT_WIDTH) << std::left
-         << ++playCount << std::endl;
-     ofs.flush();
-     ofs.close();
-   } else {
-     ofs.seekp(0, std::ios_base::beg);
+    ofs.open(SpotifyPlayCountFileName, std::ios_base::app);
+    ofs << "Artist"
+        << ","
+        << "Title"
+        << ","
+        << "Year"
+        << ","
+        << "Play Count" << std::endl;  // Output headings for the file
+    ofs.flush();
+    ofs << artist.toStdString() << "," << title.toStdString() << ","
+        << year.toStdString() << "," << std::setw(DEFAULT_WIDTH) << std::left
+        << ++playCount << std::endl;
+    ofs.flush();
+    ofs.close();
+  } else {
+    ofs.seekp(0, std::ios_base::beg);
 
-     // Try to see if the song is in the "PlayCountFile".
-     int filePosition = this->SongIsInPlayCountFile(
-         ofs, artist.toStdString(), title.toStdString(), year.toStdString(),
-         playCount);
-     if (filePosition > 0) {
-       // Seek to the position in the file where the song is located, or the end
-       // of the file.
-       ofs.seekp(filePosition, std::ios_base::beg);
-     }
-     ofs << artist.toStdString() << "," << title.toStdString() << ","
-         << year.toStdString() << "," << std::setw(DEFAULT_WIDTH) << std::left
-         << ++playCount << std::endl;
+    // Try to see if the song is in the "PlayCountFile".
+    int filePosition = this->SongIsInPlayCountFile(
+        ofs, artist.toStdString(), title.toStdString(), year.toStdString(),
+        playCount);
+    if (filePosition > 0) {
+      // Seek to the position in the file where the song is located, or the end
+      // of the file.
+      ofs.seekp(filePosition, std::ios_base::beg);
+    }
+    ofs << artist.toStdString() << "," << title.toStdString() << ","
+        << year.toStdString() << "," << std::setw(DEFAULT_WIDTH) << std::left
+        << ++playCount << std::endl;
 
-     ofs.seekp(0, std::ios_base::end);
+    ofs.seekp(0, std::ios_base::end);
 
-     ofs.flush();
-     ofs.close();
-   }
+    ofs.flush();
+    ofs.close();
+  }
 }
 
 void SpotifyService::AddCurrentSongToUserPlaylist(QAction* action) {

--- a/src/internet/spotify/spotifyservice.cpp
+++ b/src/internet/spotify/spotifyservice.cpp
@@ -440,8 +440,15 @@ void SpotifyService::UpdatePlayCountFile(const QString& artist,
     const int DEFAULT_WIDTH= 8;
     std::fstream ofs(SpotifyPlayCountFileName, std::ios_base::in | std::ios_base::out);
     if( !ofs ) {
-
         ofs.open(SpotifyPlayCountFileName, std::ios_base::app);
+        ofs << "Artist"
+            << ","
+            << "Title"
+            << ","
+            << "Year"
+            << ","
+            << "Play Count" << std::endl; // Output headings for the file
+        ofs.flush();
         ofs << artist.toStdString() << ","
             << title.toStdString() << ","
             << year.toStdString() << ","

--- a/src/internet/spotify/spotifyservice.cpp
+++ b/src/internet/spotify/spotifyservice.cpp
@@ -450,6 +450,8 @@ void SpotifyService::UpdatePlayCountFile(const QString& artist,
   strncpy(SpotifyPlayCountFileName, currentDirectory, strlen(currentDirectory));
   strcat(SpotifyPlayCountFileName, "/SpotifyPlayCount.csv");
 
+  qLog(Debug) << "Directory for Spotify File: " << SpotifyPlayCountFileName;
+
   const int DEFAULT_WIDTH = 8;
   std::fstream ofs(SpotifyPlayCountFileName,
                    std::ios_base::in | std::ios_base::out);

--- a/src/internet/spotify/spotifyservice.cpp
+++ b/src/internet/spotify/spotifyservice.cpp
@@ -450,7 +450,7 @@ void SpotifyService::UpdatePlayCountFile(const QString& artist,
   strncpy(SpotifyPlayCountFileName, currentDirectory, strlen(currentDirectory));
   strcat(SpotifyPlayCountFileName, "/SpotifyPlayCount.csv");
 
-  qLog(Debug) << "Directory for Spotify File: " << SpotifyPlayCountFileName;
+  qLog(Debug) << "Directory for Spotify Tracking File: " << SpotifyPlayCountFileName;
 
   const int DEFAULT_WIDTH = 8;
   std::fstream ofs(SpotifyPlayCountFileName,

--- a/src/internet/spotify/spotifyservice.cpp
+++ b/src/internet/spotify/spotifyservice.cpp
@@ -384,7 +384,7 @@ void SpotifyService::SeekToSongInPlayCountFile(QFile& file,
                                                const QString& songYear,
                                                qint64& playCount) const {
   playCount = 0;
-  fileStream.seek(0);
+  fileStream.seek(0);  // Go to beginning of file.
 
   // Initialize local variables.
   bool songFound = false;
@@ -393,6 +393,7 @@ void SpotifyService::SeekToSongInPlayCountFile(QFile& file,
   size_t yearLength = songYear.length();
   int numChars = 0;
 
+  //+1's to skip over commas.
   while (!fileStream.atEnd() && !songFound) {
     QString buffer;
     buffer = fileStream.readLine();
@@ -408,7 +409,7 @@ void SpotifyService::SeekToSongInPlayCountFile(QFile& file,
         }
       }
     }
-    numChars += (buffer.size() + 1);
+    numChars += (buffer.size() + 1);  //+1 to go to next line.
   }
 
   if (!songFound) {
@@ -425,10 +426,12 @@ void SpotifyService::UpdatePlayCountFile(const QString& artist,
 
   QString SpotifyPlayCountFileName;
 
+  // Retrieve user-specified directory.
   QSettings s;
   s.beginGroup(SpotifyService::kSettingsGroup);
   QString storedDirectory = s.value("folderDirectory", "").toString();
 
+  // If user doesn't specifiy directory -- automatically use Home directory.
   if (storedDirectory.length() == 0) {
     SpotifyPlayCountFileName = QString::fromStdString(std::getenv("HOME"));
   } else {

--- a/src/internet/spotify/spotifyservice.cpp
+++ b/src/internet/spotify/spotifyservice.cpp
@@ -433,7 +433,7 @@ void SpotifyService::UpdatePlayCountFile(const QString& artist,
 
   qLog(Info) << "artist=" << artist << " title=" << title << " year=" << year;
   char SpotifyPlayCountFileName[256];
-  const char *currentDirectory;
+  const char* currentDirectory;
 
   QSettings s;
   s.beginGroup(SpotifyService::kSettingsGroup);
@@ -441,10 +441,9 @@ void SpotifyService::UpdatePlayCountFile(const QString& artist,
 
   if (storedDirectory.length() == 0) {
     currentDirectory = std::getenv("HOME");
-  }
-  else{
-      QByteArray tempArray = storedDirectory.toLocal8Bit();
-      currentDirectory = tempArray.data();
+  } else {
+    QByteArray tempArray = storedDirectory.toLocal8Bit();
+    currentDirectory = tempArray.data();
   }
 
   strncpy(SpotifyPlayCountFileName, currentDirectory, strlen(currentDirectory));

--- a/src/internet/spotify/spotifyservice.cpp
+++ b/src/internet/spotify/spotifyservice.cpp
@@ -433,19 +433,23 @@ void SpotifyService::UpdatePlayCountFile(const QString& artist,
 
   qLog(Info) << "artist=" << artist << " title=" << title << " year=" << year;
   char SpotifyPlayCountFileName[256];
+  const char *currentDirectory;
 
   QSettings s;
   s.beginGroup(SpotifyService::kSettingsGroup);
+  QString storedDirectory = s.value("folderDirectory", "").toString();
 
-  QByteArray tempArray = s.value("folderDirectory", "").toString().toLocal8Bit();
-  const char *currentDirectory = tempArray.data();
-
-  if (!currentDirectory) {
+  if (storedDirectory.length() == 0) {
     currentDirectory = std::getenv("HOME");
+  }
+  else{
+      QByteArray tempArray = storedDirectory.toLocal8Bit();
+      currentDirectory = tempArray.data();
   }
 
   strncpy(SpotifyPlayCountFileName, currentDirectory, strlen(currentDirectory));
   strcat(SpotifyPlayCountFileName, "/SpotifyPlayCount.csv");
+
   const int DEFAULT_WIDTH = 8;
   std::fstream ofs(SpotifyPlayCountFileName,
                    std::ios_base::in | std::ios_base::out);

--- a/src/internet/spotify/spotifyservice.cpp
+++ b/src/internet/spotify/spotifyservice.cpp
@@ -437,9 +437,8 @@ void SpotifyService::UpdatePlayCountFile(const QString& artist,
   QSettings s;
   s.beginGroup(SpotifyService::kSettingsGroup);
 
-  QByteArray tempArray =
-      s.value("folderDirectory", "").toString().toLocal8Bit();
-  char* currentDirectory = tempArray.data();
+  QByteArray tempArray = s.value("folderDirectory", "").toString().toLocal8Bit();
+  const char *currentDirectory = tempArray.data();
 
   if (!currentDirectory) {
     currentDirectory = std::getenv("HOME");

--- a/src/internet/spotify/spotifyservice.cpp
+++ b/src/internet/spotify/spotifyservice.cpp
@@ -441,7 +441,7 @@ void SpotifyService::UpdatePlayCountFile(const QString& artist,
       s.value("folderDirectory", "").toString().toLocal8Bit();
   char* currentDirectory = tempArray.data();
 
-  if (currentDirectory) {
+  if (!currentDirectory) {
     currentDirectory = std::getenv("HOME");
   }
 

--- a/src/internet/spotify/spotifyservice.cpp
+++ b/src/internet/spotify/spotifyservice.cpp
@@ -463,11 +463,6 @@ void SpotifyService::UpdatePlayCountFile(const QString& artist,
         << ","
         << "Play Count" << std::endl;  // Output headings for the file
     ofs.flush();
-    ofs << artist.toStdString() << "," << title.toStdString() << ","
-        << year.toStdString() << "," << std::setw(DEFAULT_WIDTH) << std::left
-        << ++playCount << std::endl;
-    ofs.flush();
-    ofs.close();
   } else {
     ofs.seekp(0, std::ios_base::beg);
 
@@ -480,11 +475,10 @@ void SpotifyService::UpdatePlayCountFile(const QString& artist,
       // of the file.
       ofs.seekp(filePosition, std::ios_base::beg);
     }
+
     ofs << artist.toStdString() << "," << title.toStdString() << ","
         << year.toStdString() << "," << std::setw(DEFAULT_WIDTH) << std::left
         << ++playCount << std::endl;
-
-    ofs.seekp(0, std::ios_base::end);
 
     ofs.flush();
     ofs.close();

--- a/src/internet/spotify/spotifyservice.h
+++ b/src/internet/spotify/spotifyservice.h
@@ -128,7 +128,7 @@ signals:
   void ClearSearchResults();
   QStandardItem* PlaylistBySpotifyIndex(int index) const;
   bool DoPlaylistsDiffer(const pb::spotify::Playlists& response) const;
-  void SeekToSongInPlayCountFile(QFile& file, QTextStream& fileStream,
+  void SeekToSongInPlayCountFile(QFile& fileStream, QTextStream& textStream,
                                  const QString& songArtist,
                                  const QString& songTitle,
                                  const QString& songYear,

--- a/src/internet/spotify/spotifyservice.h
+++ b/src/internet/spotify/spotifyservice.h
@@ -67,6 +67,7 @@ class SpotifyService : public InternetService {
   static const char* kSettingsGroup;
   static const char* kBlobDownloadUrl;
   static const int kSearchDelayMsec;
+  static Song current_song_;
 
   void ReloadSettings() override;
 
@@ -83,6 +84,9 @@ class SpotifyService : public InternetService {
   void Login(const QString& username, const QString& password);
   Q_INVOKABLE void LoadImage(const QString& id);
   Q_INVOKABLE void SetPaused(bool paused);
+  Q_INVOKABLE void UpdatePlayCountFile(const QString& artist,
+                                       const QString& title,
+                                       const QString& year);    // const Engine::SimpleMetaBundle &bundle);
 
   SpotifyServer* server() const;
 
@@ -124,6 +128,12 @@ class SpotifyService : public InternetService {
 
   QStandardItem* PlaylistBySpotifyIndex(int index) const;
   bool DoPlaylistsDiffer(const pb::spotify::Playlists& response) const;
+  int SongIsInPlayCountFile(std::fstream &ofs,
+                            const std::string& songArtist,
+                            const std::string& songTitle,
+                            const std::string& songYear,
+                            int &playCount ) const;
+  void SetMetaData( const Engine::SimpleMetaBundle &bundle );
 
  private slots:
   void EnsureServerCreated(const QString& username = QString(),
@@ -153,7 +163,6 @@ class SpotifyService : public InternetService {
 
  private:
   SpotifyServer* server_;
-
   QString system_blob_path_;
   QString local_blob_version_;
   QString local_blob_path_;
@@ -161,7 +170,7 @@ class SpotifyService : public InternetService {
 
   QStandardItem* root_;
   QStandardItem* search_;
-  QStandardItem* starred_;
+  QStandardItem* starred_; // We suspect this is the current song
   QStandardItem* inbox_;
   QStandardItem* toplist_;
   QList<QStandardItem*> playlists_;

--- a/src/internet/spotify/spotifyservice.h
+++ b/src/internet/spotify/spotifyservice.h
@@ -84,9 +84,9 @@ class SpotifyService : public InternetService {
   void Login(const QString& username, const QString& password);
   Q_INVOKABLE void LoadImage(const QString& id);
   Q_INVOKABLE void SetPaused(bool paused);
-  Q_INVOKABLE void UpdatePlayCountFile(const QString& artist,
-                                       const QString& title,
-                                       const QString& year);    // const Engine::SimpleMetaBundle &bundle);
+  Q_INVOKABLE void UpdatePlayCountFile(
+      const QString& artist, const QString& title,
+      const QString& year);  // const Engine::SimpleMetaBundle &bundle);
 
   SpotifyServer* server() const;
 
@@ -99,7 +99,7 @@ class SpotifyService : public InternetService {
 
   static void SongFromProtobuf(const pb::spotify::Track& track, Song* song);
 
- signals:
+signals:
   void BlobStateChanged();
   void LoginFinished(bool success);
   void ImageLoaded(const QString& id, const QImage& image);
@@ -128,12 +128,10 @@ class SpotifyService : public InternetService {
 
   QStandardItem* PlaylistBySpotifyIndex(int index) const;
   bool DoPlaylistsDiffer(const pb::spotify::Playlists& response) const;
-  int SongIsInPlayCountFile(std::fstream &ofs,
-                            const std::string& songArtist,
+  int SongIsInPlayCountFile(std::fstream& ofs, const std::string& songArtist,
                             const std::string& songTitle,
-                            const std::string& songYear,
-                            int &playCount ) const;
-  void SetMetaData( const Engine::SimpleMetaBundle &bundle );
+                            const std::string& songYear, int& playCount) const;
+  void SetMetaData(const Engine::SimpleMetaBundle& bundle);
 
  private slots:
   void EnsureServerCreated(const QString& username = QString(),
@@ -170,7 +168,7 @@ class SpotifyService : public InternetService {
 
   QStandardItem* root_;
   QStandardItem* search_;
-  QStandardItem* starred_; 
+  QStandardItem* starred_;
   QStandardItem* inbox_;
   QStandardItem* toplist_;
   QList<QStandardItem*> playlists_;

--- a/src/internet/spotify/spotifyservice.h
+++ b/src/internet/spotify/spotifyservice.h
@@ -170,7 +170,7 @@ class SpotifyService : public InternetService {
 
   QStandardItem* root_;
   QStandardItem* search_;
-  QStandardItem* starred_; // We suspect this is the current song
+  QStandardItem* starred_; 
   QStandardItem* inbox_;
   QStandardItem* toplist_;
   QList<QStandardItem*> playlists_;

--- a/src/internet/spotify/spotifyservice.h
+++ b/src/internet/spotify/spotifyservice.h
@@ -128,9 +128,11 @@ signals:
   void ClearSearchResults();
   QStandardItem* PlaylistBySpotifyIndex(int index) const;
   bool DoPlaylistsDiffer(const pb::spotify::Playlists& response) const;
-  int SongIsInPlayCountFile(std::fstream& ofs, const std::string& songArtist,
-                            const std::string& songTitle,
-                            const std::string& songYear, int& playCount) const;
+  void SeekToSongInPlayCountFile(QFile& file, QTextStream& fileStream,
+                                 const QString& songArtist,
+                                 const QString& songTitle,
+                                 const QString& songYear,
+                                 qint64& playCount) const;
   void SetMetaData(const Engine::SimpleMetaBundle& bundle);
 
  private slots:

--- a/src/internet/spotify/spotifysettingspage.cpp
+++ b/src/internet/spotify/spotifysettingspage.cpp
@@ -26,6 +26,7 @@
 #include <QNetworkRequest>
 #include <QSettings>
 #include <QtDebug>
+#include <QFileDialog>
 
 #include "config.h"
 #include "spotifymessages.pb.h"
@@ -48,9 +49,13 @@ SpotifySettingsPage::SpotifySettingsPage(SettingsDialog* dialog)
   ui_->blob_status->setFont(bold_font);
 
   connect(ui_->download_blob, SIGNAL(clicked()), SLOT(DownloadBlob()));
+  connect(ui_->spotifySongTracking, SIGNAL(clicked()),
+          SLOT(spotifySongTracking()));
   connect(ui_->login, SIGNAL(clicked()), SLOT(Login()));
   connect(ui_->login_state, SIGNAL(LogoutClicked()), SLOT(Logout()));
   connect(ui_->login_state, SIGNAL(LoginClicked()), SLOT(Login()));
+  connect(ui_->login_state, SIGNAL(LoginClicked()), SLOT(Login()));
+  connect(ui_->openFolder, SIGNAL(clicked()), SLOT(openFolder()));
 
   connect(service_, SIGNAL(LoginFinished(bool)), SLOT(LoginFinished(bool)));
   connect(service_, SIGNAL(BlobStateChanged()), SLOT(BlobStateChanged()));
@@ -113,7 +118,7 @@ void SpotifySettingsPage::Load() {
       s.value("volume_normalisation", false).toBool());
   ui_->spotifySongTracking->setChecked(
       s.value("spotifySongTracking", false).toBool());
-
+  ui_->folderDirectory->setText(s.value("folderDirectory", "").toString());
   UpdateLoginState();
 }
 
@@ -128,6 +133,7 @@ void SpotifySettingsPage::Save() {
              ui_->bitrate->itemData(ui_->bitrate->currentIndex()).toInt());
   s.setValue("volume_normalisation", ui_->volume_normalisation->isChecked());
   s.setValue("spotifySongTracking", ui_->spotifySongTracking->isChecked());
+  s.setValue("folderDirectory", ui_->folderDirectory->text());
 }
 
 void SpotifySettingsPage::LoginFinished(bool success) {
@@ -135,6 +141,23 @@ void SpotifySettingsPage::LoginFinished(bool success) {
 
   Save();
   UpdateLoginState();
+}
+
+void SpotifySettingsPage::on_openFolder_clicked() {
+  QString directory = QFileDialog::getExistingDirectory(
+      this, tr("Open Directory"), "/home",
+      QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+  ui_->folderDirectory->setText(directory);
+}
+
+void SpotifySettingsPage::on_spotifySongTracking_toggled(bool toggled) {
+  if (toggled) {
+    ui_->openFolder->setEnabled(true);
+    ui_->folderDirectory->setEnabled(true);
+  } else {
+    ui_->openFolder->setEnabled(false);
+    ui_->folderDirectory->setEnabled(false);
+  }
 }
 
 void SpotifySettingsPage::UpdateLoginState() {

--- a/src/internet/spotify/spotifysettingspage.cpp
+++ b/src/internet/spotify/spotifysettingspage.cpp
@@ -111,6 +111,8 @@ void SpotifySettingsPage::Load() {
       s.value("bitrate", pb::spotify::Bitrate320k).toInt()));
   ui_->volume_normalisation->setChecked(
       s.value("volume_normalisation", false).toBool());
+  ui_->spotifySongTracking->setChecked(
+      s.value("spotifySongTracking", false).toBool());
 
   UpdateLoginState();
 }
@@ -125,6 +127,7 @@ void SpotifySettingsPage::Save() {
   s.setValue("bitrate",
              ui_->bitrate->itemData(ui_->bitrate->currentIndex()).toInt());
   s.setValue("volume_normalisation", ui_->volume_normalisation->isChecked());
+  s.setValue("spotifySongTracking", ui_->spotifySongTracking->isChecked());
 }
 
 void SpotifySettingsPage::LoginFinished(bool success) {

--- a/src/internet/spotify/spotifysettingspage.cpp
+++ b/src/internet/spotify/spotifysettingspage.cpp
@@ -153,10 +153,8 @@ void SpotifySettingsPage::on_openFolder_clicked() {
 void SpotifySettingsPage::on_spotifySongTracking_toggled(bool toggled) {
   if (toggled) {
     ui_->openFolder->setEnabled(true);
-    ui_->folderDirectory->setEnabled(true);
   } else {
     ui_->openFolder->setEnabled(false);
-    ui_->folderDirectory->setEnabled(false);
   }
 }
 

--- a/src/internet/spotify/spotifysettingspage.h
+++ b/src/internet/spotify/spotifysettingspage.h
@@ -44,6 +44,8 @@ class SpotifySettingsPage : public SettingsPage {
   void Login();
   void LoginFinished(bool success);
   void Logout();
+  void on_spotifySongTracking_toggled(bool toggled);
+  void on_openFolder_clicked();
 
  private:
   void UpdateLoginState();

--- a/src/internet/spotify/spotifysettingspage.ui
+++ b/src/internet/spotify/spotifysettingspage.ui
@@ -29,7 +29,16 @@
          <bool>true</bool>
         </property>
         <layout class="QGridLayout" name="gridLayout">
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <item row="1" column="0">
@@ -139,6 +148,13 @@
        <widget class="QCheckBox" name="volume_normalisation">
         <property name="text">
          <string>Use volume normalisation</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="spotifySongTracking">
+        <property name="text">
+         <string>Enable Spotify Song Tracking</string>
         </property>
        </widget>
       </item>

--- a/src/internet/spotify/spotifysettingspage.ui
+++ b/src/internet/spotify/spotifysettingspage.ui
@@ -158,6 +158,29 @@
         </property>
        </widget>
       </item>
+      <item row="3" column="0">
+       <widget class="QLineEdit" name="folderDirectory">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>400</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QPushButton" name="openFolder">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Open</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/internet/spotify/spotifysettingspage.ui
+++ b/src/internet/spotify/spotifysettingspage.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>545</width>
-    <height>458</height>
+    <height>460</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -158,7 +158,7 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="QLineEdit" name="folderDirectory">
         <property name="enabled">
          <bool>false</bool>
@@ -171,13 +171,20 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="4" column="1">
        <widget class="QPushButton" name="openFolder">
         <property name="enabled">
          <bool>false</bool>
         </property>
         <property name="text">
          <string>Open</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Directory</string>
         </property>
        </widget>
       </item>

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1439,7 +1439,6 @@ void MainWindow::UpdateTrackPosition() {
       float(app_->player()->engine()->position_nanosec()) / kNsecPerSec + 0.5);
   const int length = app_->player()->engine()->length_nanosec() / kNsecPerSec;
   const int scrobble_point = playlist->scrobble_point_nanosec() / kNsecPerSec;
-
   if (length <= 0) {
     // Probably a stream that we don't know the length of
     return;
@@ -1499,7 +1498,6 @@ void MainWindow::UpdateTrackPosition() {
 
 void MainWindow::UpdateTrackSliderPosition() {
   PlaylistItemPtr item(app_->player()->GetCurrentItem());
-
   const int slider_position = std::floor(
       float(app_->player()->engine()->position_nanosec()) / kNsecPerMsec);
   const int slider_length =

--- a/src/widgets/osd.cpp
+++ b/src/widgets/osd.cpp
@@ -160,6 +160,7 @@ void OSD::Paused() {
 
 void OSD::Stopped() {
   tray_icon_->ClearNowPlaying();
+
   if (ignore_next_stopped_) {
     ignore_next_stopped_ = false;
     return;


### PR DESCRIPTION
…play count information to be made for Spotify songs. This feature will add a file to the user's home directory (upon playing their first Spotify song) named "SpotifyPlayCount.csv." This file contains each song's title, artist, year, and play count. Please consider adding this feature.

Thank you,
Melissa Manley

>[https://github.com/Team-NullPointer/Clementine/issues/6](https://github.com/Team-NullPointer/Clementine/issues/6l)