### PR TITLE
Add Play Next Option to Queue

### DIFF
--- a/src/core/mimedata.h
+++ b/src/core/mimedata.h
@@ -27,12 +27,13 @@ class MimeData : public QMimeData {
   Q_OBJECT
 
  public:
-  MimeData(bool clear = false, bool play_now = false, bool enqueue = false,
+  MimeData(bool clear = false, bool play_now = false, bool enqueue = false, bool enqueue_next_now = false,
            bool open_in_new_playlist = false)
       : override_user_settings_(false),
         clear_first_(clear),
         play_now_(play_now),
         enqueue_now_(enqueue),
+        enqueue_next_now_(enqueue_next_now),
         open_in_new_playlist_(open_in_new_playlist),
         name_for_new_playlist_(QString()),
         from_doubleclick_(false) {}
@@ -52,6 +53,9 @@ class MimeData : public QMimeData {
 
   // If this is set then the items are added to the queue after being inserted.
   bool enqueue_now_;
+
+  // If this is set then the items are added to the beginning of the queue after being inserted.
+  bool enqueue_next_now_;
 
   // If this is set then the items are inserted into a newly created playlist.
   bool open_in_new_playlist_;

--- a/src/core/mimedata.h
+++ b/src/core/mimedata.h
@@ -27,8 +27,8 @@ class MimeData : public QMimeData {
   Q_OBJECT
 
  public:
-  MimeData(bool clear = false, bool play_now = false, bool enqueue = false, bool enqueue_next_now = false,
-           bool open_in_new_playlist = false)
+  MimeData(bool clear = false, bool play_now = false, bool enqueue = false,
+           bool enqueue_next_now = false, bool open_in_new_playlist = false)
       : override_user_settings_(false),
         clear_first_(clear),
         play_now_(play_now),
@@ -54,7 +54,8 @@ class MimeData : public QMimeData {
   // If this is set then the items are added to the queue after being inserted.
   bool enqueue_now_;
 
-  // If this is set then the items are added to the beginning of the queue after being inserted.
+  // If this is set then the items are added to the beginning of the queue after
+  // being inserted.
   bool enqueue_next_now_;
 
   // If this is set then the items are inserted into a newly created playlist.

--- a/src/library/libraryview.cpp
+++ b/src/library/libraryview.cpp
@@ -392,6 +392,9 @@ void LibraryView::contextMenuEvent(QContextMenuEvent* e) {
     add_to_playlist_enqueue_ = context_menu_->addAction(
         IconLoader::Load("go-next", IconLoader::Base), tr("Queue track"), this,
         SLOT(AddToPlaylistEnqueue()));
+    add_to_playlist_enqueue_next_ = context_menu_->addAction(
+        IconLoader::Load("go-next", IconLoader::Base), tr("Play next"), this,
+                                                        SLOT(AddToPlaylistEnqueueNext()));
     context_menu_->addSeparator();
     search_for_this_ = context_menu_->addAction(
         IconLoader::Load("system-search", IconLoader::Base),
@@ -614,6 +617,14 @@ void LibraryView::AddToPlaylistEnqueue() {
     mime_data->enqueue_now_ = true;
   }
   emit AddToPlaylistSignal(data);
+}
+
+void LibraryView::AddToPlaylistEnqueueNext() {
+    QMimeData* data = model()->mimeData(selectedIndexes());
+    if (MimeData* mime_data = qobject_cast<MimeData*>(data)) {
+        mime_data->enqueue_next_now_ = true;
+    }
+    emit AddToPlaylistSignal(data);
 }
 
 void LibraryView::OpenInNewPlaylist() {

--- a/src/library/libraryview.cpp
+++ b/src/library/libraryview.cpp
@@ -394,7 +394,7 @@ void LibraryView::contextMenuEvent(QContextMenuEvent* e) {
         SLOT(AddToPlaylistEnqueue()));
     add_to_playlist_enqueue_next_ = context_menu_->addAction(
         IconLoader::Load("go-next", IconLoader::Base), tr("Play next"), this,
-                                                        SLOT(AddToPlaylistEnqueueNext()));
+        SLOT(AddToPlaylistEnqueueNext()));
     context_menu_->addSeparator();
     search_for_this_ = context_menu_->addAction(
         IconLoader::Load("system-search", IconLoader::Base),
@@ -620,11 +620,11 @@ void LibraryView::AddToPlaylistEnqueue() {
 }
 
 void LibraryView::AddToPlaylistEnqueueNext() {
-    QMimeData* data = model()->mimeData(selectedIndexes());
-    if (MimeData* mime_data = qobject_cast<MimeData*>(data)) {
-        mime_data->enqueue_next_now_ = true;
-    }
-    emit AddToPlaylistSignal(data);
+  QMimeData* data = model()->mimeData(selectedIndexes());
+  if (MimeData* mime_data = qobject_cast<MimeData*>(data)) {
+    mime_data->enqueue_next_now_ = true;
+  }
+  emit AddToPlaylistSignal(data);
 }
 
 void LibraryView::OpenInNewPlaylist() {

--- a/src/library/libraryview.h
+++ b/src/library/libraryview.h
@@ -92,6 +92,7 @@ signals:
   void Load();
   void AddToPlaylist();
   void AddToPlaylistEnqueue();
+  void AddToPlaylistEnqueueNext();
   void OpenInNewPlaylist();
   void Organise();
   void CopyToDevice();
@@ -131,6 +132,7 @@ signals:
   QAction* load_;
   QAction* add_to_playlist_;
   QAction* add_to_playlist_enqueue_;
+  QAction* add_to_playlist_enqueue_next_;
   QAction* open_in_new_playlist_;
   QAction* organise_;
   QAction* copy_to_device_;

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -152,14 +152,14 @@ Playlist::~Playlist() {
 
 template <typename T>
 void Playlist::InsertSongItems(const SongList& songs, int pos, bool play_now,
-                               bool enqueue) {
+                               bool enqueue, bool enqueue_next) {
   PlaylistItemList items;
 
   for (const Song& song : songs) {
     items << PlaylistItemPtr(new T(song));
   }
 
-  InsertItems(items, pos, play_now, enqueue);
+  InsertItems(items, pos, play_now, enqueue, enqueue_next);
 }
 
 QVariant Playlist::headerData(int section, Qt::Orientation, int role) const {
@@ -703,7 +703,7 @@ void Playlist::InsertDynamicItems(int count) {
   connect(inserter, SIGNAL(PlayRequested(QModelIndex)),
           SIGNAL(PlayRequested(QModelIndex)));
 
-  inserter->Load(this, -1, false, false, dynamic_playlist_, count);
+  inserter->Load(this, -1, false, false, false, dynamic_playlist_, count);
 }
 
 Qt::ItemFlags Playlist::flags(const QModelIndex& index) const {
@@ -733,12 +733,14 @@ bool Playlist::dropMimeData(const QMimeData* data, Qt::DropAction action,
 
   bool play_now = false;
   bool enqueue_now = false;
+  bool enqueue_next_now = false;
   if (const MimeData* mime_data = qobject_cast<const MimeData*>(data)) {
     if (mime_data->clear_first_) {
       Clear();
     }
     play_now = mime_data->play_now_;
     enqueue_now = mime_data->enqueue_now_;
+    enqueue_next_now = mime_data->enqueue_next_now_;
   }
 
   if (const SongMimeData* song_data = qobject_cast<const SongMimeData*>(data)) {
@@ -748,33 +750,33 @@ bool Playlist::dropMimeData(const QMimeData* data, Qt::DropAction action,
     if (song_data->backend &&
         song_data->backend->songs_table() == Library::kSongsTable)
       InsertSongItems<LibraryPlaylistItem>(song_data->songs, row, play_now,
-                                           enqueue_now);
+                                           enqueue_now, enqueue_next_now);
     else if (song_data->backend &&
              song_data->backend->songs_table() == MagnatuneService::kSongsTable)
       InsertSongItems<MagnatunePlaylistItem>(song_data->songs, row, play_now,
-                                             enqueue_now);
+                                             enqueue_now, enqueue_next_now);
     else if (song_data->backend &&
              song_data->backend->songs_table() == JamendoService::kSongsTable)
       InsertSongItems<JamendoPlaylistItem>(song_data->songs, row, play_now,
-                                           enqueue_now);
+                                           enqueue_now, enqueue_next_now);
     else
       InsertSongItems<SongPlaylistItem>(song_data->songs, row, play_now,
-                                        enqueue_now);
+                                        enqueue_now, enqueue_next_now);
   } else if (const InternetMimeData* internet_data =
                  qobject_cast<const InternetMimeData*>(data)) {
     // Dragged from the Internet pane
     InsertInternetItems(internet_data->model, internet_data->indexes, row,
-                        play_now, enqueue_now);
+                        play_now, enqueue_now, enqueue_next_now);
   } else if (const InternetSongMimeData* internet_song_data =
                  qobject_cast<const InternetSongMimeData*>(data)) {
     InsertInternetItems(internet_song_data->service, internet_song_data->songs,
-                        row, play_now, enqueue_now);
+                        row, play_now, enqueue_now, enqueue_next_now);
   } else if (const GeneratorMimeData* generator_data =
                  qobject_cast<const GeneratorMimeData*>(data)) {
-    InsertSmartPlaylist(generator_data->generator_, row, play_now, enqueue_now);
+    InsertSmartPlaylist(generator_data->generator_, row, play_now, enqueue_now, enqueue_next_now);
   } else if (const PlaylistItemMimeData* item_data =
                  qobject_cast<const PlaylistItemMimeData*>(data)) {
-    InsertItems(item_data->items_, row, play_now, enqueue_now);
+    InsertItems(item_data->items_, row, play_now, enqueue_now, enqueue_next_now);
   } else if (data->hasFormat(kRowsMimetype)) {
     // Dragged from the playlist
     // Rearranging it is tricky...
@@ -809,7 +811,7 @@ bool Playlist::dropMimeData(const QMimeData* data, Qt::DropAction action,
       if (items.count() > kUndoItemLimit) {
         // Too big to keep in the undo stack. Also clear the stack because it
         // might have been invalidated.
-        InsertItemsWithoutUndo(items, row, false);
+        InsertItemsWithoutUndo(items, row, false, false);
         undo_stack_->clear();
       } else {
         undo_stack_->push(
@@ -828,26 +830,26 @@ bool Playlist::dropMimeData(const QMimeData* data, Qt::DropAction action,
     SongLoaderInserter* inserter = new SongLoaderInserter(
         task_manager_, library_, backend_->app()->player());
     connect(inserter, SIGNAL(Error(QString)), SIGNAL(Error(QString)));
-    inserter->LoadAudioCD(this, row, play_now, enqueue_now);
+    inserter->LoadAudioCD(this, row, play_now, enqueue_now, enqueue_next_now);
   } else if (data->hasUrls()) {
     // URL list dragged from the file list or some other app
-    InsertUrls(data->urls(), row, play_now, enqueue_now);
+    InsertUrls(data->urls(), row, play_now, enqueue_now, enqueue_next_now);
   }
 
   return true;
 }
 
 void Playlist::InsertUrls(const QList<QUrl>& urls, int pos, bool play_now,
-                          bool enqueue) {
+                          bool enqueue, bool enqueue_next) {
   SongLoaderInserter* inserter = new SongLoaderInserter(
       task_manager_, library_, backend_->app()->player());
   connect(inserter, SIGNAL(Error(QString)), SIGNAL(Error(QString)));
 
-  inserter->Load(this, pos, play_now, enqueue, urls);
+  inserter->Load(this, pos, play_now, enqueue, enqueue_next, urls);
 }
 
 void Playlist::InsertSmartPlaylist(GeneratorPtr generator, int pos,
-                                   bool play_now, bool enqueue) {
+                                   bool play_now, bool enqueue, bool enqueue_next) {
   // Hack: If the generator hasn't got a library set then use the main one
   if (!generator->library()) {
     generator->set_library(library_);
@@ -857,7 +859,7 @@ void Playlist::InsertSmartPlaylist(GeneratorPtr generator, int pos,
       new GeneratorInserter(task_manager_, library_, this);
   connect(inserter, SIGNAL(Error(QString)), SIGNAL(Error(QString)));
 
-  inserter->Load(this, pos, play_now, enqueue, generator);
+  inserter->Load(this, pos, play_now, enqueue, enqueue_next, generator);
 
   if (generator->is_dynamic()) {
     TurnOnDynamicPlaylist(generator);
@@ -976,7 +978,7 @@ void Playlist::MoveItemsWithoutUndo(int start, const QList<int>& dest_rows) {
 }
 
 void Playlist::InsertItems(const PlaylistItemList& itemsIn, int pos,
-                           bool play_now, bool enqueue) {
+                           bool play_now, bool enqueue, bool enqueue_next) {
   if (itemsIn.isEmpty()) return;
 
   PlaylistItemList items = itemsIn;
@@ -1026,18 +1028,18 @@ void Playlist::InsertItems(const PlaylistItemList& itemsIn, int pos,
   if (items.count() > kUndoItemLimit) {
     // Too big to keep in the undo stack. Also clear the stack because it
     // might have been invalidated.
-    InsertItemsWithoutUndo(items, pos, enqueue);
+    InsertItemsWithoutUndo(items, pos, enqueue, enqueue_next);
     undo_stack_->clear();
   } else {
     undo_stack_->push(
-        new PlaylistUndoCommands::InsertItems(this, items, pos, enqueue));
+        new PlaylistUndoCommands::InsertItems(this, items, pos, enqueue, enqueue_next));
   }
 
   if (play_now) emit PlayRequested(index(start, 0));
 }
 
 void Playlist::InsertItemsWithoutUndo(const PlaylistItemList& items, int pos,
-                                      bool enqueue) {
+                                      bool enqueue, bool enqueue_next) {
   if (items.isEmpty()) return;
 
   const int start = pos == -1 ? items_.count() : pos;
@@ -1072,22 +1074,30 @@ void Playlist::InsertItemsWithoutUndo(const PlaylistItemList& items, int pos,
     queue_->ToggleTracks(indexes);
   }
 
+  if (enqueue_next) {
+    QModelIndexList indexes;
+    for (int i = start; i <= end; ++i) {
+        indexes << index(i, 0);
+    }
+    queue_->InsertFirst(indexes);
+  }
+
   Save();
   ReshuffleIndices();
 }
 
 void Playlist::InsertLibraryItems(const SongList& songs, int pos, bool play_now,
-                                  bool enqueue) {
-  InsertSongItems<LibraryPlaylistItem>(songs, pos, play_now, enqueue);
+                                  bool enqueue, bool enqueue_next) {
+  InsertSongItems<LibraryPlaylistItem>(songs, pos, play_now, enqueue, enqueue_next);
 }
 
 void Playlist::InsertSongs(const SongList& songs, int pos, bool play_now,
-                           bool enqueue) {
-  InsertSongItems<SongPlaylistItem>(songs, pos, play_now, enqueue);
+                           bool enqueue, bool enqueue_next) {
+  InsertSongItems<SongPlaylistItem>(songs, pos, play_now, enqueue, enqueue_next);
 }
 
 void Playlist::InsertSongsOrLibraryItems(const SongList& songs, int pos,
-                                         bool play_now, bool enqueue) {
+                                         bool play_now, bool enqueue, bool enqueue_next) {
   PlaylistItemList items;
   for (const Song& song : songs) {
     if (song.is_library_song()) {
@@ -1096,12 +1106,12 @@ void Playlist::InsertSongsOrLibraryItems(const SongList& songs, int pos,
       items << PlaylistItemPtr(new SongPlaylistItem(song));
     }
   }
-  InsertItems(items, pos, play_now, enqueue);
+  InsertItems(items, pos, play_now, enqueue, enqueue_next);
 }
 
 void Playlist::InsertInternetItems(const InternetModel* model,
                                    const QModelIndexList& items, int pos,
-                                   bool play_now, bool enqueue) {
+                                   bool play_now, bool enqueue, bool enqueue_next) {
   PlaylistItemList playlist_items;
   QList<QUrl> song_urls;
 
@@ -1120,23 +1130,23 @@ void Playlist::InsertInternetItems(const InternetModel* model,
   }
 
   if (!song_urls.isEmpty()) {
-    InsertUrls(song_urls, pos, play_now, enqueue);
+    InsertUrls(song_urls, pos, play_now, enqueue, enqueue_next);
     play_now = false;
   }
 
-  InsertItems(playlist_items, pos, play_now, enqueue);
+  InsertItems(playlist_items, pos, play_now, enqueue, enqueue_next);
 }
 
 void Playlist::InsertInternetItems(InternetService* service,
                                    const SongList& songs, int pos,
-                                   bool play_now, bool enqueue) {
+                                   bool play_now, bool enqueue, bool enqueue_next) {
   PlaylistItemList playlist_items;
   for (const Song& song : songs) {
     playlist_items << shared_ptr<PlaylistItem>(
         new InternetPlaylistItem(service, song));
   }
 
-  InsertItems(playlist_items, pos, play_now, enqueue);
+  InsertItems(playlist_items, pos, play_now, enqueue, enqueue_next);
 }
 
 void Playlist::UpdateItems(const SongList& songs) {

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -773,10 +773,12 @@ bool Playlist::dropMimeData(const QMimeData* data, Qt::DropAction action,
                         row, play_now, enqueue_now, enqueue_next_now);
   } else if (const GeneratorMimeData* generator_data =
                  qobject_cast<const GeneratorMimeData*>(data)) {
-    InsertSmartPlaylist(generator_data->generator_, row, play_now, enqueue_now, enqueue_next_now);
+    InsertSmartPlaylist(generator_data->generator_, row, play_now, enqueue_now,
+                        enqueue_next_now);
   } else if (const PlaylistItemMimeData* item_data =
                  qobject_cast<const PlaylistItemMimeData*>(data)) {
-    InsertItems(item_data->items_, row, play_now, enqueue_now, enqueue_next_now);
+    InsertItems(item_data->items_, row, play_now, enqueue_now,
+                enqueue_next_now);
   } else if (data->hasFormat(kRowsMimetype)) {
     // Dragged from the playlist
     // Rearranging it is tricky...
@@ -849,7 +851,8 @@ void Playlist::InsertUrls(const QList<QUrl>& urls, int pos, bool play_now,
 }
 
 void Playlist::InsertSmartPlaylist(GeneratorPtr generator, int pos,
-                                   bool play_now, bool enqueue, bool enqueue_next) {
+                                   bool play_now, bool enqueue,
+                                   bool enqueue_next) {
   // Hack: If the generator hasn't got a library set then use the main one
   if (!generator->library()) {
     generator->set_library(library_);
@@ -1031,8 +1034,8 @@ void Playlist::InsertItems(const PlaylistItemList& itemsIn, int pos,
     InsertItemsWithoutUndo(items, pos, enqueue, enqueue_next);
     undo_stack_->clear();
   } else {
-    undo_stack_->push(
-        new PlaylistUndoCommands::InsertItems(this, items, pos, enqueue, enqueue_next));
+    undo_stack_->push(new PlaylistUndoCommands::InsertItems(
+        this, items, pos, enqueue, enqueue_next));
   }
 
   if (play_now) emit PlayRequested(index(start, 0));
@@ -1077,7 +1080,7 @@ void Playlist::InsertItemsWithoutUndo(const PlaylistItemList& items, int pos,
   if (enqueue_next) {
     QModelIndexList indexes;
     for (int i = start; i <= end; ++i) {
-        indexes << index(i, 0);
+      indexes << index(i, 0);
     }
     queue_->InsertFirst(indexes);
   }
@@ -1088,16 +1091,19 @@ void Playlist::InsertItemsWithoutUndo(const PlaylistItemList& items, int pos,
 
 void Playlist::InsertLibraryItems(const SongList& songs, int pos, bool play_now,
                                   bool enqueue, bool enqueue_next) {
-  InsertSongItems<LibraryPlaylistItem>(songs, pos, play_now, enqueue, enqueue_next);
+  InsertSongItems<LibraryPlaylistItem>(songs, pos, play_now, enqueue,
+                                       enqueue_next);
 }
 
 void Playlist::InsertSongs(const SongList& songs, int pos, bool play_now,
                            bool enqueue, bool enqueue_next) {
-  InsertSongItems<SongPlaylistItem>(songs, pos, play_now, enqueue, enqueue_next);
+  InsertSongItems<SongPlaylistItem>(songs, pos, play_now, enqueue,
+                                    enqueue_next);
 }
 
 void Playlist::InsertSongsOrLibraryItems(const SongList& songs, int pos,
-                                         bool play_now, bool enqueue, bool enqueue_next) {
+                                         bool play_now, bool enqueue,
+                                         bool enqueue_next) {
   PlaylistItemList items;
   for (const Song& song : songs) {
     if (song.is_library_song()) {
@@ -1111,7 +1117,8 @@ void Playlist::InsertSongsOrLibraryItems(const SongList& songs, int pos,
 
 void Playlist::InsertInternetItems(const InternetModel* model,
                                    const QModelIndexList& items, int pos,
-                                   bool play_now, bool enqueue, bool enqueue_next) {
+                                   bool play_now, bool enqueue,
+                                   bool enqueue_next) {
   PlaylistItemList playlist_items;
   QList<QUrl> song_urls;
 
@@ -1139,7 +1146,8 @@ void Playlist::InsertInternetItems(const InternetModel* model,
 
 void Playlist::InsertInternetItems(InternetService* service,
                                    const SongList& songs, int pos,
-                                   bool play_now, bool enqueue, bool enqueue_next) {
+                                   bool play_now, bool enqueue,
+                                   bool enqueue_next) {
   PlaylistItemList playlist_items;
   for (const Song& song : songs) {
     playlist_items << shared_ptr<PlaylistItem>(

--- a/src/playlist/playlist.h
+++ b/src/playlist/playlist.h
@@ -235,18 +235,18 @@ class Playlist : public QAbstractListModel {
 
   // Changing the playlist
   void InsertItems(const PlaylistItemList& items, int pos = -1,
-                   bool play_now = false, bool enqueue = false);
+                   bool play_now = false, bool enqueue = false, bool enqueue_next = false);
   void InsertLibraryItems(const SongList& items, int pos = -1,
-                          bool play_now = false, bool enqueue = false);
+                          bool play_now = false, bool enqueue = false, bool enqueue_next = false);
   void InsertSongs(const SongList& items, int pos = -1, bool play_now = false,
-                   bool enqueue = false);
+                   bool enqueue = false, bool enqueue_next = false);
   void InsertSongsOrLibraryItems(const SongList& items, int pos = -1,
-                                 bool play_now = false, bool enqueue = false);
+                                 bool play_now = false, bool enqueue = false, bool enqueue_next = false);
   void InsertSmartPlaylist(smart_playlists::GeneratorPtr gen, int pos = -1,
-                           bool play_now = false, bool enqueue = false);
+                           bool play_now = false, bool enqueue = false, bool enqueue_next = false);
   void InsertInternetItems(InternetService* service, const SongList& songs,
                            int pos = -1, bool play_now = false,
-                           bool enqueue = false);
+                           bool enqueue = false, bool enqueue_next = false);
   void ReshuffleIndices();
 
   // If this playlist contains the current item, this method will apply the
@@ -335,7 +335,7 @@ class Playlist : public QAbstractListModel {
   void SetColumnAlignment(const ColumnAlignmentMap& alignment);
 
   void InsertUrls(const QList<QUrl>& urls, int pos = -1, bool play_now = false,
-                  bool enqueue = false);
+                  bool enqueue = false, bool enqueue_next = false);
   // Removes items with given indices from the playlist. This operation is not
   // undoable.
   void RemoveItemsWithoutUndo(const QList<int>& indices);
@@ -366,18 +366,18 @@ signals:
 
   void InsertInternetItems(const InternetModel* model,
                            const QModelIndexList& items, int pos, bool play_now,
-                           bool enqueue);
+                           bool enqueue, bool enqueue_next = false);
 
   template <typename T>
   void InsertSongItems(const SongList& songs, int pos, bool play_now,
-                       bool enqueue);
+                       bool enqueue, bool enqueue_next = false);
 
   void InsertDynamicItems(int count);
 
   // Modify the playlist without changing the undo stack.  These are used by
   // our friends in PlaylistUndoCommands
   void InsertItemsWithoutUndo(const PlaylistItemList& items, int pos,
-                              bool enqueue = false);
+                              bool enqueue = false, bool enqueue_next = false);
   PlaylistItemList RemoveItemsWithoutUndo(int pos, int count);
   void MoveItemsWithoutUndo(const QList<int>& source_rows, int pos);
   void MoveItemWithoutUndo(int source, int dest);

--- a/src/playlist/playlist.h
+++ b/src/playlist/playlist.h
@@ -235,15 +235,19 @@ class Playlist : public QAbstractListModel {
 
   // Changing the playlist
   void InsertItems(const PlaylistItemList& items, int pos = -1,
-                   bool play_now = false, bool enqueue = false, bool enqueue_next = false);
+                   bool play_now = false, bool enqueue = false,
+                   bool enqueue_next = false);
   void InsertLibraryItems(const SongList& items, int pos = -1,
-                          bool play_now = false, bool enqueue = false, bool enqueue_next = false);
+                          bool play_now = false, bool enqueue = false,
+                          bool enqueue_next = false);
   void InsertSongs(const SongList& items, int pos = -1, bool play_now = false,
                    bool enqueue = false, bool enqueue_next = false);
   void InsertSongsOrLibraryItems(const SongList& items, int pos = -1,
-                                 bool play_now = false, bool enqueue = false, bool enqueue_next = false);
+                                 bool play_now = false, bool enqueue = false,
+                                 bool enqueue_next = false);
   void InsertSmartPlaylist(smart_playlists::GeneratorPtr gen, int pos = -1,
-                           bool play_now = false, bool enqueue = false, bool enqueue_next = false);
+                           bool play_now = false, bool enqueue = false,
+                           bool enqueue_next = false);
   void InsertInternetItems(InternetService* service, const SongList& songs,
                            int pos = -1, bool play_now = false,
                            bool enqueue = false, bool enqueue_next = false);

--- a/src/playlist/playlistundocommands.cpp
+++ b/src/playlist/playlistundocommands.cpp
@@ -24,12 +24,16 @@ Base::Base(Playlist* playlist) : QUndoCommand(0), playlist_(playlist) {}
 
 InsertItems::InsertItems(Playlist* playlist, const PlaylistItemList& items,
                          int pos, bool enqueue, bool enqueue_next)
-    : Base(playlist), items_(items), pos_(pos), enqueue_(enqueue), enqueue_next_(enqueue_next) {
+    : Base(playlist),
+      items_(items),
+      pos_(pos),
+      enqueue_(enqueue),
+      enqueue_next_(enqueue_next) {
   setText(tr("add %n songs", "", items_.count()));
 }
 
 void InsertItems::redo() {
-    playlist_->InsertItemsWithoutUndo(items_, pos_, enqueue_, enqueue_next_);
+  playlist_->InsertItemsWithoutUndo(items_, pos_, enqueue_, enqueue_next_);
 }
 
 void InsertItems::undo() {

--- a/src/playlist/playlistundocommands.cpp
+++ b/src/playlist/playlistundocommands.cpp
@@ -23,13 +23,13 @@ namespace PlaylistUndoCommands {
 Base::Base(Playlist* playlist) : QUndoCommand(0), playlist_(playlist) {}
 
 InsertItems::InsertItems(Playlist* playlist, const PlaylistItemList& items,
-                         int pos, bool enqueue)
-    : Base(playlist), items_(items), pos_(pos), enqueue_(enqueue) {
+                         int pos, bool enqueue, bool enqueue_next)
+    : Base(playlist), items_(items), pos_(pos), enqueue_(enqueue), enqueue_next_(enqueue_next) {
   setText(tr("add %n songs", "", items_.count()));
 }
 
 void InsertItems::redo() {
-  playlist_->InsertItemsWithoutUndo(items_, pos_, enqueue_);
+    playlist_->InsertItemsWithoutUndo(items_, pos_, enqueue_, enqueue_next_);
 }
 
 void InsertItems::undo() {

--- a/src/playlist/playlistundocommands.h
+++ b/src/playlist/playlistundocommands.h
@@ -40,8 +40,7 @@ class Base : public QUndoCommand {
 
 class InsertItems : public Base {
  public:
-  InsertItems(Playlist* playlist, const PlaylistItemList& items, int pos,
-              bool enqueue = false);
+  InsertItems(Playlist* playlist, const PlaylistItemList& items, int pos, bool enqueue = false, bool enqueue_next = false);
 
   void undo();
   void redo();
@@ -56,6 +55,7 @@ class InsertItems : public Base {
   PlaylistItemList items_;
   int pos_;
   bool enqueue_;
+  bool enqueue_next_;
 };
 
 class RemoveItems : public Base {

--- a/src/playlist/playlistundocommands.h
+++ b/src/playlist/playlistundocommands.h
@@ -40,7 +40,8 @@ class Base : public QUndoCommand {
 
 class InsertItems : public Base {
  public:
-  InsertItems(Playlist* playlist, const PlaylistItemList& items, int pos, bool enqueue = false, bool enqueue_next = false);
+  InsertItems(Playlist* playlist, const PlaylistItemList& items, int pos,
+              bool enqueue = false, bool enqueue_next = false);
 
   void undo();
   void redo();

--- a/src/playlist/queue.cpp
+++ b/src/playlist/queue.cpp
@@ -152,26 +152,26 @@ void Queue::ToggleTracks(const QModelIndexList& source_indexes) {
 }
 
 void Queue::InsertFirst(const QModelIndexList& source_indexes) {
-    for (const QModelIndex& source_index : source_indexes) {
-        QModelIndex proxy_index = mapFromSource(source_index);
-        if (proxy_index.isValid()) {
-            // Already in the queue, so remove it to be reinserted later
-            const int row = proxy_index.row();
-            beginRemoveRows(QModelIndex(), row, row);
-            source_indexes_.removeAt(row);
-            endRemoveRows();
-        }
+  for (const QModelIndex& source_index : source_indexes) {
+    QModelIndex proxy_index = mapFromSource(source_index);
+    if (proxy_index.isValid()) {
+      // Already in the queue, so remove it to be reinserted later
+      const int row = proxy_index.row();
+      beginRemoveRows(QModelIndex(), row, row);
+      source_indexes_.removeAt(row);
+      endRemoveRows();
     }
+  }
 
-    const int rows = source_indexes.count();
-    // Enqueue the tracks at the beginning
-    beginInsertRows(QModelIndex(), 0, rows - 1);
-    int offset = 0;
-    for (const QModelIndex& source_index : source_indexes) {
-        source_indexes_.insert(offset, QPersistentModelIndex(source_index));
-        offset++;
-    }
-    endInsertRows();
+  const int rows = source_indexes.count();
+  // Enqueue the tracks at the beginning
+  beginInsertRows(QModelIndex(), 0, rows - 1);
+  int offset = 0;
+  for (const QModelIndex& source_index : source_indexes) {
+    source_indexes_.insert(offset, QPersistentModelIndex(source_index));
+    offset++;
+  }
+  endInsertRows();
 }
 
 int Queue::PositionOf(const QModelIndex& source_index) const {

--- a/src/playlist/queue.cpp
+++ b/src/playlist/queue.cpp
@@ -151,6 +151,18 @@ void Queue::ToggleTracks(const QModelIndexList& source_indexes) {
   }
 }
 
+void Queue::InsertFirst(const QModelIndexList& source_indexes) {
+    const int rows = source_indexes.count();
+    // Enqueue the tracks at the beginning
+    beginInsertRows(QModelIndex(), 0, rows - 1);
+    int offset = 0;
+    for (const QModelIndex& source_index : source_indexes) {
+        source_indexes_.insert(offset, QPersistentModelIndex(source_index));
+        offset++;
+    }
+    endInsertRows();
+}
+
 int Queue::PositionOf(const QModelIndex& source_index) const {
   return mapFromSource(source_index).row();
 }

--- a/src/playlist/queue.cpp
+++ b/src/playlist/queue.cpp
@@ -152,6 +152,17 @@ void Queue::ToggleTracks(const QModelIndexList& source_indexes) {
 }
 
 void Queue::InsertFirst(const QModelIndexList& source_indexes) {
+    for (const QModelIndex& source_index : source_indexes) {
+        QModelIndex proxy_index = mapFromSource(source_index);
+        if (proxy_index.isValid()) {
+            // Already in the queue, so remove it to be reinserted later
+            const int row = proxy_index.row();
+            beginRemoveRows(QModelIndex(), row, row);
+            source_indexes_.removeAt(row);
+            endRemoveRows();
+        }
+    }
+
     const int rows = source_indexes.count();
     // Enqueue the tracks at the beginning
     beginInsertRows(QModelIndex(), 0, rows - 1);

--- a/src/playlist/queue.h
+++ b/src/playlist/queue.h
@@ -39,6 +39,7 @@ class Queue : public QAbstractProxyModel {
   // Modify the queue
   int TakeNext();
   void ToggleTracks(const QModelIndexList& source_indexes);
+  void InsertFirst(const QModelIndexList& source_indexes);
   void Clear();
   void Move(const QList<int>& proxy_rows, int pos);
   void MoveUp(int row);

--- a/src/playlist/songloaderinserter.cpp
+++ b/src/playlist/songloaderinserter.cpp
@@ -37,11 +37,12 @@ SongLoaderInserter::SongLoaderInserter(TaskManager* task_manager,
 SongLoaderInserter::~SongLoaderInserter() { qDeleteAll(pending_); }
 
 void SongLoaderInserter::Load(Playlist* destination, int row, bool play_now,
-                              bool enqueue, const QList<QUrl>& urls) {
+                              bool enqueue, bool enqueue_next, const QList<QUrl>& urls) {
   destination_ = destination;
   row_ = row;
   play_now_ = play_now;
   enqueue_ = enqueue;
+  enqueue_next_ = enqueue_next;
 
   connect(destination, SIGNAL(destroyed()), SLOT(DestinationDestroyed()));
   connect(this, SIGNAL(PreloadFinished()), SLOT(InsertSongs()));
@@ -78,11 +79,12 @@ void SongLoaderInserter::Load(Playlist* destination, int row, bool play_now,
 // In the meantime, MusicBrainz will be queried to get songs' metadata.
 // AudioCDTagsLoaded will be called next, and playlist's items will be updated.
 void SongLoaderInserter::LoadAudioCD(Playlist* destination, int row,
-                                     bool play_now, bool enqueue) {
+                                     bool play_now, bool enqueue, bool enqueue_next) {
   destination_ = destination;
   row_ = row;
   play_now_ = play_now;
   enqueue_ = enqueue;
+  enqueue_next_ = enqueue_next;
 
   SongLoader* loader = new SongLoader(library_, player_, this);
   NewClosure(loader, SIGNAL(AudioCDTracksLoaded()),

--- a/src/playlist/songloaderinserter.cpp
+++ b/src/playlist/songloaderinserter.cpp
@@ -37,7 +37,8 @@ SongLoaderInserter::SongLoaderInserter(TaskManager* task_manager,
 SongLoaderInserter::~SongLoaderInserter() { qDeleteAll(pending_); }
 
 void SongLoaderInserter::Load(Playlist* destination, int row, bool play_now,
-                              bool enqueue, bool enqueue_next, const QList<QUrl>& urls) {
+                              bool enqueue, bool enqueue_next,
+                              const QList<QUrl>& urls) {
   destination_ = destination;
   row_ = row;
   play_now_ = play_now;
@@ -79,7 +80,8 @@ void SongLoaderInserter::Load(Playlist* destination, int row, bool play_now,
 // In the meantime, MusicBrainz will be queried to get songs' metadata.
 // AudioCDTagsLoaded will be called next, and playlist's items will be updated.
 void SongLoaderInserter::LoadAudioCD(Playlist* destination, int row,
-                                     bool play_now, bool enqueue, bool enqueue_next) {
+                                     bool play_now, bool enqueue,
+                                     bool enqueue_next) {
   destination_ = destination;
   row_ = row;
   play_now_ = play_now;
@@ -121,7 +123,8 @@ void SongLoaderInserter::InsertSongs() {
   // Insert songs (that haven't been completely loaded) to allow user to see
   // and play them while not loaded completely
   if (destination_) {
-    destination_->InsertSongsOrLibraryItems(songs_, row_, play_now_, enqueue_, enqueue_next_);
+    destination_->InsertSongsOrLibraryItems(songs_, row_, play_now_, enqueue_,
+                                            enqueue_next_);
   }
 }
 

--- a/src/playlist/songloaderinserter.cpp
+++ b/src/playlist/songloaderinserter.cpp
@@ -121,7 +121,7 @@ void SongLoaderInserter::InsertSongs() {
   // Insert songs (that haven't been completely loaded) to allow user to see
   // and play them while not loaded completely
   if (destination_) {
-    destination_->InsertSongsOrLibraryItems(songs_, row_, play_now_, enqueue_);
+    destination_->InsertSongsOrLibraryItems(songs_, row_, play_now_, enqueue_, enqueue_next_);
   }
 }
 

--- a/src/playlist/songloaderinserter.h
+++ b/src/playlist/songloaderinserter.h
@@ -39,11 +39,12 @@ class SongLoaderInserter : public QObject {
                      LibraryBackendInterface* library, const Player* player);
   ~SongLoaderInserter();
 
-  void Load(Playlist* destination, int row, bool play_now, bool enqueue, bool enqueue_next,
-            const QList<QUrl>& urls);
-  void LoadAudioCD(Playlist* destination, int row, bool play_now, bool enqueue, bool enqueue_now);
+  void Load(Playlist* destination, int row, bool play_now, bool enqueue,
+            bool enqueue_next, const QList<QUrl>& urls);
+  void LoadAudioCD(Playlist* destination, int row, bool play_now, bool enqueue,
+                   bool enqueue_now);
 
-signals:
+ signals:
   void Error(const QString& message);
   void PreloadFinished();
   void EffectiveLoadFinished(const SongList& songs);

--- a/src/playlist/songloaderinserter.h
+++ b/src/playlist/songloaderinserter.h
@@ -39,9 +39,9 @@ class SongLoaderInserter : public QObject {
                      LibraryBackendInterface* library, const Player* player);
   ~SongLoaderInserter();
 
-  void Load(Playlist* destination, int row, bool play_now, bool enqueue,
+  void Load(Playlist* destination, int row, bool play_now, bool enqueue, bool enqueue_next,
             const QList<QUrl>& urls);
-  void LoadAudioCD(Playlist* destination, int row, bool play_now, bool enqueue);
+  void LoadAudioCD(Playlist* destination, int row, bool play_now, bool enqueue, bool enqueue_now);
 
 signals:
   void Error(const QString& message);
@@ -64,6 +64,7 @@ signals:
   int row_;
   bool play_now_;
   bool enqueue_;
+  bool enqueue_next_;
 
   SongList songs_;
 

--- a/src/smartplaylists/generatorinserter.cpp
+++ b/src/smartplaylists/generatorinserter.cpp
@@ -43,7 +43,7 @@ static PlaylistItemList Generate(GeneratorPtr generator, int dynamic_count) {
 }
 
 void GeneratorInserter::Load(Playlist* destination, int row, bool play_now,
-                             bool enqueue, GeneratorPtr generator,
+                             bool enqueue, bool enqueue_next, GeneratorPtr generator,
                              int dynamic_count) {
   task_id_ = task_manager_->StartTask(tr("Loading smart playlist"));
 
@@ -51,6 +51,7 @@ void GeneratorInserter::Load(Playlist* destination, int row, bool play_now,
   row_ = row;
   play_now_ = play_now;
   enqueue_ = enqueue;
+  enqueue_next_ = enqueue_next;
   is_dynamic_ = generator->is_dynamic();
 
   connect(generator.get(), SIGNAL(Error(QString)), SIGNAL(Error(QString)));

--- a/src/smartplaylists/generatorinserter.cpp
+++ b/src/smartplaylists/generatorinserter.cpp
@@ -43,8 +43,8 @@ static PlaylistItemList Generate(GeneratorPtr generator, int dynamic_count) {
 }
 
 void GeneratorInserter::Load(Playlist* destination, int row, bool play_now,
-                             bool enqueue, bool enqueue_next, GeneratorPtr generator,
-                             int dynamic_count) {
+                             bool enqueue, bool enqueue_next,
+                             GeneratorPtr generator, int dynamic_count) {
   task_id_ = task_manager_->StartTask(tr("Loading smart playlist"));
 
   destination_ = destination;

--- a/src/smartplaylists/generatorinserter.h
+++ b/src/smartplaylists/generatorinserter.h
@@ -40,7 +40,7 @@ class GeneratorInserter : public QObject {
   GeneratorInserter(TaskManager* task_manager, LibraryBackend* library,
                     QObject* parent);
 
-  void Load(Playlist* destination, int row, bool play_now, bool enqueue,
+  void Load(Playlist* destination, int row, bool play_now, bool enqueue, bool enqueue_next,
             GeneratorPtr generator, int dynamic_count = 0);
 
 signals:
@@ -59,6 +59,7 @@ signals:
   int row_;
   bool play_now_;
   bool enqueue_;
+  bool enqueue_next_;
   bool is_dynamic_;
 };
 

--- a/src/smartplaylists/generatorinserter.h
+++ b/src/smartplaylists/generatorinserter.h
@@ -40,10 +40,10 @@ class GeneratorInserter : public QObject {
   GeneratorInserter(TaskManager* task_manager, LibraryBackend* library,
                     QObject* parent);
 
-  void Load(Playlist* destination, int row, bool play_now, bool enqueue, bool enqueue_next,
-            GeneratorPtr generator, int dynamic_count = 0);
+  void Load(Playlist* destination, int row, bool play_now, bool enqueue,
+            bool enqueue_next, GeneratorPtr generator, int dynamic_count = 0);
 
-signals:
+ signals:
   void Error(const QString& message);
   void PlayRequested(const QModelIndex& index);
 

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -677,6 +677,9 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
   playlist_queue_ = playlist_menu_->addAction("", this, SLOT(PlaylistQueue()));
   playlist_queue_->setShortcut(QKeySequence("Ctrl+D"));
   ui_->playlist->addAction(playlist_queue_);
+  playlist_queue_play_next_ = playlist_menu_->addAction("", this, SLOT(PlaylistQueuePlayNext()));
+  playlist_queue_play_next_->setShortcut(QKeySequence("Ctrl+Shift+D"));
+  ui_->playlist->addAction(playlist_queue_play_next_);
   playlist_skip_ = playlist_menu_->addAction("", this, SLOT(PlaylistSkip()));
   ui_->playlist->addAction(playlist_skip_);
   playlist_menu_->addSeparator();
@@ -1760,6 +1763,11 @@ void MainWindow::PlaylistRightClick(const QPoint& global_pos,
   else
     playlist_queue_->setText(tr("Toggle queue status"));
 
+  if (in_queue == 0 && not_in_queue == 1)
+      playlist_queue_play_next_->setText(tr("Play next"));
+  else if (in_queue == 0 && not_in_queue > 1)
+      playlist_queue_play_next_->setText(tr("Play selected tracks next"));
+
   if (in_skipped == 1 && not_in_skipped == 0)
     playlist_skip_->setText(tr("Unskip track"));
   else if (in_skipped > 1 && not_in_skipped == 0)
@@ -2498,6 +2506,17 @@ void MainWindow::PlaylistQueue() {
   }
 
   app_->playlist_manager()->current()->queue()->ToggleTracks(indexes);
+}
+
+void MainWindow::PlaylistQueuePlayNext() {
+    QModelIndexList indexes;
+    for (const QModelIndex& proxy_index :
+        ui_->playlist->view()->selectionModel()->selectedRows()) {
+        indexes << app_->playlist_manager()->current()->proxy()->mapToSource(
+            proxy_index);
+        }
+
+        app_->playlist_manager()->current()->queue()->InsertFirst(indexes);
 }
 
 void MainWindow::PlaylistSkip() {

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1782,6 +1782,8 @@ void MainWindow::PlaylistRightClick(const QPoint& global_pos,
   else
     playlist_queue_->setIcon(IconLoader::Load("go-next", IconLoader::Base));
 
+  playlist_queue_play_next_->setIcon(IconLoader::Load("go-next", IconLoader::Base));
+
   if (!index.isValid()) {
     ui_->action_selection_set_value->setVisible(false);
     ui_->action_edit_value->setVisible(false);

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -677,7 +677,8 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
   playlist_queue_ = playlist_menu_->addAction("", this, SLOT(PlaylistQueue()));
   playlist_queue_->setShortcut(QKeySequence("Ctrl+D"));
   ui_->playlist->addAction(playlist_queue_);
-  playlist_queue_play_next_ = playlist_menu_->addAction("", this, SLOT(PlaylistQueuePlayNext()));
+  playlist_queue_play_next_ =
+      playlist_menu_->addAction("", this, SLOT(PlaylistQueuePlayNext()));
   playlist_queue_play_next_->setShortcut(QKeySequence("Ctrl+Shift+D"));
   ui_->playlist->addAction(playlist_queue_play_next_);
   playlist_skip_ = playlist_menu_->addAction("", this, SLOT(PlaylistSkip()));
@@ -1763,10 +1764,10 @@ void MainWindow::PlaylistRightClick(const QPoint& global_pos,
   else
     playlist_queue_->setText(tr("Toggle queue status"));
 
-   if (all > 1)
-      playlist_queue_play_next_->setText(tr("Play selected tracks next"));
-   else
-      playlist_queue_play_next_->setText(tr("Play next"));
+  if (all > 1)
+    playlist_queue_play_next_->setText(tr("Play selected tracks next"));
+  else
+    playlist_queue_play_next_->setText(tr("Play next"));
 
   if (in_skipped == 1 && not_in_skipped == 0)
     playlist_skip_->setText(tr("Unskip track"));
@@ -1782,7 +1783,8 @@ void MainWindow::PlaylistRightClick(const QPoint& global_pos,
   else
     playlist_queue_->setIcon(IconLoader::Load("go-next", IconLoader::Base));
 
-  playlist_queue_play_next_->setIcon(IconLoader::Load("go-next", IconLoader::Base));
+  playlist_queue_play_next_->setIcon(
+      IconLoader::Load("go-next", IconLoader::Base));
 
   if (!index.isValid()) {
     ui_->action_selection_set_value->setVisible(false);
@@ -2511,14 +2513,14 @@ void MainWindow::PlaylistQueue() {
 }
 
 void MainWindow::PlaylistQueuePlayNext() {
-    QModelIndexList indexes;
-    for (const QModelIndex& proxy_index :
-        ui_->playlist->view()->selectionModel()->selectedRows()) {
-        indexes << app_->playlist_manager()->current()->proxy()->mapToSource(
-            proxy_index);
-        }
+  QModelIndexList indexes;
+  for (const QModelIndex& proxy_index :
+       ui_->playlist->view()->selectionModel()->selectedRows()) {
+    indexes << app_->playlist_manager()->current()->proxy()->mapToSource(
+        proxy_index);
+  }
 
-        app_->playlist_manager()->current()->queue()->InsertFirst(indexes);
+  app_->playlist_manager()->current()->queue()->InsertFirst(indexes);
 }
 
 void MainWindow::PlaylistSkip() {

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1763,10 +1763,10 @@ void MainWindow::PlaylistRightClick(const QPoint& global_pos,
   else
     playlist_queue_->setText(tr("Toggle queue status"));
 
-  if (in_queue == 0 && not_in_queue == 1)
-      playlist_queue_play_next_->setText(tr("Play next"));
-  else if (in_queue == 0 && not_in_queue > 1)
+   if (all > 1)
       playlist_queue_play_next_->setText(tr("Play selected tracks next"));
+   else
+      playlist_queue_play_next_->setText(tr("Play next"));
 
   if (in_skipped == 1 && not_in_skipped == 0)
     playlist_skip_->setText(tr("Unskip track"));

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -162,6 +162,7 @@ signals:
   void PlaylistPlay();
   void PlaylistStopAfter();
   void PlaylistQueue();
+  void PlaylistQueuePlayNext();
   void PlaylistSkip();
   void PlaylistRemoveCurrent();
   void PlaylistEditFinished(const QModelIndex& index);
@@ -361,6 +362,7 @@ signals:
   QAction* playlist_delete_;
   QAction* playlist_open_in_browser_;
   QAction* playlist_queue_;
+  QAction* playlist_queue_play_next_;
   QAction* playlist_skip_;
   QAction* playlist_add_to_another_;
   QList<QAction*> playlistitem_actions_;


### PR DESCRIPTION
Adds a feature similar to what is seen in other music apps like Google Play Music, where you can select one or more songs from either the library or playlist and insert them at the top of the queue to be played immediately after the current track ends.