### PR TITLE
Fix loading output/device setting in Playback Settings

### DIFF
--- a/src/engines/gstengine.cpp
+++ b/src/engines/gstengine.cpp
@@ -951,6 +951,7 @@ GstEngine::OutputDetailsList GstEngine::GetOutputsList() const {
   OutputDetails default_output;
   default_output.description = tr("Choose automatically");
   default_output.gstreamer_plugin_name = kAutoSink;
+  default_output.device_property_value = QString("");
   ret.append(default_output);
 
   for (DeviceFinder* finder : device_finders_) {
@@ -976,6 +977,7 @@ GstEngine::OutputDetailsList GstEngine::GetOutputsList() const {
       OutputDetails output;
       output.description = tr("Default device on %1").arg(plugin.description);
       output.gstreamer_plugin_name = plugin.name;
+      output.device_property_value = QString("");
       ret.append(output);
     }
   }

--- a/src/ui/playbacksettingspage.cpp
+++ b/src/ui/playbacksettingspage.cpp
@@ -91,7 +91,7 @@ void PlaybackSettingsPage::Load() {
 
   s.beginGroup(GstEngine::kSettingsGroup);
   QString sink = s.value("sink", GstEngine::kAutoSink).toString();
-  QString device = s.value("device").toString();
+  QVariant device = s.value("device");
 
   ui_->gst_output->setCurrentIndex(0);
   for (int i = 0; i < ui_->gst_output->count(); ++i) {


### PR DESCRIPTION
Currently there is a bug in the Playback Settings. It does successfully save the selected value for output device when you close the settings, but it does not load it if it is set to a plain sink without a device.
This is because in PlaybackSettingsPage::Load() it's comparing a invalid QVariant value to a the loaded device which is a empty string (details.device_property_value == device) which does not match.

- Load device setting as a QVariant instead of a QString.
- Set empty string for sinks with default devices and auto sink (optional)

The output device setting is now loaded. Tested on Linux. Also tested on the Qt 5 branch. On Windows this was not broken before, since there are no sinks without devices, but I've also tested to cross build and run on windows just to make sure it still works.

Fixes #5241 