### PR TITLE
Work around Qt's QUrl parser.

### DIFF
--- a/src/internet/subsonic/subsonicservice.cpp
+++ b/src/internet/subsonic/subsonicservice.cpp
@@ -541,7 +541,10 @@ void SubsonicLibraryScanner::OnGetAlbumFinished(QNetworkReply* reply) {
     qint64 length = reader.attributes().value("duration").toString().toInt();
     length *= kNsecPerSec;
     song.set_length_nanosec(length);
-    QUrl url = QUrl(QString("subsonic://%1").arg(id));
+    QUrl url = QUrl(QString("subsonic://"));
+    QUrlQuery song_query(url.query());
+    song_query.addQueryItem("id", id);
+    url.setQuery(song_query);
     QUrl cover_url = service_->BuildRequestUrl("getCoverArt");
     QUrlQuery cover_url_query(url.query());
     cover_url_query.addQueryItem("id", id);

--- a/src/internet/subsonic/subsonicurlhandler.cpp
+++ b/src/internet/subsonic/subsonicurlhandler.cpp
@@ -30,9 +30,10 @@ UrlHandler::LoadResult SubsonicUrlHandler::StartLoading(const QUrl& url) {
   if (service_->login_state() != SubsonicService::LoginState_Loggedin)
     return LoadResult(url);
 
+  QUrlQuery id(url.query());
   QUrl newurl = service_->BuildRequestUrl("stream");
   QUrlQuery url_query(newurl.query());
-  url_query.addQueryItem("id", url.host());
+  url_query.addQueryItem("id", id.queryItemValue("id"));
   newurl.setQuery(url_query);
   return LoadResult(url, LoadResult::TrackAvailable, newurl);
 }


### PR DESCRIPTION
Qt's QUrl parser does no longer accept pure numeric hostnames without
trying to make a dotted IPv4 address of them.
Thus current method of storing subsonic's numeric ids in the host part
of a QUrl ("subsonic://<id>") does no longer work.
Instead a query is constructed omitting the host-part entirely and using
"subsonic://?id=<id>" to store and retrieve subsonic titles.