### PR TITLE
Fix misc. source comment typos

### DIFF
--- a/cmake/FindFFTW3.cmake
+++ b/cmake/FindFFTW3.cmake
@@ -54,8 +54,8 @@ SET(FFTW3_POSSIBLE_LIBRARY_PATH
 )
 
   
-# the lib prefix is containe din filename onf W32, unfortuantely. JW
-# teh "general" lib: 
+# the lib prefix is contained in filename on W32, unfortunately. JW
+# the "general" lib: 
 FIND_LIBRARY(FFTW3_FFTW_LIBRARY
   NAMES fftw3 libfftw libfftw3 libfftw3-3
   PATHS 

--- a/data/lyrics/ultimate_providers.xml
+++ b/data/lyrics/ultimate_providers.xml
@@ -63,11 +63,11 @@
   <provider name="genius.com" charset="utf-8" url="https://www.genius.com/{artist}-{title}-lyrics">
     <urlFormat replace=",._@!#%^*+;\/&quot;'()[]" with=""/>
     <urlFormat replace=" :" with="-"/>
-    <!-- When $ is used as the dollar sign it is ommitted from the url
+    <!-- When $ is used as the dollar sign it is omitted from the url
          When $ is used instead of 's',
          in some cases it is replaced by 's'(Too $hort -> too-short)
-         in other cases it is ommited ($uicideboy$ -> uicideboy)
-         I chose to ommit it though, in some cases it's gonna be problematic -->
+         in other cases it is omitted ($uicideboy$ -> uicideboy)
+         I chose to omit it though, in some cases it's gonna be problematic -->
     <urlFormat replace="$" with=""/>
     <urlFormat replace="ÄÂÀÁÃäâàáã" with="a"/>
     <urlFormat replace="ËÊÈÉëêèé" with="e"/>

--- a/dist/cpplint.py
+++ b/dist/cpplint.py
@@ -6110,7 +6110,7 @@ def ParseArguments(args):
       try:
           _valid_extensions = set(val.split(','))
       except ValueError:
-          PrintUsage('Extensions must be comma seperated list.')
+          PrintUsage('Extensions must be comma separated list.')
 
   if not filenames:
     PrintUsage('No files were specified.')

--- a/dist/format.py
+++ b/dist/format.py
@@ -23,7 +23,7 @@ def main():
       help='edit files inplace instead of showing a diff')
   parser.add_argument('--files', nargs='*', metavar='FIL',
       default=[],
-      help='get files as arguments insted of git')
+      help='get files as arguments instead of git')
   args = parser.parse_args()
 
   try:

--- a/ext/libclementine-remote/remotecontrolmessages.proto
+++ b/ext/libclementine-remote/remotecontrolmessages.proto
@@ -137,7 +137,7 @@ message SongMetadata {
   optional Type type = 22;
 }
 
-// Playlist informations
+// Playlist information
 message Playlist {
   optional int32 id = 1;
   optional string name = 2;

--- a/src/analyzers/analyzercontainer.cpp
+++ b/src/analyzers/analyzercontainer.cpp
@@ -163,7 +163,7 @@ void AnalyzerContainer::ChangeAnalyzer(int id) {
       analyzer_types_[id]->newInstance(Q_ARG(QWidget*, this));
 
   if (!instance) {
-    qLog(Warning) << "Couldn't intialise a new"
+    qLog(Warning) << "Couldn't initialise a new"
                   << analyzer_types_[id]->className();
     return;
   }

--- a/src/analyzers/blockanalyzer.cpp
+++ b/src/analyzers/blockanalyzer.cpp
@@ -284,7 +284,7 @@ QColor ensureContrast(const QColor& bg, const QColor& fg, uint _amount = 150) {
   int dh = abs(bh - fh);
 
   if (dh > 120) {
-    // a third of the colour wheel automatically guarentees contrast
+    // a third of the colour wheel automatically guarantees contrast
     // but only if the values are high enough and saturations significant enough
     // to allow the colours to be visible and not be shades of grey or black
 

--- a/src/covers/albumcoverfetchersearch.cpp
+++ b/src/covers/albumcoverfetchersearch.cpp
@@ -48,7 +48,7 @@ AlbumCoverFetcherSearch::AlbumCoverFetcherSearch(
       image_load_timeout_(new NetworkTimeouts(kImageLoadTimeoutMs, this)),
       network_(network),
       cancel_requested_(false) {
-  // we will terminate the search after kSearchTimeoutMs miliseconds if we are
+  // we will terminate the search after kSearchTimeoutMs milliseconds if we are
   // not
   // able to find all of the results before that point in time
   QTimer::singleShot(kSearchTimeoutMs, this, SLOT(TerminateSearch()));

--- a/src/dbus/org.freedesktop.UDisks.Device.xml
+++ b/src/dbus/org.freedesktop.UDisks.Device.xml
@@ -1152,7 +1152,7 @@
       <doc:doc>
         <doc:description>
           <doc:para>
-            Detachs the device by e.g. powering down the physical port
+            Detaches the device by e.g. powering down the physical port
             it is connected to. Note that not all devices or ports are
             capable of this. Check the
             <doc:ref type="property" to="Device:DriveCanDetach">DriveCanDetach</doc:ref>
@@ -2408,7 +2408,7 @@
             <quote>BAD_ATTRIBUTE_NOW</quote> (At least one pre-fail attribute is exceeding its threshold now),
             <quote>BAD_SECTOR_MANY</quote> (Many bad sectors)),
             <quote>BAD_STATUS</quote> (Smart Self Assessment negative)
-            or empty if some error occured trying to determine the result.
+            or empty if some error occurred trying to determine the result.
             This property is only valid if
             <doc:ref type="property" to="Device:DriveAtaSmartTimeCollected">DriveAtaSmartTimeCollected</doc:ref>
             is greater than zero.

--- a/src/devices/udisks2lister.h
+++ b/src/devices/udisks2lister.h
@@ -96,7 +96,7 @@ class Udisks2Lister : public DeviceLister {
     quint64 capacity;
     QString dbus_drive_path;
 
-    // Paritition
+    // Partition
     QString label;
     QString uuid;
     quint64 free_space;

--- a/src/engines/enginebase.h
+++ b/src/engines/enginebase.h
@@ -61,7 +61,7 @@ class Base : public QObject {
   virtual qint64 length_nanosec() const = 0;
 
   // Subclasses should respect given markers (beginning and end) which are
-  // in miliseconds.
+  // in milliseconds.
   virtual bool Load(const QUrl& url, TrackChangeFlags change,
                     bool force_stop_at_end, quint64 beginning_nanosec,
                     qint64 end_nanosec);

--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -504,7 +504,7 @@ bool GstEnginePipeline::InitFromUrl(const QUrl& url, qint64 end_nanosec) {
 
   if (url.scheme() == "cdda" && !url.path().isEmpty()) {
     // Currently, Gstreamer can't handle input CD devices inside cdda URL. So
-    // we handle them ourselve: we extract the track number and re-create an
+    // we handle them ourself: we extract the track number and re-create an
     // URL with only cdda:// + the track number (which can be handled by
     // Gstreamer). We keep the device in mind, and we will set it later using
     // SourceSetupCallback
@@ -996,7 +996,7 @@ void GstEnginePipeline::SourceSetupCallback(GstURIDecodeBin* bin,
 
   if (g_object_class_find_property(G_OBJECT_GET_CLASS(element), "device") &&
       !instance->source_device().isEmpty()) {
-    // Gstreamer is not able to handle device in URL (refering to Gstreamer
+    // Gstreamer is not able to handle device in URL (referring to Gstreamer
     // documentation, this might be added in the future). Despite that, for now
     // we include device inside URL: we decompose it during Init and set device
     // here, when this callback is called.
@@ -1221,7 +1221,7 @@ void GstEnginePipeline::FaderTimelineFinished() {
   fader_.reset();
 
   // Wait a little while longer before emitting the finished signal (and
-  // probably distroying the pipeline) to account for delays in the audio
+  // probably destroying the pipeline) to account for delays in the audio
   // server/driver.
   if (use_fudge_timer_) {
     fader_fudge_timer_.start(kFaderFudgeMsec, this);

--- a/src/internet/podcasts/podcastdownloader.cpp
+++ b/src/internet/podcasts/podcastdownloader.cpp
@@ -97,7 +97,7 @@ void Task::finishedInternal() {
 
   emit ProgressChanged(episode_, PodcastDownload::Finished, 0);
 
-  // I didn't ecountered even a single podcast with a corect metadata
+  // I didn't ecountered even a single podcast with a correct metadata
   TagReaderClient::Instance()->SaveFileBlocking(file_->fileName(), song);
   emit finished(this);
 }

--- a/src/internet/podcasts/podcastupdater.cpp
+++ b/src/internet/podcasts/podcastupdater.cpp
@@ -133,7 +133,7 @@ void PodcastUpdater::PodcastLoaded(PodcastUrlLoaderReply* reply,
   if (one_of_many) {
     if (--pending_replies_ == 0) {
       // This was the last reply we were waiting for.  Save this time as being
-      // the last sucessful update and restart the timer.
+      // the last successful update and restart the timer.
       last_full_update_ = QDateTime::currentDateTime();
       SaveSettings();
       RestartTimer();

--- a/src/internet/seafile/seafileservice.h
+++ b/src/internet/seafile/seafileservice.h
@@ -27,7 +27,7 @@
  *  - Seafile stores files in libraries (or repositories) so variable with the
  *name "library" corresponds to the
  *     Seafile library, not to the Clementine library
- *  - The authentification of Seafile's API is simply a token (REST API)
+ *  - The authentication of Seafile's API is simply a token (REST API)
  *  - Seafile stores a hash for each entry. This hash changes when the entry is
  *modified.
  *     This is the reason why we just have to compare the local hash with the

--- a/src/internet/subsonic/subsonicdynamicplaylist.cpp
+++ b/src/internet/subsonic/subsonicdynamicplaylist.cpp
@@ -125,7 +125,7 @@ PlaylistItemList SubsonicDynamicPlaylist::GenerateMore(int count) {
   if (reader.attributes().value("status") != "ok") {
     reader.readNextStartElement();
     int error = reader.attributes().value("code").toString().toInt();
-    qLog(Warning) << "An error occured fetching data.  Code: " << error
+    qLog(Warning) << "An error occurred fetching data.  Code: " << error
                   << " Message: "
                   << reader.attributes().value("message").toString();
   }

--- a/src/internet/subsonic/subsonicservice.cpp
+++ b/src/internet/subsonic/subsonicservice.cpp
@@ -347,7 +347,7 @@ void SubsonicService::OnPingFinished(QNetworkReply* reply) {
         login_state_ = LoginState_RedirectNoUrl;
       } else {
         redirect_count_++;
-        qLog(Debug) << "Redirect receieved to "
+        qLog(Debug) << "Redirect received to "
                     << redirect_url.toString(QUrl::RemoveQuery)
                     << ", current redirect count is " << redirect_count_;
         if (redirect_count_ <= kMaxRedirects) {

--- a/src/networkremote/incomingdataparser.cpp
+++ b/src/networkremote/incomingdataparser.cpp
@@ -32,7 +32,7 @@
 #endif
 
 IncomingDataParser::IncomingDataParser(Application* app) : app_(app) {
-  // load settings initaily and sign up for updates
+  // load settings initially and sign up for updates
   ReloadSettings();
   connect(app_, SIGNAL(SettingsChanged()), SLOT(ReloadSettings()));
 

--- a/src/networkremote/networkremotehelper.cpp
+++ b/src/networkremote/networkremotehelper.cpp
@@ -49,7 +49,7 @@ void NetworkRemoteHelper::StartServer() {
 
 void NetworkRemoteHelper::ReloadSettings() { emit ReloadSettingsSig(); }
 
-// For using in Settingsdialog, we haven't the appication there
+// For using in Settingsdialog, we haven't the application there
 NetworkRemoteHelper* NetworkRemoteHelper::Instance() {
   if (!sInstance) {
     // normally he shouldn't go here. Only for safety

--- a/src/playlist/playlistmanager.cpp
+++ b/src/playlist/playlistmanager.cpp
@@ -357,7 +357,7 @@ void PlaylistManager::SetActiveToCurrent() {
   // Check if we need to update the active playlist.
   // By calling SetActiveToCurrent, the playlist manager emits the signal
   // "ActiveChanged". This signal causes the network remote module to
-  // send all playlists to the clients, even no change happend.
+  // send all playlists to the clients, even if no change happened.
   if (current_id() != active_id()) {
     SetActivePlaylist(current_id());
   }

--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -750,7 +750,7 @@ void PlaylistView::closeEditor(QWidget* editor,
 }
 
 void PlaylistView::mouseMoveEvent(QMouseEvent* event) {
-  // Check wheather rating section is locked by user or not
+  // Check whether rating section is locked by user or not
   if (!ratings_locked_) {
     QModelIndex index = indexAt(event->pos());
     if (index.isValid() && index.data(Playlist::Role_CanSetRating).toBool()) {

--- a/src/playlistparsers/parserbase.h
+++ b/src/playlistparsers/parserbase.h
@@ -40,7 +40,7 @@ class ParserBase : public QObject {
 
   // Loads all songs from playlist found at path 'playlist_path' in directory
   // 'dir'.
-  // The 'device' argument is an opened and ready to read from represantation of
+  // The 'device' argument is an opened and ready to read from representation of
   // this playlist.
   // This method might not return all of the songs found in the playlist. Any
   // playlist

--- a/src/songinfo/songinfobase.cpp
+++ b/src/songinfo/songinfobase.cpp
@@ -75,7 +75,7 @@ void SongInfoBase::Clear() {
   delete section_container_;
   sections_.clear();
 
-  // Container for collapsable sections goes below
+  // Container for collapsible sections goes below
   section_container_ = new QWidget;
   section_container_->setLayout(new QVBoxLayout);
   section_container_->layout()->setContentsMargins(0, 0, 0, 0);
@@ -161,7 +161,7 @@ void SongInfoBase::CollapseSections() {
 
   // Sections are already sorted by type and relevance, so the algorithm we use
   // to determine which ones to show by default is:
-  //   * In the absense of any user preference, show the first (highest
+  //   * In the absence of any user preference, show the first (highest
   //     relevance section of each type and hide the rest)
   //   * If one or more sections in a type have been explicitly hidden/shown
   //     by the user before then hide all sections in that type and show only

--- a/src/ui/behavioursettingspage.ui
+++ b/src/ui/behavioursettingspage.ui
@@ -421,7 +421,7 @@
       <item>
        <widget class="QLineEdit" name="sort_ignore_prefix_list">
         <property name="toolTip">
-         <string>Comma seperated list of prefix words to ignore when sorting</string>
+         <string>Comma separated list of prefix words to ignore when sorting</string>
         </property>
        </widget>
       </item>

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -937,7 +937,7 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
 
   // Load theme
   // This is tricky: we need to save the default/system palette now, before
-  // loading user preferred theme (which will overide it), to be able to restore
+  // loading user preferred theme (which will override it), to be able to restore
   // it later
   const_cast<QPalette&>(Appearance::kDefaultPalette) = QApplication::palette();
   app_->appearance()->LoadUserTheme();
@@ -1544,7 +1544,7 @@ void MainWindow::UpdateTrackPosition() {
                 << ", scrobble point:" << scrobble_point
                 << ", lastfm status:" << playlist->get_lastfm_status()
                 << ", play count point:" << play_count_point
-                << ", is local libary item:" << item->IsLocalLibraryItem()
+                << ", is local library item:" << item->IsLocalLibraryItem()
                 << ", playlist have incremented playcount: "
                 << playlist->have_incremented_playcount();
 

--- a/src/widgets/osd.cpp
+++ b/src/widgets/osd.cpp
@@ -242,7 +242,7 @@ void OSD::CallFinished(QDBusPendingCallWatcher*) {}
 void OSD::WiiremoteActived(int id) {
   ShowMessage(QString(tr("%1: Wiimotedev module"))
                   .arg(QCoreApplication::applicationName()),
-              tr("Wii Remote %1: actived").arg(QString::number(id)));
+              tr("Wii Remote %1: activated").arg(QString::number(id)));
 }
 
 void OSD::WiiremoteDeactived(int id) {

--- a/tests/librarybackend_test.cpp
+++ b/tests/librarybackend_test.cpp
@@ -288,7 +288,7 @@ TEST_F(SingleSong, DeleteSongs) {
   EXPECT_EQ("Title", songs_deleted[0].title());
   EXPECT_EQ(1, songs_deleted[0].id());
 
-  // Check we can't retreive that song any more
+  // Check we can't retrieve that song any more
   Song song = backend_->GetSongById(1);
   EXPECT_FALSE(song.is_valid());
   EXPECT_EQ(-1, song.id());


### PR DESCRIPTION
Typos found via `codespell`