### PR TITLE
Periodically save settings

### DIFF
--- a/src/core/application.cpp
+++ b/src/core/application.cpp
@@ -20,6 +20,9 @@
    along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <QSettings>
+#include <QTimer>
+
 #include "application.h"
 
 #include "config.h"
@@ -67,7 +70,8 @@ bool Application::kIsPortable = false;
 class ApplicationImpl {
  public:
   ApplicationImpl(Application* app)
-      : tag_reader_client_([=]() {
+      : settings_timer_(app),
+        tag_reader_client_([=]() {
           TagReaderClient* client = new TagReaderClient(app);
           app->MoveToNewThread(client);
           client->Start();
@@ -150,6 +154,9 @@ class ApplicationImpl {
         }) {
   }
 
+  QTimer settings_timer_;
+  QSettings settings_;
+
   Lazy<TagReaderClient> tag_reader_client_;
   Lazy<Database> database_;
   Lazy<AlbumCoverLoader> album_cover_loader_;
@@ -188,6 +195,10 @@ Application::Application(QObject* parent)
 
   // TODO(John Maguire): Make this not a weird singleton.
   tag_reader_client();
+
+  p_->settings_timer_.setInterval(1000);
+  p_->settings_timer_.setSingleShot(true);
+  connect(&(p_->settings_timer_), SIGNAL(timeout()), SLOT(SaveSettings_()));
 }
 
 Application::~Application() {
@@ -228,6 +239,8 @@ QString Application::language_without_region() const {
   }
   return language_name_;
 }
+
+void Application::SaveSettings_() { emit SaveSettings(&(p_->settings_)); }
 
 void Application::ReloadSettings() { emit SettingsChanged(); }
 
@@ -326,3 +339,5 @@ TagReaderClient* Application::tag_reader_client() const {
 TaskManager* Application::task_manager() const {
   return p_->task_manager_.get();
 }
+
+void Application::DirtySettings() { p_->settings_timer_.start(); }

--- a/src/core/application.h
+++ b/src/core/application.h
@@ -28,6 +28,8 @@
 
 #include "ui/settingsdialog.h"
 
+class QSettings;
+
 class AlbumCoverLoader;
 class Appearance;
 class ApplicationImpl;
@@ -98,6 +100,8 @@ class Application : public QObject {
   TagReaderClient* tag_reader_client() const;
   TaskManager* task_manager() const;
 
+  void DirtySettings();
+
   void MoveToNewThread(QObject* object);
   void MoveToThread(QObject* object, QThread* thread);
 
@@ -109,7 +113,11 @@ class Application : public QObject {
 signals:
   void ErrorAdded(const QString& message);
   void SettingsChanged();
+  void SaveSettings(QSettings* settings);
   void SettingsDialogRequested(SettingsDialog::Page page);
+
+ private slots:
+  void SaveSettings_();
 
  private:
   QString language_name_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -430,6 +430,7 @@ int main(int argc, char* argv[]) {
   QtConcurrent::run(&ParseAProto);
 
   Application app;
+  QObject::connect(&a, SIGNAL(aboutToQuit()), &app, SLOT(SaveSettings_()));
   app.set_language_name(language);
 
   // Network proxy

--- a/src/playlist/playlistcontainer.cpp
+++ b/src/playlist/playlistcontainer.cpp
@@ -16,6 +16,7 @@
 */
 
 #include "core/appearance.h"
+#include "core/application.h"
 #include "core/logging.h"
 #include "core/player.h"
 #include "core/timeconstants.h"
@@ -43,6 +44,7 @@ const int PlaylistContainer::kFilterDelayPlaylistSizeThreshold = 5000;
 
 PlaylistContainer::PlaylistContainer(QWidget* parent)
     : QWidget(parent),
+      app_(nullptr),
       ui_(new Ui_PlaylistContainer),
       manager_(nullptr),
       undo_(nullptr),
@@ -52,7 +54,8 @@ PlaylistContainer::PlaylistContainer(QWidget* parent)
       tab_bar_visible_(false),
       tab_bar_animation_(new QTimeLine(500, this)),
       no_matches_label_(nullptr),
-      filter_timer_(new QTimer(this)) {
+      filter_timer_(new QTimer(this)),
+      dirty_(false) {
   ui_->setupUi(this);
 
   no_matches_label_ = new QLabel(ui_->playlist);
@@ -96,6 +99,7 @@ PlaylistContainer::PlaylistContainer(QWidget* parent)
   ui_->tab_bar->setMaximumHeight(0);
 
   // Connections
+  connect(ui_->tab_bar, SIGNAL(currentChanged(int)), SLOT(DirtyTabBar()));
   connect(ui_->tab_bar, SIGNAL(Save(int)), SLOT(SavePlaylist(int)));
 
   // set up timer for delayed filter updates
@@ -111,8 +115,15 @@ PlaylistContainer::PlaylistContainer(QWidget* parent)
 }
 
 PlaylistContainer::~PlaylistContainer() {
-  Save();
   delete ui_;
+}
+
+void PlaylistContainer::SetApplication(Application* app) {
+  Q_ASSERT(app);
+  app_ = app;
+  SetManager(app_->playlist_manager());
+  ui_->playlist->SetApplication(app_);
+  connect(app_, SIGNAL(SaveSettings(QSettings*)), SLOT(Save(QSettings*)));
 }
 
 PlaylistView* PlaylistContainer::view() const { return ui_->playlist; }
@@ -334,10 +345,18 @@ void PlaylistContainer::GoToPreviousPlaylistTab() {
   manager_->SetCurrentPlaylist(id_previous);
 }
 
-void PlaylistContainer::Save() {
-  if (starting_up_) return;
+void PlaylistContainer::DirtyTabBar() {
+  dirty_ = true;
+  app_->DirtySettings();
+}
 
-  settings_.setValue("current_playlist", ui_->tab_bar->current_id());
+void PlaylistContainer::Save(QSettings* settings_) {
+  if (starting_up_ || !dirty_) return;
+  dirty_ = false;
+
+  settings_->beginGroup(kSettingsGroup);
+  settings_->setValue("current_playlist", ui_->tab_bar->current_id());
+  settings_->endGroup();
 }
 
 void PlaylistContainer::SetTabBarVisible(bool visible) {

--- a/src/playlist/playlistcontainer.h
+++ b/src/playlist/playlistcontainer.h
@@ -23,6 +23,7 @@
 
 class Ui_PlaylistContainer;
 
+class Application;
 class LineEditInterface;
 class Playlist;
 class PlaylistManager;
@@ -41,6 +42,7 @@ class PlaylistContainer : public QWidget {
 
   static const char* kSettingsGroup;
 
+  void SetApplication(Application* app);
   void SetActions(QAction* new_playlist, QAction* load_playlist,
                   QAction* save_playlist, QAction* next_playlist,
                   QAction* previous_playlist);
@@ -83,7 +85,8 @@ signals:
   void ActivePaused();
   void ActiveStopped();
 
-  void Save();
+  void DirtyTabBar();
+  void Save(QSettings* settings_);
 
   void SetTabBarVisible(bool visible);
   void SetTabBarHeight(int height);
@@ -103,6 +106,7 @@ signals:
   static const int kFilterDelayMs;
   static const int kFilterDelayPlaylistSizeThreshold;
 
+  Application* app_;
   Ui_PlaylistContainer* ui_;
 
   PlaylistManager* manager_;
@@ -119,6 +123,8 @@ signals:
   QLabel* no_matches_label_;
 
   QTimer* filter_timer_;
+
+  bool dirty_;
 };
 
 #endif  // PLAYLISTCONTAINER_H

--- a/src/playlist/playlistview.h
+++ b/src/playlist/playlistview.h
@@ -145,7 +145,9 @@ signals:
  private slots:
   void LoadGeometry();
   void LoadRatingLockStatus();
-  void SaveGeometry();
+  void DirtyGeometry();
+  void DirtySettings();
+  void SaveGeometry(QSettings* settings);
   void SetRatingLockStatus(bool state);
   void GlowIntensityChanged();
   void InhibitAutoscrollTimeout();
@@ -153,7 +155,7 @@ signals:
   void InvalidateCachedCurrentPixmap();
   void PlaylistDestroyed();
 
-  void SaveSettings();
+  void SaveSettings(QSettings* s);
   void StretchChanged(bool stretch);
 
   void RatingHoverIn(const QModelIndex& index, const QPoint& pos);
@@ -250,6 +252,9 @@ signals:
   QPixmap cached_tree_;
   int drop_indicator_row_;
   bool drag_over_;
+
+  bool dirty_geometry_;
+  bool dirty_settings_;
 
   bool ratings_locked_;  // To store Ratings section lock status
 

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -297,7 +297,7 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
   ui_->tabs->setBackgroundPixmap(QPixmap(":/sidebar_background.png"));
 
   // Do this only after all default tabs have been added
-  ui_->tabs->loadSettings(kSettingsGroup);
+  ui_->tabs->loadSettings(settings_);
 
   track_position_timer_->setInterval(kTrackPositionUpdateTimeMs);
   connect(track_position_timer_, SIGNAL(timeout()),

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -223,6 +223,8 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
       track_position_timer_(new QTimer(this)),
       track_slider_timer_(new QTimer(this)),
       initialized_(false),
+      dirty_geometry_(false),
+      dirty_playback_(false),
       saved_playback_position_(0),
       saved_playback_state_(Engine::Empty),
       doubleclick_addmode_(AddBehaviour_Append),
@@ -257,6 +259,9 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
 
   connect(global_search_view_, SIGNAL(AddToPlaylist(QMimeData*)),
           SLOT(AddToPlaylist(QMimeData*)));
+
+  // Set up the settings group early
+  settings_.beginGroup(kSettingsGroup);
 
   // Add tabs to the fancy tab widget
   ui_->tabs->addTab(global_search_view_,
@@ -300,6 +305,9 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
   track_slider_timer_->setInterval(kTrackSliderUpdateTimeMs);
   connect(track_slider_timer_, SIGNAL(timeout()),
           SLOT(UpdateTrackSliderPosition()));
+
+  connect(app_, SIGNAL(SaveSettings(QSettings*)),
+          SLOT(SaveSettings(QSettings*)));
 
   // Start initialising the player
   qLog(Debug) << "Initialising player";
@@ -977,7 +985,6 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
 
   // Load settings
   qLog(Debug) << "Loading settings";
-  settings_.beginGroup(kSettingsGroup);
 
   // Set last used geometry to position window on the correct monitor
   // Set window state only if the window was last maximized
@@ -1064,13 +1071,11 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
   if (!options.contains_play_options()) LoadPlaybackStatus();
 
   initialized_ = true;
-  SaveGeometry();
 
   qLog(Debug) << "Started";
 }
 
 MainWindow::~MainWindow() {
-  SaveGeometry();
   delete ui_;
 }
 
@@ -1085,18 +1090,15 @@ void MainWindow::ReloadSettings() {
     show();
 #endif
 
-  QSettings s;
-  s.beginGroup(kSettingsGroup);
-
-  doubleclick_addmode_ =
-      AddBehaviour(s.value("doubleclick_addmode", AddBehaviour_Append).toInt());
+  doubleclick_addmode_ = AddBehaviour(
+      settings_.value("doubleclick_addmode", AddBehaviour_Append).toInt());
   doubleclick_playmode_ = PlayBehaviour(
-      s.value("doubleclick_playmode", PlayBehaviour_IfStopped).toInt());
-  doubleclick_playlist_addmode_ =
-      PlaylistAddBehaviour(s.value("doubleclick_playlist_addmode",
-                                   PlaylistAddBehaviour_Play).toInt());
-  menu_playmode_ =
-      PlayBehaviour(s.value("menu_playmode", PlayBehaviour_IfStopped).toInt());
+      settings_.value("doubleclick_playmode", PlayBehaviour_IfStopped).toInt());
+  doubleclick_playlist_addmode_ = PlaylistAddBehaviour(
+      settings_.value("doubleclick_playlist_addmode", PlaylistAddBehaviour_Play)
+          .toInt());
+  menu_playmode_ = PlayBehaviour(
+      settings_.value("menu_playmode", PlayBehaviour_IfStopped).toInt());
 
   bool show_sidebar = settings_.value("show_sidebar", true).toBool();
   ui_->sidebar_layout->setVisible(show_sidebar);
@@ -1278,54 +1280,61 @@ void MainWindow::ScrobbleButtonVisibilityChanged(bool value) {
   }
 }
 
-void MainWindow::changeEvent(QEvent*) {
+void MainWindow::SaveSettings(QSettings* settings) {
   if (!initialized_) return;
-  SaveGeometry();
+  settings->beginGroup(kSettingsGroup);
+  if (dirty_geometry_) SaveGeometry(settings);
+  if (dirty_playback_) SavePlaybackStatus(settings);
+  settings->endGroup();
+}
+
+void MainWindow::changeEvent(QEvent*) {
+  dirty_geometry_ = true;
+  app_->DirtySettings();
 }
 
 void MainWindow::resizeEvent(QResizeEvent*) {
-  if (!initialized_) return;
-  SaveGeometry();
+  dirty_geometry_ = true;
+  app_->DirtySettings();
 }
 
-void MainWindow::SaveGeometry() {
+void MainWindow::SaveGeometry(QSettings* settings) {
   if (!initialized_) return;
+  dirty_geometry_ = false;
 
   was_maximized_ = isMaximized();
-  settings_.setValue("maximized", was_maximized_);
+  settings->setValue("maximized", was_maximized_);
   // Save the geometry only when mainwindow is not in maximized state
   if (!was_maximized_) {
-    settings_.setValue("geometry", saveGeometry());
+    settings->setValue("geometry", saveGeometry());
   }
-  settings_.setValue("splitter_state", ui_->splitter->saveState());
-  settings_.setValue("current_tab", ui_->tabs->currentIndex());
-  settings_.setValue("tab_mode", ui_->tabs->mode());
+  settings->setValue("splitter_state", ui_->splitter->saveState());
+  settings->setValue("current_tab", ui_->tabs->currentIndex());
+  settings->setValue("tab_mode", ui_->tabs->mode());
 
-  ui_->tabs->saveSettings(kSettingsGroup);
+  // Leaving this here for now
+  ui_->tabs->saveSettings(settings);
 }
 
-void MainWindow::SavePlaybackStatus() {
-  QSettings settings;
-  settings.beginGroup(MainWindow::kSettingsGroup);
-  settings.setValue("playback_state", app_->player()->GetState());
+void MainWindow::SavePlaybackStatus(QSettings* settings) {
+  dirty_playback_ = false;
+  settings->setValue("playback_state", app_->player()->GetState());
   if (app_->player()->GetState() == Engine::Playing ||
       app_->player()->GetState() == Engine::Paused) {
-    settings.setValue(
+    settings->setValue(
         "playback_position",
         app_->player()->engine()->position_nanosec() / kNsecPerSec);
   } else {
-    settings.setValue("playback_position", 0);
+    settings->setValue("playback_position", 0);
   }
 }
 
 void MainWindow::LoadPlaybackStatus() {
-  QSettings settings;
-  settings.beginGroup(MainWindow::kSettingsGroup);
   bool resume_playback =
-      settings.value("resume_playback_after_start", false).toBool();
+      settings_.value("resume_playback_after_start", false).toBool();
   saved_playback_state_ = static_cast<Engine::State>(
-      settings.value("playback_state", Engine::Empty).toInt());
-  saved_playback_position_ = settings.value("playback_position", 0).toDouble();
+      settings_.value("playback_state", Engine::Empty).toInt());
+  saved_playback_position_ = settings_.value("playback_position", 0).toDouble();
   if (!resume_playback || saved_playback_state_ == Engine::Empty ||
       saved_playback_state_ == Engine::Idle) {
     return;
@@ -1433,12 +1442,10 @@ void MainWindow::StopAfterCurrent() {
 }
 
 void MainWindow::closeEvent(QCloseEvent* event) {
-  QSettings s;
-  s.beginGroup(kSettingsGroup);
-
   bool keep_running(false);
   if (tray_icon_)
-    keep_running = s.value("keeprunning", tray_icon_->IsVisible()).toBool();
+    keep_running =
+        settings_.value("keeprunning", tray_icon_->IsVisible()).toBool();
 
   if (keep_running && event->spontaneous()) {
     event->ignore();
@@ -2794,10 +2801,13 @@ bool MainWindow::winEvent(MSG* msg, long*) {
 #endif  // Q_OS_WIN32
 
 void MainWindow::Exit() {
-  SaveGeometry();
-  SavePlaybackStatus();
+  // FIXME: This may add an extra write.
+  dirty_playback_ = true;
   settings_.setValue("show_sidebar",
                      ui_->action_toggle_show_sidebar->isChecked());
+  settings_.endGroup();
+  SaveSettings(&settings_);
+  settings_.sync();
 
   if (app_->player()->engine()->is_fadeout_enabled()) {
     // To shut down the application when fadeout will be finished

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -325,8 +325,7 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
 
   connect(ui_->playlist, SIGNAL(ViewSelectionModelChanged()),
           SLOT(PlaylistViewSelectionModelChanged()));
-  ui_->playlist->SetManager(app_->playlist_manager());
-  ui_->playlist->view()->SetApplication(app_);
+  ui_->playlist->SetApplication(app_);
 
   library_view_->view()->setModel(library_sort_model_);
   library_view_->view()->SetApplication(app_);

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -151,6 +151,7 @@ signals:
  private slots:
   void FilePathChanged(const QString& path);
 
+  void SaveSettings(QSettings* settings);
   void MediaStopped();
   void MediaPaused();
   void MediaPlaying();
@@ -266,8 +267,8 @@ signals:
   void OpenSettingsDialogAtPage(SettingsDialog::Page page);
   void ShowSongInfoConfig();
 
-  void SaveGeometry();
-  void SavePlaybackStatus();
+  void SaveGeometry(QSettings* settings);
+  void SavePlaybackStatus(QSettings* settings);
   void LoadPlaybackStatus();
   void ResumePlayback();
 
@@ -380,6 +381,10 @@ signals:
   QSettings settings_;
 
   bool initialized_;
+
+  bool dirty_geometry_;
+  bool dirty_playback_;
+
   bool was_maximized_;
   int saved_playback_position_;
   Engine::State saved_playback_state_;

--- a/src/widgets/fancytabwidget.cpp
+++ b/src/widgets/fancytabwidget.cpp
@@ -290,10 +290,7 @@ FancyTabWidget::FancyTabWidget(QWidget* parent) : QTabWidget(parent),
     connect(tabBar, SIGNAL(currentChanged(int)), this, SLOT(currentTabChanged(int)));
 }
 
-void FancyTabWidget::loadSettings(const char *kSettingsGroup) {
-    QSettings settings;
-    settings.beginGroup(kSettingsGroup);
-
+void FancyTabWidget::loadSettings(const QSettings& settings) {
   for (int i = 0; i < count(); i++) {
     int originalIndex = tabBar()->tabData(i).toInt();
     QString k = "tab_index_" + QString::number(originalIndex);

--- a/src/widgets/fancytabwidget.cpp
+++ b/src/widgets/fancytabwidget.cpp
@@ -307,16 +307,13 @@ void FancyTabWidget::loadSettings(const char *kSettingsGroup) {
     }
 }
 
-void FancyTabWidget::saveSettings(const char *kSettingsGroup) {
-    QSettings settings;
-    settings.beginGroup(kSettingsGroup);
+void FancyTabWidget::saveSettings(QSettings* settings) {
+  for (int i = 0; i < count(); i++) {
+    int originalIndex = tabBar()->tabData(i).toInt();
+    std::string k = "tab_index_" + std::to_string(originalIndex);
 
-    for(int i =0;i<count();i++) {
-        int originalIndex = tabBar()->tabData(i).toInt();
-        std::string k = "tab_index_" + std::to_string(originalIndex);
-
-        settings.setValue(QString::fromStdString(k), i);
-    }
+    settings->setValue(QString::fromStdString(k), i);
+  }
 }
 
 

--- a/src/widgets/fancytabwidget.cpp
+++ b/src/widgets/fancytabwidget.cpp
@@ -294,25 +294,25 @@ void FancyTabWidget::loadSettings(const char *kSettingsGroup) {
     QSettings settings;
     settings.beginGroup(kSettingsGroup);
 
-    for(int i =0;i<count();i++) {
-        int originalIndex = tabBar()->tabData(i).toInt();
-        std::string k = "tab_index_" + std::to_string(originalIndex);
+  for (int i = 0; i < count(); i++) {
+    int originalIndex = tabBar()->tabData(i).toInt();
+    QString k = "tab_index_" + QString::number(originalIndex);
 
-        int newIndex = settings.value(QString::fromStdString(k), i).toInt();
+    int newIndex = settings.value(k, i).toInt();
 
-        if(newIndex >= 0)
-            tabBar()->moveTab(i,newIndex);
-        else
-            removeTab(i); // Does not delete page
-    }
+    if (newIndex >= 0)
+      tabBar()->moveTab(i, newIndex);
+    else
+      removeTab(i);  // Does not delete page
+  }
 }
 
 void FancyTabWidget::saveSettings(QSettings* settings) {
   for (int i = 0; i < count(); i++) {
     int originalIndex = tabBar()->tabData(i).toInt();
-    std::string k = "tab_index_" + std::to_string(originalIndex);
+    QString k = "tab_index_" + QString::number(originalIndex);
 
-    settings->setValue(QString::fromStdString(k), i);
+    settings->setValue(k, i);
   }
 }
 

--- a/src/widgets/fancytabwidget.h
+++ b/src/widgets/fancytabwidget.h
@@ -25,6 +25,7 @@
 
 class QActionGroup;
 class QMenu;
+class QSettings;
 class QSignalMapper;
 
 namespace Core {
@@ -44,7 +45,7 @@ class FancyTabWidget : public QTabWidget {
         void addSpacer();
 
         void loadSettings(const char *);
-        void saveSettings(const char *);
+        void saveSettings(QSettings*);
         // Values are persisted - only add to the end
         enum Mode {
             Mode_None = 0,

--- a/src/widgets/fancytabwidget.h
+++ b/src/widgets/fancytabwidget.h
@@ -44,7 +44,7 @@ class FancyTabWidget : public QTabWidget {
         void setBackgroundPixmap(const QPixmap& pixmap);
         void addSpacer();
 
-        void loadSettings(const char *);
+        void loadSettings(const QSettings&);
         void saveSettings(QSettings*);
         // Values are persisted - only add to the end
         enum Mode {


### PR DESCRIPTION
This patchset consists of two patches, representing the development timeline. The first patch introduces an efficient framework to periodically save modified settings, rather than doing so immediately. This is the convention for events that may happen many times per second (such as flipping through tabs or resizing a window) in, e.g., KDE (see `kxmlgui`'s `kmainwindow.cpp`).  Instead, the setting is marked as dirty, and a timer is set (to 1 second), and saved then. If the program is closed before then, the dirty data is also saved via an `aboutToQuit` signal connection.

By coordinating the saving, the number of write locks that are required can be reduced to a maximum of one per second, tremendously improving user experience on systems with slow locks, reducing power consumption, and significantly reducing wear on devices (e.g., SSD drives).

The first patch implements this for geometry changes (both for `MainWindow` and  `PlaylistView`) and for `PlaylistView` stretched settings. It also cleans up some inconsistent uses of `QSettings`, possibly further reducing the need for read locks.

Compare to #6057 (6a312e7), which only ever intended to save on program exit (and may have failed to do so for those using Nvidia drivers), causing problems for some people (see #6217 and #6209, these are probably nvidia users whose shutdown sequence was abruptly terminated by 5237c005c940, inhibiting the intended save logic). At this point the workaround for that ancient Nvidia bug has been reverted (see 783dada13, #6334), so there is no reason to expect users of "recent" (release in the last ~7 years) drivers to experience any shutdown issues. Furthermore, this would only ever result in at most 1 second of lost settings.

The second commit uses the framework to also save the currently selected tab, which at the time is only saved at program exit. Along the way, it can happily simplify the logic of applying `SetApplication`.