### PR TITLE
Set non-zero minimum for fade times.

### DIFF
--- a/src/ui/playbacksettingspage.ui
+++ b/src/ui/playbacksettingspage.ui
@@ -88,6 +88,9 @@
            <property name="suffix">
             <string> ms</string>
            </property>
+           <property name="minimum">
+            <number>1</number>
+           </property>
            <property name="maximum">
             <number>10000</number>
            </property>
@@ -138,6 +141,9 @@
          <widget class="QSpinBox" name="fading_pause_duration">
           <property name="suffix">
            <string> ms</string>
+          </property>
+          <property name="minimum">
+           <number>1</number>
           </property>
           <property name="maximum">
            <number>10000</number>


### PR DESCRIPTION
QTimeLine duration must be greater than 0. If set to 0, a default of 1000ms will
be used. To avoid this, enforce a minimum of 1ms for pause and cross fade values
if those fades are enabled.