### PR TITLE
Use the correct hint names for desktop notifications on linux.

### DIFF
--- a/src/widgets/osd.h
+++ b/src/widgets/osd.h
@@ -23,6 +23,7 @@
 #include <QDateTime>
 #include <QImage>
 #include <QObject>
+#include <QVersionNumber>
 
 #include "config.h"
 #include "engines/engine_fwd.h"
@@ -137,6 +138,7 @@ class OSD : public QObject {
   std::unique_ptr<OrgFreedesktopNotificationsInterface> interface_;
   uint notification_id_;
   QDateTime last_notification_time_;
+  QVersionNumber desktop_notification_version_;
 #endif
 };
 


### PR DESCRIPTION
The [Desktop Notification Spec](https://developer.gnome.org/notification-spec/#hints) defines different hints depending on the spec version. Clementine currently hardcodes version 1.1, which is not understood by, e.g., the dunst notification daemon version 1.2.0. This means that cover art is currently not displayed in dunst notifications.

This patch fixes the icon rendering, but *only* on the qt5 branch, since this is the one I'm using and I don't have qt4 installed.