### PR TITLE
gtk icons by default on linux

### DIFF
--- a/src/ui/appearancesettingspage.cpp
+++ b/src/ui/appearancesettingspage.cpp
@@ -80,7 +80,7 @@ AppearanceSettingsPage::AppearanceSettingsPage(SettingsDialog* dialog)
           SLOT(DisableBlurAndOpacitySliders(bool)));
   connect(ui_->use_no_background, SIGNAL(toggled(bool)),
           SLOT(DisableBlurAndOpacitySliders(bool)));
-#if !defined (Q_OS_UNIX) || defined (Q_OS_MACOS)
+#if !defined (Q_OS_UNIX) || defined (Q_OS_MACOS) // any OS except OS X or Windows
   ui_->sys_icons->setDisabled(true);
 #endif
 }
@@ -108,7 +108,8 @@ void AppearanceSettingsPage::Load() {
   current_background_color_ = original_background_color_;
 
   InitColorSelectorsColors();
-  ui_->b_use_sys_icons->setChecked(s.value("b_use_sys_icons", false).toBool());
+  if(ui_->b_use_sys_icons->isEnabled())
+    ui_->b_use_sys_icons->setChecked(s.value("b_use_sys_icons", true).toBool());
   s.endGroup();
 
   // Playlist settings

--- a/src/ui/iconloader.cpp
+++ b/src/ui/iconloader.cpp
@@ -38,7 +38,7 @@ void IconLoader::Init() {
   icon_sub_path_ << "/icons" << "/providers" << "/last.fm" << "";
   QSettings settings;
   settings.beginGroup(Appearance::kSettingsGroup);
-  use_sys_icons_ = settings.value("b_use_sys_icons", false).toBool();
+  use_sys_icons_ = settings.value("b_use_sys_icons", true).toBool();
 }
 
 QIcon IconLoader::Load(const QString& name, const IconType& icontype) {


### PR DESCRIPTION
I'm not sure about this option, but this is how it was always for linux users, they won't be surprised after next clementine update