### PR TITLE
Do not reset column_widths_ on model change

### DIFF
--- a/src/widgets/stretchheaderview.cpp
+++ b/src/widgets/stretchheaderview.cpp
@@ -39,11 +39,6 @@ StretchHeaderView::StretchHeaderView(Qt::Orientation orientation,
 
 void StretchHeaderView::setModel(QAbstractItemModel* model) {
   QHeaderView::setModel(model);
-
-  if (stretch_enabled_) {
-    column_widths_.resize(count());
-    std::fill(column_widths_.begin(), column_widths_.end(), 1.0 / count());
-  }
 }
 
 void StretchHeaderView::NormaliseWidths(const QList<int>& sections) {


### PR DESCRIPTION
`column_widths_` is managed elsewhere. Resetting it on model change makes tab-switching slow, and---if a vertical scroll bar becomes visible or hidden---can be triggered in unexpected situations, leading to
visible column information loss.

### Testing
I'm running this. New playlists create fine, changing tabs works fine (and its fast with "Stretch columns to fit window"). A fresh install seems to work fine, too.