### PR TITLE
Support per-app notification settings in KDE Plasma 5.16

### DIFF
--- a/src/widgets/osd_x11.cpp
+++ b/src/widgets/osd_x11.cpp
@@ -111,6 +111,7 @@ void OSD::ShowMessageNative(const QString& summary, const QString& message,
     hints["image_data"] = QVariant(image);
   }
 
+  hints["desktop-entry"] = QVariant(QCoreApplication::applicationName());
   hints["transient"] = QVariant(true);
 
   int id = 0;

--- a/src/widgets/osd_x11.cpp
+++ b/src/widgets/osd_x11.cpp
@@ -111,7 +111,7 @@ void OSD::ShowMessageNative(const QString& summary, const QString& message,
     hints["image_data"] = QVariant(image);
   }
 
-  hints["desktop-entry"] = QVariant(QCoreApplication::applicationName());
+  hints["desktop-entry"] = QVariant("clementine");
   hints["transient"] = QVariant(true);
 
   int id = 0;


### PR DESCRIPTION
With KDE Plasma 5.16+, all Clementine notifications sent via D-Bus are retained in the notification history applet if the user doesn't manually dismiss the notification before it times out. Plasma's notifications control module allows you to turn off notification history for specific applications (among other things), but Clementine doesn't appear as a configurable application, and manually adding Clementine to the list via config files has no effect on the notification behavior.

Comparing Clementine's D-Bus messages to Slack (which does support per-app notification settings in KDE), I discovered that Clementine is missing a [`desktop-entry`](https://developer.gnome.org/notification-spec/#hints) hint in the call to `org.freedesktop.Notifications.Notify`. Adding this hint to the messages causes Clementine to appear as an application in Plasma's notification settings, and all of Clementine's notifications will obey the user's per-app notification settings. As a bonus, a little Clementine icon now shows in the message header (Breeze theme shown here):

![image](https://user-images.githubusercontent.com/4631197/59567371-2fbe9480-903b-11e9-8e47-822fb3ccbd84.png)

I also tested this on GNOME and LXDE, which are both unaffected by the change; GNOME appears to use the Application Name string for its settings, and LXDE doesn't have per-app settings.
