### PR TITLE
Try to obtain USB bus and device number from device name if unavailab…

### DIFF
--- a/src/devices/mtpconnection.cpp
+++ b/src/devices/mtpconnection.cpp
@@ -26,13 +26,19 @@ MtpConnection::MtpConnection(const QUrl& url) : device_(nullptr) {
   // Parse the URL
   QRegExp host_re("^usb-(\\d+)-(\\d+)$");
 
-  if (host_re.indexIn(hostname) == -1) {
+  unsigned int bus_location;
+  unsigned int device_num;
+
+  if (host_re.indexIn(hostname) >= 0) {
+    bus_location = host_re.cap(1).toUInt();
+    device_num = host_re.cap(2).toUInt();
+  } else if (url.hasQueryItem("busnum")) {
+    bus_location = url.queryItemValue("busnum").toUInt();
+    device_num = url.queryItemValue("devnum").toUInt();
+  } else {
     qLog(Warning) << "Invalid MTP device:" << hostname;
     return;
   }
-
-  const unsigned int bus_location = host_re.cap(1).toInt();
-  const unsigned int device_num = host_re.cap(2).toInt();
 
   if (url.hasQueryItem("vendor")) {
     LIBMTP_raw_device_t* raw_device =


### PR DESCRIPTION
…le in URI.

In 1.37.2, gvfs switched to URIs that remain consistent across USB device
re-enumerations. This removed the usb bus and device numbers from the URI. In
the case that these values aren't found in the URI, try to parse Unix device
name property and pass results as query params on the URL. Pay attention to
these params in MtpConnection.

See gvfs commits 3a7bb06b and efc76d0c for reference.