### PR TITLE
SoundCloud service simple search limit is set. (Issue: #5529)

### DIFF
--- a/src/internet/soundcloud/soundcloudservice.cpp
+++ b/src/internet/soundcloud/soundcloudservice.cpp
@@ -61,7 +61,7 @@ const char* SoundCloudService::kHomepage = "http://soundcloud.com/";
 
 const int SoundCloudService::kSearchDelayMsec = 400;
 const int SoundCloudService::kSongSearchLimit = 100;
-const int SoundCloudService::kSongSimpleSearchLimit = 10;
+const int SoundCloudService::kSongSimpleSearchLimit = 100;
 
 typedef QPair<QString, QString> Param;
 
@@ -324,7 +324,7 @@ void SoundCloudService::DoSearch() {
   ClearSearchResults();
 
   QList<Param> parameters;
-  parameters << Param("q", pending_search_);
+  parameters << Param("q", pending_search_) << Param("limit", QString::number(kSongSearchLimit));
   QNetworkReply* reply = CreateRequest("tracks", parameters);
   const int id = next_pending_search_id_++;
   NewClosure(reply, SIGNAL(finished()), this,
@@ -353,7 +353,7 @@ void SoundCloudService::ClearSearchResults() {
 
 int SoundCloudService::SimpleSearch(const QString& text) {
   QList<Param> parameters;
-  parameters << Param("q", text);
+  parameters << Param("q", text) << Param("limit", QString::number(kSongSimpleSearchLimit));
   QNetworkReply* reply = CreateRequest("tracks", parameters);
   const int id = next_pending_search_id_++;
   NewClosure(reply, SIGNAL(finished()), this,


### PR DESCRIPTION
SoundCloud search limit it set to 100. Pagination may be added soon. (see SoundCloud HTTP api: https://developers.soundcloud.com/docs/api/guide#pagination)