### PR TITLE
Workaround for broken CD playback in Qt5

### DIFF
--- a/src/devices/cddasongloader.cpp
+++ b/src/devices/cddasongloader.cpp
@@ -35,7 +35,7 @@ CddaSongLoader::~CddaSongLoader() {
 
 QUrl CddaSongLoader::GetUrlFromTrack(int track_number) const {
   if (url_.isEmpty()) {
-    return QUrl(QString("cdda://%1").arg(track_number));
+    return QUrl(QString("cdda://%1a").arg(track_number));
   } else {
     return QUrl(QString("cdda://%1/%2").arg(url_.path()).arg(track_number));
   }

--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -181,8 +181,17 @@ bool GstEnginePipeline::ReplaceDecodeBin(const QUrl& url) {
         spotify_server, "StartPlayback", Qt::QueuedConnection,
         Q_ARG(QString, url.toString()), Q_ARG(quint16, port));
   } else {
+    QByteArray uri;
+    if (url.scheme() == "cdda") {
+      QString str = url.toString();
+      str.remove(str.lastIndexOf(QChar('a')), 1);
+      uri = str.toUtf8();;
+    }
+    else {
+      uri = url.toEncoded();
+    }
     new_bin = engine_->CreateElement("uridecodebin");
-    g_object_set(G_OBJECT(new_bin), "uri", url.toEncoded().constData(),
+    g_object_set(G_OBJECT(new_bin), "uri", uri.constData(),
                  nullptr);
     CHECKED_GCONNECT(G_OBJECT(new_bin), "drained", &SourceDrainedCallback,
                      this);

--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -185,9 +185,8 @@ bool GstEnginePipeline::ReplaceDecodeBin(const QUrl& url) {
     if (url.scheme() == "cdda") {
       QString str = url.toString();
       str.remove(str.lastIndexOf(QChar('a')), 1);
-      uri = str.toUtf8();;
-    }
-    else {
+      uri = str.toUtf8();
+    } else {
       uri = url.toEncoded();
     }
     new_bin = engine_->CreateElement("uridecodebin");

--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -190,8 +190,7 @@ bool GstEnginePipeline::ReplaceDecodeBin(const QUrl& url) {
       uri = url.toEncoded();
     }
     new_bin = engine_->CreateElement("uridecodebin");
-    g_object_set(G_OBJECT(new_bin), "uri", uri.constData(),
-                 nullptr);
+    g_object_set(G_OBJECT(new_bin), "uri", uri.constData(), nullptr);
     CHECKED_GCONNECT(G_OBJECT(new_bin), "drained", &SourceDrainedCallback,
                      this);
     CHECKED_GCONNECT(G_OBJECT(new_bin), "pad-added", &NewPadCallback, this);


### PR DESCRIPTION
QUrl() does not accept a single number as the host, it translates it to 0.0.0.1.
This is a simple workaround instead of replacing QUrl with QString or QVariant.
The first commit fixes it by adding a single character after the tracknumber, ie: cdda://1a for track number one. This URL will still work with gstreamer and can be played. The second commit removes the added "a" from the URL, just in case it would break in another version of gstreamer.
