### PR TITLE
Song selection via remote app respecting behavioral settings

### DIFF
--- a/src/networkremote/incomingdataparser.h
+++ b/src/networkremote/incomingdataparser.h
@@ -5,6 +5,7 @@
 #include "core/application.h"
 #include "remotecontrolmessages.pb.h"
 #include "remoteclient.h"
+#include "ui/mainwindow.h"
 
 class IncomingDataParser : public QObject {
   Q_OBJECT
@@ -16,6 +17,7 @@ class IncomingDataParser : public QObject {
 
  public slots:
   void Parse(const pb::remote::Message& msg);
+  void ReloadSettings();
 
 signals:
   void SendClementineInfo();
@@ -38,6 +40,7 @@ signals:
   void Previous();
   void SetVolume(int volume);
   void PlayAt(int i, Engine::TrackChangeFlags change, bool reshuffle);
+  void Enque(int id, int i);
   void SetActivePlaylist(int id);
   void ShuffleCurrent();
   void SetRepeatMode(PlaylistSequence::RepeatMode mode);
@@ -56,6 +59,7 @@ signals:
  private:
   Application* app_;
   bool close_connection_;
+  MainWindow::PlaylistAddBehaviour doubleclick_playlist_addmode_;
 
   void GetPlaylistSongs(const pb::remote::Message& msg);
   void ChangeSong(const pb::remote::Message& msg);

--- a/src/playlist/playlistmanager.cpp
+++ b/src/playlist/playlistmanager.cpp
@@ -29,6 +29,7 @@
 #include "library/libraryplaylistitem.h"
 #include "playlistparsers/playlistparser.h"
 #include "smartplaylists/generator.h"
+#include "queue.h"
 
 #include <QFileDialog>
 #include <QFileInfo>
@@ -63,7 +64,7 @@ PlaylistManager::~PlaylistManager() {
 void PlaylistManager::Init(LibraryBackend* library_backend,
                            PlaylistBackend* playlist_backend,
                            PlaylistSequence* sequence,
-                           PlaylistContainer* playlist_container) {
+                           PlaylistContainer* playlist_container) { 
   library_backend_ = library_backend;
   playlist_backend_ = playlist_backend;
   sequence_ = sequence;
@@ -395,6 +396,15 @@ void PlaylistManager::RateCurrentSong(int rating) {
 
 void PlaylistManager::ChangePlaylistOrder(const QList<int>& ids) {
   playlist_backend_->SetPlaylistOrder(ids);
+}
+
+void PlaylistManager::Enque(int id, int i) {
+    QModelIndexList dummyIndexList;
+
+    Q_ASSERT(playlists_.contains(id));
+
+    dummyIndexList.append(playlist(id)->index(i, 0));
+    playlist(id)->queue()->ToggleTracks(dummyIndexList);
 }
 
 void PlaylistManager::UpdateSummaryText() {

--- a/src/playlist/playlistmanager.h
+++ b/src/playlist/playlistmanager.h
@@ -84,6 +84,8 @@ class PlaylistManagerInterface : public QObject {
   virtual void Open(int id) = 0;
   virtual void ChangePlaylistOrder(const QList<int>& ids) = 0;
 
+  virtual void Enque(int id, int index) = 0;
+
   virtual void SongChangeRequestProcessed(const QUrl& url, bool valid) = 0;
 
   virtual void SetCurrentPlaylist(int id) = 0;
@@ -191,6 +193,8 @@ class PlaylistManager : public PlaylistManagerInterface {
   bool Close(int id);
   void Open(int id);
   void ChangePlaylistOrder(const QList<int>& ids);
+
+  void Enque(int id, int index);
 
   void SetCurrentPlaylist(int id);
   void SetActivePlaylist(int id);


### PR DESCRIPTION
Currently, clicking on songs in playlists via remote control will result in direct playback. With this changes, the behavioral settings are taken into account. Therefore, the selected song will either be played directly or added to Queue, depending on user setup (using parameter "doubleclick_playlist_addmode"). For reading parameters, a ReloadSettings() hook has been added, too.
This makes the remote control app behave more like the local GUI without changing anything within the remote protocol. Unfortunately, it is currently not possible to display the queued elements within the remote app without changing the protocol.
