### PR TITLE
Fix bug in fetching album covers from Amazon

### DIFF
--- a/src/covers/amazoncoverprovider.cpp
+++ b/src/covers/amazoncoverprovider.cpp
@@ -23,8 +23,8 @@
 #include <QDateTime>
 #include <QNetworkReply>
 #include <QStringList>
-#include <QXmlStreamReader>
 #include <QUrlQuery>
+#include <QXmlStreamReader>
 
 #include "core/closure.h"
 #include "core/logging.h"
@@ -86,7 +86,8 @@ bool AmazonCoverProvider::StartSearch(const QString& artist,
 
   // Add the signature to the request
 
-  url_query.addQueryItem("Signature", QUrl::toPercentEncoding(signature.toBase64()));
+  url_query.addQueryItem("Signature",
+                         QUrl::toPercentEncoding(signature.toBase64()));
   url.setQuery(url_query);
 
   QNetworkReply* reply = network_->get(QNetworkRequest(url));

--- a/src/covers/amazoncoverprovider.cpp
+++ b/src/covers/amazoncoverprovider.cpp
@@ -63,19 +63,19 @@ bool AmazonCoverProvider::StartSearch(const QString& artist,
                                         "yyyy-MM-ddThh:mm:ss.zzzZ"))
                 << Arg("Version", "2009-11-01");
 
-  EncodedArgList encoded_args;
+  QUrlQuery url_query;
+  QUrl url(kUrl);
   QStringList query_items;
 
   // Encode the arguments
   for (const Arg& arg : args) {
     EncodedArg encoded_arg(QUrl::toPercentEncoding(arg.first),
                            QUrl::toPercentEncoding(arg.second));
-    encoded_args << encoded_arg;
     query_items << QString(encoded_arg.first + "=" + encoded_arg.second);
+    url_query.addQueryItem(encoded_arg.first, encoded_arg.second);
   }
 
   // Sign the request
-  QUrl url(kUrl);
 
   const QByteArray data_to_sign =
       QString("GET\n%1\n%2\n%3")
@@ -85,7 +85,7 @@ bool AmazonCoverProvider::StartSearch(const QString& artist,
       QByteArray::fromBase64(kSecretAccessKeyB64), data_to_sign));
 
   // Add the signature to the request
-  QUrlQuery url_query;
+
   url_query.addQueryItem("Signature", QUrl::toPercentEncoding(signature.toBase64()));
   url.setQuery(url_query);
 


### PR DESCRIPTION
Fix bug where the http request is not sending anything else than the signature.

The associate key currently in the code is not working for me, but maybe it's specific to my IP region or the key has been banned by amazon, however the code now works if I replace it with my own key.

"<?xml version=\"1.0\"?>\n<ItemSearchErrorResponse xmlns=\"http://ecs.amazonaws.com/doc/2009-11-01/\"><Error><Code>AWS.InvalidAssociate</Code><Message>Your AKIAIQH26RVM6UZ4WA6Q is not registered as an Amazon Associate. Please register as an associate at https://affiliate-program.amazon.com/assoc_credentials/home.</Message></Error><RequestID>31069391-03f4-427e-8521-95c16fd9690c</RequestID></ItemSearchErrorResponse>"
