### PR TITLE
Fix track change hang

### DIFF
--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -276,7 +276,7 @@ bool GstEnginePipeline::Init() {
   audioconvert_ = engine_->CreateElement("audioconvert", audiobin_);
   tee = engine_->CreateElement("tee", audiobin_);
 
-  probe_queue = engine_->CreateElement("queue", audiobin_);
+  probe_queue = engine_->CreateElement("queue2", audiobin_);
   probe_converter = engine_->CreateElement("audioconvert", audiobin_);
   probe_sink = engine_->CreateElement("fakesink", audiobin_);
 


### PR DESCRIPTION
This fixes https://github.com/clementine-player/Clementine/issues/4189 and https://github.com/clementine-player/Clementine/issues/6062 on at least Linux systems with PulseAudio. I do not have Windows/MacOS to test on.

When switching between tracks with different sample rates, the probe queue blocks before the pipeline can emit EOS. This prevents the track change from proceeding without manual intervention. This appears to be because the queue element doesn't handle the rate change correctly (either due to buffer length, or cap negotiation). The queue2 element however does handle this properly without blocking indefinitely.

The previous workaround for these issues was to force the sample rate for the entire pipeline to a fixed value in the settings so that a rate change never occurred.