### PR TITLE
Fix cmake with Qt 5.11_beta3 (dropping qt5_use_modules)

### DIFF
--- a/3rdparty/qtiocompressor/CMakeLists.txt
+++ b/3rdparty/qtiocompressor/CMakeLists.txt
@@ -15,4 +15,4 @@ ADD_LIBRARY(qtiocompressor STATIC
     ${IOCOMPRESSOR-SOURCES-MOC}
 )
 
-QT5_USE_MODULES(qtiocompressor Core)
+target_link_libraries(qtiocompressor Qt5::Core)

--- a/3rdparty/qtsingleapplication/CMakeLists.txt
+++ b/3rdparty/qtsingleapplication/CMakeLists.txt
@@ -25,4 +25,4 @@ ADD_LIBRARY(qtsingleapplication STATIC
     ${SINGLEAPP-SOURCES-MOC}
 )
 
-QT5_USE_MODULES(qtsingleapplication Core Widgets Network)
+target_link_libraries(qtsingleapplication Qt5::Core Qt5::Widgets Qt5::Network)

--- a/3rdparty/qxt/CMakeLists.txt
+++ b/3rdparty/qxt/CMakeLists.txt
@@ -29,7 +29,7 @@ ADD_LIBRARY(qxt STATIC
 )
 
 if(WIN32)
-  QT5_USE_MODULES(qxt Core Widgets)
+  target_link_libraries(qxt Qt5::Core Qt5::Widgets)
 else(WIN32)
-  QT5_USE_MODULES(qxt Core Widgets X11Extras)
+  target_link_libraries(qxt Qt5::Core Qt5::Widgets Qt5::X11Extras)
 endif(WIN32)

--- a/ext/libclementine-common/CMakeLists.txt
+++ b/ext/libclementine-common/CMakeLists.txt
@@ -40,4 +40,4 @@ target_link_libraries(libclementine-common
   ${CMAKE_THREAD_LIBS_INIT}
 )
 
-QT5_USE_MODULES(libclementine-common Core Network)
+target_link_libraries(libclementine-common Qt5::Core Qt5::Network)

--- a/gst/moodbar/CMakeLists.txt
+++ b/gst/moodbar/CMakeLists.txt
@@ -28,4 +28,4 @@ target_link_libraries(gstmoodbar
   ${FFTW3_FFTW_LIBRARY}
 )
 
-QT5_USE_MODULES(gstmoodbar Core)
+target_link_libraries(gstmoodbar Qt5::Core)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -99,8 +99,7 @@ macro(add_test_file test_source gui_required)
       EXCLUDE_FROM_ALL
       ${test_source}
     )
-    target_link_libraries(${TEST_NAME} ${GMOCK_LIBRARIES} clementine_lib test_utils)
-    qt5_use_modules (${TEST_NAME} Test)
+    target_link_libraries(${TEST_NAME} ${GMOCK_LIBRARIES} clementine_lib test_utils Qt5::Test)
     set(GUI_REQUIRED ${gui_required})
     if (GUI_REQUIRED)
       target_link_libraries(${TEST_NAME} test_gui_main)


### PR DESCRIPTION
One usage of the macro remains in the bundled libmygpo-qt5. This should
be updated once the pending upstream fix was merged. qtsingleapplication
is already fixed upstream.