### PR TITLE
[qxt] Compil fix for qt version > 5.6

### DIFF
--- a/3rdparty/qxt/qxtglobalshortcut_x11.cpp
+++ b/3rdparty/qxt/qxtglobalshortcut_x11.cpp
@@ -29,8 +29,11 @@
 ** <http://libqxt.org>  <foundation@libqxt.org>
 *****************************************************************************/
 
-#if QT_VERSION < QT_VERSION_CHECK(5,0,0)
+#if QT_VERSION < QT_VERSION_CHECK(5,0,0) || QT_VERSION > QT_VERSION_CHECK(5,6,0) 
 #   include <QX11Info>
+#if QT_VERSION > QT_VERSION_CHECK(5,6,0)
+#   include <xcb/xcb.h>
+#endif
 #else
 #   include <QApplication>
 #   include <qpa/qplatformnativeinterface.h>
@@ -92,7 +95,7 @@ class QxtX11Data {
 public:
     QxtX11Data()
     {
-#if QT_VERSION < QT_VERSION_CHECK(5,0,0)
+#if QT_VERSION < QT_VERSION_CHECK(5,0,0) || QT_VERSION > QT_VERSION_CHECK(5,6,0)
         m_display = QX11Info::display();
 #else
         QPlatformNativeInterface *native = qApp->platformNativeInterface();

--- a/3rdparty/qxt/qxtglobalshortcut_x11.cpp
+++ b/3rdparty/qxt/qxtglobalshortcut_x11.cpp
@@ -29,16 +29,8 @@
 ** <http://libqxt.org>  <foundation@libqxt.org>
 *****************************************************************************/
 
-#if QT_VERSION < QT_VERSION_CHECK(5,0,0) || QT_VERSION > QT_VERSION_CHECK(5,6,0) 
-#   include <QX11Info>
-#if QT_VERSION > QT_VERSION_CHECK(5,6,0)
-#   include <xcb/xcb.h>
-#endif
-#else
-#   include <QApplication>
-#   include <qpa/qplatformnativeinterface.h>
-#   include <xcb/xcb.h>
-#endif
+#include <QX11Info>
+#include <xcb/xcb.h>
 #include <QVector>
 #include <X11/Xlib.h>
 #include "keymapper_x11.h"
@@ -95,14 +87,7 @@ class QxtX11Data {
 public:
     QxtX11Data()
     {
-#if QT_VERSION < QT_VERSION_CHECK(5,0,0) || QT_VERSION > QT_VERSION_CHECK(5,6,0)
         m_display = QX11Info::display();
-#else
-        QPlatformNativeInterface *native = qApp->platformNativeInterface();
-        void *display = native->nativeResourceForScreen(QByteArray("display"),
-                                                        QGuiApplication::primaryScreen());
-        m_display = reinterpret_cast<Display *>(display);
-#endif
     }
 
     bool isValid()


### PR DESCRIPTION
qxt required QPlatformNativeInterface which is not available in qt > 5.6 (I compiled with 5.9 under ubuntu 18.04), so let's use QX11Info instead 