### PR TITLE
Add appearance option to hide playlist filter toolbar

### DIFF
--- a/src/playlist/playlistcontainer.cpp
+++ b/src/playlist/playlistcontainer.cpp
@@ -19,6 +19,7 @@
 #include "playlistmanager.h"
 #include "ui_playlistcontainer.h"
 #include "core/logging.h"
+#include "core/appearance.h"
 #include "playlistparsers/playlistparser.h"
 #include "ui/iconloader.h"
 
@@ -70,6 +71,11 @@ PlaylistContainer::PlaylistContainer(QWidget* parent)
 
   // Remove QFrame border
   ui_->toolbar->setStyleSheet("QFrame { border: 0px; }");
+
+  QSettings settings;
+  settings.beginGroup(Appearance::kSettingsGroup);
+  bool hide_toolbar = settings.value("b_hide_filter_toolbar", false).toBool();
+  ui_->toolbar->setVisible(!hide_toolbar);
 
   // Make it bold
   QFont no_matches_font = no_matches_label_->font();
@@ -451,4 +457,11 @@ bool PlaylistContainer::eventFilter(QObject* objectWatched, QEvent* event) {
     }
   }
   return QWidget::eventFilter(objectWatched, event);
+}
+
+void PlaylistContainer::ReloadSettings() {
+  QSettings settings;
+  settings.beginGroup(Appearance::kSettingsGroup);
+  bool hide_toolbar = settings.value("b_hide_filter_toolbar", false).toBool();
+  ui_->toolbar->setVisible(!hide_toolbar);
 }

--- a/src/playlist/playlistcontainer.h
+++ b/src/playlist/playlistcontainer.h
@@ -61,6 +61,9 @@ signals:
   // QWidget
   void resizeEvent(QResizeEvent*);
 
+ public slots:
+  void ReloadSettings();
+
  private slots:
   void NewPlaylist();
   void LoadPlaylist();

--- a/src/ui/appearancesettingspage.cpp
+++ b/src/ui/appearancesettingspage.cpp
@@ -109,6 +109,7 @@ void AppearanceSettingsPage::Load() {
 
   InitColorSelectorsColors();
   ui_->b_use_sys_icons->setChecked(s.value("b_use_sys_icons", false).toBool());
+  ui_->b_hide_filter_toolbar->setChecked(s.value("b_hide_filter_toolbar",false).toBool());
   s.endGroup();
 
   // Playlist settings
@@ -171,6 +172,7 @@ void AppearanceSettingsPage::Save() {
     dialog()->appearance()->ResetToSystemDefaultTheme();
   }
   s.setValue("b_use_sys_icons", ui_->b_use_sys_icons->isChecked());
+  s.setValue("b_hide_filter_toolbar", ui_->b_hide_filter_toolbar->isChecked());
   s.endGroup();
 
   // Playlist settings

--- a/src/ui/appearancesettingspage.ui
+++ b/src/ui/appearancesettingspage.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>596</width>
-    <height>566</height>
+    <height>666</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -279,21 +279,19 @@
         </item>
        </layout>
       </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
+        <item>
+         <widget class="QCheckBox" name="b_hide_filter_toolbar">
+          <property name="text">
+           <string>Hide playlist filter toolbar</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
      </layout>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1096,6 +1096,7 @@ void MainWindow::ReloadAllSettings() {
   library_view_->ReloadSettings();
   song_info_view_->ReloadSettings();
   app_->player()->engine()->ReloadSettings();
+  ui_->playlist->ReloadSettings();
   ui_->playlist->view()->ReloadSettings();
   app_->internet_model()->ReloadSettings();
 #ifdef HAVE_WIIMOTEDEV


### PR DESCRIPTION
Gives the user the option of a cleaner looking interface if the filter toolbar isn't used.

I've tried to follow existing coding style to the best of my knowledge.

PS: This is my first ever pull request so be kind :)