### PR TITLE
Device fixes for MacOs

### DIFF
--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -248,6 +248,9 @@ bool GstEnginePipeline::Init() {
       case QVariant::Int:
         g_object_set(G_OBJECT(audiosink_), "device", device_.toInt(), nullptr);
         break;
+      case QVariant::LongLong:
+        g_object_set(G_OBJECT(audiosink_), "device", device_.toLongLong(), nullptr);
+        break;
       case QVariant::String:
         g_object_set(G_OBJECT(audiosink_), "device",
                      device_.toString().toUtf8().constData(), nullptr);

--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -249,7 +249,8 @@ bool GstEnginePipeline::Init() {
         g_object_set(G_OBJECT(audiosink_), "device", device_.toInt(), nullptr);
         break;
       case QVariant::LongLong:
-        g_object_set(G_OBJECT(audiosink_), "device", device_.toLongLong(), nullptr);
+        g_object_set(G_OBJECT(audiosink_), "device", device_.toLongLong(),
+                     nullptr);
         break;
       case QVariant::String:
         g_object_set(G_OBJECT(audiosink_), "device",

--- a/src/engines/osxdevicefinder.cpp
+++ b/src/engines/osxdevicefinder.cpp
@@ -107,6 +107,7 @@ QList<DeviceFinder::Device> OsxDeviceFinder::ListDevices() {
     Device dev;
     dev.description = QString::fromUtf8(
         CFStringGetCStringPtr(*device_name, CFStringGetSystemEncoding()));
+    if (dev.description.isEmpty()) dev.description = QString("Unknown device");
     dev.device_property_value = id;
     dev.icon_name = GuessIconName(dev.description);
     ret.append(dev);


### PR DESCRIPTION
- Fix setting device on newer MacOs where the property value is longlong.
- Some devices (ie one my USB Arcam DAC's) return an empty description, set this to "Unknown device" so it's possible to select it.
