### PR TITLE
New shortcut: remove current playing song from playlist

### DIFF
--- a/src/core/globalshortcuts.cpp
+++ b/src/core/globalshortcuts.cpp
@@ -79,6 +79,9 @@ GlobalShortcuts::GlobalShortcuts(QWidget* parent)
               SIGNAL(Love()));
   AddShortcut("ban_last_fm_scrobbling", tr("Ban (Last.fm scrobbling)"),
               SIGNAL(Ban()));
+  AddShortcut("remove_current_song_from_playlist",
+              tr("Remove current song from playlist"),
+              SIGNAL(RemoveCurrentSong()));
 
   AddRatingShortcut("rate_zero_star", tr("Rate the current song 0 stars"),
                     rating_signals_mapper_, 0);

--- a/src/core/globalshortcuts.h
+++ b/src/core/globalshortcuts.h
@@ -82,6 +82,7 @@ signals:
   void ToggleScrobbling();
   void Love();
   void Ban();
+  void RemoveCurrentSong();
 
  private:
   void AddShortcut(const QString& id, const QString& name, const char* signal,

--- a/src/playlist/playlistmanager.cpp
+++ b/src/playlist/playlistmanager.cpp
@@ -494,6 +494,10 @@ void PlaylistManager::RemoveItemsWithoutUndo(int id,
   playlists_[id].p->RemoveItemsWithoutUndo(indices);
 }
 
+void PlaylistManager::RemoveCurrentSong() {
+  active()->removeRows(active()->current_index().row(), 1);
+}
+
 void PlaylistManager::InvalidateDeletedSongs() {
   for (Playlist* playlist : GetAllPlaylists()) {
     playlist->InvalidateDeletedSongs();

--- a/src/playlist/playlistmanager.h
+++ b/src/playlist/playlistmanager.h
@@ -225,6 +225,8 @@ class PlaylistManager : public PlaylistManagerInterface {
   // Removes items with given indices from the playlist. This operation is not
   // undoable.
   void RemoveItemsWithoutUndo(int id, const QList<int>& indices);
+  // Remove the current playing song
+  void RemoveCurrentSong();
 
  private slots:
   void SetActivePlaying();

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -848,6 +848,8 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
 
   connect(global_shortcuts_, SIGNAL(RateCurrentSong(int)),
           app_->playlist_manager(), SLOT(RateCurrentSong(int)));
+  connect(global_shortcuts_, SIGNAL(RemoveCurrentSong()),
+          app_->playlist_manager(), SLOT(RemoveCurrentSong()));
 
   // Fancy tabs
   connect(ui_->tabs, SIGNAL(ModeChanged(FancyTabWidget::Mode)),


### PR DESCRIPTION
The title says it. It's a new shortcut (no default set) for removing the current playing song from the playlist.

Usage:
Clementine runs in the background, a horrible song starts playing - oh no! never want to hear it again -, you press *your favourite shortcut* to remove it from the playlist and *your second favourite shortcut* to start the next() song.