### PR TITLE
Fix crash when uridecodebin fails.

### DIFF
--- a/src/engines/gstengine.cpp
+++ b/src/engines/gstengine.cpp
@@ -759,7 +759,7 @@ GstElement* GstEngine::CreateElement(const QString& factoryName,
                    "GStreamer could not create the element: %1.  "
                    "Please make sure that you have installed all necessary "
                    "GStreamer plugins (e.g. OGG and MP3)").arg(factoryName));
-    gst_object_unref(GST_OBJECT(bin));
+    if (bin) gst_object_unref(GST_OBJECT(bin));
     return nullptr;
   }
 

--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -157,8 +157,9 @@ bool GstEnginePipeline::ReplaceDecodeBin(const QUrl& url) {
 
     // Create elements
     GstElement* src = engine_->CreateElement("tcpserversrc", new_bin);
+    if (!src) return false;
     GstElement* gdp = engine_->CreateElement("gdpdepay", new_bin);
-    if (!src || !gdp) return false;
+    if (!gdp) return false;
 
     // Pick a port number
     const int port = Utilities::PickUnusedPort();
@@ -182,6 +183,7 @@ bool GstEnginePipeline::ReplaceDecodeBin(const QUrl& url) {
         Q_ARG(QString, url.toString()), Q_ARG(quint16, port));
   } else {
     new_bin = engine_->CreateElement("uridecodebin");
+    if (!new_bin) return false;
     g_object_set(G_OBJECT(new_bin), "uri", url.toEncoded().constData(),
                  nullptr);
     CHECKED_GCONNECT(G_OBJECT(new_bin), "drained", &SourceDrainedCallback,


### PR DESCRIPTION
Let's the user see the error message what failed instead of Clementine crashing.

Also don't do gst_object_unref unless bin is set.
This fixes GStreamer-CRITICAL gst_object_unref: assertion 'object != NULL' failed

Fixes #5753 
