### PR TITLE
Handle MTP connection failures more gracefully.

### DIFF
--- a/src/devices/cddadevice.cpp
+++ b/src/devices/cddadevice.cpp
@@ -40,9 +40,10 @@ CddaDevice::CddaDevice(const QUrl& url, DeviceLister* lister,
 
 CddaDevice::~CddaDevice() {}
 
-void CddaDevice::Init() {
+bool CddaDevice::Init() {
   song_count_ = 0;  // Reset song count, in case it was already set
   cdda_song_loader_.LoadSongs();
+  return true;
 }
 
 void CddaDevice::Refresh() {

--- a/src/devices/cddadevice.h
+++ b/src/devices/cddadevice.h
@@ -38,7 +38,7 @@ class CddaDevice : public ConnectedDevice {
                          Application* app, int database_id, bool first_time);
   ~CddaDevice();
 
-  void Init();
+  bool Init();
   void Refresh();
   bool CopyToStorage(const MusicStorage::CopyJob&) { return false; }
   bool DeleteFromStorage(const MusicStorage::DeleteJob&) { return false; }

--- a/src/devices/connecteddevice.h
+++ b/src/devices/connecteddevice.h
@@ -45,7 +45,7 @@ class ConnectedDevice : public QObject,
                   Application* app, int database_id, bool first_time);
   ~ConnectedDevice();
 
-  virtual void Init() = 0;
+  virtual bool Init() = 0;
   // For some devices (e.g. CD devices) we don't have callbacks to be notified
   // when something change: we can call this method to refresh device's state
   virtual void Refresh() {}

--- a/src/devices/devicemanager.cpp
+++ b/src/devices/devicemanager.cpp
@@ -613,9 +613,11 @@ std::shared_ptr<ConnectedDevice> DeviceManager::Connect(int row) {
 
   if (!ret) {
     qLog(Warning) << "Could not create device for" << device_url.toString();
+  } else if (!ret->Init()) {
+    app_->AddError(
+        tr("Could not connect to device: %1").arg(device_url.toString()));
+    ret.reset();
   } else {
-    ret->Init();
-
     info.device_ = ret;
     emit dataChanged(index(row), index(row));
     connect(info.device_.get(), SIGNAL(TaskStarted(int)),

--- a/src/devices/filesystemdevice.cpp
+++ b/src/devices/filesystemdevice.cpp
@@ -63,9 +63,10 @@ FilesystemDevice::FilesystemDevice(const QUrl& url, DeviceLister* lister,
   connect(watcher_, SIGNAL(ScanStarted(int)), SIGNAL(TaskStarted(int)));
 }
 
-void FilesystemDevice::Init() {
+bool FilesystemDevice::Init() {
   InitBackendDirectory(url_.toLocalFile(), first_time_);
   model_->Init();
+  return true;
 }
 
 FilesystemDevice::~FilesystemDevice() {

--- a/src/devices/filesystemdevice.h
+++ b/src/devices/filesystemdevice.h
@@ -35,7 +35,7 @@ class FilesystemDevice : public ConnectedDevice,
                                bool first_time);
   ~FilesystemDevice();
 
-  void Init();
+  bool Init();
 
   static QStringList url_schemes() { return QStringList() << "file"; }
 

--- a/src/devices/gpoddevice.cpp
+++ b/src/devices/gpoddevice.cpp
@@ -39,7 +39,7 @@ GPodDevice::GPodDevice(const QUrl& url, DeviceLister* lister,
       loader_(nullptr),
       db_(nullptr) {}
 
-void GPodDevice::Init() {
+bool GPodDevice::Init() {
   InitBackendDirectory(url_.path(), first_time_);
   model_->Init();
 
@@ -53,6 +53,7 @@ void GPodDevice::Init() {
           SLOT(LoadFinished(Itdb_iTunesDB*)));
   connect(loader_thread_, SIGNAL(started()), loader_, SLOT(LoadDatabase()));
   loader_thread_->start();
+  return true;
 }
 
 GPodDevice::~GPodDevice() {}

--- a/src/devices/gpoddevice.h
+++ b/src/devices/gpoddevice.h
@@ -37,7 +37,7 @@ class GPodDevice : public ConnectedDevice, public virtual MusicStorage {
                          Application* app, int database_id, bool first_time);
   ~GPodDevice();
 
-  void Init();
+  bool Init();
 
   static QStringList url_schemes() { return QStringList() << "ipod"; }
 

--- a/src/devices/mtpdevice.h
+++ b/src/devices/mtpdevice.h
@@ -44,7 +44,7 @@ class MtpDevice : public ConnectedDevice {
                          << "gphoto2";
   }
 
-  void Init();
+  bool Init();
 
   bool GetSupportedFiletypes(QList<Song::FileType>* ret);
   int GetFreeSpace();

--- a/src/devices/mtploader.cpp
+++ b/src/devices/mtploader.cpp
@@ -32,11 +32,17 @@ MtpLoader::MtpLoader(const QUrl& url, TaskManager* task_manager,
       device_(device),
       url_(url),
       task_manager_(task_manager),
-      backend_(backend) {
+      backend_(backend),
+      connection_(nullptr) {
   original_thread_ = thread();
 }
 
-MtpLoader::~MtpLoader() {}
+MtpLoader::~MtpLoader() { delete connection_; }
+
+bool MtpLoader::Init() {
+  connection_ = new MtpConnection(url_);
+  return connection_->is_valid();
+}
 
 void MtpLoader::LoadDatabase() {
   int task_id = task_manager_->StartTask(tr("Loading MTP device"));
@@ -51,16 +57,10 @@ void MtpLoader::LoadDatabase() {
 }
 
 bool MtpLoader::TryLoad() {
-  MtpConnection dev(url_);
-  if (!dev.is_valid()) {
-    emit Error(tr("Error connecting MTP device"));
-    return false;
-  }
-
   // Load the list of songs on the device
   SongList songs;
-  LIBMTP_track_t* tracks =
-      LIBMTP_Get_Tracklisting_With_Callback(dev.device(), nullptr, nullptr);
+  LIBMTP_track_t* tracks = LIBMTP_Get_Tracklisting_With_Callback(
+      connection_->device(), nullptr, nullptr);
   while (tracks) {
     LIBMTP_track_t* track = tracks;
 

--- a/src/devices/mtploader.h
+++ b/src/devices/mtploader.h
@@ -26,6 +26,7 @@
 class ConnectedDevice;
 class LibraryBackend;
 class TaskManager;
+class MtpConnection;
 
 class MtpLoader : public QObject {
   Q_OBJECT
@@ -35,6 +36,7 @@ class MtpLoader : public QObject {
             std::shared_ptr<ConnectedDevice> device);
   ~MtpLoader();
 
+  bool Init();
  public slots:
   void LoadDatabase();
 
@@ -53,6 +55,7 @@ signals:
   QUrl url_;
   TaskManager* task_manager_;
   LibraryBackend* backend_;
+  MtpConnection* connection_;
 };
 
 #endif  // MTPLOADER_H


### PR DESCRIPTION
Currently, the failure to connect to an MTP device results in the display of an
open device that appears empty.
- Modify ConnectedDevice::Init to return a boolean to indicate success.
- Add an Init to MtpLoader to create the MtpConnection and check the result.
- Call MtpLoader::Init from MtpDevice::Init. This does cause the MTP device to
  be opened on the main thread rather than the MtpDevice's loader thread.
- Handle the result in the device manager.