### PR TITLE
Attempt to reload stream on "Server does not support seeking." error

### DIFF
--- a/src/engines/gstengine.cpp
+++ b/src/engines/gstengine.cpp
@@ -692,6 +692,18 @@ void GstEngine::HandlePipelineError(int pipeline_id, const QString& message,
 
   qLog(Warning) << "Gstreamer error:" << message;
 
+  // try to reload the URL in case of a drop of the connection
+  if (domain == GST_RESOURCE_ERROR && error_code == GST_RESOURCE_ERROR_SEEK) {
+    if (Load(url_, 0, false, 0, 0)) {
+
+      current_pipeline_->SetState(GST_STATE_PLAYING);
+
+      return;
+    }
+
+    qLog(Warning) << "Attempt to reload " << url_ << " failed";
+  }
+
   current_pipeline_.reset();
 
   BufferingFinished();


### PR DESCRIPTION
When the network connection changes while playing an HTTP stream, I always get the "Server does not support seeking." error from GStreamer.
It seems like GStreamer tries to seek on reconnect, which fails, an propagates the error to Clementine which in turn ceases playback with
the error message handed through from GStreamer, even though there is now a perfectly fine network connection again.

An easy way to reproduce this is switching from a wired to a wireless connection or the other way round.

As a workaround, try to reload the stream when this error occurs.

I'm not sure if this is the correct way to handle this problem, but as I'm experiencing this problem quite frequently (I seem to have a rather flaky connection here) it's very annoying so I was looking for quick hack to fix it.