### PR TITLE
Prevent closing of the RipCDDialog if the ripper is running

### DIFF
--- a/src/ripper/ripcddialog.cpp
+++ b/src/ripper/ripcddialog.cpp
@@ -18,6 +18,7 @@
 #include "ripper/ripcddialog.h"
 
 #include <QCheckBox>
+#include <QCloseEvent>
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QLineEdit>
@@ -45,7 +46,7 @@ const int kCheckboxColumn = 0;
 const int kTrackNumberColumn = 1;
 const int kTrackTitleColumn = 2;
 const int kTrackDurationColumn = 3;
-}
+}  // namespace
 
 const char* RipCDDialog::kSettingsGroup = "Transcoder";
 const int RipCDDialog::kMaxDestinationItems = 10;
@@ -131,6 +132,12 @@ RipCDDialog::RipCDDialog(QWidget* parent)
 RipCDDialog::~RipCDDialog() {}
 
 bool RipCDDialog::CheckCDIOIsValid() { return ripper_->CheckCDIOIsValid(); }
+
+void RipCDDialog::closeEvent(QCloseEvent* event) {
+  if (working_) {
+    event->ignore();
+  }
+}
 
 void RipCDDialog::showEvent(QShowEvent* event) {
   ResetDialog();

--- a/src/ripper/ripcddialog.h
+++ b/src/ripper/ripcddialog.h
@@ -19,6 +19,7 @@
 #define SRC_RIPPER_RIPCDDIALOG_H_
 
 #include <memory>
+
 #include <QDialog>
 #include <QFile>
 
@@ -26,7 +27,9 @@
 #include "core/tagreaderclient.h"
 
 class QCheckBox;
+class QCloseEvent;
 class QLineEdit;
+class QShowEvent;
 
 class CddaSongLoader;
 class Ripper;
@@ -41,6 +44,7 @@ class RipCDDialog : public QDialog {
   bool CheckCDIOIsValid();
 
  protected:
+  void closeEvent(QCloseEvent* event);
   void showEvent(QShowEvent* event);
 
  private slots:


### PR DESCRIPTION
This prevents a segfault when a running dialog is closed and later reopened.