### PR TITLE
Hide TrackSliderPopup on exit from popup instead of from TrackSliderSlider

### DIFF
--- a/src/widgets/tracksliderpopup.cpp
+++ b/src/widgets/tracksliderpopup.cpp
@@ -66,6 +66,11 @@ void TrackSliderPopup::paintEvent(QPaintEvent*) {
   p.drawPixmap(0, 0, pixmap_);
 }
 
+void TrackSliderPopup::leaveEvent(QEvent* e) {
+  QWidget::leaveEvent(e);
+  hide();
+}
+
 void TrackSliderPopup::UpdatePixmap() {
   const int text_width =
       qMax(font_metrics_.width(text_), small_font_metrics_.width(small_text_));

--- a/src/widgets/tracksliderpopup.h
+++ b/src/widgets/tracksliderpopup.h
@@ -33,6 +33,7 @@ class TrackSliderPopup : public QWidget {
 
  protected:
   void paintEvent(QPaintEvent*);
+  void leaveEvent(QEvent*);
 
  private:
   static const int kTextMargin;

--- a/src/widgets/tracksliderslider.cpp
+++ b/src/widgets/tracksliderslider.cpp
@@ -103,11 +103,6 @@ void TrackSliderSlider::enterEvent(QEvent* e) {
   }
 }
 
-void TrackSliderSlider::leaveEvent(QEvent* e) {
-  QSlider::leaveEvent(e);
-  popup_->hide();
-}
-
 void TrackSliderSlider::keyPressEvent(QKeyEvent* event) {
   if (event->key() == Qt::Key_Left || event->key() == Qt::Key_Down) {
     emit SeekBackward();

--- a/src/widgets/tracksliderslider.h
+++ b/src/widgets/tracksliderslider.h
@@ -39,7 +39,6 @@ signals:
   void mouseMoveEvent(QMouseEvent* e);
   void wheelEvent(QWheelEvent *e);
   void enterEvent(QEvent*);
-  void leaveEvent(QEvent*);
   void keyPressEvent(QKeyEvent* event);
 
  private slots:


### PR DESCRIPTION
The previous behavior exited on leaving TrackSliderSlider, which causes the popup to flicker, as it is shown and hidden rapidly, at least for me (on Debian unstable).