### PR TITLE
Fix blank window when restoring from systray

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1441,7 +1441,7 @@ void MainWindow::closeEvent(QCloseEvent* event) {
     keep_running = s.value("keeprunning", tray_icon_->IsVisible()).toBool();
 
   if (keep_running && event->spontaneous()) {
-    event->accept();
+	event->ignore();
     SetHiddenInTray(true);
   } else {
     Exit();
@@ -1454,7 +1454,7 @@ void MainWindow::SetHiddenInTray(bool hidden) {
   // Some window managers don't remember maximized state between calls to
   // hide() and show(), so we have to remember it ourself.
   if (hidden) {
-    hide();
+    QTimer::singleShot(0, this, &QWidget::hide);
   } else {
     if (was_maximized_)
       showMaximized();

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1441,7 +1441,7 @@ void MainWindow::closeEvent(QCloseEvent* event) {
     keep_running = s.value("keeprunning", tray_icon_->IsVisible()).toBool();
 
   if (keep_running && event->spontaneous()) {
-	event->ignore();
+    event->ignore();
     SetHiddenInTray(true);
   } else {
     Exit();


### PR DESCRIPTION
Fix #6111 by ignoring instead of accepting the main window's closeEvent.

This applies the fix qBittorrent used for this same issue (https://github.com/qbittorrent/qBittorrent/issues/9240) to clementine, so credit goes to those guys.