### PR TITLE
Update lyrics.wikia parsing

### DIFF
--- a/data/lyrics/ultimate_providers.xml
+++ b/data/lyrics/ultimate_providers.xml
@@ -105,7 +105,7 @@
     <urlFormat replace=" _@;\&quot;" with="_"/>
     <urlFormat replace="?" with="%3F"/>
     <extract>
-      <item begin="&lt;div class='lyricbox'&gt;" end="&lt;!--"/>
+      <item begin="&lt;div class='lyricbox'&gt;" end="&lt;div class='lyricsbreak'"/>
     </extract>
     <exclude>
       <item tag="&lt;div class='rtMatcher'&gt;"/>


### PR DESCRIPTION
Some time ago lyrics.wikia seemed to update their website, so the lyrics were getting a lot of extra data in them, such as links to itunes, amazon, etc. This commit fixes the parsing to just take the lyrics.

Before:
![before](https://user-images.githubusercontent.com/22151537/27505743-21d7cfb0-589f-11e7-8df0-015fdaf2be1c.png)

After:
![after](https://user-images.githubusercontent.com/22151537/27505744-21d818d0-589f-11e7-90fe-17425a543d8f.png)


