### PR TITLE
Fix crash in messagereply

### DIFF
--- a/ext/libclementine-common/core/messagereply.h
+++ b/ext/libclementine-common/core/messagereply.h
@@ -89,7 +89,6 @@ void MessageReply<MessageType>::SetReply(const MessageType& message) {
   qLog(Debug) << "Releasing ID" << id() << "(finished)";
   semaphore_.release();
   emit Finished(success_);
-
 }
 
 #endif  // MESSAGEREPLY_H

--- a/ext/libclementine-common/core/messagereply.h
+++ b/ext/libclementine-common/core/messagereply.h
@@ -86,9 +86,10 @@ void MessageReply<MessageType>::SetReply(const MessageType& message) {
   finished_ = true;
   success_ = true;
 
-  emit Finished(success_);
   qLog(Debug) << "Releasing ID" << id() << "(finished)";
   semaphore_.release();
+  emit Finished(success_);
+
 }
 
 #endif  // MESSAGEREPLY_H


### PR DESCRIPTION
The messagereply gets deleted too early, I tried different approaches to solving it including using invokeMethod with Qt::QueuedConnection on deleteLater() which had no affect, but found that simply moving the signal works.
It seem like the messagereply gets deleted in the main thread before the semaphore is released.
I've set up a small test program that does tags on files in a directory in a loop. Before this it always crashed, typically around something like 300 tagwrites. Now I'm testing 10.000 writes in a loop without any crash.

Fixes https://github.com/clementine-player/Clementine/issues/5777 and https://github.com/clementine-player/Clementine/issues/6317
