### PR TITLE
Change default group by in library to album artist

### DIFF
--- a/src/library/libraryfilterwidget.cpp
+++ b/src/library/libraryfilterwidget.cpp
@@ -258,7 +258,7 @@ void LibraryFilterWidget::SetLibraryModel(LibraryModel* model) {
     s.beginGroup(settings_group_);
     model_->SetGroupBy(LibraryModel::Grouping(
         LibraryModel::GroupBy(
-            s.value("group_by1", int(LibraryModel::GroupBy_Artist)).toInt()),
+            s.value("group_by1", int(LibraryModel::GroupBy_AlbumArtist)).toInt()),
         LibraryModel::GroupBy(
             s.value("group_by2", int(LibraryModel::GroupBy_Album)).toInt()),
         LibraryModel::GroupBy(

--- a/src/library/libraryfilterwidget.cpp
+++ b/src/library/libraryfilterwidget.cpp
@@ -258,7 +258,8 @@ void LibraryFilterWidget::SetLibraryModel(LibraryModel* model) {
     s.beginGroup(settings_group_);
     model_->SetGroupBy(LibraryModel::Grouping(
         LibraryModel::GroupBy(
-            s.value("group_by1", int(LibraryModel::GroupBy_AlbumArtist)).toInt()),
+            s.value("group_by1", int(LibraryModel::GroupBy_AlbumArtist))
+                .toInt()),
         LibraryModel::GroupBy(
             s.value("group_by2", int(LibraryModel::GroupBy_Album)).toInt()),
         LibraryModel::GroupBy(


### PR DESCRIPTION
I suggest changing the default group by in the library to album artist, otherwise albums that use album artist will have songs spread all over the library when there are multiple artists on the album, which will confuse newcomers that don't know that they can change this behavior. It also makes more sense that songs that are on the same album appear under the same album.
