### PR TITLE
Replace all uses of QSignalMapper with C++11 lambda expressions

### DIFF
--- a/src/analyzers/analyzercontainer.cpp
+++ b/src/analyzers/analyzercontainer.cpp
@@ -250,11 +250,10 @@ void AnalyzerContainer::SavePsychedelic() {
 }
 
 void AnalyzerContainer::AddFramerate(const QString& name, int framerate) {
-  QAction* action =
-      context_menu_framerate_->addAction(name);
+  QAction* action = context_menu_framerate_->addAction(name);
   group_framerate_->addAction(action);
   framerate_list_ << framerate;
   action->setCheckable(true);
-  connect(action, &QAction::triggered, [this, framerate]() { ChangeFramerate(framerate); } );
+  connect(action, &QAction::triggered,
+          [this, framerate]() { ChangeFramerate(framerate); });
 }
-

--- a/src/analyzers/analyzercontainer.cpp
+++ b/src/analyzers/analyzercontainer.cpp
@@ -51,8 +51,6 @@ AnalyzerContainer::AnalyzerContainer(QWidget* parent)
       context_menu_framerate_(new QMenu(tr("Framerate"), this)),
       group_(new QActionGroup(this)),
       group_framerate_(new QActionGroup(this)),
-      mapper_(new QSignalMapper(this)),
-      mapper_framerate_(new QSignalMapper(this)),
       visualisation_action_(nullptr),
       double_click_timer_(new QTimer(this)),
       ignore_next_click_(false),
@@ -69,7 +67,6 @@ AnalyzerContainer::AnalyzerContainer(QWidget* parent)
   AddFramerate(tr("High (%1 fps)").arg(kHighFramerate), kHighFramerate);
   AddFramerate(tr("Super high (%1 fps)").arg(kSuperHighFramerate),
                kSuperHighFramerate);
-  connect(mapper_framerate_, SIGNAL(mapped(int)), SLOT(ChangeFramerate(int)));
 
   context_menu_->addMenu(context_menu_framerate_);
   context_menu_->addSeparator();
@@ -82,7 +79,6 @@ AnalyzerContainer::AnalyzerContainer(QWidget* parent)
   AddAnalyzerType<Rainbow::NyanCatAnalyzer>();
   AddAnalyzerType<Rainbow::RainbowDashAnalyzer>();
 
-  connect(mapper_, SIGNAL(mapped(int)), SLOT(ChangeAnalyzer(int)));
   disable_action_ = context_menu_->addAction(tr("No analyzer"), this,
                                              SLOT(DisableAnalyzer()));
   disable_action_->setCheckable(true);
@@ -255,10 +251,10 @@ void AnalyzerContainer::SavePsychedelic() {
 
 void AnalyzerContainer::AddFramerate(const QString& name, int framerate) {
   QAction* action =
-      context_menu_framerate_->addAction(name, mapper_framerate_, SLOT(map()));
-  mapper_framerate_->setMapping(action, framerate);
+      context_menu_framerate_->addAction(name);
   group_framerate_->addAction(action);
   framerate_list_ << framerate;
   action->setCheckable(true);
+  connect(action, &QAction::triggered, [this, framerate]() { ChangeFramerate(framerate); } );
 }
 

--- a/src/analyzers/analyzercontainer.h
+++ b/src/analyzers/analyzercontainer.h
@@ -96,13 +96,11 @@ template <typename T>
 void AnalyzerContainer::AddAnalyzerType() {
   int id = analyzer_types_.count();
   analyzer_types_ << &T::staticMetaObject;
-  QAction* action =
-    context_menu_->addAction(tr(T::kName));
+  QAction* action = context_menu_->addAction(tr(T::kName));
   group_->addAction(action);
   action->setCheckable(true);
   actions_ << action;
-  connect(action, &QAction::triggered, [this, id]() { ChangeAnalyzer(id); } );
-
+  connect(action, &QAction::triggered, [this, id]() { ChangeAnalyzer(id); });
 }
 
 #endif  // ANALYZERS_ANALYZERCONTAINER_H_

--- a/src/analyzers/analyzercontainer.h
+++ b/src/analyzers/analyzercontainer.h
@@ -25,7 +25,6 @@
 
 #include <QWidget>
 #include <QMenu>
-#include <QSignalMapper>
 
 #include "analyzerbase.h"
 #include "engines/engine_fwd.h"
@@ -76,8 +75,6 @@ signals:
   QMenu* context_menu_framerate_;
   QActionGroup* group_;
   QActionGroup* group_framerate_;
-  QSignalMapper* mapper_;
-  QSignalMapper* mapper_framerate_;
 
   QList<const QMetaObject*> analyzer_types_;
   QList<int> framerate_list_;
@@ -100,11 +97,12 @@ void AnalyzerContainer::AddAnalyzerType() {
   int id = analyzer_types_.count();
   analyzer_types_ << &T::staticMetaObject;
   QAction* action =
-    context_menu_->addAction(tr(T::kName), mapper_, SLOT(map()));
+    context_menu_->addAction(tr(T::kName));
   group_->addAction(action);
-  mapper_->setMapping(action, id);
   action->setCheckable(true);
   actions_ << action;
+  connect(action, &QAction::triggered, [this, id]() { ChangeAnalyzer(id); } );
+
 }
 
 #endif  // ANALYZERS_ANALYZERCONTAINER_H_

--- a/src/core/globalshortcuts.cpp
+++ b/src/core/globalshortcuts.cpp
@@ -108,10 +108,12 @@ void GlobalShortcuts::AddShortcut(const QString& id, const QString& name,
   connect(shortcut.action, SIGNAL(triggered()), this, signal);
 }
 
-void GlobalShortcuts::AddRatingShortcut(const QString& id, const QString& name, int rating,
+void GlobalShortcuts::AddRatingShortcut(const QString& id, const QString& name,
+                                        int rating,
                                         const QKeySequence& default_key) {
   Shortcut shortcut = AddShortcut(id, name, default_key);
-  connect(shortcut.action, &QAction::triggered, [this, rating]() { RateCurrentSong(rating); } );
+  connect(shortcut.action, &QAction::triggered,
+          [this, rating]() { RateCurrentSong(rating); });
 }
 
 GlobalShortcuts::Shortcut GlobalShortcuts::AddShortcut(

--- a/src/core/globalshortcuts.cpp
+++ b/src/core/globalshortcuts.cpp
@@ -29,7 +29,6 @@
 
 #include <QAction>
 #include <QShortcut>
-#include <QSignalMapper>
 #include <QtDebug>
 
 #ifdef HAVE_DBUS
@@ -42,8 +41,7 @@ GlobalShortcuts::GlobalShortcuts(QWidget* parent)
     : QWidget(parent),
       gnome_backend_(nullptr),
       system_backend_(nullptr),
-      use_gnome_(false),
-      rating_signals_mapper_(new QSignalMapper(this)) {
+      use_gnome_(false) {
   settings_.beginGroup(kSettingsGroup);
 
   // Create actions
@@ -84,21 +82,12 @@ GlobalShortcuts::GlobalShortcuts(QWidget* parent)
               tr("Remove current song from playlist"),
               SIGNAL(RemoveCurrentSong()));
 
-  AddRatingShortcut("rate_zero_star", tr("Rate the current song 0 stars"),
-                    rating_signals_mapper_, 0);
-  AddRatingShortcut("rate_one_star", tr("Rate the current song 1 star"),
-                    rating_signals_mapper_, 1);
-  AddRatingShortcut("rate_two_star", tr("Rate the current song 2 stars"),
-                    rating_signals_mapper_, 2);
-  AddRatingShortcut("rate_three_star", tr("Rate the current song 3 stars"),
-                    rating_signals_mapper_, 3);
-  AddRatingShortcut("rate_four_star", tr("Rate the current song 4 stars"),
-                    rating_signals_mapper_, 4);
-  AddRatingShortcut("rate_five_star", tr("Rate the current song 5 stars"),
-                    rating_signals_mapper_, 5);
-
-  connect(rating_signals_mapper_, SIGNAL(mapped(int)),
-          SIGNAL(RateCurrentSong(int)));
+  AddRatingShortcut("rate_zero_star", tr("Rate the current song 0 stars"), 0);
+  AddRatingShortcut("rate_one_star", tr("Rate the current song 1 star"), 1);
+  AddRatingShortcut("rate_two_star", tr("Rate the current song 2 stars"), 2);
+  AddRatingShortcut("rate_three_star", tr("Rate the current song 3 stars"), 3);
+  AddRatingShortcut("rate_four_star", tr("Rate the current song 4 stars"), 4);
+  AddRatingShortcut("rate_five_star", tr("Rate the current song 5 stars"), 5);
 
   // Create backends - these do the actual shortcut registration
   gnome_backend_ = new GnomeGlobalShortcutBackend(this);
@@ -119,12 +108,10 @@ void GlobalShortcuts::AddShortcut(const QString& id, const QString& name,
   connect(shortcut.action, SIGNAL(triggered()), this, signal);
 }
 
-void GlobalShortcuts::AddRatingShortcut(const QString& id, const QString& name,
-                                        QSignalMapper* mapper, int rating,
+void GlobalShortcuts::AddRatingShortcut(const QString& id, const QString& name, int rating,
                                         const QKeySequence& default_key) {
   Shortcut shortcut = AddShortcut(id, name, default_key);
-  connect(shortcut.action, SIGNAL(triggered()), mapper, SLOT(map()));
-  mapper->setMapping(shortcut.action, rating);
+  connect(shortcut.action, &QAction::triggered, [this, rating]() { RateCurrentSong(rating); } );
 }
 
 GlobalShortcuts::Shortcut GlobalShortcuts::AddShortcut(

--- a/src/core/globalshortcuts.h
+++ b/src/core/globalshortcuts.h
@@ -32,7 +32,6 @@ class QAction;
 class QShortcut;
 
 class GlobalShortcutBackend;
-class QSignalMapper;
 
 class GlobalShortcuts : public QWidget {
   Q_OBJECT
@@ -87,8 +86,7 @@ signals:
  private:
   void AddShortcut(const QString& id, const QString& name, const char* signal,
                    const QKeySequence& default_key = QKeySequence(0));
-  void AddRatingShortcut(const QString& id, const QString& name,
-                         QSignalMapper* mapper, int rating,
+  void AddRatingShortcut(const QString& id, const QString& name, int rating,
                          const QKeySequence& default_key = QKeySequence(0));
   Shortcut AddShortcut(const QString& id, const QString& name,
                        const QKeySequence& default_key);
@@ -101,7 +99,6 @@ signals:
   QSettings settings_;
 
   bool use_gnome_;
-  QSignalMapper* rating_signals_mapper_;
 };
 
 #endif  // CORE_GLOBALSHORTCUTS_H_

--- a/src/internet/icecast/icecastfilterwidget.cpp
+++ b/src/internet/icecast/icecastfilterwidget.cpp
@@ -56,7 +56,8 @@ IcecastFilterWidget::IcecastFilterWidget(QWidget* parent)
 void IcecastFilterWidget::AddAction(QActionGroup* group, QAction* action,
                                     IcecastModel::SortMode mode) {
   group->addAction(action);
-  connect(action, &QAction::triggered, [this, mode]() { SortModeChanged(mode); } );
+  connect(action, &QAction::triggered,
+          [this, mode]() { SortModeChanged(mode); });
 }
 
 IcecastFilterWidget::~IcecastFilterWidget() { delete ui_; }

--- a/src/internet/icecast/icecastfilterwidget.cpp
+++ b/src/internet/icecast/icecastfilterwidget.cpp
@@ -22,7 +22,6 @@
 #include <QKeyEvent>
 #include <QMenu>
 #include <QSettings>
-#include <QSignalMapper>
 
 #include "icecastmodel.h"
 #include "ui_icecastfilterwidget.h"
@@ -33,8 +32,7 @@ const char* IcecastFilterWidget::kSettingsGroup = "Icecast";
 IcecastFilterWidget::IcecastFilterWidget(QWidget* parent)
     : QWidget(parent),
       ui_(new Ui_IcecastFilterWidget),
-      menu_(new QMenu(tr("Display options"), this)),
-      sort_mode_mapper_(new QSignalMapper(this)) {
+      menu_(new QMenu(tr("Display options"), this)) {
   ui_->setupUi(this);
 
   // Icons
@@ -53,15 +51,12 @@ IcecastFilterWidget::IcecastFilterWidget(QWidget* parent)
   menu_->setIcon(ui_->options->icon());
   menu_->addActions(group->actions());
   ui_->options->setMenu(menu_);
-
-  connect(sort_mode_mapper_, SIGNAL(mapped(int)), SLOT(SortModeChanged(int)));
 }
 
 void IcecastFilterWidget::AddAction(QActionGroup* group, QAction* action,
                                     IcecastModel::SortMode mode) {
   group->addAction(action);
-  sort_mode_mapper_->setMapping(action, mode);
-  connect(action, SIGNAL(triggered()), sort_mode_mapper_, SLOT(map()));
+  connect(action, &QAction::triggered, [this, mode]() { SortModeChanged(mode); } );
 }
 
 IcecastFilterWidget::~IcecastFilterWidget() { delete ui_; }

--- a/src/internet/icecast/icecastfilterwidget.h
+++ b/src/internet/icecast/icecastfilterwidget.h
@@ -29,7 +29,6 @@ class Ui_IcecastFilterWidget;
 
 class QActionGroup;
 class QMenu;
-class QSignalMapper;
 
 class IcecastFilterWidget : public QWidget {
   Q_OBJECT
@@ -58,8 +57,6 @@ class IcecastFilterWidget : public QWidget {
   Ui_IcecastFilterWidget* ui_;
   IcecastModel* model_;
   QMenu* menu_;
-
-  QSignalMapper* sort_mode_mapper_;
 };
 
 #endif  // INTERNET_ICECAST_ICECASTFILTERWIDGET_H_

--- a/src/library/libraryfilterwidget.cpp
+++ b/src/library/libraryfilterwidget.cpp
@@ -233,9 +233,10 @@ void LibraryFilterWidget::SetLibraryModel(LibraryModel* model) {
   connect(group_by_dialog_.get(), SIGNAL(Accepted(LibraryModel::Grouping)),
           model_, SLOT(SetGroupBy(LibraryModel::Grouping)));
 
-  for (QAction *action : filter_ages_.keys()) {
+  for (QAction* action : filter_ages_.keys()) {
     int age = filter_ages_[action];
-    connect(action, &QAction::triggered, [this, age]() { model_->SetFilterAge(age); } );
+    connect(action, &QAction::triggered,
+            [this, age]() { model_->SetFilterAge(age); });
   }
 
   // Load settings

--- a/src/library/libraryfilterwidget.h
+++ b/src/library/libraryfilterwidget.h
@@ -20,8 +20,8 @@
 
 #include <memory>
 
-#include <QWidget>
 #include <QMap>
+#include <QWidget>
 
 #include "librarymodel.h"
 #include "savedgroupingmanager.h"

--- a/src/library/libraryfilterwidget.h
+++ b/src/library/libraryfilterwidget.h
@@ -21,6 +21,7 @@
 #include <memory>
 
 #include <QWidget>
+#include <QMap>
 
 #include "librarymodel.h"
 #include "savedgroupingmanager.h"
@@ -33,7 +34,6 @@ struct QueryOptions;
 
 class QMenu;
 class QActionGroup;
-class QSignalMapper;
 
 class LibraryFilterWidget : public QWidget {
   Q_OBJECT
@@ -109,7 +109,7 @@ signals:
   QMenu* group_by_menu_;
   QMenu* library_menu_;
   QActionGroup* group_by_group_;
-  QSignalMapper* filter_age_mapper_;
+  QMap<QAction*, int> filter_ages_;
 
   QTimer* filter_delay_;
 

--- a/src/playlist/playlistheader.cpp
+++ b/src/playlist/playlistheader.cpp
@@ -22,14 +22,12 @@
 #include <QContextMenuEvent>
 #include <QMenu>
 #include <QSettings>
-#include <QSignalMapper>
 
 PlaylistHeader::PlaylistHeader(Qt::Orientation orientation, PlaylistView* view,
                                QWidget* parent)
     : StretchHeaderView(orientation, parent),
       view_(view),
-      menu_(new QMenu(this)),
-      show_mapper_(new QSignalMapper(this)) {
+      menu_(new QMenu(this)) {
   hide_action_ = menu_->addAction(tr("&Hide..."), this, SLOT(HideCurrent()));
   stretch_action_ = menu_->addAction(tr("&Stretch columns to fit window"), this,
                                      SLOT(ToggleStretchEnabled()));
@@ -62,7 +60,6 @@ PlaylistHeader::PlaylistHeader(Qt::Orientation orientation, PlaylistView* view,
   stretch_action_->setCheckable(true);
   stretch_action_->setChecked(is_stretch_enabled());
 
-  connect(show_mapper_, SIGNAL(mapped(int)), SLOT(ToggleVisible(int)));
   connect(this, SIGNAL(StretchEnabledChanged(bool)), stretch_action_,
           SLOT(setChecked(bool)));
 }
@@ -110,12 +107,13 @@ void PlaylistHeader::AddColumnAction(int index) {
 
   QString title(model()->headerData(index, Qt::Horizontal).toString());
 
-  QAction* action = menu_->addAction(title, show_mapper_, SLOT(map()));
+  QAction* action = menu_->addAction(title);
   action->setCheckable(true);
   action->setChecked(!isSectionHidden(index));
   show_actions_ << action;
 
-  show_mapper_->setMapping(action, index);
+  connect(action, &QAction::triggered, [this, index]() { ToggleVisible(index); } );
+
 }
 
 void PlaylistHeader::HideCurrent() {

--- a/src/playlist/playlistheader.cpp
+++ b/src/playlist/playlistheader.cpp
@@ -112,8 +112,8 @@ void PlaylistHeader::AddColumnAction(int index) {
   action->setChecked(!isSectionHidden(index));
   show_actions_ << action;
 
-  connect(action, &QAction::triggered, [this, index]() { ToggleVisible(index); } );
-
+  connect(action, &QAction::triggered,
+          [this, index]() { ToggleVisible(index); });
 }
 
 void PlaylistHeader::HideCurrent() {

--- a/src/playlist/playlistheader.h
+++ b/src/playlist/playlistheader.h
@@ -23,7 +23,6 @@
 class PlaylistView;
 
 class QMenu;
-class QSignalMapper;
 
 class PlaylistHeader : public StretchHeaderView {
   Q_OBJECT
@@ -63,7 +62,6 @@ signals:
   QAction* align_right_action_;
   QList<QAction*> show_actions_;
 
-  QSignalMapper* show_mapper_;
 };
 
 #endif  // PLAYLISTHEADER_H

--- a/src/smartplaylists/wizard.cpp
+++ b/src/smartplaylists/wizard.cpp
@@ -121,7 +121,8 @@ void Wizard::AddPlugin(WizardPlugin* plugin) {
   type_page_->layout()->addWidget(radio_button);
   type_page_->layout()->addWidget(description);
 
-  connect(radio_button, &QRadioButton::clicked, [this, index]() { TypeChanged(index); } );
+  connect(radio_button, &QRadioButton::clicked,
+          [this, index]() { TypeChanged(index); });
 
   if (index == 0) {
     radio_button->setChecked(true);

--- a/src/smartplaylists/wizard.cpp
+++ b/src/smartplaylists/wizard.cpp
@@ -22,7 +22,6 @@
 
 #include <QLabel>
 #include <QRadioButton>
-#include <QSignalMapper>
 #include <QVBoxLayout>
 
 namespace smart_playlists {
@@ -57,8 +56,7 @@ Wizard::Wizard(Application* app, LibraryBackend* library, QWidget* parent)
       library_(library),
       type_page_(new TypePage(this)),
       finish_page_(new FinishPage(this)),
-      type_index_(-1),
-      type_mapper_(new QSignalMapper(this)) {
+      type_index_(-1) {
   setWindowIcon(QIcon(":/icon.png"));
   setWindowTitle(tr("Smart playlist"));
   resize(788, 628);
@@ -83,8 +81,6 @@ Wizard::Wizard(Application* app, LibraryBackend* library, QWidget* parent)
   finish_page_->setTitle(tr("Finish"));
   finish_page_->setSubTitle(tr("Choose a name for your smart playlist"));
   finish_id_ = addPage(finish_page_);
-
-  connect(type_mapper_, SIGNAL(mapped(int)), SLOT(TypeChanged(int)));
 
   new QVBoxLayout(type_page_);
   AddPlugin(new QueryWizardPlugin(app_, library_, this));
@@ -125,8 +121,7 @@ void Wizard::AddPlugin(WizardPlugin* plugin) {
   type_page_->layout()->addWidget(radio_button);
   type_page_->layout()->addWidget(description);
 
-  type_mapper_->setMapping(radio_button, index);
-  connect(radio_button, SIGNAL(clicked()), type_mapper_, SLOT(map()));
+  connect(radio_button, &QRadioButton::clicked, [this, index]() { TypeChanged(index); } );
 
   if (index == 0) {
     radio_button->setChecked(true);

--- a/src/smartplaylists/wizard.h
+++ b/src/smartplaylists/wizard.h
@@ -26,8 +26,6 @@ class Application;
 class LibraryBackend;
 class Ui_SmartPlaylistWizardFinishPage;
 
-class QSignalMapper;
-
 namespace smart_playlists {
 
 class WizardPlugin;
@@ -63,7 +61,6 @@ class Wizard : public QWizard {
 
   int type_index_;
   QList<WizardPlugin*> plugins_;
-  QSignalMapper* type_mapper_;
 };
 
 }  // namespace

--- a/src/songinfo/songinfofetcher.cpp
+++ b/src/songinfo/songinfofetcher.cpp
@@ -45,7 +45,7 @@ int SongInfoFetcher::FetchInfo(const Song& metadata) {
   timeout_timers_[id]->setInterval(timeout_duration_);
   timeout_timers_[id]->start();
 
-  connect(timeout_timers_[id], &QTimer::timeout, [this, id]() { Timeout(id); } );
+  connect(timeout_timers_[id], &QTimer::timeout, [this, id]() { Timeout(id); });
 
   for (SongInfoProvider* provider : providers_) {
     if (provider->is_enabled()) {
@@ -85,7 +85,6 @@ void SongInfoFetcher::ProviderFinished(int id) {
 }
 
 void SongInfoFetcher::Timeout(int id) {
-
   if (!results_.contains(id)) return;
   if (!waiting_for_.contains(id)) return;
 

--- a/src/songinfo/songinfofetcher.h
+++ b/src/songinfo/songinfofetcher.h
@@ -27,8 +27,6 @@
 
 class SongInfoProvider;
 
-class QSignalMapper;
-
 class SongInfoFetcher : public QObject {
   Q_OBJECT
 
@@ -64,7 +62,6 @@ signals:
   QMap<int, QList<SongInfoProvider*> > waiting_for_;
   QMap<int, QTimer*> timeout_timers_;
 
-  QSignalMapper* timeout_timer_mapper_;
   int timeout_duration_;
 
   int next_id_;

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -31,7 +31,6 @@
 #include <QPainter>
 #include <QSettings>
 #include <QShortcut>
-#include <QSignalMapper>
 #include <QSortFilterProxyModel>
 #include <QStatusBar>
 #include <QSystemTrayIcon>

--- a/src/ui/organisedialog.cpp
+++ b/src/ui/organisedialog.cpp
@@ -100,7 +100,7 @@ OrganiseDialog::OrganiseDialog(
   for (const QString& title : tag_titles) {
     QAction* action = tag_menu->addAction(title);
     QString tag = tags[title];
-    connect(action, &QAction::triggered, [this, tag]() { InsertTag(tag); } );
+    connect(action, &QAction::triggered, [this, tag]() { InsertTag(tag); });
   }
 
   ui_->insert->setMenu(tag_menu);

--- a/src/ui/organisedialog.cpp
+++ b/src/ui/organisedialog.cpp
@@ -28,7 +28,6 @@
 #include <QPushButton>
 #include <QResizeEvent>
 #include <QSettings>
-#include <QSignalMapper>
 #include <QtConcurrentRun>
 #include <QtDebug>
 
@@ -98,13 +97,12 @@ OrganiseDialog::OrganiseDialog(
 
   // Build the insert menu
   QMenu* tag_menu = new QMenu(this);
-  QSignalMapper* tag_mapper = new QSignalMapper(this);
   for (const QString& title : tag_titles) {
-    QAction* action = tag_menu->addAction(title, tag_mapper, SLOT(map()));
-    tag_mapper->setMapping(action, tags[title]);
+    QAction* action = tag_menu->addAction(title);
+    QString tag = tags[title];
+    connect(action, &QAction::triggered, [this, tag]() { InsertTag(tag); } );
   }
 
-  connect(tag_mapper, SIGNAL(mapped(QString)), SLOT(InsertTag(QString)));
   ui_->insert->setMenu(tag_menu);
 }
 

--- a/src/visualisations/visualisationcontainer.cpp
+++ b/src/visualisations/visualisationcontainer.cpp
@@ -32,7 +32,6 @@
 #include <QMessageBox>
 #include <QSettings>
 #include <QShortcut>
-#include <QSignalMapper>
 #include <QtDebug>
 
 // Framerates
@@ -102,31 +101,24 @@ void VisualisationContainer::Init() {
                    tr("Toggle fullscreen"), this, SLOT(ToggleFullscreen()));
 
   QMenu* fps_menu = menu_->addMenu(tr("Framerate"));
-  QSignalMapper* fps_mapper = new QSignalMapper(this);
   QActionGroup* fps_group = new QActionGroup(this);
-  AddMenuItem(tr("Low (%1 fps)").arg(kLowFramerate), kLowFramerate, fps_,
-              fps_group, fps_mapper);
-  AddMenuItem(tr("Medium (%1 fps)").arg(kMediumFramerate), kMediumFramerate,
-              fps_, fps_group, fps_mapper);
-  AddMenuItem(tr("High (%1 fps)").arg(kHighFramerate), kHighFramerate, fps_,
-              fps_group, fps_mapper);
-  AddMenuItem(tr("Super high (%1 fps)").arg(kSuperHighFramerate),
-              kSuperHighFramerate, fps_, fps_group, fps_mapper);
+  AddFramerateMenuItem(tr("Low (%1 fps)").arg(kLowFramerate), kLowFramerate, fps_,
+              fps_group);
+  AddFramerateMenuItem(tr("Medium (%1 fps)").arg(kMediumFramerate), kMediumFramerate,
+              fps_, fps_group);
+  AddFramerateMenuItem(tr("High (%1 fps)").arg(kHighFramerate), kHighFramerate, fps_,
+              fps_group);
+  AddFramerateMenuItem(tr("Super high (%1 fps)").arg(kSuperHighFramerate),
+              kSuperHighFramerate, fps_, fps_group);
   fps_menu->addActions(fps_group->actions());
-  connect(fps_mapper, SIGNAL(mapped(int)), SLOT(SetFps(int)));
 
   QMenu* quality_menu = menu_->addMenu(tr("Quality", "Visualisation quality"));
-  QSignalMapper* quality_mapper = new QSignalMapper(this);
   QActionGroup* quality_group = new QActionGroup(this);
-  AddMenuItem(tr("Low (256x256)"), 256, size_, quality_group, quality_mapper);
-  AddMenuItem(tr("Medium (512x512)"), 512, size_, quality_group,
-              quality_mapper);
-  AddMenuItem(tr("High (1024x1024)"), 1024, size_, quality_group,
-              quality_mapper);
-  AddMenuItem(tr("Super high (2048x2048)"), 2048, size_, quality_group,
-              quality_mapper);
+  AddQualityMenuItem(tr("Low (256x256)"), 256, size_, quality_group);
+  AddQualityMenuItem(tr("Medium (512x512)"), 512, size_, quality_group);
+  AddQualityMenuItem(tr("High (1024x1024)"), 1024, size_, quality_group);
+  AddQualityMenuItem(tr("Super high (2048x2048)"), 2048, size_, quality_group);
   quality_menu->addActions(quality_group->actions());
-  connect(quality_mapper, SIGNAL(mapped(int)), SLOT(SetQuality(int)));
 
   menu_->addAction(tr("Select visualizations..."), selector_, SLOT(show()));
 
@@ -135,14 +127,22 @@ void VisualisationContainer::Init() {
                    tr("Close visualization"), this, SLOT(hide()));
 }
 
-void VisualisationContainer::AddMenuItem(const QString& name, int value,
-                                         int def, QActionGroup* group,
-                                         QSignalMapper* mapper) {
+void VisualisationContainer::AddFramerateMenuItem(const QString& name, int value, int def, QActionGroup* group) {
+
   QAction* action = group->addAction(name);
   action->setCheckable(true);
   action->setChecked(value == def);
-  mapper->setMapping(action, value);
-  connect(action, SIGNAL(triggered()), mapper, SLOT(map()));
+  connect(action, &QAction::triggered, [this, value]() { SetFps(value); } );
+
+}
+
+void VisualisationContainer::AddQualityMenuItem(const QString& name, int value, int def, QActionGroup* group) {
+
+  QAction* action = group->addAction(name);
+  action->setCheckable(true);
+  action->setChecked(value == def);
+  connect(action, &QAction::triggered, [this, value]() { SetQuality(value); } );
+
 }
 
 void VisualisationContainer::SetEngine(GstEngine* engine) {

--- a/src/visualisations/visualisationcontainer.cpp
+++ b/src/visualisations/visualisationcontainer.cpp
@@ -102,14 +102,14 @@ void VisualisationContainer::Init() {
 
   QMenu* fps_menu = menu_->addMenu(tr("Framerate"));
   QActionGroup* fps_group = new QActionGroup(this);
-  AddFramerateMenuItem(tr("Low (%1 fps)").arg(kLowFramerate), kLowFramerate, fps_,
-              fps_group);
-  AddFramerateMenuItem(tr("Medium (%1 fps)").arg(kMediumFramerate), kMediumFramerate,
-              fps_, fps_group);
-  AddFramerateMenuItem(tr("High (%1 fps)").arg(kHighFramerate), kHighFramerate, fps_,
-              fps_group);
+  AddFramerateMenuItem(tr("Low (%1 fps)").arg(kLowFramerate), kLowFramerate,
+                       fps_, fps_group);
+  AddFramerateMenuItem(tr("Medium (%1 fps)").arg(kMediumFramerate),
+                       kMediumFramerate, fps_, fps_group);
+  AddFramerateMenuItem(tr("High (%1 fps)").arg(kHighFramerate), kHighFramerate,
+                       fps_, fps_group);
   AddFramerateMenuItem(tr("Super high (%1 fps)").arg(kSuperHighFramerate),
-              kSuperHighFramerate, fps_, fps_group);
+                       kSuperHighFramerate, fps_, fps_group);
   fps_menu->addActions(fps_group->actions());
 
   QMenu* quality_menu = menu_->addMenu(tr("Quality", "Visualisation quality"));
@@ -127,22 +127,21 @@ void VisualisationContainer::Init() {
                    tr("Close visualization"), this, SLOT(hide()));
 }
 
-void VisualisationContainer::AddFramerateMenuItem(const QString& name, int value, int def, QActionGroup* group) {
-
+void VisualisationContainer::AddFramerateMenuItem(const QString& name,
+                                                  int value, int def,
+                                                  QActionGroup* group) {
   QAction* action = group->addAction(name);
   action->setCheckable(true);
   action->setChecked(value == def);
-  connect(action, &QAction::triggered, [this, value]() { SetFps(value); } );
-
+  connect(action, &QAction::triggered, [this, value]() { SetFps(value); });
 }
 
-void VisualisationContainer::AddQualityMenuItem(const QString& name, int value, int def, QActionGroup* group) {
-
+void VisualisationContainer::AddQualityMenuItem(const QString& name, int value,
+                                                int def, QActionGroup* group) {
   QAction* action = group->addAction(name);
   action->setCheckable(true);
   action->setChecked(value == def);
-  connect(action, &QAction::triggered, [this, value]() { SetQuality(value); } );
-
+  connect(action, &QAction::triggered, [this, value]() { SetQuality(value); });
 }
 
 void VisualisationContainer::SetEngine(GstEngine* engine) {

--- a/src/visualisations/visualisationcontainer.h
+++ b/src/visualisations/visualisationcontainer.h
@@ -29,7 +29,6 @@ class VisualisationOverlay;
 class VisualisationSelector;
 
 class QMenu;
-class QSignalMapper;
 class QActionGroup;
 
 class VisualisationContainer : public QGraphicsView {
@@ -74,8 +73,8 @@ class VisualisationContainer : public QGraphicsView {
   void Init();
 
   void SizeChanged();
-  void AddMenuItem(const QString& name, int value, int def, QActionGroup* group,
-                   QSignalMapper* mapper);
+  void AddFramerateMenuItem(const QString& name, int value, int def, QActionGroup* group);
+  void AddQualityMenuItem(const QString& name, int value, int def, QActionGroup* group);
 
  private slots:
   void ChangeOverlayOpacity(qreal value);

--- a/src/visualisations/visualisationcontainer.h
+++ b/src/visualisations/visualisationcontainer.h
@@ -73,8 +73,10 @@ class VisualisationContainer : public QGraphicsView {
   void Init();
 
   void SizeChanged();
-  void AddFramerateMenuItem(const QString& name, int value, int def, QActionGroup* group);
-  void AddQualityMenuItem(const QString& name, int value, int def, QActionGroup* group);
+  void AddFramerateMenuItem(const QString& name, int value, int def,
+                            QActionGroup* group);
+  void AddQualityMenuItem(const QString& name, int value, int def,
+                          QActionGroup* group);
 
  private slots:
   void ChangeOverlayOpacity(qreal value);

--- a/src/widgets/fancytabwidget.cpp
+++ b/src/widgets/fancytabwidget.cpp
@@ -411,10 +411,11 @@ void FancyTabWidget::SetMode(FancyTabWidget::Mode mode) {
     emit ModeChanged(mode);
 }
 
-void FancyTabWidget::addMenuItem(QActionGroup* group, const QString& text, Mode mode) {
+void FancyTabWidget::addMenuItem(QActionGroup* group, const QString& text,
+                                 Mode mode) {
   QAction* action = group->addAction(text);
   action->setCheckable(true);
-  connect(action, &QAction::triggered, [this, mode]() { SetMode(mode); } );
+  connect(action, &QAction::triggered, [this, mode]() { SetMode(mode); });
 
   if (mode == mode_) action->setChecked(true);
 }

--- a/src/widgets/fancytabwidget.cpp
+++ b/src/widgets/fancytabwidget.cpp
@@ -25,7 +25,6 @@
 #include <QMenu>
 #include <QMouseEvent>
 #include <QPainter>
-#include <QSignalMapper>
 #include <QTabBar>
 #include <QStylePainter>
 #include <QTimer>
@@ -412,12 +411,10 @@ void FancyTabWidget::SetMode(FancyTabWidget::Mode mode) {
     emit ModeChanged(mode);
 }
 
-void FancyTabWidget::addMenuItem(QSignalMapper* mapper, QActionGroup* group,
-                                 const QString& text, Mode mode) {
+void FancyTabWidget::addMenuItem(QActionGroup* group, const QString& text, Mode mode) {
   QAction* action = group->addAction(text);
   action->setCheckable(true);
-  mapper->setMapping(action, mode);
-  connect(action, SIGNAL(triggered()), mapper, SLOT(map()));
+  connect(action, &QAction::triggered, [this, mode]() { SetMode(mode); } );
 
   if (mode == mode_) action->setChecked(true);
 }
@@ -427,16 +424,13 @@ void FancyTabWidget::contextMenuEvent(QContextMenuEvent* e) {
   if (!menu_) {
     menu_ = new QMenu(this);
 
-    QSignalMapper* mapper = new QSignalMapper(this);
     QActionGroup* group = new QActionGroup(this);
-    addMenuItem(mapper, group, tr("Large sidebar"), Mode_LargeSidebar);
-    addMenuItem(mapper, group, tr("Small sidebar"), Mode_SmallSidebar);
-    addMenuItem(mapper, group, tr("Plain sidebar"), Mode_PlainSidebar);
-    addMenuItem(mapper, group, tr("Tabs on top"), Mode_Tabs);
-    addMenuItem(mapper, group, tr("Icons on top"), Mode_IconOnlyTabs);
+    addMenuItem(group, tr("Large sidebar"), Mode_LargeSidebar);
+    addMenuItem(group, tr("Small sidebar"), Mode_SmallSidebar);
+    addMenuItem(group, tr("Plain sidebar"), Mode_PlainSidebar);
+    addMenuItem(group, tr("Tabs on top"), Mode_Tabs);
+    addMenuItem(group, tr("Icons on top"), Mode_IconOnlyTabs);
     menu_->addActions(group->actions());
-
-    connect(mapper, SIGNAL(mapped(int)), SLOT(SetMode(int)));
   }
 
   menu_->popup(e->globalPos());

--- a/src/widgets/fancytabwidget.h
+++ b/src/widgets/fancytabwidget.h
@@ -86,7 +86,6 @@ class FancyTabWidget : public QTabWidget {
      QMenu* menu_;
      Mode mode_;
      QWidget* bottom_widget_;
-
 };
 
 }  // namespace Internal

--- a/src/widgets/fancytabwidget.h
+++ b/src/widgets/fancytabwidget.h
@@ -80,13 +80,12 @@ class FancyTabWidget : public QTabWidget {
         void paintEvent(QPaintEvent *);
         void contextMenuEvent(QContextMenuEvent* e);
     private:
-        void addMenuItem(QActionGroup* group,
-                                 const QString& text, Mode mode);
+     void addMenuItem(QActionGroup* group, const QString& text, Mode mode);
 
-        QPixmap background_pixmap_;
-        QMenu* menu_;
-        Mode mode_;
-        QWidget *bottom_widget_;
+     QPixmap background_pixmap_;
+     QMenu* menu_;
+     Mode mode_;
+     QWidget* bottom_widget_;
 
 };
 

--- a/src/widgets/fancytabwidget.h
+++ b/src/widgets/fancytabwidget.h
@@ -26,7 +26,6 @@
 class QActionGroup;
 class QMenu;
 class QSettings;
-class QSignalMapper;
 
 namespace Core {
 namespace Internal {
@@ -81,7 +80,7 @@ class FancyTabWidget : public QTabWidget {
         void paintEvent(QPaintEvent *);
         void contextMenuEvent(QContextMenuEvent* e);
     private:
-        void addMenuItem(QSignalMapper* mapper, QActionGroup* group,
+        void addMenuItem(QActionGroup* group,
                                  const QString& text, Mode mode);
 
         QPixmap background_pixmap_;

--- a/src/widgets/nowplayingwidget.cpp
+++ b/src/widgets/nowplayingwidget.cpp
@@ -94,8 +94,10 @@ NowPlayingWidget::NowPlayingWidget(QWidget* parent)
   QActionGroup* mode_group = new QActionGroup(this);
   CreateModeAction(SmallSongDetails, tr("Small album cover"), mode_group);
   CreateModeAction(LargeSongDetails, tr("Large album cover"), mode_group);
-  CreateModeAction(LargeSongDetailsBelow, tr("Large album cover (details below)"), mode_group);
-  CreateModeAction(LargeNoSongDetails, tr("Large album cover (no details)"), mode_group);
+  CreateModeAction(LargeSongDetailsBelow,
+                   tr("Large album cover (details below)"), mode_group);
+  CreateModeAction(LargeNoSongDetails, tr("Large album cover (no details)"),
+                   mode_group);
 
   menu_->addActions(mode_group->actions());
 
@@ -182,7 +184,7 @@ void NowPlayingWidget::CreateModeAction(Mode mode, const QString& text,
                                         QActionGroup* group) {
   QAction* action = new QAction(text, group);
   action->setCheckable(true);
-  connect(action, &QAction::triggered, [this, mode]() { SetMode(mode); } );
+  connect(action, &QAction::triggered, [this, mode]() { SetMode(mode); });
 
   if (mode == mode_) action->setChecked(true);
 }

--- a/src/widgets/nowplayingwidget.cpp
+++ b/src/widgets/nowplayingwidget.cpp
@@ -23,7 +23,6 @@
 #include <QPainter>
 #include <QPaintEvent>
 #include <QSettings>
-#include <QSignalMapper>
 #include <QTextDocument>
 #include <QTimeLine>
 #include <QtDebug>
@@ -93,17 +92,10 @@ NowPlayingWidget::NowPlayingWidget(QWidget* parent)
 
   // Context menu
   QActionGroup* mode_group = new QActionGroup(this);
-  QSignalMapper* mode_mapper = new QSignalMapper(this);
-  connect(mode_mapper, SIGNAL(mapped(int)), SLOT(SetMode(int)));
-  CreateModeAction(SmallSongDetails, tr("Small album cover"), mode_group,
-                   mode_mapper);
-  CreateModeAction(LargeSongDetails, tr("Large album cover"), mode_group,
-                   mode_mapper);
-  CreateModeAction(LargeSongDetailsBelow,
-                   tr("Large album cover (details below)"), mode_group,
-                   mode_mapper);
-  CreateModeAction(LargeNoSongDetails, tr("Large album cover (no details)"),
-                   mode_group, mode_mapper);
+  CreateModeAction(SmallSongDetails, tr("Small album cover"), mode_group);
+  CreateModeAction(LargeSongDetails, tr("Large album cover"), mode_group);
+  CreateModeAction(LargeSongDetailsBelow, tr("Large album cover (details below)"), mode_group);
+  CreateModeAction(LargeNoSongDetails, tr("Large album cover (no details)"), mode_group);
 
   menu_->addActions(mode_group->actions());
 
@@ -187,12 +179,10 @@ void NowPlayingWidget::SetApplication(Application* app) {
 }
 
 void NowPlayingWidget::CreateModeAction(Mode mode, const QString& text,
-                                        QActionGroup* group,
-                                        QSignalMapper* mapper) {
+                                        QActionGroup* group) {
   QAction* action = new QAction(text, group);
   action->setCheckable(true);
-  mapper->setMapping(action, mode);
-  connect(action, SIGNAL(triggered()), mapper, SLOT(map()));
+  connect(action, &QAction::triggered, [this, mode]() { SetMode(mode); } );
 
   if (mode == mode_) action->setChecked(true);
 }

--- a/src/widgets/nowplayingwidget.h
+++ b/src/widgets/nowplayingwidget.h
@@ -34,7 +34,6 @@ class QAction;
 class QActionGroup;
 class QMenu;
 class QMovie;
-class QSignalMapper;
 class QTextDocument;
 class QTimeLine;
 
@@ -111,8 +110,7 @@ signals:
   void AutomaticCoverSearchDone();
 
  private:
-  void CreateModeAction(Mode mode, const QString& text, QActionGroup* group,
-                        QSignalMapper* mapper);
+  void CreateModeAction(Mode mode, const QString& text, QActionGroup* group);
   void UpdateDetailsText();
   void UpdateHeight();
   void DrawContents(QPainter* p);


### PR DESCRIPTION
QSignalMapper is deprecated. Since we use C++11 anyway it can be replaced with lambda expressions.