### PR TITLE
Implemented SPC File Playback and Tag Reading Functionality

### DIFF
--- a/ext/libclementine-remote/remotecontrolmessages.proto
+++ b/ext/libclementine-remote/remotecontrolmessages.proto
@@ -105,6 +105,7 @@ message SongMetadata {
     CDDA = 12;
     OGGOPUS = 13;
     WAVPACK = 14;
+    SPC = 15;
     STREAM = 99;
   }
 

--- a/ext/libclementine-tagreader/CMakeLists.txt
+++ b/ext/libclementine-tagreader/CMakeLists.txt
@@ -14,6 +14,7 @@ set(MESSAGES
 set(SOURCES
   fmpsparser.cpp
   tagreader.cpp
+  gmereader.cpp
 )
 
 set(HEADERS

--- a/ext/libclementine-tagreader/gmereader.cpp
+++ b/ext/libclementine-tagreader/gmereader.cpp
@@ -1,0 +1,151 @@
+#include "core/logging.h"
+#include "core/timeconstants.h"
+#include "gmereader.h"
+#include "tagreader.h"
+
+#include <apefile.h>
+#include <tag.h>
+#include <QByteArray>
+#include <QFile>
+#include <QFileInfo>
+#include <QString>
+#include <QtEndian>
+
+bool GME::IsSupportedFormat(const QFileInfo& file_info) {
+  return file_info.completeSuffix().endsWith("spc");
+}
+
+void GME::ReadFile(const QFileInfo& file_info,
+                   pb::tagreader::SongMetadata* song_info) {
+  if (file_info.completeSuffix().endsWith("spc"))
+    GME::SPC::Read(file_info, song_info);
+}
+
+void GME::SPC::Read(const QFileInfo& file_info,
+                    pb::tagreader::SongMetadata* song_info) {
+  QFile file(file_info.filePath());
+  if (!file.open(QIODevice::ReadOnly)) return;
+
+  qLog(Debug) << "Reading SPC from file" << file_info.fileName();
+
+  // Check for header -- more reliable than file name alone.
+  if (!file.read(33).startsWith(QString("SNES-SPC700").toAscii())) return;
+
+  /*
+   * First order of business -- get any tag values that exist within the core
+   * file information. These only allow for a certain number of bytes
+   * per field, so they will likely be overwritten either by the id666 standard
+   * or the APETAG format (as used by other players, such as foobar and winamp)
+   *
+   * Make sure to check id6 documentation before changing the read values!
+   */
+
+  file.seek(HAS_ID6_OFFSET);
+  bool has_id6 = (file.read(1)[0] == (char)xID6_STATUS::ON);
+
+  file.seek(SONG_TITLE_OFFSET);
+  song_info->set_title(QString::fromAscii(file.read(32)).toStdString());
+
+  file.seek(GAME_TITLE_OFFSET);
+  song_info->set_album(QString::fromAscii(file.read(32)).toStdString());
+
+  file.seek(ARTIST_OFFSET);
+  song_info->set_artist(QString::fromAscii(file.read(32)).toStdString());
+
+  file.seek(INTRO_LENGTH_OFFSET);
+  QByteArray length_bytes = file.read(INTRO_LENGTH_SIZE);
+  quint64 length_in_sec = 0;
+  if (length_bytes.size() >= INTRO_LENGTH_SIZE) {
+    length_in_sec = ConvertSPCStringToNum(length_bytes);
+    qLog(Debug) << length_in_sec << "------ LENGTH";
+
+    if (!length_in_sec || length_in_sec >= 0x1FFF) {
+      // This means that parsing the length as a string failed, so get value LE.
+      length_in_sec =
+          length_bytes[0] | (length_bytes[1] << 8) | (length_bytes[2] << 16);
+    }
+
+    if (length_in_sec < 0x1FFF) {
+      song_info->set_length_nanosec(length_in_sec * kNsecPerSec);
+    }
+  }
+
+  file.seek(FADE_LENGTH_OFFSET);
+  QByteArray fade_bytes = file.read(FADE_LENGTH_SIZE);
+  if (fade_bytes.size() >= FADE_LENGTH_SIZE) {
+    quint64 fade_length_in_ms = ConvertSPCStringToNum(fade_bytes);
+    qLog(Debug) << fade_length_in_ms << "------ Fade Length";
+
+    if (fade_length_in_ms > 0x7FFF) {
+      fade_length_in_ms = fade_bytes[0] | (fade_bytes[1] << 8) |
+                          (fade_bytes[2] << 16) | (fade_bytes[3] << 24);
+    }
+  }
+
+  /*  Check for XID6 data -- this is infrequently used, but being able to fill
+   * in data from this is ideal before trying to rely on APETAG values. XID6
+   * format follows EA's binary file format standard named "IFF" */
+  file.seek(XID6_OFFSET);
+  if (has_id6 && file.read(4) == QString("xid6").toAscii()) {
+    QByteArray xid6_head_data = file.read(4);
+    if (xid6_head_data.size() >= 4) {
+      qint64 xid6_size = xid6_head_data[0] | (xid6_head_data[1] << 8) |
+                         (xid6_head_data[2] << 16) | xid6_head_data[3];
+      /* This should be the size remaining for entire ID6 block, but it
+       * seems that most files treat this as the size of the remaining header
+       * space... */
+
+      qLog(Debug) << file_info.fileName() << " has ID6 tag.";
+
+      while ((file.pos()) + 4 < XID6_OFFSET + xid6_size) {
+        QByteArray arr = file.read(4);
+        if (arr.size() < 4) break;
+
+        qint8 id = arr[0];
+        qint8 type = arr[1];
+        qint16 length = arr[2] | (arr[3] << 8);
+
+        file.read(GetNextMemAddressAlign32bit(length));
+      }
+    }
+  }
+
+  /* Music Players that support SPC tend to support additional tagging data as
+   * an APETAG entry at the bottom of the file instead of writing into the xid6
+   * tagging space. This is where a lot of the extra data for a file is stored,
+   * such as genre or replaygain data.
+   *
+   * This data is currently supported by TagLib, so we will simply use that for
+   * the remaining values. */
+  TagLib::APE::File ape(file_info.filePath().toStdString().data());
+  if (ape.hasAPETag()) {
+    TagLib::Tag* tag = ape.tag();
+    if (!tag) return;
+
+    song_info->set_year(tag->year());
+    song_info->set_track(tag->track());
+    TagReader::Decode(tag->artist(), nullptr, song_info->mutable_artist());
+    TagReader::Decode(tag->title(), nullptr, song_info->mutable_title());
+    TagReader::Decode(tag->album(), nullptr, song_info->mutable_album());
+    TagReader::Decode(tag->genre(), nullptr, song_info->mutable_genre());
+    song_info->set_valid(true);
+  }
+
+  song_info->set_type(pb::tagreader::SongMetadata_Type_SPC);
+}
+
+qint16 GME::SPC::GetNextMemAddressAlign32bit(qint16 input) {
+  return ((input + 0x3) & ~0x3);
+  // Plus 0x3 for rounding up (not down), AND NOT to flatten out on a 32 bit
+  // level.
+}
+
+quint64 GME::SPC::ConvertSPCStringToNum(const QByteArray& arr) {
+  quint64 result = 0;
+  for (auto it = arr.begin(); it != arr.end(); it++) {
+    unsigned int num = *it - '0';
+    if (num > 9) break;
+    result = (result * 10) + num;  // Shift Left and add.
+  }
+  return result;
+}

--- a/ext/libclementine-tagreader/gmereader.h
+++ b/ext/libclementine-tagreader/gmereader.h
@@ -1,0 +1,51 @@
+#ifndef GMEREADER_H
+#define GMEREADER_H
+
+#include <QtCore>
+#include "tagreadermessages.pb.h"
+
+class QFileInfo;
+class QByteArray;
+
+namespace GME {
+bool IsSupportedFormat(const QFileInfo& file_info);
+void ReadFile(const QFileInfo& file_info,
+              pb::tagreader::SongMetadata* song_info);
+
+namespace SPC {
+/* SPC SPEC:
+ * http://vspcplay.raphnet.net/spc_file_format.txt
+ */
+const int HAS_ID6_OFFSET = 0x23;
+const int SONG_TITLE_OFFSET = 0x2E;
+const int GAME_TITLE_OFFSET = 0x4E;
+const int DUMPER_OFFSET = 0x6E;
+const int COMMENTS_OFFSET = 0x7E;
+/*It seems that intro length and fade length are inconsistent from
+ *file to file. It should be looked into within the GME source code
+ *to see how GStreamer gets its values for playback length.*/
+const int INTRO_LENGTH_OFFSET = 0xA9;
+const int INTRO_LENGTH_SIZE = 3;
+const int FADE_LENGTH_OFFSET = 0xAC;
+const int FADE_LENGTH_SIZE = 4;
+const int ARTIST_OFFSET = 0xB1;
+const int XID6_OFFSET = (0x101C0 + 64);
+
+const int NANO_PER_MS = 1000000;
+
+enum xID6_STATUS {
+  ON = 0x26,
+  OFF = 0x27,
+};
+
+enum xID6_ID { SongName = 0x01, GameName = 0x02, ArtistName = 0x03 };
+
+enum xID6_TYPE { Length = 0x0, String = 0x1, Integer = 0x4 };
+
+void Read(const QFileInfo& file_info, pb::tagreader::SongMetadata* song_info);
+qint16 GetNextMemAddressAlign32bit(qint16 input);
+quint64 ConvertSPCStringToNum(const QByteArray& arr);
+}  // namespace SPC
+}  // namespace GME
+
+#endif

--- a/ext/libclementine-tagreader/tagreadermessages.proto
+++ b/ext/libclementine-tagreader/tagreadermessages.proto
@@ -17,6 +17,7 @@ message SongMetadata {
     CDDA = 12;
     OGGOPUS = 13;
     WAVPACK = 14;
+    SPC = 15;
     STREAM = 99;
   }
 

--- a/src/core/song.cpp
+++ b/src/core/song.cpp
@@ -70,6 +70,7 @@
 #include "core/utilities.h"
 #include "covers/albumcoverloader.h"
 #include "engines/enginebase.h"
+#include "gmereader.h"
 #include "library/sqlrow.h"
 #include "tagreadermessages.pb.h"
 #include "widgets/trackslider.h"
@@ -434,6 +435,8 @@ QString Song::TextForFiletype(FileType type) {
       return QObject::tr("TrueAudio");
     case Song::Type_Cdda:
       return QObject::tr("CDDA");
+    case Song::Type_Spc:
+      return QObject::tr("SNES SPC700");
 
     case Song::Type_Stream:
       return QObject::tr("Stream");
@@ -672,12 +675,13 @@ void Song::InitFromFilePartial(const QString& filename) {
   QString suffix = info.suffix().toLower();
 
   TagLib::FileRef fileref(filename.toUtf8().constData());
-  if (fileref.file()) d->valid_ = true;
+  if (fileref.file() || GME::IsSupportedFormat(info))
+    d->valid_ = true;
   else {
     d->valid_ = false;
-    qLog(Error) << "File" << filename << "is not recognized by TagLib as a valid audio file.";
+    qLog(Error) << "File" << filename
+                << "is not recognized by TagLib as a valid audio file.";
   }
-
 }
 
 void Song::InitArtManual() {

--- a/src/core/song.h
+++ b/src/core/song.h
@@ -102,6 +102,7 @@ class Song {
     Type_Cdda = 12,
     Type_OggOpus = 13,
     Type_WavPack = 14,
+    Type_Spc = 15,
     Type_Stream = 99,
   };
   static QString TextForFiletype(FileType type);

--- a/src/widgets/fileview.cpp
+++ b/src/widgets/fileview.cpp
@@ -15,17 +15,17 @@
    along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "fileview.h"
-#include "ui_fileview.h"
 #include "core/deletefiles.h"
 #include "core/filesystemmusicstorage.h"
 #include "core/mimedata.h"
+#include "fileview.h"
 #include "ui/iconloader.h"
 #include "ui/mainwindow.h"  // for filter information
 #include "ui/organiseerrordialog.h"
+#include "ui_fileview.h"
 
-#include <QKeyEvent>
 #include <QFileSystemModel>
+#include <QKeyEvent>
 #include <QMessageBox>
 #include <QScrollBar>
 
@@ -33,7 +33,7 @@ const char* FileView::kFileFilter =
     "*.mp3 *.ogg *.flac *.mpc *.m4a *.m4b *.aac *.wma "
     "*.mp4 *.spx *.wav *.m3u *.m3u8 *.pls *.xspf "
     "*.asx *.asxini *.cue *.ape *.wv *.mka *.opus "
-    "*.oga *.mka *.mp2";
+    "*.oga *.mka *.mp2 *.spc";
 
 FileView::FileView(QWidget* parent)
     : QWidget(parent),


### PR DESCRIPTION
Solving issue #5866 and in progress of #2284 , I've added playback of SPC (SNES emulated) music files and also support reading tag data from the SPC ID6 format.  

The SPC format is an emulated SNES song format that is supported by GStreamer, so much of the complicated backend work was already completed. For the time being, since TagLib does not recognize SPC's internal tagging format, the reading of tagging information is handled in a GMEReader namespace added to libclementine-tagreader. In order to maintain parity with other playback systems (such as foobar and winamp), additional tagging information is sometimes stored within an ApeTag suffix to the SPC file data.

The code has been documented wherever necessary, and the groundwork for adding more game song emulation formats has been introduced. I'd like to eventually add support for other playback formats such as VGM and NSF, and I'd also be interested in upstreaming SPC tag support to taglib (but I haven't looked into that yet.)

Also, I can share some SPC files for testing purposes if needed. 