### PR TITLE
Fix oversized currenttrack icon in playlistview

### DIFF
--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -141,11 +141,11 @@ PlaylistView::PlaylistView(QWidget* parent)
   QIcon currenttrack_play =
       IconLoader::Load("currenttrack_play", IconLoader::Other);
   currenttrack_play_ =
-      currenttrack_play.pixmap(currenttrack_play.availableSizes().last());
+      currenttrack_play.pixmap(currenttrack_play.actualSize(QSize(32, 32)));
   QIcon currenttrack_pause =
       IconLoader::Load("currenttrack_pause", IconLoader::Other);
   currenttrack_pause_ =
-      currenttrack_pause.pixmap(currenttrack_pause.availableSizes().last());
+      currenttrack_pause.pixmap(currenttrack_pause.actualSize(QSize(32, 32)));
 
   connect(header_, SIGNAL(sectionResized(int, int, int)), SLOT(SaveGeometry()));
   connect(header_, SIGNAL(sectionMoved(int, int, int)), SLOT(SaveGeometry()));


### PR DESCRIPTION
With some iconsets (like Papirus for example) `availableSizes().last()` returns gigantic icons making playlist look like this:
![photo_2017-10-18_02-08-37](https://user-images.githubusercontent.com/10263434/31693811-60a5a23e-b3a9-11e7-904e-1b9f56b676ad.jpg)
This small patch fixes the problem.