### PR TITLE
Correctly delete duplicate AAC music

### DIFF
--- a/src/core/song.cpp
+++ b/src/core/song.cpp
@@ -1113,13 +1113,13 @@ uint qHash(const Song& song) {
 }
 
 bool Song::IsSimilar(const Song& other) const {
-  return title().compare(other.title(), Qt::CaseInsensitive) == 0 &&
+  return basefilename().compare(other.basefilename(), Qt::CaseInsensitive) == 0 &&
          artist().compare(other.artist(), Qt::CaseInsensitive) == 0;
 }
 
 uint HashSimilar(const Song& song) {
   // Should compare the same fields as function IsSimilar
-  return qHash(song.title().toLower()) ^ qHash(song.artist().toLower());
+  return qHash(song.basefilename().toLower()) ^ qHash(song.artist().toLower());
 }
 
 bool Song::IsOnSameAlbum(const Song& other) const {


### PR DESCRIPTION
All AAC files will generate the same hash for duplicate checking. This is due to the fields used for hashing are always empty strings for AAC files. So clementine will just keep the first aac song and delete the rest thinking it's a duplicate. I switched one of the fields to use basefilename which has never been empty in all of the files I've tested.