### PR TITLE
Passes network proxy information through to gstreamer

### DIFF
--- a/src/engines/gstengine.cpp
+++ b/src/engines/gstengine.cpp
@@ -80,6 +80,7 @@ using std::vector;
 
 const char* GstEngine::kSettingsGroup = "GstEngine";
 const char* GstEngine::kAutoSink = "autoaudiosink";
+const char* GstEngine::kProxySettingsGroup = "Proxy";
 const char* GstEngine::kHypnotoadPipeline =
     "audiotestsrc wave=6 ! "
     "audioecho intensity=1 delay=50000000 ! "
@@ -106,6 +107,9 @@ GstEngine::GstEngine(TaskManager* task_manager)
       buffer_min_fill_(33),
       mono_playback_(false),
       sample_rate_(kAutoSampleRate),
+      proxy_url_(QString::null),
+      proxy_user_(QString::null),
+      proxy_passwd_(QString::null),
       seek_timer_(new QTimer(this)),
       timer_id_(-1),
       next_element_id_(0),
@@ -210,6 +214,44 @@ void GstEngine::ReloadSettings() {
 
   mono_playback_ = s.value("monoplayback", false).toBool();
   sample_rate_ = s.value("samplerate", kAutoSampleRate).toInt();
+
+  s.endGroup();
+
+  s.beginGroup(kProxySettingsGroup);
+  const int mode = s.value("mode", 0).toInt();
+  proxy_url_.clear(); // make it null, assume no proxy
+
+  if (mode == 2) {
+    // 2 = manual config, we need to do something
+    const int type = s.value("type", 0).toInt(); // 1 = SOCKS, 3 = HTTP
+    if (type == 1) {
+      // See https://bugzilla.gnome.org/show_bug.cgi?id=783012
+      // When that bug is resoved we can append socks:// here
+      qLog(Warning) << "GStreamer doesn't currently support socks proxies." <<
+        " Will not use proxy for gstreamer streams";
+    } else if (type == 3) {
+      proxy_url_.append("http://");
+    } else {
+      qLog(Warning) << "Unknown proxy type: "
+                    << type
+                    << ". Will not use proxy for gstreamer streams";
+    }
+    if (!proxy_url_.isEmpty()) {
+      proxy_url_.append(s.value("hostname").toString());
+      proxy_url_.append(":");
+      proxy_url_.append(s.value("port").toString());
+    }
+
+    QString user = s.value("username").toString();
+    QString pass = s.value("password").toString();
+    if (!user.isEmpty() && !pass.isEmpty()) {
+      proxy_user_ = user;
+      proxy_passwd_ = pass;
+    } else {
+      proxy_user_.clear();
+      proxy_passwd_.clear();
+    }
+  }
 }
 
 qint64 GstEngine::position_nanosec() const {
@@ -791,6 +833,8 @@ shared_ptr<GstEnginePipeline> GstEngine::CreatePipeline() {
   ret->set_buffer_min_fill(buffer_min_fill_);
   ret->set_mono_playback(mono_playback_);
   ret->set_sample_rate(sample_rate_);
+  ret->set_proxy_url(proxy_url_);
+  ret->set_proxy_login(proxy_user_, proxy_passwd_);
 
   ret->AddBufferConsumer(this);
   for (BufferConsumer* consumer : buffer_consumers_) {

--- a/src/engines/gstengine.h
+++ b/src/engines/gstengine.h
@@ -73,6 +73,7 @@ class GstEngine : public Engine::Base, public BufferConsumer {
   static const int kAutoSampleRate = -1;
   static const char* kSettingsGroup;
   static const char* kAutoSink;
+  static const char* kProxySettingsGroup;
 
   bool Init();
   void EnsureInitialised() { initialising_.waitForFinished(); }
@@ -212,6 +213,11 @@ class GstEngine : public Engine::Base, public BufferConsumer {
 
   bool mono_playback_;
   int sample_rate_;
+
+  // proxy_url_.isNull => no proxy
+  QString proxy_url_;
+  QString proxy_user_;
+  QString proxy_passwd_;
 
   mutable bool can_decode_success_;
   mutable bool can_decode_last_;

--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -75,6 +75,9 @@ GstEnginePipeline::GstEnginePipeline(GstEngine* engine)
       next_end_offset_nanosec_(-1),
       ignore_next_seek_(false),
       ignore_tags_(false),
+      proxy_url_(QString::null),
+      proxy_user_(QString::null),
+      proxy_passwd_(QString::null),
       pipeline_is_initialised_(false),
       pipeline_is_connected_(false),
       pending_seek_nanosec_(-1),
@@ -129,6 +132,15 @@ void GstEnginePipeline::set_mono_playback(bool enabled) {
 }
 
 void GstEnginePipeline::set_sample_rate(int rate) { sample_rate_ = rate; }
+
+void GstEnginePipeline::set_proxy_url(const QString& url) {
+  proxy_url_ = url;
+}
+
+void GstEnginePipeline::set_proxy_login(const QString& user, const QString& pass) {
+  proxy_user_ = user;
+  proxy_passwd_ = pass;
+}
 
 bool GstEnginePipeline::ReplaceDecodeBin(GstElement* new_bin) {
   if (!new_bin) return false;
@@ -985,6 +997,24 @@ void GstEnginePipeline::SourceSetupCallback(GstURIDecodeBin* bin,
     g_object_set(element, "ssl-use-system-ca-file", false, nullptr);
     g_object_set(element, "ssl-strict", TRUE, nullptr);
 #endif
+  }
+
+  const QString proxy_url = instance->proxy_url();
+  if (!proxy_url.isNull() && g_object_class_find_property(G_OBJECT_GET_CLASS(element), "proxy")) {
+    qLog(Debug) << "Setting proxy on stream to: " << proxy_url;
+    g_object_set(element, "proxy", proxy_url.toLocal8Bit().constData(), nullptr);
+
+    const QString user = instance->proxy_user();
+    const QString passwd = instance->proxy_passwd();
+    if (!user.isEmpty() && // we set them together so only check one
+        g_object_class_find_property(G_OBJECT_GET_CLASS(element), "proxy-id") &&
+        g_object_class_find_property(G_OBJECT_GET_CLASS(element), "proxy-pw")) {
+      qLog(Debug) << "Setting proxy login to: " << user << " (password redacted)";
+      g_object_set (element,
+                    "proxy-id", user.toLocal8Bit().constData(),
+                    "proxy-pw", passwd.toLocal8Bit().constData(),
+                    NULL);
+    }
   }
 }
 

--- a/src/engines/gstenginepipeline.h
+++ b/src/engines/gstenginepipeline.h
@@ -56,6 +56,8 @@ class GstEnginePipeline : public QObject {
   void set_buffer_min_fill(int percent);
   void set_mono_playback(bool enabled);
   void set_sample_rate(int rate);
+  void set_proxy_url(const QString& url);
+  void set_proxy_login(const QString& user, const QString& pass);
 
   // Creates the pipeline, returns false on error
   bool InitFromUrl(const QUrl& url, qint64 end_nanosec);
@@ -105,6 +107,10 @@ class GstEnginePipeline : public QObject {
   QUrl redirect_url() const { return redirect_url_; }
 
   QString source_device() const { return source_device_; }
+
+  QString proxy_url() const { return proxy_url_; }
+  QString proxy_user() const { return proxy_user_; }
+  QString proxy_passwd() const { return proxy_passwd_; }
 
  public slots:
   void SetVolumeModifier(qreal mod);
@@ -252,6 +258,11 @@ signals:
 
   // When we need to specify the device to use as source (for CD device)
   QString source_device_;
+
+  // Proxy settings
+  QString proxy_url_;
+  QString proxy_user_;
+  QString proxy_passwd_;
 
   // Seeking while the pipeline is in the READY state doesn't work, so we have
   // to wait until it goes to PAUSED or PLAYING.


### PR DESCRIPTION
This uses the already defined network proxy settings, which before
did not apply to the actual streams.  This is useful for something
like a caching proxy that prevents re-downloading of network
resources (like tracks from a subsonic server for instance).

A few notes:
- gstreamer has a bug that prevents the use of socks proxies at the
  moment.  I've added a reference to the bug report in a comment and
  when that bug is resolved this code can be modified to also use
  socks proxies.

- I didn't make any changes to the UI.  In theory there could be
  another checkbox on the setting pane with something like "Use proxy
  for media streams" to control the behavior.  My feeling was that it
  would be odd to want to proxy things like last.fm API requests but
  not network streams, so I didn't add that.