### PR TITLE
Make the initial SmartPlaylistQuerySearchPage vertically resizeable

### DIFF
--- a/src/smartplaylists/querysearchpage.ui
+++ b/src/smartplaylists/querysearchpage.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>


### PR DESCRIPTION
The outmost QWidget had vsizetype="Fixed", changed that to "Preferred" made the
preview window take up a small amount of resize. This made it possible to resize
the window a little at least.

There should be opportunity for more flexibility here by allowing the searchterm scrollbox to resize. But I don't know enough of QT to figure out how to do that.

In some small manner this addresses #3892.