### PR TITLE
Fix bug in covermanager not saving album cover to DB.

### DIFF
--- a/src/library/librarybackend.cpp
+++ b/src/library/librarybackend.cpp
@@ -16,14 +16,14 @@
 */
 
 #include "librarybackend.h"
+#include "libraryquery.h"
+#include "sqlrow.h"
 #include "core/application.h"
 #include "core/database.h"
 #include "core/scopedtransaction.h"
 #include "core/tagreaderclient.h"
 #include "core/utilities.h"
-#include "libraryquery.h"
 #include "smartplaylists/search.h"
-#include "sqlrow.h"
 
 #include <QCoreApplication>
 #include <QDateTime>
@@ -124,8 +124,9 @@ void LibraryBackend::ChangeDirPath(int id, const QString& old_path,
   const int path_len = old_url.length();
 
   // Do the subdirs table
-  q = QSqlQuery(QString("UPDATE %1 SET path=:path || substr(path, %2)"
-                        " WHERE directory=:id")
+  q = QSqlQuery(QString(
+                    "UPDATE %1 SET path=:path || substr(path, %2)"
+                    " WHERE directory=:id")
                     .arg(subdirs_table_)
                     .arg(path_len),
                 db);
@@ -135,8 +136,9 @@ void LibraryBackend::ChangeDirPath(int id, const QString& old_path,
   if (db_->CheckErrors(q)) return;
 
   // Do the songs table
-  q = QSqlQuery(QString("UPDATE %1 SET filename=:path || substr(filename, %2)"
-                        " WHERE directory=:id")
+  q = QSqlQuery(QString(
+                    "UPDATE %1 SET filename=:path || substr(filename, %2)"
+                    " WHERE directory=:id")
                     .arg(songs_table_)
                     .arg(path_len),
                 db);
@@ -175,9 +177,9 @@ SubdirectoryList LibraryBackend::SubdirsInDirectory(int id) {
 }
 
 SubdirectoryList LibraryBackend::SubdirsInDirectory(int id, QSqlDatabase& db) {
-  QSqlQuery q(QString("SELECT path, mtime FROM %1"
-                      " WHERE directory = :dir")
-                  .arg(subdirs_table_),
+  QSqlQuery q(QString(
+                  "SELECT path, mtime FROM %1"
+                  " WHERE directory = :dir").arg(subdirs_table_),
               db);
   q.bindValue(":dir", id);
   q.exec();
@@ -215,18 +217,17 @@ void LibraryBackend::AddDirectory(const QString& path) {
 
   if (Application::kIsPortable && Utilities::UrlOnSameDriveAsClementine(
                                       QUrl::fromLocalFile(canonical_path))) {
-    db_path =
-        Utilities::GetRelativePathToClementineBin(QUrl::fromLocalFile(db_path))
-            .toLocalFile();
+    db_path = Utilities::GetRelativePathToClementineBin(
+                  QUrl::fromLocalFile(db_path)).toLocalFile();
     qLog(Debug) << "db_path" << db_path;
   }
 
   QMutexLocker l(db_->Mutex());
   QSqlDatabase db(db_->Connect());
 
-  QSqlQuery q(QString("INSERT INTO %1 (path, subdirs)"
-                      " VALUES (:path, 1)")
-                  .arg(dirs_table_),
+  QSqlQuery q(QString(
+                  "INSERT INTO %1 (path, subdirs)"
+                  " VALUES (:path, 1)").arg(dirs_table_),
               db);
   q.bindValue(":path", db_path);
   q.exec();
@@ -271,10 +272,10 @@ SongList LibraryBackend::FindSongsInDirectory(int id) {
   QMutexLocker l(db_->Mutex());
   QSqlDatabase db(db_->Connect());
 
-  QSqlQuery q(QString("SELECT ROWID, " + Song::kColumnSpec +
-                      " FROM %1 WHERE directory = :directory")
-                  .arg(songs_table_),
-              db);
+  QSqlQuery q(
+      QString("SELECT ROWID, " + Song::kColumnSpec +
+              " FROM %1 WHERE directory = :directory").arg(songs_table_),
+      db);
   q.bindValue(":directory", id);
   q.exec();
   if (db_->CheckErrors(q)) return SongList();
@@ -301,22 +302,25 @@ void LibraryBackend::SongPathChanged(const Song& song,
 void LibraryBackend::AddOrUpdateSubdirs(const SubdirectoryList& subdirs) {
   QMutexLocker l(db_->Mutex());
   QSqlDatabase db(db_->Connect());
-  QSqlQuery find_query(QString("SELECT ROWID FROM %1"
-                               " WHERE directory = :id AND path = :path")
-                           .arg(subdirs_table_),
-                       db);
-  QSqlQuery add_query(QString("INSERT INTO %1 (directory, path, mtime)"
-                              " VALUES (:id, :path, :mtime)")
-                          .arg(subdirs_table_),
+  QSqlQuery find_query(
+      QString(
+          "SELECT ROWID FROM %1"
+          " WHERE directory = :id AND path = :path").arg(subdirs_table_),
+      db);
+  QSqlQuery add_query(QString(
+                          "INSERT INTO %1 (directory, path, mtime)"
+                          " VALUES (:id, :path, :mtime)").arg(subdirs_table_),
                       db);
-  QSqlQuery update_query(QString("UPDATE %1 SET mtime = :mtime"
-                                 " WHERE directory = :id AND path = :path")
-                             .arg(subdirs_table_),
-                         db);
-  QSqlQuery delete_query(QString("DELETE FROM %1"
-                                 " WHERE directory = :id AND path = :path")
-                             .arg(subdirs_table_),
-                         db);
+  QSqlQuery update_query(
+      QString(
+          "UPDATE %1 SET mtime = :mtime"
+          " WHERE directory = :id AND path = :path").arg(subdirs_table_),
+      db);
+  QSqlQuery delete_query(
+      QString(
+          "DELETE FROM %1"
+          " WHERE directory = :id AND path = :path").arg(subdirs_table_),
+      db);
 
   ScopedTransaction transaction(&db);
   for (const Subdirectory& subdir : subdirs) {
@@ -357,26 +361,23 @@ void LibraryBackend::AddOrUpdateSongs(const SongList& songs) {
 
   QSqlQuery check_dir(
       QString("SELECT ROWID FROM %1 WHERE ROWID = :id").arg(dirs_table_), db);
-  QSqlQuery add_song(
-      QString("INSERT INTO %1 (" + Song::kColumnSpec + ")"
-                                                       " VALUES (" +
-              Song::kBindSpec + ")")
-          .arg(songs_table_),
+  QSqlQuery add_song(QString("INSERT INTO %1 (" + Song::kColumnSpec +
+                             ")"
+                             " VALUES (" +
+                             Song::kBindSpec + ")").arg(songs_table_),
+                     db);
+  QSqlQuery update_song(QString("UPDATE %1 SET " + Song::kUpdateSpec +
+                                " WHERE ROWID = :id").arg(songs_table_),
+                        db);
+  QSqlQuery add_song_fts(
+      QString("INSERT INTO %1 (ROWID, " + Song::kFtsColumnSpec +
+              ")"
+              " VALUES (:id, " +
+              Song::kFtsBindSpec + ")").arg(fts_table_),
       db);
-  QSqlQuery update_song(
-      QString("UPDATE %1 SET " + Song::kUpdateSpec + " WHERE ROWID = :id")
-          .arg(songs_table_),
-      db);
-  QSqlQuery add_song_fts(QString("INSERT INTO %1 (ROWID, " +
-                                 Song::kFtsColumnSpec + ")"
-                                                        " VALUES (:id, " +
-                                 Song::kFtsBindSpec + ")")
-                             .arg(fts_table_),
-                         db);
-  QSqlQuery update_song_fts(
-      QString("UPDATE %1 SET " + Song::kFtsUpdateSpec + " WHERE ROWID = :id")
-          .arg(fts_table_),
-      db);
+  QSqlQuery update_song_fts(QString("UPDATE %1 SET " + Song::kFtsUpdateSpec +
+                                    " WHERE ROWID = :id").arg(fts_table_),
+                            db);
 
   ScopedTransaction transaction(&db);
 
@@ -674,11 +675,10 @@ SongList LibraryBackend::GetSongsById(const QStringList& ids,
                                       QSqlDatabase& db) {
   QString in = ids.join(",");
 
-  QSqlQuery q(
-      QString("SELECT ROWID, " + Song::kColumnSpec + " FROM %1"
-                                                     " WHERE ROWID IN (%2)")
-          .arg(songs_table_, in),
-      db);
+  QSqlQuery q(QString("SELECT ROWID, " + Song::kColumnSpec +
+                      " FROM %1"
+                      " WHERE ROWID IN (%2)").arg(songs_table_, in),
+              db);
   q.exec();
   if (db_->CheckErrors(q)) return SongList();
 
@@ -753,10 +753,11 @@ void LibraryBackend::UpdateCompilations() {
   // in the same
   // directory
 
-  QSqlQuery q(QString("SELECT effective_albumartist, album, filename, sampler "
-                      "FROM %1 WHERE unavailable = 0 ORDER BY album")
-                  .arg(songs_table_),
-              db);
+  QSqlQuery q(
+      QString(
+          "SELECT effective_albumartist, album, filename, sampler "
+          "FROM %1 WHERE unavailable = 0 ORDER BY album").arg(songs_table_),
+      db);
   q.exec();
   if (db_->CheckErrors(q)) return;
 
@@ -785,12 +786,12 @@ void LibraryBackend::UpdateCompilations() {
 
   // Now mark the songs that we think are in compilations
   QSqlQuery update(
-      QString("UPDATE %1"
-              " SET sampler = :sampler,"
-              "     effective_compilation = ((compilation OR :sampler OR "
-              "forced_compilation_on) AND NOT forced_compilation_off) + 0"
-              " WHERE album = :album AND unavailable = 0")
-          .arg(songs_table_),
+      QString(
+          "UPDATE %1"
+          " SET sampler = :sampler,"
+          "     effective_compilation = ((compilation OR :sampler OR "
+          "forced_compilation_on) AND NOT forced_compilation_off) + 0"
+          " WHERE album = :album AND unavailable = 0").arg(songs_table_),
       db);
   QSqlQuery find_songs(
       QString(
@@ -982,9 +983,10 @@ void LibraryBackend::UpdateManualAlbumArt(const QString& artist,
   }
 
   // Update the songs
-  QString sql(QString("UPDATE %1 SET art_manual = :art"
-                      " WHERE album = :album AND unavailable = 0")
-                  .arg(songs_table_));
+  QString sql(
+      QString(
+          "UPDATE %1 SET art_manual = :art"
+          " WHERE album = :album AND unavailable = 0").arg(songs_table_));
   if (!albumartist.isNull() && !albumartist.isEmpty()) {
     sql += " AND albumartist = :albumartist";
   } else if (!artist.isNull()) {
@@ -1047,8 +1049,7 @@ void LibraryBackend::ForceCompilation(const QString& album,
             "              forced_compilation_off = :forced_compilation_off,"
             "              effective_compilation = ((compilation OR sampler OR "
             ":forced_compilation_on) AND NOT :forced_compilation_off) + 0"
-            " WHERE album = :album AND unavailable = 0")
-            .arg(songs_table_));
+            " WHERE album = :album AND unavailable = 0").arg(songs_table_));
     if (!artist.isEmpty()) sql += " AND artist = :artist";
 
     QSqlQuery q(sql, db);
@@ -1116,11 +1117,12 @@ void LibraryBackend::IncrementPlayCount(int id) {
   QMutexLocker l(db_->Mutex());
   QSqlDatabase db(db_->Connect());
 
-  QSqlQuery q(QString("UPDATE %1 SET playcount = playcount + 1,"
-                      "              lastplayed = :now,"
-                      "              score = " +
-                      QString(kNewScoreSql).arg("1.0") + " WHERE ROWID = :id")
-                  .arg(songs_table_),
+  QSqlQuery q(QString(
+                  "UPDATE %1 SET playcount = playcount + 1,"
+                  "              lastplayed = :now,"
+                  "              score = " +
+                  QString(kNewScoreSql).arg("1.0") +
+                  " WHERE ROWID = :id").arg(songs_table_),
               db);
   q.bindValue(":now", QDateTime::currentDateTime().toTime_t());
   q.bindValue(":id", id);
@@ -1138,12 +1140,12 @@ void LibraryBackend::IncrementSkipCount(int id, float progress) {
   QMutexLocker l(db_->Mutex());
   QSqlDatabase db(db_->Connect());
 
-  QSqlQuery q(
-      QString("UPDATE %1 SET skipcount = skipcount + 1,"
-              "              score = " +
-              QString(kNewScoreSql).arg(progress) + " WHERE ROWID = :id")
-          .arg(songs_table_),
-      db);
+  QSqlQuery q(QString(
+                  "UPDATE %1 SET skipcount = skipcount + 1,"
+                  "              score = " +
+                  QString(kNewScoreSql).arg(progress) +
+                  " WHERE ROWID = :id").arg(songs_table_),
+              db);
   q.bindValue(":id", id);
   q.exec();
   if (db_->CheckErrors(q)) return;
@@ -1158,10 +1160,10 @@ void LibraryBackend::ResetStatistics(int id) {
   QMutexLocker l(db_->Mutex());
   QSqlDatabase db(db_->Connect());
 
-  QSqlQuery q(QString("UPDATE %1 SET playcount = 0, skipcount = 0,"
-                      "              lastplayed = -1, score = 0"
-                      " WHERE ROWID = :id")
-                  .arg(songs_table_),
+  QSqlQuery q(QString(
+                  "UPDATE %1 SET playcount = 0, skipcount = 0,"
+                  "              lastplayed = -1, score = 0"
+                  " WHERE ROWID = :id").arg(songs_table_),
               db);
   q.bindValue(":id", id);
   q.exec();
@@ -1191,9 +1193,9 @@ void LibraryBackend::UpdateSongsRating(const QList<int>& id_list,
     id_str_list << QString::number(i);
   }
   QString ids = id_str_list.join(",");
-  QSqlQuery q(QString("UPDATE %1 SET rating = :rating"
-                      " WHERE ROWID IN (%2)")
-                  .arg(songs_table_, ids),
+  QSqlQuery q(QString(
+                  "UPDATE %1 SET rating = :rating"
+                  " WHERE ROWID IN (%2)").arg(songs_table_, ids),
               db);
   q.bindValue(":rating", rating);
   q.exec();

--- a/src/library/librarybackend.cpp
+++ b/src/library/librarybackend.cpp
@@ -967,7 +967,7 @@ void LibraryBackend::UpdateManualAlbumArt(const QString& artist,
   query.SetColumnSpec("ROWID, " + Song::kColumnSpec);
   query.AddWhere("album", album);
 
-  if (!albumartist.isNull()) {
+  if (!albumartist.isNull() && !albumartist.isEmpty()) {
     query.AddWhere("albumartist", albumartist);
   } else if (!artist.isNull()) {
     query.AddWhere("artist", artist);
@@ -987,7 +987,7 @@ void LibraryBackend::UpdateManualAlbumArt(const QString& artist,
       QString(
           "UPDATE %1 SET art_manual = :art"
           " WHERE album = :album AND unavailable = 0").arg(songs_table_));
-  if (!albumartist.isNull()) {
+  if (!albumartist.isNull() && !albumartist.isEmpty()) {
     sql += " AND albumartist = :albumartist";
   } else if (!artist.isNull()) {
     sql += " AND artist = :artist";
@@ -996,7 +996,7 @@ void LibraryBackend::UpdateManualAlbumArt(const QString& artist,
   QSqlQuery q(sql, db);
   q.bindValue(":art", art);
   q.bindValue(":album", album);
-  if (!albumartist.isNull()) {
+  if (!albumartist.isNull() && !albumartist.isEmpty()) {
     q.bindValue(":albumartist", albumartist);
   } else if (!artist.isNull()) {
     q.bindValue(":artist", artist);

--- a/src/ui/albumcovermanager.cpp
+++ b/src/ui/albumcovermanager.cpp
@@ -750,7 +750,7 @@ void AlbumCoverManager::LoadSelectedToPlaylist() {
 void AlbumCoverManager::SaveAndSetCover(QListWidgetItem* item,
                                         const QImage& image) {
   const QString artist = item->data(Role_ArtistName).toString();
-  const QString albumartist = item->data(Role_ArtistName).toString();
+  const QString albumartist = item->data(Role_AlbumArtistName).toString();
   const QString album = item->data(Role_AlbumName).toString();
 
   QString path =


### PR DESCRIPTION
After fetching covers in covermanager, it does not sucessfully update art_manual in the DB because it is trying to update using albumartist instead of artist, even if the string is empty. You can see this if you go in cover manager and fetch missing covers, close it and go back, they still have nocover.
