### PR TITLE
Allow ignoring prefixes when sorting playlist

### DIFF
--- a/src/playlist/playlist.h
+++ b/src/playlist/playlist.h
@@ -37,6 +37,7 @@ class TaskManager;
 
 class QSortFilterProxyModel;
 class QUndoStack;
+class QStringList;
 
 namespace PlaylistUndoCommands {
 class InsertItems;
@@ -157,6 +158,8 @@ class Playlist : public QAbstractListModel {
 
   static const char* kPathType;
   static const char* kWriteMetadata;
+  static const char* kSortIgnorePrefix;
+  static const char* kSortIgnorePrefixList;
 
   static const int kUndoStackSize;
   static const int kUndoItemLimit;
@@ -165,7 +168,7 @@ class Playlist : public QAbstractListModel {
   static const qint64 kMaxScrobblePointNsecs;
 
   static bool CompareItems(int column, Qt::SortOrder order, PlaylistItemPtr a,
-                           PlaylistItemPtr b);
+                           PlaylistItemPtr b, const QStringList& prefixes = {});
 
   static QString column_name(Column column);
   static QString abbreviated_column_name(Column column);

--- a/src/ui/behavioursettingspage.cpp
+++ b/src/ui/behavioursettingspage.cpp
@@ -178,6 +178,12 @@ void BehaviourSettingsPage::Load() {
   }
   ui_->b_write_metadata->setChecked(
       s.value(Playlist::kWriteMetadata, true).toBool());
+
+  ui_->sort_ignore_prefix->setChecked(
+      s.value(Playlist::kSortIgnorePrefix, true).toBool());
+  ui_->sort_ignore_prefix_list->setText(
+      s.value(Playlist::kSortIgnorePrefixList, QStringLiteral("a, the"))
+          .toString());
   s.endGroup();
 
   s.beginGroup(PlaylistTabBar::kSettingsGroup);
@@ -258,6 +264,9 @@ void BehaviourSettingsPage::Save() {
   s.setValue("click_edit_inline", ui_->b_click_edit_inline_->isChecked());
   s.setValue(Playlist::kPathType, static_cast<int>(path));
   s.setValue(Playlist::kWriteMetadata, ui_->b_write_metadata->isChecked());
+  s.setValue(Playlist::kSortIgnorePrefix, ui_->sort_ignore_prefix->isChecked());
+  s.setValue(Playlist::kSortIgnorePrefixList,
+             ui_->sort_ignore_prefix_list->text());
   s.endGroup();
 
   s.beginGroup(PlaylistTabBar::kSettingsGroup);

--- a/src/ui/behavioursettingspage.ui
+++ b/src/ui/behavioursettingspage.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>516</width>
-    <height>792</height>
+    <height>1081</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -415,6 +415,29 @@
         </property>
         <property name="checked">
          <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_sort_ignore">
+     <property name="title">
+      <string>When sorting artists, albums and titles</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QCheckBox" name="sort_ignore_prefix">
+        <property name="text">
+         <string>Ignore prefix word(s)</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="sort_ignore_prefix_list">
+        <property name="toolTip">
+         <string>Comma seperated list of prefix words to ignore when sorting</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This introduces new configuration options which allow you to ignore
prefixes while sorting the playlist on album, artist and titles.
Prefixes are configurable, default are "a" and "the".

Closes #6143 