### PR TITLE
Prevent UI hang during device scan.

### DIFF
--- a/src/devices/filesystemdevice.cpp
+++ b/src/devices/filesystemdevice.cpp
@@ -71,6 +71,7 @@ void FilesystemDevice::Init() {
 }
 
 FilesystemDevice::~FilesystemDevice() {
+  watcher_->Stop();
   watcher_->deleteLater();
   watcher_thread_->exit();
   watcher_thread_->wait();

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -121,6 +121,7 @@ Library::Library(Application* app, QObject* parent)
 }
 
 Library::~Library() {
+  watcher_->Stop();
   watcher_->deleteLater();
   watcher_thread_->exit();
   watcher_thread_->wait(5000 /* five seconds */);

--- a/src/library/librarywatcher.cpp
+++ b/src/library/librarywatcher.cpp
@@ -678,6 +678,8 @@ QString LibraryWatcher::PickBestImage(const QStringList& images) {
   QString biggest_path;
 
   for (const QString& path : filtered) {
+    if (stop_requested_) return "";
+
     QImage image(path);
     if (image.isNull()) continue;
 


### PR DESCRIPTION
When unmounting a device, the ConnectedDevice object is destroyed. The
FileSystemDevice destructor waits on its worker thread. If a scan is in
progress, this will block until completion.

There is an existing Stop method in the LibraryWatcher class that is intended to
stop long running operations. To fix, or at least significantly shorten this
hang, we'll call this before waiting for the thread to exit. Also add a
stop_requested check in the cover art scan.

In addition, add a call to Stop in the Library destructor, which has a similar
usage.