### PR TITLE
Fix channels loading for DI.fm services after API domain changes

### DIFF
--- a/src/internet/digitally/digitallyimportedclient.cpp
+++ b/src/internet/digitally/digitallyimportedclient.cpp
@@ -38,7 +38,7 @@ const char* DigitallyImportedClient::kAuthUrl =
     "http://api.audioaddict.com/v1/%1/members/authenticate";
 
 const char* DigitallyImportedClient::kChannelListUrl =
-    "http://api.v2.audioaddict.com/v1/%1/mobile/"
+    "http://api.audioaddict.com/v1/%1/mobile/"
     "batch_update?asset_group_key=mobile_icons&stream_set_key=";
 
 DigitallyImportedClient::DigitallyImportedClient(const QString& service_name,


### PR DESCRIPTION
Clementine no longer loads channels list from DI.FM services. The issue is caused by obsolete api.v2.audioaddict.com domain usage. api.audioaddict.com should be used instead.