### PR TITLE
Fix saving geometry and fancytab settings

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -221,6 +221,7 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
       library_sort_model_(new QSortFilterProxyModel(this)),
       track_position_timer_(new QTimer(this)),
       track_slider_timer_(new QTimer(this)),
+      initialized_(false),
       saved_playback_position_(0),
       saved_playback_state_(Engine::Empty),
       doubleclick_addmode_(AddBehaviour_Append),
@@ -1066,7 +1067,11 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
 
   if (!options.contains_play_options()) LoadPlaybackStatus();
 
+  initialized_ = true;
+  SaveGeometry();
+
   qLog(Debug) << "Started";
+
 }
 
 MainWindow::~MainWindow() {
@@ -1278,9 +1283,19 @@ void MainWindow::ScrobbleButtonVisibilityChanged(bool value) {
   }
 }
 
-void MainWindow::resizeEvent(QResizeEvent*) { SaveGeometry(); }
+void MainWindow::changeEvent(QEvent *) {
+  if (!initialized_) return;
+  SaveGeometry();
+}
+
+void MainWindow::resizeEvent(QResizeEvent*) {
+  if (!initialized_) return;
+  SaveGeometry();
+}
 
 void MainWindow::SaveGeometry() {
+  if (!initialized_) return;
+
   was_maximized_ = isMaximized();
   settings_.setValue("maximized", was_maximized_);
   // Save the geometry only when mainwindow is not in maximized state
@@ -2790,6 +2805,7 @@ bool MainWindow::winEvent(MSG* msg, long*) {
 #endif  // Q_OS_WIN32
 
 void MainWindow::Exit() {
+  SaveGeometry();
   SavePlaybackStatus();
   settings_.setValue("show_sidebar",
                      ui_->action_toggle_show_sidebar->isChecked());

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1071,7 +1071,6 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
   SaveGeometry();
 
   qLog(Debug) << "Started";
-
 }
 
 MainWindow::~MainWindow() {
@@ -1283,7 +1282,7 @@ void MainWindow::ScrobbleButtonVisibilityChanged(bool value) {
   }
 }
 
-void MainWindow::changeEvent(QEvent *) {
+void MainWindow::changeEvent(QEvent*) {
   if (!initialized_) return;
   SaveGeometry();
 }

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -131,7 +131,8 @@ class MainWindow : public QMainWindow, public PlatformInterface {
 
  protected:
   void keyPressEvent(QKeyEvent* event);
-  void resizeEvent(QResizeEvent* event);
+  void changeEvent(QEvent*);
+  void resizeEvent(QResizeEvent*);
   void closeEvent(QCloseEvent* event);
 
 #ifdef Q_OS_WIN32
@@ -378,6 +379,7 @@ signals:
   QTimer* track_slider_timer_;
   QSettings settings_;
 
+  bool initialized_;
   bool was_maximized_;
   int saved_playback_position_;
   Engine::State saved_playback_state_;


### PR DESCRIPTION
This fixes a problem where SaveGeometry() gets called before settings like tab_mode is loaded, tab_mode gets saved as 0 and is reset before the setting is loaded.
It also fixes window positions not being saved on certain conditions.
