### PR TITLE
Fix encoding of GError messages when logging.

### DIFF
--- a/src/core/songloader.cpp
+++ b/src/core/songloader.cpp
@@ -520,8 +520,8 @@ void SongLoader::ErrorMessageReceived(GstMessage* msg) {
   gchar* debugs;
 
   gst_message_parse_error(msg, &error, &debugs);
-  qLog(Error) << error->message;
-  qLog(Error) << debugs;
+  qLog(Error) << QString::fromLocal8Bit(error->message);
+  qLog(Error) << QString::fromLocal8Bit(debugs);
 
   QString message_str = error->message;
 

--- a/src/devices/cddasongloader.cpp
+++ b/src/devices/cddasongloader.cpp
@@ -56,7 +56,7 @@ void CddaSongLoader::LoadSongsFromCdda() {
   GError* error = nullptr;
   cdda_ = gst_element_make_from_uri(GST_URI_SRC, "cdda://", nullptr, &error);
   if (error) {
-    qLog(Error) << error->code << error->message;
+    qLog(Error) << error->code << QString::fromLocal8Bit(error->message);
   }
   if (cdda_ == nullptr) {
     return;

--- a/src/devices/giolister.cpp
+++ b/src/devices/giolister.cpp
@@ -60,7 +60,8 @@ void OperationFinished(F f, GObject* object, GAsyncResult* result) {
   f(obj, result, &error);
 
   if (error) {
-    qLog(Error) << "Mount/unmount error:" << error->message;
+    qLog(Error) << "Mount/unmount error:"
+                << QString::fromLocal8Bit(error->message);
     g_error_free(error);
   }
 }
@@ -381,7 +382,7 @@ void GioLister::DeviceInfo::ReadMountInfo(GMount* mount) {
       "," G_FILE_ATTRIBUTE_FILESYSTEM_FREE "," G_FILE_ATTRIBUTE_FILESYSTEM_TYPE,
       nullptr, &error);
   if (error) {
-    qLog(Warning) << error->message;
+    qLog(Warning) << QString::fromLocal8Bit(error->message);
     g_error_free(error);
   } else {
     filesystem_size = g_file_info_get_attribute_uint64(
@@ -400,7 +401,7 @@ void GioLister::DeviceInfo::ReadMountInfo(GMount* mount) {
     info = g_file_query_info(root, G_FILE_ATTRIBUTE_ID_FILESYSTEM,
                              G_FILE_QUERY_INFO_NONE, nullptr, &error);
     if (error) {
-      qLog(Warning) << error->message;
+      qLog(Warning) << QString::fromLocal8Bit(error->message);
       g_error_free(error);
     } else {
       mount_uuid = QString::fromUtf8(g_file_info_get_attribute_string(
@@ -513,7 +514,7 @@ void GioLister::UpdateDeviceFreeSpace(const QString& id) {
     GFileInfo* info = g_file_query_filesystem_info(
         root, G_FILE_ATTRIBUTE_FILESYSTEM_FREE, nullptr, &error);
     if (error) {
-      qLog(Warning) << error->message;
+      qLog(Warning) << QString::fromLocal8Bit(error->message);
       g_error_free(error);
     } else {
       device_info.filesystem_free = g_file_info_get_attribute_uint64(

--- a/src/devices/gpoddevice.cpp
+++ b/src/devices/gpoddevice.cpp
@@ -113,7 +113,7 @@ bool GPodDevice::CopyToStorage(const CopyJob& job) {
       track, QDir::toNativeSeparators(job.source_).toLocal8Bit().constData(),
       &error);
   if (error) {
-    qLog(Error) << "copying failed:" << error->message;
+    qLog(Error) << "copying failed:" << QString::fromUtf8(error->message);
     app_->AddError(QString::fromUtf8(error->message));
     g_error_free(error);
 
@@ -138,7 +138,8 @@ void GPodDevice::WriteDatabase(bool success) {
     GError* error = nullptr;
     itdb_write(db_, &error);
     if (error) {
-      qLog(Error) << "writing database failed:" << error->message;
+      qLog(Error) << "writing database failed:"
+                  << QString::fromUtf8(error->message);
       app_->AddError(QString::fromUtf8(error->message));
       g_error_free(error);
     } else {

--- a/src/devices/gpodloader.cpp
+++ b/src/devices/gpodloader.cpp
@@ -53,7 +53,8 @@ void GPodLoader::LoadDatabase() {
   // Check for errors
   if (!db) {
     if (error) {
-      qLog(Error) << "loading database failed:" << error->message;
+      qLog(Error) << "loading database failed:"
+                  << QString::fromUtf8(error->message);
       emit Error(QString::fromUtf8(error->message));
       g_error_free(error);
     } else {


### PR DESCRIPTION
GError messages contain non-ascii characters. This normally just produces some garbage when we use the default QString contructor that assumes ASCII for logging. However, when a message includes the right double quote, UTF-8 sequence 0xE2 0x80 0x9D, the final byte is OSC. VT100 expects a command sequence to follow and stops echoing output until it sees ST or BEL character, which may never come. Thus, the console output is halted.

This change uses QString::fromLocal8Bit instead of depending on the default constructor. About half of the sites in the codebase had already been converted.

One side effect is that log messages are quoted. There are additional options to control this, but those were only introduced in Qt 5.4.