### PR TITLE
Ensure that the correct playlist is played

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1354,6 +1354,7 @@ void MainWindow::PlaylistDoubleClick(const QModelIndex& index) {
       app_->playlist_manager()->current()->queue()->ToggleTracks(
           dummyIndexList);
       if (app_->player()->GetState() != Engine::Playing) {
+        app_->playlist_manager()->SetActiveToCurrent();
         app_->player()->PlayAt(
             app_->playlist_manager()->current()->queue()->TakeNext(),
             Engine::Manual, true);


### PR DESCRIPTION
When the playlist double-click behavior is set to add songs to the queue, the playback of the queue also starts if no song is currently playing. To play the queue from the current playlist, we must set the active playlist to the current one before starting the playback.

Fixes #5714.