### PR TITLE
Fix parsing of the Geolocator response.

### DIFF
--- a/src/internet/core/geolocator.cpp
+++ b/src/internet/core/geolocator.cpp
@@ -97,9 +97,10 @@ void Geolocator::RequestFinished(QNetworkReply* reply) {
     return;
   }
 
+  QByteArray reply_data = reply->readAll();
   QJson::Parser parser;
   bool ok = false;
-  QVariant result = parser.parse(reply, &ok);
+  QVariant result = parser.parse(reply_data, &ok);
   if (!ok) {
     emit Finished(LatLng());
     return;


### PR DESCRIPTION
The QNetworkReply::read method, as described in the QIODevice documentation, will
return -1 if the user reads past the end of the stream. If a read is short due
to the end of a stream, the next read will return -1. The current qjson release
(0.9.0) ignores the short read and returns a fatal error on the next read:

00:53:32.178 ERROR unknown                          JSonScanner::yylex - error while reading from io device
00:53:32.179 ERROR unknown                          json_parser - syntax error found,  forcing abort, Line 1 Column 1

Reading the response into a buffer then passing that to the parse function
(which then uses it as a stream again) corrects this problem.

I believe this issue is fixed upstream in qjson, but the last official release
was in 2016, so I don't know when we might expect 1.0.0.