### PR TITLE
Fix Appstream data installation target

### DIFF
--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -66,7 +66,7 @@ if (NOT APPLE)
   )
 
   install(FILES clementine.appdata.xml
-    DESTINATION share/appdata
+    DESTINATION share/metainfo
   )
 
   if(INSTALL_UBUNTU_ICONS)


### PR DESCRIPTION
According to the Appstream specifications, Appdata files must now be installed
in /usr/share/metainfo. /usr/share/appdata is a legacy path.

See: https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Application.html
and: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html