### PR TITLE
Spelling: "%" → "percent" for consistency

### DIFF
--- a/src/core/commandlineoptions.cpp
+++ b/src/core/commandlineoptions.cpp
@@ -158,8 +158,8 @@ bool CommandlineOptions::Parse() {
                 .arg(tr("Skip backwards in playlist"),
                      tr("Skip forwards in playlist"),
                      tr("Set the volume to <value> percent"),
-                     tr("Increase the volume by 4%"),
-                     tr("Decrease the volume by 4%"),
+                     tr("Increase the volume by 4 percent"),
+                     tr("Decrease the volume by 4 percent"),
                      tr("Increase the volume by <value> percent"),
                      tr("Decrease the volume by <value> percent"))
                 .arg(tr("Seek the currently playing track to an absolute "


### PR DESCRIPTION
American english "percent" used for reasons it is used elsewhere.
If brevity is the aim, "Lower volume 4%" and "Add 4% volume" would do.