### PR TITLE
Fix Qt 5 build

### DIFF
--- a/3rdparty/qocoa/CMakeLists.txt
+++ b/3rdparty/qocoa/CMakeLists.txt
@@ -29,4 +29,9 @@ endif()
 add_library(Qocoa STATIC
     ${SOURCES} ${MOC_SOURCES} ${RESOURCES_SOURCES}
 )
-target_link_libraries(Qocoa Qt5::Widgets Qt5::MacExtras)
+
+if(APPLE)
+  target_link_libraries(Qocoa Qt5::Widgets Qt5::MacExtras)
+else()
+  target_link_libraries(Qocoa Qt5::Widgets)
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1245,21 +1245,13 @@ target_link_libraries(clementine_lib
   libclementine-tagreader
   libclementine-remote
 
-  Qt5::Concurrent
-  Qt5::Core
-  Qt5::Network
-  Qt5::OpenGL
-  Qt5::OpenGL
-  Qt5::Sql
-  Qt5::Widgets
-  Qt5::Xml
-
   ${TAGLIB_LIBRARIES}
   ${MYGPOQT5_LIBRARIES}
   ${CHROMAPRINT_LIBRARIES}
   ${GOBJECT_LIBRARIES}
   ${GLIB_LIBRARIES}
   ${GIO_LIBRARIES}
+  ${QT_LIBRARIES}
   ${GSTREAMER_BASE_LIBRARIES}
   ${GSTREAMER_LIBRARIES}
   ${GSTREAMER_APP_LIBRARIES}


### PR DESCRIPTION
Commit 453270c broke building.
Because the link line does not include dbus or x11 if found.
Also, visualizations are optional and newer macOS don't have OpenGL so it shouldn't be forced to link.
