### PR TITLE
SPC Playback Correction - Prevent Duplicate Playback

### DIFF
--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -900,7 +900,8 @@ GstPadProbeReturn GstEnginePipeline::HandoffCallback(GstPad*,
 
   if (instance->emit_track_ended_on_time_discontinuity_) {
     if (GST_BUFFER_FLAG_IS_SET(buf, GST_BUFFER_FLAG_DISCONT) ||
-        GST_BUFFER_OFFSET(buf) < instance->last_buffer_offset_) {
+        GST_BUFFER_OFFSET(buf) < instance->last_buffer_offset_ ||
+        !GST_BUFFER_OFFSET_IS_VALID(buf)) {
       qLog(Debug) << "Buffer discontinuity - emitting EOS";
       instance->emit_track_ended_on_time_discontinuity_ = false;
       emit instance->EndOfStreamReached(instance->id(), true);


### PR DESCRIPTION
Addressing #6125 -- This fixes an issue with SPC playback where tracks would not properly register end-of-stream (TrackEnded, specifically) notifications when a new track begins due to a SourceDrained event. This caused tracks to play twice and not update the "current playing track" status in a given playlist. 

This was fixed by adding an extra condition to the "emit_track_ended_on_time_discontinuity_" stem where we now also check if a GST Buffer type is not valid (since the return of GST_Buffer_Offset will always return maximum size, giving garbage data back.)