### PR TITLE
Introduce limit for number of tag client processes.

### DIFF
--- a/src/core/tagreaderclient.cpp
+++ b/src/core/tagreaderclient.cpp
@@ -18,6 +18,7 @@
    along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "player.h"
 #include "tagreaderclient.h"
 
 #include <QCoreApplication>
@@ -34,8 +35,14 @@ TagReaderClient::TagReaderClient(QObject* parent)
     : QObject(parent), worker_pool_(new WorkerPool<HandlerType>(this)) {
   sInstance = this;
 
+  QSettings s;
+  s.beginGroup(Player::kSettingsGroup);
+
+  int max_workers = QThread::idealThreadCount();
+  int num_workers = s.value("max_numprocs_tagclients", max_workers).toInt();
+
   worker_pool_->SetExecutableName(kWorkerExecutableName);
-  worker_pool_->SetWorkerCount(QThread::idealThreadCount());
+  worker_pool_->SetWorkerCount(num_workers);
   connect(worker_pool_, SIGNAL(WorkerFailedToStart()),
           SLOT(WorkerFailedToStart()));
 }

--- a/src/ui/behavioursettingspage.cpp
+++ b/src/ui/behavioursettingspage.cpp
@@ -40,6 +40,15 @@ BehaviourSettingsPage::BehaviourSettingsPage(SettingsDialog* dialog)
   connect(ui_->b_show_tray_icon_, SIGNAL(toggled(bool)),
           SLOT(ShowTrayIconToggled(bool)));
 
+  connect(ui_->max_numprocs_tagclients, SIGNAL(valueChanged(int)),
+          SLOT(MaxNumProcsTagClientsChanged(int)));
+  ui_->max_numprocs_tagclients_value_label->setMinimumWidth(
+      QFontMetrics(ui_->max_numprocs_tagclients_value_label->font())
+          .width("WWW"));
+
+  // Limit max tag clients to number of CPU cores.
+  ui_->max_numprocs_tagclients->setMaximum(QThread::idealThreadCount());
+
   ui_->doubleclick_addmode->setItemData(0, MainWindow::AddBehaviour_Append);
   ui_->doubleclick_addmode->setItemData(1, MainWindow::AddBehaviour_Load);
   ui_->doubleclick_addmode->setItemData(2, MainWindow::AddBehaviour_OpenInNew);
@@ -171,6 +180,12 @@ void BehaviourSettingsPage::Load() {
           .toInt()));
   ui_->seek_step_sec->setValue(s.value("seek_step_sec", 10).toInt());
 
+  int max_numprocs_tagclients =
+      s.value("max_numprocs_tagclients", QThread::idealThreadCount()).toInt();
+  ui_->max_numprocs_tagclients->setValue(max_numprocs_tagclients);
+  ui_->max_numprocs_tagclients_value_label->setText(
+      QString::number(max_numprocs_tagclients));
+
   if (s.value("play_count_short_duration", false).toBool()) {
     ui_->b_play_count_short_duration->setChecked(true);
     ui_->b_play_count_normal_duration->setChecked(false);
@@ -283,6 +298,7 @@ void BehaviourSettingsPage::Save() {
              ui_->stop_play_if_fail_->isChecked());
   s.setValue("menu_previousmode", menu_previousmode);
   s.setValue("seek_step_sec", ui_->seek_step_sec->value());
+  s.setValue("max_numprocs_tagclients", ui_->max_numprocs_tagclients->value());
 
   if (ui_->b_play_count_short_duration->isChecked()) {
     s.setValue("play_count_short_duration", true);
@@ -320,4 +336,8 @@ void BehaviourSettingsPage::ShowTrayIconToggled(bool on) {
   ui_->b_keep_running_->setEnabled(on);
   ui_->b_keep_running_->setChecked(on);
   ui_->b_scroll_tray_icon_->setEnabled(on);
+}
+
+void BehaviourSettingsPage::MaxNumProcsTagClientsChanged(int value) {
+  ui_->max_numprocs_tagclients_value_label->setText(QString::number(value));
 }

--- a/src/ui/behavioursettingspage.h
+++ b/src/ui/behavioursettingspage.h
@@ -36,6 +36,7 @@ class BehaviourSettingsPage : public SettingsPage {
 
  private slots:
   void ShowTrayIconToggled(bool on);
+  void MaxNumProcsTagClientsChanged(int value);
 
  private:
   Ui_BehaviourSettingsPage* ui_;

--- a/src/ui/behavioursettingspage.ui
+++ b/src/ui/behavioursettingspage.ui
@@ -340,6 +340,48 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="groupBox_max_tagclients">
+     <property name="title">
+      <string>Maximum number of child processes for tag handling (requires restart)</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_8">
+      <item>
+       <widget class="QLabel" name="numprocs_tagclients_label">
+        <property name="text">
+         <string>Number of processes:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="max_numprocs_tagclients_value_label">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QSlider" name="max_numprocs_tagclients">
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>32</number>
+        </property>
+        <property name="value">
+         <number>4</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="tickInterval">
+         <number>1</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="groupBox_9">
      <property name="title">
       <string>When saving a playlist, file paths should be</string>


### PR DESCRIPTION
Previously, the number of processes spawned was always
QThread::idealThreadCount() (returning the number of logical CPU
cores). On new systems with many cores, however, this can result
in 12, 16, 24, or ... processes being spawned, which is a bit
excessive.

This establishes a new config variable,
'max_numprocs_tagclients' within the Settings group, in order
to limit the maximum number of tag client processes that get
spawned. It also adds a means of setting this via the Behavior
page in Settings. It can be set to any integer in the interval
[1, QThread::idealThreadCount()]; it defaults to the maximal value
so as to emulate the old behavior.