### PR TITLE
Fix global shortcuts using GSD D-Bus backend

### DIFF
--- a/src/core/globalshortcuts.cpp
+++ b/src/core/globalshortcuts.cpp
@@ -149,8 +149,7 @@ GlobalShortcuts::Shortcut GlobalShortcuts::AddShortcut(
 
 bool GlobalShortcuts::IsGsdAvailable() const {
 #ifdef HAVE_DBUS
-  return QDBusConnection::sessionBus().interface()->isServiceRegistered(
-      GnomeGlobalShortcutBackend::kGsdService);
+  return QDBusConnection::sessionBus().interface()->isServiceRegistered(GnomeGlobalShortcutBackend::kGsdService) || QDBusConnection::sessionBus().interface()->isServiceRegistered(GnomeGlobalShortcutBackend::kGsdService2);
 #else  // HAVE_DBUS
   return false;
 #endif

--- a/src/core/globalshortcuts.cpp
+++ b/src/core/globalshortcuts.cpp
@@ -149,7 +149,10 @@ GlobalShortcuts::Shortcut GlobalShortcuts::AddShortcut(
 
 bool GlobalShortcuts::IsGsdAvailable() const {
 #ifdef HAVE_DBUS
-  return QDBusConnection::sessionBus().interface()->isServiceRegistered(GnomeGlobalShortcutBackend::kGsdService) || QDBusConnection::sessionBus().interface()->isServiceRegistered(GnomeGlobalShortcutBackend::kGsdService2);
+  return QDBusConnection::sessionBus().interface()->isServiceRegistered(
+             GnomeGlobalShortcutBackend::kGsdService) ||
+         QDBusConnection::sessionBus().interface()->isServiceRegistered(
+             GnomeGlobalShortcutBackend::kGsdService2);
 #else  // HAVE_DBUS
   return false;
 #endif

--- a/src/core/gnomeglobalshortcutbackend.cpp
+++ b/src/core/gnomeglobalshortcutbackend.cpp
@@ -55,11 +55,14 @@ bool GnomeGlobalShortcutBackend::DoRegister() {
 
   if (!interface_) {
     // Check if the GSD service is available
-    if (QDBusConnection::sessionBus().interface()->isServiceRegistered(kGsdService)) {
-      interface_ = new OrgGnomeSettingsDaemonMediaKeysInterface(kGsdService, kGsdPath, QDBusConnection::sessionBus(), this);
-    }
-    else if (QDBusConnection::sessionBus().interface()->isServiceRegistered(kGsdService2)) {
-      interface_ = new OrgGnomeSettingsDaemonMediaKeysInterface(kGsdService2, kGsdPath, QDBusConnection::sessionBus(), this);
+    if (QDBusConnection::sessionBus().interface()->isServiceRegistered(
+            kGsdService)) {
+      interface_ = new OrgGnomeSettingsDaemonMediaKeysInterface(
+          kGsdService, kGsdPath, QDBusConnection::sessionBus(), this);
+    } else if (QDBusConnection::sessionBus().interface()->isServiceRegistered(
+                   kGsdService2)) {
+      interface_ = new OrgGnomeSettingsDaemonMediaKeysInterface(
+          kGsdService2, kGsdPath, QDBusConnection::sessionBus(), this);
     }
   }
 

--- a/src/core/gnomeglobalshortcutbackend.h
+++ b/src/core/gnomeglobalshortcutbackend.h
@@ -33,8 +33,8 @@ class GnomeGlobalShortcutBackend : public GlobalShortcutBackend {
   explicit GnomeGlobalShortcutBackend(GlobalShortcuts* parent);
 
   static const char* kGsdService;
+  static const char* kGsdService2;
   static const char* kGsdPath;
-  static const char* kGsdInterface;
 
  protected:
   bool RegisterInNewThread() const { return true; }


### PR DESCRIPTION
The GSD D-Bus backend is broken with newer versions of gnome-settings-daemon (GSD) because of this change done about a year ago.
See:
https://gitlab.gnome.org/GNOME/gnome-settings-daemon/commit/33d47e655606ac88ed7d529c1132e5be6299633b
This caused it to fallback to using X11 shortcuts using XGrabKey.

This change makes it use org.gnome.SettingsDaemon.MediaKeys instead, but will also fallback to trying
org.gnome.SettingsDaemon instead so that distros that use old packages like Debian will still work.

I've tested it on opensuse tumbleweed with Gnome 3, it uses up-to-date packages, the backend now registers, grabs shortcuts and opens the gnome shortcut settings.

Fixes #6204 , #5462 and #6191 
