### PR TITLE
Convert uses of QtAlgorithms to std:: algorithms

### DIFF
--- a/src/analyzers/analyzerbase.cpp
+++ b/src/analyzers/analyzerbase.cpp
@@ -24,6 +24,7 @@
 
 #include "analyzerbase.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 
@@ -87,9 +88,9 @@ void Analyzer::Base::transform(Scope& scope) {
 
   QVector<float> aux(fht_->size());
   if (aux.size() >= scope.size()) {
-    qCopy(scope.begin(), scope.end(), aux.begin());
+    std::copy(scope.begin(), scope.end(), aux.begin());
   } else {
-    qCopy(scope.begin(), scope.begin() + aux.size(), aux.begin());
+    std::copy(scope.begin(), scope.begin() + aux.size(), aux.begin());
   }
 
   fht_->logSpectrum(scope.data(), aux.data());

--- a/src/core/cachedlist.h
+++ b/src/core/cachedlist.h
@@ -20,6 +20,8 @@
 #ifndef CORE_CACHEDLIST_H_
 #define CORE_CACHEDLIST_H_
 
+#include <algorithm>
+
 #include <QDateTime>
 #include <QSettings>
 
@@ -81,7 +83,7 @@ class CachedList {
                cache_duration_secs_;
   }
 
-  void Sort() { qSort(data_); }
+  void Sort() { std::sort(data_.begin(), data_.end()); }
 
   const ListType& Data() const { return data_; }
   operator ListType() const { return data_; }

--- a/src/core/song.cpp
+++ b/src/core/song.cpp
@@ -486,7 +486,7 @@ int CompareSongsName(const Song& song1, const Song& song2) {
 
 void Song::SortSongsListAlphabetically(SongList* songs) {
   Q_ASSERT(songs);
-  qSort(songs->begin(), songs->end(), CompareSongsName);
+  std::sort(songs->begin(), songs->end(), CompareSongsName);
 }
 
 void Song::Init(const QString& title, const QString& artist,

--- a/src/core/songloader.cpp
+++ b/src/core/songloader.cpp
@@ -22,6 +22,7 @@
 
 #include "songloader.h"
 
+#include <algorithm>
 #include <memory>
 
 #include <QBuffer>
@@ -311,7 +312,7 @@ void SongLoader::LoadLocalDirectory(const QString& filename) {
     LoadLocalPartial(it.next());
   }
 
-  qStableSort(songs_.begin(), songs_.end(), CompareSongs);
+  std::stable_sort(songs_.begin(), songs_.end(), CompareSongs);
 
   // Load the first song: all songs will be loaded async, but we want the first
   // one in our list to be fully loaded, so if the user has the "Start playing

--- a/src/covers/albumcoverfetchersearch.cpp
+++ b/src/covers/albumcoverfetchersearch.cpp
@@ -20,6 +20,7 @@
 
 #include "albumcoverfetchersearch.h"
 
+#include <algorithm>
 #include <cmath>
 
 #include <QMutexLocker>
@@ -133,7 +134,7 @@ void AlbumCoverFetcherSearch::AllProvidersFinished() {
   // from each category and use some heuristics to score them.  If no images
   // are good enough we'll keep loading more images until we find one that is
   // or we run out of results.
-  qStableSort(results_.begin(), results_.end(), CompareProviders);
+  std::stable_sort(results_.begin(), results_.end(), CompareProviders);
   FetchMoreImages();
 }
 

--- a/src/covers/coversearchstatisticsdialog.cpp
+++ b/src/covers/coversearchstatisticsdialog.cpp
@@ -21,6 +21,8 @@
 #include "ui_coversearchstatisticsdialog.h"
 #include "core/utilities.h"
 
+#include <algorithm>
+
 CoverSearchStatisticsDialog::CoverSearchStatisticsDialog(QWidget* parent)
     : QDialog(parent), ui_(new Ui_CoverSearchStatisticsDialog) {
   ui_->setupUi(this);
@@ -47,7 +49,7 @@ CoverSearchStatisticsDialog::~CoverSearchStatisticsDialog() { delete ui_; }
 void CoverSearchStatisticsDialog::Show(
     const CoverSearchStatistics& statistics) {
   QStringList providers(statistics.total_images_by_provider_.keys());
-  qSort(providers);
+  std::sort(providers.begin(), providers.end());
 
   ui_->summary->setText(
       tr("Got %1 covers out of %2 (%3 failed)")

--- a/src/globalsearch/globalsearchsettingspage.cpp
+++ b/src/globalsearch/globalsearchsettingspage.cpp
@@ -22,6 +22,8 @@
 #include "ui/settingsdialog.h"
 #include "ui_globalsearchsettingspage.h"
 
+#include <algorithm>
+
 #include <QSettings>
 
 GlobalSearchSettingsPage::GlobalSearchSettingsPage(SettingsDialog* dialog)
@@ -57,7 +59,7 @@ void GlobalSearchSettingsPage::Load() {
 
   // Sort the list of providers alphabetically (by id) initially, so any that
   // aren't in the provider_order list will take this order.
-  qSort(providers.begin(), providers.end(), CompareProviderId);
+  std::sort(providers.begin(), providers.end(), CompareProviderId);
 
   // Add the ones in the configured list first
   ui_->sources->clear();

--- a/src/globalsearch/globalsearchview.cpp
+++ b/src/globalsearch/globalsearchview.cpp
@@ -22,6 +22,7 @@
 #include <QStandardItem>
 #include <QTimer>
 
+#include <algorithm>
 #include <functional>
 
 #include "globalsearch.h"
@@ -224,8 +225,8 @@ void GlobalSearchView::ReloadSettings() {
   if (show_providers_) {
     // Sort the list of providers
     QList<SearchProvider*> providers = engine_->providers();
-    qSort(providers.begin(), providers.end(),
-          std::bind(&CompareProvider, std::cref(provider_order), _1, _2));
+    std::sort(providers.begin(), providers.end(),
+              std::bind(&CompareProvider, std::cref(provider_order), _1, _2));
 
     bool any_disabled = false;
 
@@ -307,8 +308,8 @@ void GlobalSearchView::AddResults(int id,
 void GlobalSearchView::SwapModels() {
   art_requests_.clear();
 
-  qSwap(front_model_, back_model_);
-  qSwap(front_proxy_, back_proxy_);
+  std::swap(front_model_, back_model_);
+  std::swap(front_proxy_, back_proxy_);
 
   ui_->results->setModel(front_proxy_);
 

--- a/src/internet/digitally/digitallyimportedservicebase.cpp
+++ b/src/internet/digitally/digitallyimportedservicebase.cpp
@@ -20,6 +20,8 @@
 
 #include "digitallyimportedservicebase.h"
 
+#include <algorithm>
+
 #include <QDesktopServices>
 #include <QMenu>
 #include <QNetworkReply>
@@ -112,7 +114,7 @@ void DigitallyImportedServiceBase::RefreshStreamsFinished(QNetworkReply* reply,
   // Parse the list and sort by name
   DigitallyImportedClient::ChannelList channels =
       api_client_->ParseChannelList(reply);
-  qSort(channels);
+  std::sort(channels.begin(), channels.end());
 
   saved_channels_.Update(channels);
 

--- a/src/internet/lastfm/lastfmservice.cpp
+++ b/src/internet/lastfm/lastfmservice.cpp
@@ -39,6 +39,8 @@
 
 #include "lastfmservice.h"
 
+#include <algorithm>
+
 #include <QCryptographicHash>
 #include <QDesktopServices>
 #include <QMenu>
@@ -138,7 +140,7 @@ bool LastFMService::IsSubscriber() const {
 
 namespace {
 QByteArray SignApiRequest(QList<QPair<QString, QString>> params) {
-  qSort(params);
+  std::sort(params.begin(), params.end());
   QString to_sign;
   for (const auto& p : params) {
     to_sign += p.first;

--- a/src/library/librarymodel.cpp
+++ b/src/library/librarymodel.cpp
@@ -17,6 +17,7 @@
 
 #include "librarymodel.h"
 
+#include <algorithm>
 #include <functional>
 
 #include <QFuture>
@@ -658,7 +659,7 @@ QVariant LibraryModel::data(const LibraryItem* item, int role) const {
       return item->SortText();
 
     case Role_DisplayText:
-      return item->DisplayText(); 
+      return item->DisplayText();
   }
   return QVariant();
 }
@@ -1268,8 +1269,8 @@ void LibraryModel::GetChildSongs(LibraryItem* item, QList<QUrl>* urls,
       const_cast<LibraryModel*>(this)->LazyPopulate(item);
 
       QList<LibraryItem*> children = item->children;
-      qSort(children.begin(), children.end(),
-            std::bind(&LibraryModel::CompareItems, this, _1, _2));
+      std::sort(children.begin(), children.end(),
+                std::bind(&LibraryModel::CompareItems, this, _1, _2));
 
       for (LibraryItem* child : children)
         GetChildSongs(child, urls, songs, song_ids);

--- a/src/musicbrainz/acoustidclient.cpp
+++ b/src/musicbrainz/acoustidclient.cpp
@@ -17,6 +17,8 @@
 
 #include "acoustidclient.h"
 
+#include <algorithm>
+
 #include <QCoreApplication>
 #include <QNetworkReply>
 #include <QStringList>
@@ -131,7 +133,7 @@ void AcoustidClient::RequestFinished(QNetworkReply* reply, int request_id) {
     }
   }
 
-  qStableSort(id_source_list);
+  std::stable_sort(id_source_list.begin(), id_source_list.end());
 
   QList<QString> id_list;
   for (const IdSource& is : id_source_list) {

--- a/src/musicbrainz/musicbrainzclient.cpp
+++ b/src/musicbrainz/musicbrainzclient.cpp
@@ -17,6 +17,8 @@
 
 #include "musicbrainzclient.h"
 
+#include <algorithm>
+
 #include <QCoreApplication>
 #include <QNetworkReply>
 #include <QSet>
@@ -207,7 +209,7 @@ void MusicBrainzClient::RequestFinished(QNetworkReply* reply, int id,
     // Merge the results we have
     ResultList ret;
     QList<PendingResults> result_list_list = pending_results_.take(id);
-    qSort(result_list_list);
+    std::sort(result_list_list.begin(), result_list_list.end());
     for (const PendingResults& result_list : result_list_list) {
       ret << result_list.results_;
     }
@@ -312,7 +314,7 @@ MusicBrainzClient::ResultList MusicBrainzClient::ParseTrack(
   if (releases.isEmpty()) {
     ret << result;
   } else {
-    qStableSort(releases);
+    std::stable_sort(releases.begin(), releases.end());
     for (const Release& release : releases) {
       ret << release.CopyAndMergeInto(result);
     }
@@ -381,7 +383,7 @@ MusicBrainzClient::ResultList MusicBrainzClient::UniqueResults(
   ResultList ret;
   if (opt == SortResults) {
     ret = QSet<Result>::fromList(results).toList();
-    qSort(ret);
+    std::sort(ret.begin(), ret.end());
   } else {  // KeepOriginalOrder
     // Qt doesn't provide a ordered set (QSet "stores values in an unspecified
     // order" according to Qt documentation).

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -812,7 +812,8 @@ bool Playlist::dropMimeData(const QMimeData* data, Qt::DropAction action,
       pid = !own_pid;
     }
 
-    qStableSort(source_rows);  // Make sure we take them in order
+    std::stable_sort(source_rows.begin(),
+                     source_rows.end());  // Make sure we take them in order
 
     if (source_playlist == this) {
       // Dragged from this playlist - rearrange the items
@@ -1464,25 +1465,25 @@ void Playlist::sort(int column, Qt::SortOrder order) {
 
   if (column == Column_Album) {
     // When sorting by album, also take into account discs and tracks.
-    qStableSort(begin, new_items.end(),
-                std::bind(&Playlist::CompareItems, Column_Track, order, _1, _2,
-                          prefixes));
-    qStableSort(begin, new_items.end(),
-                std::bind(&Playlist::CompareItems, Column_Disc, order, _1, _2,
-                          prefixes));
-    qStableSort(begin, new_items.end(),
-                std::bind(&Playlist::CompareItems, Column_Album, order, _1, _2,
-                          prefixes));
+    std::stable_sort(begin, new_items.end(),
+                     std::bind(&Playlist::CompareItems, Column_Track, order, _1,
+                               _2, prefixes));
+    std::stable_sort(begin, new_items.end(),
+                     std::bind(&Playlist::CompareItems, Column_Disc, order, _1,
+                               _2, prefixes));
+    std::stable_sort(begin, new_items.end(),
+                     std::bind(&Playlist::CompareItems, Column_Album, order, _1,
+                               _2, prefixes));
   } else if (column == Column_Filename) {
     // When sorting by full paths we also expect a hierarchical order. This
     // returns a breath-first ordering of paths.
-    qStableSort(begin, new_items.end(),
-                std::bind(&Playlist::CompareItems, Column_Filename, order, _1,
-                          _2, prefixes));
-    qStableSort(begin, new_items.end(),
-                std::bind(&Playlist::ComparePathDepths, order, _1, _2));
+    std::stable_sort(begin, new_items.end(),
+                     std::bind(&Playlist::CompareItems, Column_Filename, order,
+                               _1, _2, prefixes));
+    std::stable_sort(begin, new_items.end(),
+                     std::bind(&Playlist::ComparePathDepths, order, _1, _2));
   } else {
-    qStableSort(
+    std::stable_sort(
         begin, new_items.end(),
         std::bind(&Playlist::CompareItems, column, order, _1, _2, prefixes));
   }
@@ -1618,7 +1619,7 @@ void Playlist::RemoveItemsWithoutUndo(const QList<int>& indicesIn) {
   // Sort the indices descending because removing elements 'backwards'
   // is easier - indices don't 'move' in the process.
   QList<int> indices = indicesIn;
-  qSort(indices.begin(), indices.end(), DescendingIntLessThan);
+  std::sort(indices.begin(), indices.end(), DescendingIntLessThan);
 
   for (int j = 0; j < indices.count(); j++) {
     int beginning = indices[j], end = indices[j];
@@ -1661,7 +1662,7 @@ bool Playlist::removeRows(QList<int>& rows) {
 
   // start from the end to be sure that indices won't 'move' during
   // the removal process
-  qSort(rows.begin(), rows.end(), qGreater<int>());
+  std::sort(rows.begin(), rows.end(), std::greater<int>());
 
   QList<int> part;
   while (!rows.isEmpty()) {

--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -42,6 +42,7 @@
 #include <QTimeLine>
 
 #include <math.h>
+#include <algorithm>
 
 #ifdef HAVE_MOODBAR
 #include "moodbar/moodbaritemdelegate.h"
@@ -655,7 +656,7 @@ void PlaylistView::RemoveSelected(bool deleting_from_disk) {
 
   // Sort the selection so we remove the items at the *bottom* first, ensuring
   // we don't have to mess around with changing row numbers
-  qSort(selection.begin(), selection.end(), CompareSelectionRanges);
+  std::sort(selection.begin(), selection.end(), CompareSelectionRanges);
 
   for (const QItemSelectionRange& range : selection) {
     if (range.top() < last_row) rows_removed += range.height();
@@ -698,7 +699,7 @@ QList<int> PlaylistView::GetEditableColumns() {
     QModelIndex index = model()->index(0, col);
     if (index.flags() & Qt::ItemIsEditable) columns << h->visualIndex(col);
   }
-  qSort(columns);
+  std::sort(columns.begin(), columns.end());
   return columns;
 }
 

--- a/src/playlist/queue.cpp
+++ b/src/playlist/queue.cpp
@@ -17,6 +17,8 @@
 
 #include "queue.h"
 
+#include <algorithm>
+
 #include <QBuffer>
 #include <QMimeData>
 #include <QtDebug>
@@ -317,7 +319,8 @@ bool Queue::dropMimeData(const QMimeData* data, Qt::DropAction action, int row,
     QList<int> proxy_rows;
     QDataStream stream(data->data(kRowsMimetype));
     stream >> proxy_rows;
-    qStableSort(proxy_rows);  // Make sure we take them in order
+    // Make sure we take them in order
+    std::stable_sort(proxy_rows.begin(), proxy_rows.end());
 
     Move(proxy_rows, row);
   } else if (data->hasFormat(Playlist::kRowsMimetype)) {
@@ -388,7 +391,7 @@ QVariant Queue::headerData(int section, Qt::Orientation orientation,
 
 void Queue::Remove(QList<int>& proxy_rows) {
   // order the rows
-  qStableSort(proxy_rows);
+  std::stable_sort(proxy_rows.begin(), proxy_rows.end());
 
   // reflects immediately changes in the playlist
   layoutAboutToBeChanged();

--- a/src/playlist/queuemanager.cpp
+++ b/src/playlist/queuemanager.cpp
@@ -23,6 +23,8 @@
 #include "ui_queuemanager.h"
 #include "ui/iconloader.h"
 
+#include <algorithm>
+
 #include <QKeySequence>
 #include <QShortcut>
 
@@ -105,7 +107,7 @@ void QueueManager::CurrentPlaylistChanged(Playlist* playlist) {
 
 void QueueManager::MoveUp() {
   QModelIndexList indexes = ui_->list->selectionModel()->selectedRows();
-  qStableSort(indexes);
+  std::stable_sort(indexes.begin(), indexes.end());
 
   if (indexes.isEmpty() || indexes.first().row() == 0) return;
 
@@ -116,7 +118,7 @@ void QueueManager::MoveUp() {
 
 void QueueManager::MoveDown() {
   QModelIndexList indexes = ui_->list->selectionModel()->selectedRows();
-  qStableSort(indexes);
+  std::stable_sort(indexes.begin(), indexes.end());
 
   if (indexes.isEmpty() ||
       indexes.last().row() == current_playlist_->queue()->rowCount() - 1)

--- a/src/playlistparsers/playlistparser.cpp
+++ b/src/playlistparsers/playlistparser.cpp
@@ -25,6 +25,8 @@
 #include "xspfparser.h"
 #include "core/logging.h"
 
+#include <algorithm>
+
 #include <QtDebug>
 
 const int PlaylistParser::kMagicSize = 512;
@@ -49,7 +51,7 @@ QStringList PlaylistParser::file_extensions() const {
     ret << parser->file_extensions();
   }
 
-  qStableSort(ret);
+  std::stable_sort(ret.begin(), ret.end());
   return ret;
 }
 
@@ -60,7 +62,7 @@ QStringList PlaylistParser::mime_types() const {
     if (!parser->mime_type().isEmpty()) ret << parser->mime_type();
   }
 
-  qStableSort(ret);
+  std::stable_sort(ret.begin(), ret.end());
   return ret;
 }
 

--- a/src/ripper/ripcddialog.cpp
+++ b/src/ripper/ripcddialog.cpp
@@ -17,6 +17,8 @@
 
 #include "ripper/ripcddialog.h"
 
+#include <algorithm>
+
 #include <QCheckBox>
 #include <QCloseEvent>
 #include <QFileDialog>
@@ -107,7 +109,7 @@ RipCDDialog::RipCDDialog(QWidget* parent)
 
   // Get presets
   QList<TranscoderPreset> presets = Transcoder::GetAllPresets();
-  qSort(presets.begin(), presets.end(), ComparePresetsByName);
+  std::sort(presets.begin(), presets.end(), ComparePresetsByName);
   for (const TranscoderPreset& preset : presets) {
     ui_->format->addItem(
         QString("%1 (.%2)").arg(preset.name_).arg(preset.extension_),

--- a/src/songinfo/songinfoview.cpp
+++ b/src/songinfo/songinfoview.cpp
@@ -17,6 +17,8 @@
 
 #include "songinfo/songinfoview.h"
 
+#include <algorithm>
+
 #include <QFuture>
 #include <QSettings>
 #include <QtConcurrentRun>
@@ -159,6 +161,6 @@ QList<const UltimateLyricsProvider*> SongInfoView::lyric_providers() const {
       ret << lyrics;
     }
   }
-  qSort(ret.begin(), ret.end(), CompareLyricProviders);
+  std::sort(ret.begin(), ret.end(), CompareLyricProviders);
   return ret;
 }

--- a/src/transcoder/transcodedialog.cpp
+++ b/src/transcoder/transcodedialog.cpp
@@ -24,6 +24,8 @@
 #include "ui/mainwindow.h"
 #include "widgets/fileview.h"
 
+#include <algorithm>
+
 #include <QPushButton>
 #include <QFileDialog>
 #include <QDirIterator>
@@ -63,7 +65,7 @@ TranscodeDialog::TranscodeDialog(QWidget* parent)
 
   // Get presets
   QList<TranscoderPreset> presets = Transcoder::GetAllPresets();
-  qSort(presets.begin(), presets.end(), ComparePresetsByName);
+  std::sort(presets.begin(), presets.end(), ComparePresetsByName);
   for (const TranscoderPreset& preset : presets) {
     ui_->format->addItem(
         QString("%1 (.%2)").arg(preset.name_, preset.extension_),

--- a/src/transcoder/transcoder.cpp
+++ b/src/transcoder/transcoder.cpp
@@ -17,6 +17,7 @@
 
 #include "transcoder.h"
 
+#include <algorithm>
 #include <memory>
 
 #include <QCoreApplication>
@@ -138,7 +139,7 @@ GstElement* Transcoder::CreateElementForMimeType(const QString& element_type,
   if (suitable_elements_.isEmpty()) return nullptr;
 
   // Sort by rank
-  qSort(suitable_elements_);
+  std::sort(suitable_elements_.begin(), suitable_elements_.end());
   const SuitableElement& best = suitable_elements_.last();
 
   LogLine(QString("Using '%1' (rank %2)").arg(best.name_).arg(best.rank_));

--- a/src/ui/about.cpp
+++ b/src/ui/about.cpp
@@ -19,6 +19,8 @@
 #include "config.h"
 #include "ui_about.h"
 
+#include <algorithm>
+
 #include <QCoreApplication>
 #include <QPushButton>
 
@@ -53,8 +55,8 @@ About::About(QWidget* parent) : QDialog(parent) {
              << Person("Andreas Muttscheller", "asfa194@gmail.com")
              << Person("Mark Furneaux", "mark@furneaux.ca");
 
-  qSort(authors_);
-  qSort(thanks_to_);
+  std::sort(authors_.begin(), authors_.end());
+  std::sort(thanks_to_.begin(), thanks_to_.end());
 
   ui_.content->setHtml(MakeHtml());
 

--- a/src/ui/albumcovermanager.cpp
+++ b/src/ui/albumcovermanager.cpp
@@ -36,6 +36,8 @@
 #include "ui/albumcoverexport.h"
 #include "ui/iconloader.h"
 
+#include <algorithm>
+
 #include <QActionGroup>
 #include <QPushButton>
 #include <QContextMenuEvent>
@@ -265,7 +267,7 @@ void AlbumCoverManager::Reset() {
                       Various_Artists);
 
   QStringList artists(library_backend_->GetAllArtistsWithAlbums());
-  qStableSort(artists.begin(), artists.end(), CompareNocase);
+  std::stable_sort(artists.begin(), artists.end(), CompareNocase);
 
   for (const QString& artist : artists) {
     if (artist.isEmpty()) continue;
@@ -313,7 +315,7 @@ void AlbumCoverManager::ArtistChanged(QListWidgetItem* current) {
 
   // Sort by album name.  The list is already sorted by sqlite but it was done
   // case sensitively.
-  qStableSort(albums.begin(), albums.end(), CompareAlbumNameNocase);
+  std::stable_sort(albums.begin(), albums.end(), CompareAlbumNameNocase);
 
   for (const LibraryBackend::Album& info : albums) {
     // Don't show songs without an album, obviously

--- a/src/ui/behavioursettingspage.cpp
+++ b/src/ui/behavioursettingspage.cpp
@@ -22,6 +22,8 @@
 #include "playlist/playlist.h"
 #include "playlist/playlisttabbar.h"
 
+#include <algorithm>
+
 #include <QDir>
 #include <QSystemTrayIcon>
 
@@ -91,7 +93,7 @@ BehaviourSettingsPage::BehaviourSettingsPage(SettingsDialog* dialog)
 
   // Sort the names and show them in the UI
   QStringList names = language_map_.keys();
-  qStableSort(names.begin(), names.end(), LocaleAwareCompare);
+  std::stable_sort(names.begin(), names.end(), LocaleAwareCompare);
   ui_->language->addItems(names);
 
 #ifdef Q_OS_DARWIN

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -148,6 +148,7 @@
 #include "moodbar/moodbarproxystyle.h"
 #endif
 
+#include <algorithm>
 #include <cmath>
 
 #ifdef Q_OS_DARWIN
@@ -1962,7 +1963,7 @@ void MainWindow::RenumberTracks() {
   int track = 1;
 
   // Get the index list in order
-  qStableSort(indexes);
+  std::stable_sort(indexes.begin(), indexes.end());
 
   // if first selected song has a track number set, start from that offset
   if (!indexes.isEmpty()) {
@@ -2187,7 +2188,7 @@ void MainWindow::CommandlineOptionsReceived(
 
 void MainWindow::CommandlineOptionsReceived(const CommandlineOptions& options) {
   qLog(Debug) << "command line options received";
-  
+
   switch (options.player_action()) {
     case CommandlineOptions::Player_Play:
       if (options.urls().empty()) {
@@ -2269,21 +2270,21 @@ void MainWindow::CommandlineOptionsReceived(const CommandlineOptions& options) {
 
   qLog(Debug) << options.delete_current_track();
 
-  // Just pass the url of the currently playing 
+  // Just pass the url of the currently playing
   if (options.delete_current_track()) {
     qLog(Debug) << "deleting current track";
-    
+
     Playlist* activePlaylist = app_->playlist_manager()->active();
     PlaylistItemPtr playlistItemPtr = activePlaylist->current_item();
 
     if (playlistItemPtr) {
       const QUrl& url = playlistItemPtr->Url();
       qLog(Debug) << url;
-      
-      std::shared_ptr<MusicStorage> storage(new FilesystemMusicStorage("/"));  
-      
+
+      std::shared_ptr<MusicStorage> storage(new FilesystemMusicStorage("/"));
+
       app_->player()->Next();
-        
+
       DeleteFiles* delete_files = new DeleteFiles(app_->task_manager(), storage);
       connect(delete_files, SIGNAL(Finished(SongList)),
               SLOT(DeleteFinished(SongList)));
@@ -2293,7 +2294,7 @@ void MainWindow::CommandlineOptionsReceived(const CommandlineOptions& options) {
       qLog(Debug) << "no currently playing track to delete";
     }
   }
-  
+
   if (options.show_osd()) app_->player()->ShowOSD();
 
   if (options.toggle_pretty_osd()) app_->player()->TogglePrettyOSD();
@@ -2509,9 +2510,9 @@ void MainWindow::DeleteFinished(const SongList& songs_with_errors) {
       activePlaylist->RemoveUnavailableSongs();
       qLog(Debug) << "Found active playlist and removed unavailable songs";
     }
-    
+
     return;
-  } 
+  }
 
   OrganiseErrorDialog* dialog = new OrganiseErrorDialog(this);
   dialog->Show(OrganiseErrorDialog::Type_Delete, songs_with_errors);

--- a/src/ui/networkremotesettingspage.cpp
+++ b/src/ui/networkremotesettingspage.cpp
@@ -18,6 +18,8 @@
 #include "networkremotesettingspage.h"
 #include "ui_networkremotesettingspage.h"
 
+#include <algorithm>
+
 #include <QDesktopServices>
 #include <QFile>
 #include <QHostInfo>
@@ -52,7 +54,7 @@ NetworkRemoteSettingsPage::NetworkRemoteSettingsPage(SettingsDialog* dialog)
 
   // Get presets
   QList<TranscoderPreset> presets = Transcoder::GetAllPresets();
-  qSort(presets.begin(), presets.end(), ComparePresetsByName);
+  std::sort(presets.begin(), presets.end(), ComparePresetsByName);
   for (const TranscoderPreset& preset : presets) {
     ui_->format->addItem(
         QString("%1 (.%2)").arg(preset.name_, preset.extension_),

--- a/src/ui/organisedialog.cpp
+++ b/src/ui/organisedialog.cpp
@@ -18,6 +18,7 @@
 #include "organisedialog.h"
 #include "ui_organisedialog.h"
 
+#include <algorithm>
 #include <memory>
 
 #include <QDir>
@@ -93,7 +94,7 @@ OrganiseDialog::OrganiseDialog(
 
   // Get the titles of the tags to put in the insert menu
   QStringList tag_titles = tags.keys();
-  qStableSort(tag_titles);
+  std::stable_sort(tag_titles.begin(), tag_titles.end());
 
   // Build the insert menu
   QMenu* tag_menu = new QMenu(this);

--- a/src/ui/organiseerrordialog.cpp
+++ b/src/ui/organiseerrordialog.cpp
@@ -18,6 +18,8 @@
 #include "organiseerrordialog.h"
 #include "ui_organiseerrordialog.h"
 
+#include <algorithm>
+
 #include <QUrl>
 
 OrganiseErrorDialog::OrganiseErrorDialog(QWidget* parent)
@@ -45,7 +47,7 @@ void OrganiseErrorDialog::Show(OperationType type,
 void OrganiseErrorDialog::Show(OperationType type,
                                const QStringList& files_with_errors) {
   QStringList sorted_files = files_with_errors;
-  qStableSort(sorted_files);
+  std::stable_sort(sorted_files.begin(), sorted_files.end());
 
   switch (type) {
     case Type_Copy:


### PR DESCRIPTION
Qt5 has deprecated QtAlgorithms and recommends using the standard algorithms.
This patch converts all uses of Qt algorithms to the corresponding std:: function.