### PR TITLE
Limit both QSettings reads and writes

### DIFF
--- a/src/playlist/playlistcontainer.cpp
+++ b/src/playlist/playlistcontainer.cpp
@@ -94,7 +94,6 @@ PlaylistContainer::PlaylistContainer(QWidget* parent)
   ui_->tab_bar->setMaximumHeight(0);
 
   // Connections
-  connect(ui_->tab_bar, SIGNAL(currentChanged(int)), SLOT(Save()));
   connect(ui_->tab_bar, SIGNAL(Save(int)), SLOT(SavePlaylist(int)));
 
   // set up timer for delayed filter updates
@@ -109,7 +108,10 @@ PlaylistContainer::PlaylistContainer(QWidget* parent)
   ui_->filter->installEventFilter(this);
 }
 
-PlaylistContainer::~PlaylistContainer() { delete ui_; }
+PlaylistContainer::~PlaylistContainer() {
+  Save();
+  delete ui_;
+}
 
 PlaylistView* PlaylistContainer::view() const { return ui_->playlist; }
 

--- a/src/playlist/playlistview.h
+++ b/src/playlist/playlistview.h
@@ -57,6 +57,8 @@ class PlaylistProxyStyle : public QProxyStyle {
 class PlaylistView : public QTreeView {
   Q_OBJECT
  public:
+  ~PlaylistView();
+
   enum BackgroundImageType { Default, None, Custom, AlbumCover };
 
   PlaylistView(QWidget* parent = nullptr);
@@ -194,6 +196,7 @@ signals:
   bool upgrading_from_qheaderview_;
   bool read_only_settings_;
   int upgrading_from_version_;
+  bool header_loaded_;
 
   bool background_initialized_;
   BackgroundImageType background_image_type_;

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -865,11 +865,6 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
   connect(global_shortcuts_, SIGNAL(RemoveCurrentSong()),
           app_->playlist_manager(), SLOT(RemoveCurrentSong()));
 
-  // Fancy tabs
-  connect(ui_->tabs, SIGNAL(ModeChanged(FancyTabWidget::Mode)),
-          SLOT(SaveGeometry()));
-  connect(ui_->tabs, SIGNAL(CurrentChanged(int)), SLOT(SaveGeometry()));
-
   // Lyrics
   ConnectInfoView(song_info_view_);
   ConnectInfoView(artist_info_view_);
@@ -1260,8 +1255,6 @@ void MainWindow::ScrobbleButtonVisibilityChanged(bool value) {
     }
   }
 }
-
-void MainWindow::resizeEvent(QResizeEvent*) { SaveGeometry(); }
 
 void MainWindow::SaveGeometry() {
   was_maximized_ = isMaximized();

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -131,7 +131,6 @@ class MainWindow : public QMainWindow, public PlatformInterface {
 
  protected:
   void keyPressEvent(QKeyEvent* event);
-  void resizeEvent(QResizeEvent* event);
   void closeEvent(QCloseEvent* event);
 
 #ifdef Q_OS_WIN32


### PR DESCRIPTION
Any access, read or write, via QSettings requires locking `Clementine.conf`. On some devices, this can be slow. Moreover, it also increases power use and wear on devices such as SSDs.

To improve the situation, defer QSettings updates until program close for window resize, current playlist tab, and playlist geometry, i.e. `PlaylistView::SaveGeometry`.

Also, limit `PlaylistView::LoadGeometry` to once per program run.

### Testing
I'm running this on my machine right now. Before, trying to just hold down Control-Tab caused Clementine's display to hang with very high disk IO. Now it moves smoothly. Similarly, resizing the window is now smooth, whereas before it hung similarly.