### PR TITLE
Fix a number of zero-value tag issues

### DIFF
--- a/ext/libclementine-tagreader/tagreader.cpp
+++ b/ext/libclementine-tagreader/tagreader.cpp
@@ -38,7 +38,6 @@
 #include <mp4file.h>
 #include <mp4tag.h>
 #include <mpcfile.h>
-#include <apefile.h>
 #include <mpegfile.h>
 #include <oggfile.h>
 #ifdef TAGLIB_HAS_OPUS

--- a/ext/libclementine-tagreader/tagreader.cpp
+++ b/ext/libclementine-tagreader/tagreader.cpp
@@ -38,6 +38,7 @@
 #include <mp4file.h>
 #include <mp4tag.h>
 #include <mpcfile.h>
+#include <apefile.h>
 #include <mpegfile.h>
 #include <oggfile.h>
 #ifdef TAGLIB_HAS_OPUS


### PR DESCRIPTION
Some fixes to prevent the writing of zero values and also addressing the inability to clear some tag fields in the tag editor.

- Fix compilation and disc field zero-value checks
- Check year, track and statistics fields for zero-values