### PR TITLE
Accept closeEvent() for mainwindow when closing to tray

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1408,7 +1408,7 @@ void MainWindow::closeEvent(QCloseEvent* event) {
   bool keep_running = s.value("keeprunning", tray_icon_->IsVisible()).toBool();
 
   if (keep_running && event->spontaneous()) {
-    event->ignore();
+    event->accept();
     SetHiddenInTray(true);
   } else {
     QApplication::quit();


### PR DESCRIPTION
There's no difference between close() and hide() if WA_DeleteOnClose is not set, so if we're going to hide the window we might as well accept the event.

Ignoring the event may interrupt shutdowns since it signals that the application doesn't want to close the window, at least this happens on Plasma 5.11 when Clementine is not minimized to tray.