### PR TITLE
Fix ratings not saved to file tag (Fix #6385)

### DIFF
--- a/ext/libclementine-tagreader/tagreader.cpp
+++ b/ext/libclementine-tagreader/tagreader.cpp
@@ -981,7 +981,7 @@ bool TagReader::SaveSongRatingToFile(
   if (filename.isNull()) return false;
 
   qLog(Debug) << "Saving song rating tags to" << filename;
-  if (song.rating()) {
+  if (song.rating() < 0) {
     // The FMPS spec says unrated == "tag not present". For us, no rating
     // results in rating being -1, so don't write anything in that case.
     // Actually, we should also remove tag set in this case, but in


### PR DESCRIPTION
Commit 96a7e18a8d2be8d9f3223a6a6c81fbaac1179869 by @smithjd15 from
2019-04-03 fixed a number of potential zero-value field values, but it
also flipped the early exit condition skipping saving a rating to file.

It seems out of place with the rest of the commit, so considering it a
mistake and reverting to the original condition.

Manually tested; works and saves again ratings to file.