### PR TITLE
Hide TrackSliderPopup on appropriate leaveEvent

### DIFF
--- a/src/widgets/tracksliderslider.cpp
+++ b/src/widgets/tracksliderslider.cpp
@@ -105,7 +105,11 @@ void TrackSliderSlider::enterEvent(QEvent* e) {
 
 void TrackSliderSlider::leaveEvent(QEvent* e) {
   QSlider::leaveEvent(e);
-  popup_->hide();
+  // On some (but not all) systems, displaying the TrackSliderPopup
+  // generates a leaveEvent. Ensure that this leaveEvent is genuine.
+  if (!geometry().contains(mapFromGlobal(QCursor::pos()))) {
+    popup_->hide();
+  }
 }
 
 void TrackSliderSlider::keyPressEvent(QKeyEvent* event) {


### PR DESCRIPTION
The previous fix introduces a regression on some platforms which did not generate a leaveEvent when the TrackSliderPopup was displayed. The previous fix is reverted and logic is introduced to identify bonafide mouse motion out of the TrackSliderSlider.

Sorry about the noise on this. I only have two systems to check this on, but since this patch is much simpler than my first one, I expect it is less likely to cause a regression.