### PR TITLE
Add search filter to playlist list page

### DIFF
--- a/src/playlist/playlistlistcontainer.cpp
+++ b/src/playlist/playlistlistcontainer.cpp
@@ -255,6 +255,7 @@ void PlaylistListContainer::SetApplication(Application* app) {
     parent_folder->appendRow(playlist_item);
     for (const Song s : app->playlist_backend()->GetPlaylistSongs(p.id)) {
       QStandardItem* track_item = model_->NewTrack(s);
+      track_item->setDragEnabled(false);
       playlist_item->appendRow(track_item);
     }
   }

--- a/src/playlist/playlistlistcontainer.cpp
+++ b/src/playlist/playlistlistcontainer.cpp
@@ -250,14 +250,7 @@ void PlaylistListContainer::SetApplication(Application* app) {
   // Get all playlists, even ones that are hidden in the UI.
   for (const PlaylistBackend::Playlist& p :
        app->playlist_backend()->GetAllFavoritePlaylists()) {
-    QStandardItem* playlist_item = model_->NewPlaylist(p.name, p.id);
-    QStandardItem* parent_folder = model_->FolderByPath(p.ui_path);
-    parent_folder->appendRow(playlist_item);
-    for (const Song s : app->playlist_backend()->GetPlaylistSongs(p.id)) {
-      QStandardItem* track_item = model_->NewTrack(s);
-      track_item->setDragEnabled(false);
-      playlist_item->appendRow(track_item);
-    }
+    AddPlaylist(p.id,p.name,true,&p.ui_path);
   }
 }
 
@@ -274,7 +267,7 @@ void PlaylistListContainer::NewFolderClicked() {
 }
 
 void PlaylistListContainer::AddPlaylist(int id, const QString& name,
-                                        bool favorite) {
+                                        bool favorite, const QString *ui_path) {
   if (!favorite) {
     return;
   }
@@ -285,11 +278,18 @@ void PlaylistListContainer::AddPlaylist(int id, const QString& name,
     return;
   }
 
-  const QString& ui_path = app_->playlist_manager()->playlist(id)->ui_path();
+  if(ui_path == nullptr)
+    ui_path = &app_->playlist_manager()->playlist(id)->ui_path();
 
   QStandardItem* playlist_item = model_->NewPlaylist(name, id);
-  QStandardItem* parent_folder = model_->FolderByPath(ui_path);
+  QStandardItem* parent_folder = model_->FolderByPath(*ui_path);
   parent_folder->appendRow(playlist_item);
+  for (const Song s : app_->playlist_backend()->GetPlaylistSongs(id)) {
+    QStandardItem* track_item = model_->NewTrack(s);
+    track_item->setDragEnabled(false);
+    playlist_item->appendRow(track_item);
+  }
+
 }
 
 void PlaylistListContainer::PlaylistRenamed(int id, const QString& new_name) {

--- a/src/playlist/playlistlistcontainer.cpp
+++ b/src/playlist/playlistlistcontainer.cpp
@@ -367,10 +367,11 @@ void PlaylistListContainer::SearchTextEdited(const QString& text) {
     QRegExp regexp(text);
     regexp.setCaseSensitivity(Qt::CaseInsensitive);
 
+    proxy_->setFilterRegExp(regexp);
+
     if(regexp.isEmpty()) {
       ui_->tree->collapseAll();
     } else {
-      proxy_->setFilterRegExp(regexp);
       proxy_->refreshExpanded(ui_->tree);
     }
 }

--- a/src/playlist/playlistlistcontainer.h
+++ b/src/playlist/playlistlistcontainer.h
@@ -31,6 +31,8 @@ class Playlist;
 class PlaylistListModel;
 class Ui_PlaylistListContainer;
 
+class PlaylistListFilterProxyModel;
+
 class PlaylistListContainer : public QWidget {
   Q_OBJECT
 
@@ -49,6 +51,7 @@ class PlaylistListContainer : public QWidget {
   void NewFolderClicked();
   void DeleteClicked();
   void ItemDoubleClicked(const QModelIndex& index);
+  void SearchTextEdited(const QString& text);
 
   // From the model
   void PlaylistPathChanged(int id, const QString& new_path);
@@ -87,7 +90,7 @@ class PlaylistListContainer : public QWidget {
   QAction* action_save_playlist_;
 
   PlaylistListModel* model_;
-  QSortFilterProxyModel* proxy_;
+  PlaylistListFilterProxyModel* proxy_;
 
   bool loaded_icons_;
   QIcon padded_play_icon_;

--- a/src/playlist/playlistlistcontainer.h
+++ b/src/playlist/playlistlistcontainer.h
@@ -59,7 +59,7 @@ class PlaylistListContainer : public QWidget {
   // From the PlaylistManager
   void PlaylistRenamed(int id, const QString& new_name);
   // Add playlist if favorite == true
-  void AddPlaylist(int id, const QString& name, bool favorite);
+  void AddPlaylist(int id, const QString& name, bool favorite, const QString *ui_path = nullptr);
   void RemovePlaylist(int id);
   void SavePlaylist();
   void PlaylistFavoriteStateChanged(int id, bool favorite);

--- a/src/playlist/playlistlistcontainer.ui
+++ b/src/playlist/playlistlistcontainer.ui
@@ -42,6 +42,13 @@
        <number>0</number>
       </property>
       <item>
+       <widget class="QSearchField" name="search" native="true">
+        <property name="placeholderText" stdset="0">
+         <string>Search for anything</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QToolButton" name="new_folder">
         <property name="toolTip">
          <string>New folder</string>
@@ -71,19 +78,6 @@
          <enum>Qt::Vertical</enum>
         </property>
        </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>70</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
       </item>
      </layout>
     </widget>
@@ -125,6 +119,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QSearchField</class>
+   <extends>QWidget</extends>
+   <header>3rdparty/qocoa/qsearchfield.h</header>
+  </customwidget>
   <customwidget>
    <class>AutoExpandingTreeView</class>
    <extends>QTreeView</extends>

--- a/src/playlist/playlistlistmodel.cpp
+++ b/src/playlist/playlistlistmodel.cpp
@@ -71,6 +71,12 @@ void PlaylistListModel::AddRowMappings(const QModelIndex& begin,
 void PlaylistListModel::AddRowItem(QStandardItem* item,
                                    const QString& parent_path) {
   switch (item->data(Role_Type).toInt()) {
+    case Type_Track: {
+      // const int id = item->data(Role_TrackId).toInt();
+      // TODO
+      break;
+    }
+
     case Type_Playlist: {
       const int id = item->data(Role_PlaylistId).toInt();
       playlists_by_id_[id] = item;
@@ -169,6 +175,16 @@ QStandardItem* PlaylistListModel::NewPlaylist(const QString& name,
   ret->setIcon(playlist_icon_);
   ret->setFlags(Qt::ItemIsDragEnabled | Qt::ItemIsEnabled |
                 Qt::ItemIsSelectable | Qt::ItemIsEditable);
+  return ret;
+}
+
+QStandardItem* PlaylistListModel::NewTrack(const Song& song) const {
+  QStandardItem* ret = new QStandardItem;
+  ret->setText(song.artist() + " - " + song.title());
+  ret->setData(PlaylistListModel::Type_Track, PlaylistListModel::Role_Type);
+  ret->setData(song.id(), PlaylistListModel::Role_TrackId);
+  ret->setIcon(track_icon_);
+  ret->setFlags(Qt::ItemIsDragEnabled | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
   return ret;
 }
 

--- a/src/playlist/playlistlistmodel.h
+++ b/src/playlist/playlistlistmodel.h
@@ -2,16 +2,16 @@
 #define PLAYLISTLISTMODEL_H
 
 #include <QStandardItemModel>
-
+#include "core/song.h"
 class PlaylistListModel : public QStandardItemModel {
   Q_OBJECT
 
  public:
   PlaylistListModel(QObject* parent = nullptr);
 
-  enum Types { Type_Folder, Type_Playlist };
+  enum Types { Type_Folder, Type_Playlist, Type_Track };
 
-  enum Roles { Role_Type = Qt::UserRole, Role_PlaylistId };
+  enum Roles { Role_Type = Qt::UserRole, Role_PlaylistId, Role_TrackId };
 
   bool dropMimeData(const QMimeData* data, Qt::DropAction action, int row,
                     int column, const QModelIndex& parent);
@@ -19,6 +19,7 @@ class PlaylistListModel : public QStandardItemModel {
   // These icons will be used for newly created playlists and folders.
   // The caller will need to set these icons on existing items if there are any.
   void SetIcons(const QIcon& playlist_icon, const QIcon& folder_icon);
+  const QIcon& track_icon() const { return track_icon_; }
   const QIcon& playlist_icon() const { return playlist_icon_; }
   const QIcon& folder_icon() const { return folder_icon_; }
 
@@ -41,6 +42,9 @@ class PlaylistListModel : public QStandardItemModel {
   // added to the model yet.
   QStandardItem* NewPlaylist(const QString& name, int id) const;
 
+  // Returns a new track item. The item isn't added to the model yet.
+  QStandardItem* NewTrack(const Song& song) const;
+
   // QStandardItemModel
   bool setData(const QModelIndex& index, const QVariant& value, int role);
 
@@ -61,6 +65,7 @@ signals:
  private:
   bool dropping_rows_;
 
+  QIcon track_icon_;
   QIcon playlist_icon_;
   QIcon folder_icon_;
 


### PR DESCRIPTION
This allows power users who keep 100s of playlists to easily find a playlist either by searching for directory name, playlist name or a song artist/title a playlist might contain

This commit also adds track "$artist - $title" items to each playlist tree node