### PR TITLE
Add settings option to stop playback if song fails to play (Don't play next song)

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -613,7 +613,16 @@ void Player::InvalidSongRequested(const QUrl& url) {
   emit SongChangeRequestProcessed(url, false);
   // ... and now when our listeners have completed their processing of the
   // current item we can change the current item by skipping to the next song
-  NextItem(Engine::Auto);
+  
+  QSettings s;
+  s.beginGroup(kSettingsGroup);
+
+  bool stop_playback = s.value("stop_play_if_fail", 0).toBool();
+  s.endGroup();
+
+  if (!stop_playback) {
+    NextItem(Engine::Auto);
+  }
 }
 
 void Player::RegisterUrlHandler(UrlHandler* handler) {

--- a/src/ui/behavioursettingspage.cpp
+++ b/src/ui/behavioursettingspage.cpp
@@ -141,6 +141,8 @@ void BehaviourSettingsPage::Load() {
   s.endGroup();
 
   s.beginGroup(Player::kSettingsGroup);
+  ui_->stop_play_if_fail_->setChecked(
+      s.value("stop_play_if_fail", false).toBool());
   ui_->menu_previousmode->setCurrentIndex(ui_->menu_previousmode->findData(
       s.value("menu_previousmode", Player::PreviousBehaviour_DontRestart)
           .toInt()));
@@ -241,6 +243,8 @@ void BehaviourSettingsPage::Save() {
   s.endGroup();
 
   s.beginGroup(Player::kSettingsGroup);
+  s.setValue("stop_play_if_fail",
+             ui_->stop_play_if_fail_->isChecked());
   s.setValue("menu_previousmode", menu_previousmode);
   s.setValue("seek_step_sec", ui_->seek_step_sec->value());
   s.endGroup();

--- a/src/ui/behavioursettingspage.ui
+++ b/src/ui/behavioursettingspage.ui
@@ -137,6 +137,16 @@
        </widget>
       </item>
       <item>
+       <widget class="QCheckBox" name="stop_play_if_fail_">
+        <property name="text">
+         <string>Stop playback if song fails to play</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QCheckBox" name="b_grey_out_deleted_">
         <property name="text">
          <string>Grey out non existent songs in my playlists</string>


### PR DESCRIPTION
The checkbox is in General->Behavior. It is unchecked by default.

When checked, Clementine will not try to play the next song whenever it fails to play a song. This is useful for users like me who have their music library on a Windows or linux share, or on the internet which means sometimes the library is down and I cannot access it. When this happens, Clementine will try to play all the songs in my huge library while spamming error messages. The only way to stop it is to close the program.