### PR TITLE
Remove "-qt5" suffix from ApplicationName and OrganizationName

### DIFF
--- a/ext/clementine-spotifyblob/main.cpp
+++ b/ext/clementine-spotifyblob/main.cpp
@@ -28,8 +28,8 @@
 
 int main(int argc, char** argv) {
   QCoreApplication a(argc, argv);
-  QCoreApplication::setApplicationName("Clementine-qt5");
-  QCoreApplication::setOrganizationName("Clementine-qt5");
+  QCoreApplication::setApplicationName("Clementine");
+  QCoreApplication::setOrganizationName("Clementine");
   QCoreApplication::setOrganizationDomain("clementine-player.org");
 
   logging::Init();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -252,9 +252,9 @@ int main(int argc, char* argv[]) {
   }
 #endif
 
-  QCoreApplication::setApplicationName("Clementine-qt5");
+  QCoreApplication::setApplicationName("Clementine");
   QCoreApplication::setApplicationVersion(CLEMENTINE_VERSION_DISPLAY);
-  QCoreApplication::setOrganizationName("Clementine-qt5");
+  QCoreApplication::setOrganizationName("Clementine");
   QCoreApplication::setOrganizationDomain("clementine-player.org");
 
 // This makes us show up nicely in gnome-volume-control


### PR DESCRIPTION
Renaming the application does not really make sense, but keeping it in qLog info to identify it in debug output.