### PR TITLE
Fix missing signal

### DIFF
--- a/src/widgets/fancytabwidget.cpp
+++ b/src/widgets/fancytabwidget.cpp
@@ -274,7 +274,7 @@ void FancyTabWidget::currentTabChanged(int index) {
     QLayout *layout = currentPage->layout();
     if(bottom_widget_ != nullptr)
         layout->addWidget(bottom_widget_);
-  emit CurrentChanged(index);
+    emit CurrentChanged(index);
 }
 
 FancyTabWidget::FancyTabWidget(QWidget* parent) : QTabWidget(parent), 

--- a/src/widgets/fancytabwidget.cpp
+++ b/src/widgets/fancytabwidget.cpp
@@ -274,6 +274,7 @@ void FancyTabWidget::currentTabChanged(int index) {
     QLayout *layout = currentPage->layout();
     if(bottom_widget_ != nullptr)
         layout->addWidget(bottom_widget_);
+  emit CurrentChanged(index);
 }
 
 FancyTabWidget::FancyTabWidget(QWidget* parent) : QTabWidget(parent), 

--- a/src/widgets/fancytabwidget.h
+++ b/src/widgets/fancytabwidget.h
@@ -66,7 +66,7 @@ class FancyTabWidget : public QTabWidget {
         void ModeChanged(FancyTabWidget::Mode mode);
         void CurrentChanged(int);
 
-    public slots:
+       public slots:
         void setCurrentIndex(int index);
         void SetMode(Mode mode);
         // Mapper mapped signal needs this convenience function 

--- a/src/widgets/fancytabwidget.h
+++ b/src/widgets/fancytabwidget.h
@@ -64,6 +64,7 @@ class FancyTabWidget : public QTabWidget {
 
     signals:
         void ModeChanged(FancyTabWidget::Mode mode);
+        void CurrentChanged(int);
 
     public slots:
         void setCurrentIndex(int index);


### PR DESCRIPTION
This fixes the following error on startup:
17:00:43.041 WARN  unknown                          Object::connect: No such signal Core::Internal::FancyTabWidget::CurrentChanged(int) 
17:00:43.041 WARN  unknown                          Object::connect:  (sender name:   'tabs') 
17:00:43.041 WARN  unknown                          Object::connect:  (receiver name: 'MainWindow') 
