### PR TITLE
Set OpenGL_GL_PREFERENCE to LEGACY to silence warnings on cmake 3.11+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ if(APPLE)
   endif(NOT QT_MAC_USE_COCOA)
 endif(APPLE)
 
+set(OpenGL_GL_PREFERENCE LEGACY)
 find_package(OpenGL REQUIRED)
 find_package(Boost REQUIRED)
 find_package(Gettext REQUIRED)


### PR DESCRIPTION
Explicitly set `OpenGL_GL_PREFERENCE` to `LEGACY` to silence cmake warnings for not setting
`CMP0072`.
Fixes #6156 