### PR TITLE
Bugfixes

### DIFF
--- a/src/covers/lastfmcoverprovider.cpp
+++ b/src/covers/lastfmcoverprovider.cpp
@@ -60,6 +60,7 @@ void LastFmCoverProvider::QueryFinished(QNetworkReply* reply, int id) {
       result.description =
           element["artist"].text() + " - " + element["name"].text();
       result.image_url = QUrl(element["image size=extralarge"].text());
+      if (result.image_url.isEmpty()) continue;
       results << result;
     }
   } else {

--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -112,7 +112,9 @@ PlaylistView::PlaylistView(QWidget* parent)
       upgrading_from_qheaderview_(false),
       read_only_settings_(true),
       upgrading_from_version_(-1),
+      background_initialized_(false),
       background_image_type_(Default),
+      //background_image_filename_("_"),
       blur_radius_(kDefaultBlurRadius),
       opacity_level_(kDefaultOpacityLevel),
       previous_background_image_opacity_(0.0),
@@ -1127,10 +1129,11 @@ void PlaylistView::ReloadSettings() {
   // set_background_image when it is not needed, as this will cause the fading
   // animation to start again. This also avoid to do useless
   // "force_background_redraw".
-  if (background_image_filename != background_image_filename_ ||
+  if (background_initialized_ == false || background_image_filename != background_image_filename_ ||
       background_type != background_image_type_ ||
       blur_radius_ != blur_radius || opacity_level_ != opacity_level) {
     // Store background properties
+    background_initialized_ = true;
     background_image_type_ = background_type;
     background_image_filename_ = background_image_filename;
     blur_radius_ = blur_radius;

--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -1128,7 +1128,8 @@ void PlaylistView::ReloadSettings() {
   // set_background_image when it is not needed, as this will cause the fading
   // animation to start again. This also avoid to do useless
   // "force_background_redraw".
-  if (background_initialized_ == false || background_image_filename != background_image_filename_ ||
+  if (background_initialized_ == false ||
+      background_image_filename != background_image_filename_ ||
       background_type != background_image_type_ ||
       blur_radius_ != blur_radius || opacity_level_ != opacity_level) {
     // Store background properties

--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -114,7 +114,6 @@ PlaylistView::PlaylistView(QWidget* parent)
       upgrading_from_version_(-1),
       background_initialized_(false),
       background_image_type_(Default),
-      //background_image_filename_("_"),
       blur_radius_(kDefaultBlurRadius),
       opacity_level_(kDefaultOpacityLevel),
       previous_background_image_opacity_(0.0),

--- a/src/playlist/playlistview.h
+++ b/src/playlist/playlistview.h
@@ -195,15 +195,17 @@ signals:
   bool read_only_settings_;
   int upgrading_from_version_;
 
+  bool background_initialized_;
   BackgroundImageType background_image_type_;
+  // Used if background image is a filemane
+  QString background_image_filename_;
   // Stores the background image to be displayed. As we want this image to be
   // particular (in terms of format, opacity), you should probably use
   // set_background_image_type instead of modifying background_image_ directly
   QImage background_image_;
   int blur_radius_;
   int opacity_level_;
-  // Used if background image is a filemane
-  QString background_image_filename_;
+
   QImage current_song_cover_art_;
   QPixmap cached_scaled_background_image_;
 

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1412,7 +1412,7 @@ void MainWindow::closeEvent(QCloseEvent* event) {
     event->ignore();
     SetHiddenInTray(true);
   } else {
-    QApplication::quit();
+    Exit();
   }
 }
 


### PR DESCRIPTION
- LastFM is returning lot's of "image" tags with no URL's in the results, don't use those.
- Resume playback on start is not working if you exit Clementine using [X] instead of Music / Quit. Call Exit() to properly save the play position.
- Fix bug where background is not loading.
