### PR TITLE
Fix potential use of streamer element after deletion.

### DIFF
--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -1004,7 +1004,10 @@ void GstEnginePipeline::TransitionToNext() {
 
   ignore_tags_ = true;
 
-  ReplaceDecodeBin(next_url_);
+  if (!ReplaceDecodeBin(next_url_)) {
+    qLog(Error) << "ReplaceDecodeBin failed with " << next_url_;
+    return;
+  }
   gst_element_set_state(uridecodebin_, GST_STATE_PLAYING);
   MaybeLinkDecodeToAudio();
 


### PR DESCRIPTION
If ReplaceDecodeBin fails from TransitionToNext, uridecodebin_ will not be
replaced with a new element. Since TransitionToNext does not check the return
value, it unknowingly deletes uridecodebin_.