### PR TITLE
Date columns for use in library search queries.

### DIFF
--- a/src/core/song.cpp
+++ b/src/core/song.cpp
@@ -131,6 +131,10 @@ const QStringList Song::kIntColumns = QStringList() << "track"
 const QStringList Song::kFloatColumns = QStringList() << "rating"
                                                       << "bpm";
 
+const QStringList Song::kDateColumns = QStringList() << "lastplayed"
+                                                     << "mtime"
+                                                     << "ctime";
+
 const QString Song::kColumnSpec = Song::kColumns.join(", ");
 const QString Song::kBindSpec =
     Utilities::Prepend(":", Song::kColumns).join(", ");

--- a/src/core/song.h
+++ b/src/core/song.h
@@ -75,6 +75,7 @@ class Song {
 
   static const QStringList kIntColumns;
   static const QStringList kFloatColumns;
+  static const QStringList kDateColumns;
 
   static const QStringList kFtsColumns;
   static const QString kFtsColumnSpec;

--- a/src/library/libraryfilterwidget.cpp
+++ b/src/library/libraryfilterwidget.cpp
@@ -46,7 +46,8 @@ LibraryFilterWidget::LibraryFilterWidget(QWidget* parent)
   // Add the available fields to the tooltip here instead of the ui
   // file to prevent that they get translated by mistake.
   QString available_fields =
-      (Song::kFtsColumns + Song::kIntColumns + Song::kFloatColumns)
+      (Song::kFtsColumns + Song::kIntColumns +
+       Song::kFloatColumns + Song::kDateColumns)
           .join(", ").replace(QRegExp("\\bfts"), "");
   ui_->filter->setToolTip(ui_->filter->toolTip().arg(available_fields));
 

--- a/src/library/libraryfilterwidget.cpp
+++ b/src/library/libraryfilterwidget.cpp
@@ -46,7 +46,8 @@ LibraryFilterWidget::LibraryFilterWidget(QWidget* parent)
   // Add the available fields to the tooltip here instead of the ui
   // file to prevent that they get translated by mistake.
   QString available_fields =
-      Song::kFtsColumns.join(", ").replace(QRegExp("\\bfts"), "");
+      (Song::kFtsColumns + Song::kIntColumns + Song::kFloatColumns)
+          .join(", ").replace(QRegExp("\\bfts"), "");
   ui_->filter->setToolTip(ui_->filter->toolTip().arg(available_fields));
 
   connect(ui_->filter, SIGNAL(returnPressed()), SIGNAL(ReturnPressed()));

--- a/src/library/libraryfilterwidget.cpp
+++ b/src/library/libraryfilterwidget.cpp
@@ -45,10 +45,10 @@ LibraryFilterWidget::LibraryFilterWidget(QWidget* parent)
 
   // Add the available fields to the tooltip here instead of the ui
   // file to prevent that they get translated by mistake.
-  QString available_fields =
-      (Song::kFtsColumns + Song::kIntColumns +
-       Song::kFloatColumns + Song::kDateColumns)
-          .join(", ").replace(QRegExp("\\bfts"), "");
+  QString available_fields = (Song::kFtsColumns + Song::kIntColumns +
+                              Song::kFloatColumns + Song::kDateColumns)
+                                 .join(", ")
+                                 .replace(QRegExp("\\bfts"), "");
   ui_->filter->setToolTip(ui_->filter->toolTip().arg(available_fields));
 
   connect(ui_->filter, SIGNAL(returnPressed()), SIGNAL(ReturnPressed()));

--- a/src/library/libraryfilterwidget.ui
+++ b/src/library/libraryfilterwidget.ui
@@ -17,13 +17,22 @@
    <property name="spacing">
     <number>0</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
     <widget class="QSearchField" name="filter" native="true">
      <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Prefix a word with a field name to limit the search to that field, e.g. &lt;span style=&quot; font-weight:600;&quot;&gt;artist:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Bode&lt;/span&gt; searches the library for all artists that contain the word Bode.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Available fields: &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;%1&lt;/span&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Prefix a word with a field name to limit the search to that field, e.g. &lt;span style=&quot; font-weight:600;&quot;&gt;artist:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Bode&lt;/span&gt; searches the library for all artists that contain the word Bode, &lt;span style=&quot; font-weight:600;&quot;&gt;playcount:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;&amp;gt;=2&lt;/span&gt; searches the library for songs played at least twice, &lt;span style=&quot; font-weight:600;&quot;&gt;lastplayed:&lt;/span&gt;&amp;lt;&lt;span style=&quot; font-style:italic;&quot;&gt;1h30m&lt;/span&gt; searches the library for songs played in the last 180 minutes.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Available fields: &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;%1&lt;/span&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="placeholderText" stdset="0">
       <string>Enter search terms here</string>
@@ -99,14 +108,14 @@
    </property>
   </action>
   <action name="save_grouping">
-    <property name="text">
-      <string>Save current grouping</string>
-    </property>
+   <property name="text">
+    <string>Save current grouping</string>
+   </property>
   </action>
   <action name="manage_groupings">
-    <property name="text">
-      <string>Manage saved groupings</string>
-    </property>
+   <property name="text">
+    <string>Manage saved groupings</string>
+   </property>
   </action>
  </widget>
  <customwidgets>

--- a/src/library/libraryquery.cpp
+++ b/src/library/libraryquery.cpp
@@ -105,6 +105,35 @@ LibraryQuery::LibraryQuery(const QueryOptions& options)
             }
           } else if (columntoken == "filetype") {
             AddWhere(columntoken, kFiletypeId[val]);
+          } else if (Song::kDateColumns.contains(columntoken)) {
+            int seconds = 0;
+            QString tmp = "";
+            QString allowedChars = "smhd";
+            for (QChar c : val) {
+              if (c.isDigit()) {
+                tmp.append(c);
+              } else if (allowedChars.contains(c)){
+                bool ok;
+                int intVal = tmp.toInt(&ok);
+                tmp = "";
+                if (ok) {
+                  if (c == 's') {
+                    seconds += intVal;
+                  } else if (c == 'm') {
+                    seconds += intVal * 60;
+                  } else if (c == 'h') {
+                    seconds += intVal * 60 * 60;
+                  } else if (c == 'd') {
+                    seconds += intVal * 60 * 60 * 24;
+                  }
+                }
+              }
+            }
+            if (seconds > 0) {
+              int now = QDateTime::currentDateTime().toTime_t();
+              QString dt = QString("(%1-%2)").arg(now).arg(columntoken);
+              AddWhere(dt, seconds, op);
+            }
           } else {
             AddWhere(columntoken, val, op);
           }

--- a/src/library/libraryquery.cpp
+++ b/src/library/libraryquery.cpp
@@ -112,7 +112,7 @@ LibraryQuery::LibraryQuery(const QueryOptions& options)
             for (QChar c : val) {
               if (c.isDigit()) {
                 tmp.append(c);
-              } else if (allowedChars.contains(c)){
+              } else if (allowedChars.contains(c)) {
                 bool ok;
                 int intVal = tmp.toInt(&ok);
                 tmp = "";


### PR DESCRIPTION
Maybe this can close #338. Adds search by date like `lastplayed:<1h` to find songs played in the last hour. Also shows usage in the tooltip.
I changed the tooltip text in `libraryfilterwidget.ui`, is this the correct way? Will this work correctly with translations?

Also, there were some other issues merged into #338 (namely #256, #2334, #2441). #2441 specifically requested the `OR` operator, but the issue was closed and merged into #338. Maybe #2441 should be reopened or I can open a similar issue.