### PR TITLE
Add missing Player::Stop()

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -622,8 +622,7 @@ void Player::InvalidSongRequested(const QUrl& url) {
 
   if (stop_playback) {
     Stop();
-  }
-  else {
+  } else {
     NextItem(Engine::Auto);
   }
 }

--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -620,7 +620,10 @@ void Player::InvalidSongRequested(const QUrl& url) {
   bool stop_playback = s.value("stop_play_if_fail", 0).toBool();
   s.endGroup();
 
-  if (!stop_playback) {
+  if (stop_playback) {
+    Stop();
+  }
+  else {
     NextItem(Engine::Auto);
   }
 }


### PR DESCRIPTION
This fixes bug created by PR #5905
The stop was done in Player::NextItem(), but is never done if "Stop playback if song fails to play" is enabled.