### PR TITLE
Fix gst_buffer_unref assertion with chromaprinter

### DIFF
--- a/src/musicbrainz/chromaprinter.cpp
+++ b/src/musicbrainz/chromaprinter.cpp
@@ -204,12 +204,16 @@ GstFlowReturn Chromaprinter::NewBufferCallback(GstAppSink* app_sink,
   Chromaprinter* me = reinterpret_cast<Chromaprinter*>(self);
 
   GstSample* sample = gst_app_sink_pull_sample(app_sink);
+  if (!sample) return GST_FLOW_ERROR;
   GstBuffer* buffer = gst_sample_get_buffer(sample);
-  GstMapInfo map;
-  gst_buffer_map(buffer, &map, GST_MAP_READ);
-  me->buffer_.write(reinterpret_cast<const char*>(map.data), map.size);
-  gst_buffer_unmap(buffer, &map);
-  gst_buffer_unref(buffer);
+  if (buffer) {
+    GstMapInfo map;
+    if (gst_buffer_map(buffer, &map, GST_MAP_READ)) {
+      me->buffer_.write(reinterpret_cast<const char*>(map.data), map.size);
+      gst_buffer_unmap(buffer, &map);
+    }
+  }
+  gst_sample_unref(sample);
 
   return GST_FLOW_OK;
 }


### PR DESCRIPTION
Automatic tag fetching is broken as of at least gstreamer 1.5.90 and newer. With the official released gstreamer 1.6.0 this leaves the feature broken.
There is an incorrect call to gst_buffer_unref that causes an assertion in gstreamer followed by a crash.
My understanding is that gst_buffer_unref should only be done when gst_buffer_ref is called, see:
https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer/html/GstSample.html#gst-sample-get-buffer
This fix adds a missing gst_sample_unref which is enough to free the buffer too according to the documentation.

Fixes https://github.com/clementine-player/Clementine/issues/6333