### PR TITLE
Updated accessibility check logic to fix Mojave crash

### DIFF
--- a/src/core/macglobalshortcutbackend.mm
+++ b/src/core/macglobalshortcutbackend.mm
@@ -24,6 +24,7 @@
 #include <AppKit/NSWorkspace.h>
 #include <Foundation/NSString.h>
 #include <IOKit/hidsystem/ev_keymap.h>
+#include <ApplicationServices/ApplicationServices.h>
 
 #include <QAction>
 #include <QList>
@@ -128,7 +129,14 @@ bool MacGlobalShortcutBackend::KeyPressed(const QKeySequence& sequence) {
 }
 
 bool MacGlobalShortcutBackend::IsAccessibilityEnabled() const {
-  return AXAPIEnabled();
+  bool accessibilityEnabled;
+  try{
+    accessibilityEnabled = AXAPIEnabled();
+  }catch(...){
+    NSDictionary *options = @{(id)kAXTrustedCheckOptionPrompt: @YES};
+    accessibilityEnabled = AXIsProcessTrustedWithOptions((CFDictionaryRef)options);
+  }
+  return accessibilityEnabled;
 }
 
 void MacGlobalShortcutBackend::ShowAccessibilityDialog() {


### PR DESCRIPTION
This PR fixes issue #6148 and the duplicates of those issues.

The crash seems to occur because `AXAPIEnabled()` is depreciated.

My fix tries to use `AXAPIEnabled()` which was depreciated in Mavericks `macOS 10.9` and falls back to `AXIsProcessTrustedWithOptions` if it fails.

There may be a safer way to implement this by detecting the OS version so if anyone's got any suggestions I'd appreciate it.
