### PR TITLE
Attempt to fix track unpause hang (revert "Attempt to fix track change hang")

### DIFF
--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -302,7 +302,7 @@ bool GstEnginePipeline::Init() {
   audioconvert_ = engine_->CreateElement("audioconvert", audiobin_);
   tee = engine_->CreateElement("tee", audiobin_);
 
-  probe_queue = engine_->CreateElement("queue2", audiobin_);
+  probe_queue = engine_->CreateElement("queue", audiobin_);
   probe_converter = engine_->CreateElement("audioconvert", audiobin_);
   probe_sink = engine_->CreateElement("fakesink", audiobin_);
 


### PR DESCRIPTION
Fixes #6320. 

Queue2 tends to hang up on pause, unable to start playing
again. Pipeline actually stays PLAYING with ASYNC state
change, so it becomes impossible to unpause the player
without stop or forward/backward seeks.

I've been testing this fix for over 3,5 months (synchronizing with origin/qt5 from time to time), and it has worked just as intended without any track hangs.