### PR TITLE
Add option to verify subsonic server certificate.

### DIFF
--- a/src/internet/subsonic/subsonicservice.cpp
+++ b/src/internet/subsonic/subsonicservice.cpp
@@ -195,6 +195,10 @@ void SubsonicService::ReloadSettings() {
   username_ = s.value("username").toString();
   password_ = s.value("password").toString();
   usesslv3_ = s.value("usesslv3").toBool();
+  if (s.contains("verifycert"))
+    verifycert_ = s.value("verifycert").toBool();
+  else
+    verifycert_ = true;
 
   Login();
 }
@@ -225,11 +229,13 @@ void SubsonicService::Login() {
 }
 
 void SubsonicService::Login(const QString& server, const QString& username,
-                            const QString& password, const bool& usesslv3) {
+                            const QString& password,
+                            const bool& usesslv3, const bool& verifycert) {
   UpdateServer(server);
   username_ = username;
   password_ = password;
   usesslv3_ = usesslv3;
+  verifycert_ = verifycert;
   Login();
 }
 
@@ -263,7 +269,7 @@ QNetworkReply* SubsonicService::Send(const QUrl& url) {
   // Don't try and check the authenticity of the SSL certificate - it'll almost
   // certainly be self-signed.
   QSslConfiguration sslconfig = QSslConfiguration::defaultConfiguration();
-  sslconfig.setPeerVerifyMode(QSslSocket::VerifyNone);
+  sslconfig.setPeerVerifyMode(verifycert_ ? QSslSocket::VerifyPeer : QSslSocket::VerifyNone);
   if (usesslv3_) {
     sslconfig.setProtocol(QSsl::SslV3);
   }

--- a/src/internet/subsonic/subsonicservice.h
+++ b/src/internet/subsonic/subsonicservice.h
@@ -97,7 +97,8 @@ class SubsonicService : public InternetService {
 
   void Login();
   void Login(const QString& server, const QString& username,
-             const QString& password, const bool& usesslv3);
+             const QString& password,
+             const bool& usesslv3, const bool& verifycert);
 
   LoginState login_state() const { return login_state_; }
 
@@ -154,6 +155,7 @@ signals:
   QString username_;
   QString password_;
   bool usesslv3_;
+  bool verifycert_;
 
   LoginState login_state_;
   QString working_server_;  // The actual server, possibly post-redirect

--- a/src/internet/subsonic/subsonicsettingspage.cpp
+++ b/src/internet/subsonic/subsonicsettingspage.cpp
@@ -45,6 +45,7 @@ SubsonicSettingsPage::SubsonicSettingsPage(SettingsDialog* dialog)
   ui_->login_state->AddCredentialField(ui_->username);
   ui_->login_state->AddCredentialField(ui_->password);
   ui_->login_state->AddCredentialField(ui_->usesslv3);
+  ui_->login_state->AddCredentialField(ui_->verifycert);
   ui_->login_state->AddCredentialGroup(ui_->server_group);
 
   ui_->login_state->SetAccountTypeText(
@@ -63,6 +64,11 @@ void SubsonicSettingsPage::Load() {
   ui_->username->setText(s.value("username").toString());
   ui_->password->setText(s.value("password").toString());
   ui_->usesslv3->setChecked(s.value("usesslv3").toBool());
+  if (s.contains("verifycert"))
+    ui_->verifycert->setChecked(s.value("verifycert").toBool());
+  else
+    ui_->verifycert->setChecked(true);
+
 
   // If the settings are complete, SubsonicService will have used them already
   // and
@@ -80,6 +86,7 @@ void SubsonicSettingsPage::Save() {
   s.setValue("username", ui_->username->text());
   s.setValue("password", ui_->password->text());
   s.setValue("usesslv3", ui_->usesslv3->isChecked());
+  s.setValue("verifycert", ui_->verifycert->isChecked());
 }
 
 void SubsonicSettingsPage::LoginStateChanged(
@@ -190,7 +197,9 @@ void SubsonicSettingsPage::ServerEditingFinished() {
 void SubsonicSettingsPage::Login() {
   ui_->login_state->SetLoggedIn(LoginStateWidget::LoginInProgress);
   service_->Login(ui_->server->text(), ui_->username->text(),
-                  ui_->password->text(), ui_->usesslv3->isChecked());
+                  ui_->password->text(),
+                  ui_->usesslv3->isChecked(),
+                  ui_->verifycert->isChecked());
 }
 
 void SubsonicSettingsPage::Logout() {

--- a/src/internet/subsonic/subsonicsettingspage.ui
+++ b/src/internet/subsonic/subsonicsettingspage.ui
@@ -44,17 +44,17 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1" colspan="2">
+      <item row="2" column="1" colspan="3">
        <widget class="QLineEdit" name="password">
         <property name="echoMode">
          <enum>QLineEdit::Password</enum>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="1" column="1" colspan="2">
        <widget class="QLineEdit" name="username"/>
       </item>
-      <item row="0" column="1" colspan="2">
+      <item row="0" column="1" colspan="3">
        <widget class="QLineEdit" name="server"/>
       </item>
       <item row="3" column="1">
@@ -64,7 +64,17 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
+      <item row="3" column="2">
+       <widget class="QCheckBox" name="verifycert">
+        <property name="text">
+         <string>Verify Server certificate</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
        <widget class="QPushButton" name="login">
         <property name="text">
          <string>Login</string>


### PR DESCRIPTION
Defaults to true, as it is safer to have a server certificate verified,
even more so, if the server is used over an insecure WAN link.
During subsonic configuration the checkbox can be deactivated, so that
no certificate verification will occur when talking to a subsonic
server, allowing for self-signed certificates.

With the proliferation of let's encrypt certificates there's probably
less need for this option but it has been requested and hard-coding
verify-off is IMHO bad security practice.
If a valid certificate has been installed, the configuration file can be
modified manually and after a restart Clementine will perform a proper
server certificate verification.

The patch might need some UI polishing and asks for string translations
but is operational so far.