### PR TITLE
fixed issue #5868: IpIsPrivate returns false when IPv4 are translated to IPv6

### DIFF
--- a/src/networkremote/networkremote.cpp
+++ b/src/networkremote/networkremote.cpp
@@ -197,6 +197,10 @@ bool NetworkRemote::IpIsPrivate(const QHostAddress& address) {
       address.isInSubnet(QHostAddress::parseSubnet("192.168.0.0/16")) ||
       address.isInSubnet(QHostAddress::parseSubnet("172.16.0.0/12")) ||
       address.isInSubnet(QHostAddress::parseSubnet("10.0.0.0/8")) ||
+      // Private v4 range translated to v6
+      address.isInSubnet(QHostAddress::parseSubnet("::ffff:192.168.0.0/112")) ||
+      address.isInSubnet(QHostAddress::parseSubnet("::ffff:172.16.0.0/108")) ||
+      address.isInSubnet(QHostAddress::parseSubnet("::ffff:10.0.0.0/104")) ||
       // Private v6 range
       address.isInSubnet(QHostAddress::parseSubnet("fc00::/7"));
 }


### PR DESCRIPTION
fixed issue #5868: IPs were not recognized as private when Qt translates ipv4 to ipv6

As a result, the Network Remote would disconnect whenever the option to "Only allow connections from the local network" was selected.

Added translated IPs to NetworkRemote::IpIsPrivate