### PR TITLE
Revert "Blacklist all NVidia drivers"

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -480,7 +480,11 @@ int main(int argc, char* argv[]) {
   QFile self_maps("/proc/self/maps");
   if (self_maps.open(QIODevice::ReadOnly)) {
     QByteArray data = self_maps.readAll();
-    if (data.contains("libnvidia-tls.so.")) {
+    if (data.contains("libnvidia-tls.so.304.37") ||
+        data.contains("libnvidia-tls.so.285.03") ||
+        data.contains("libnvidia-tls.so.280.13") ||
+        data.contains("libnvidia-tls.so.275.28") ||
+        data.contains("libnvidia-tls.so.275.19")) {
       qLog(Warning) << "Exiting immediately to work around NVIDIA driver bug";
       _exit(ret);
     }


### PR DESCRIPTION
In 2011, there was a bug that caused NVIDIA drivers to hang Clementine on shutdown. In 2012, only some drivers had the fix for this issue, but the list was becoming tedious to maintain.  Now, in 2019, we do not need to work around this bug. By reverting commit c2723008a22c5a4c4e307ba9a278fd2162ef6bdb we work around known bad drivers, but do not penalize all NVIDIA users for this ancient bug.

Merging this will close #6061 .