### PR TITLE
Free decoder bin if error occurs during setup.

### DIFF
--- a/src/engines/gstenginepipeline.h
+++ b/src/engines/gstenginepipeline.h
@@ -151,6 +151,7 @@ signals:
 
   bool Init();
   GstElement* CreateDecodeBinFromString(const char* pipeline);
+  GstElement* CreateDecodeBinFromUrl(const QUrl& url);
 
   void UpdateVolume();
   void UpdateEqualizer();


### PR DESCRIPTION
In the case that an error occurs in ReplaceDecodeBin before the bin is added to
the pipeline, unreference the object to allow cleanup. This change also separates
CreateDecodeBinFromUrl from ReplaceDecodeBin, following the pattern of
CreateDecodeBinFromString.