### PR TITLE
Quit thread before deleting the loader

### DIFF
--- a/src/devices/gpoddevice.cpp
+++ b/src/devices/gpoddevice.cpp
@@ -62,6 +62,11 @@ void GPodDevice::LoadFinished(Itdb_iTunesDB* db) {
   db_ = db;
   db_wait_cond_.wakeAll();
 
+  loader_thread_->quit();
+  loader_thread_->wait(1000);
+  loader_thread_->deleteLater();
+  loader_thread_ = nullptr;
+
   loader_->deleteLater();
   loader_ = nullptr;
 }


### PR DESCRIPTION
Fixes: "QThread: Destroyed while thread is still running" when unmounting a gpod device.
Also tested on the Qt 5 branch, with Qt 5 it crashed before without quitting the thread.
