### PR TITLE
Fix setting device on windows

### DIFF
--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -253,7 +253,8 @@ bool GstEnginePipeline::Init() {
                      device_.toString().toUtf8().constData(), nullptr);
         break;
       case QVariant::ByteArray: {
-	g_object_set(G_OBJECT(audiosink_), "device", device_.toByteArray().constData(), nullptr);
+        g_object_set(G_OBJECT(audiosink_), "device",
+                     device_.toByteArray().constData(), nullptr);
         break;
       }
 

--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -21,7 +21,6 @@
 #include <QDir>
 #include <QPair>
 #include <QRegExp>
-#include <QUuid>
 
 #include "bufferconsumer.h"
 #include "config.h"
@@ -253,14 +252,10 @@ bool GstEnginePipeline::Init() {
         g_object_set(G_OBJECT(audiosink_), "device",
                      device_.toString().toUtf8().constData(), nullptr);
         break;
-
-#ifdef Q_OS_WIN32
       case QVariant::ByteArray: {
-        GUID guid = QUuid(device_.toByteArray());
-        g_object_set(G_OBJECT(audiosink_), "device", &guid, nullptr);
+	g_object_set(G_OBJECT(audiosink_), "device", device_.toByteArray().constData(), nullptr);
         break;
       }
-#endif  // Q_OS_WIN32
 
       default:
         qLog(Warning) << "Unknown device type" << device_;


### PR DESCRIPTION
Setting device on windows is currently broken, possible because of newer version of gstreamer.
This is tested on Windows 10 with gstreamer 1.14.0
Also tested on Qt5 branch.
