### PR TITLE
Switch to queue2 for probe queue and set properties

### DIFF
--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -302,7 +302,7 @@ bool GstEnginePipeline::Init() {
   audioconvert_ = engine_->CreateElement("audioconvert", audiobin_);
   tee = engine_->CreateElement("tee", audiobin_);
 
-  probe_queue = engine_->CreateElement("queue", audiobin_);
+  probe_queue = engine_->CreateElement("queue2", audiobin_);
   probe_converter = engine_->CreateElement("audioconvert", audiobin_);
   probe_sink = engine_->CreateElement("fakesink", audiobin_);
 
@@ -419,6 +419,10 @@ bool GstEnginePipeline::Init() {
   if (buffer_duration_nanosec_ > 0) {
     g_object_set(G_OBJECT(queue_), "use-buffering", true, nullptr);
   }
+
+  g_object_set(G_OBJECT(probe_queue), "max-size-buffers", 0, nullptr);
+  g_object_set(G_OBJECT(probe_queue), "max-size-bytes", 0, nullptr);
+  g_object_set(G_OBJECT(probe_queue), "max-size-time", 0, nullptr);
 
   gst_element_link_many(queue_, audioconvert_, convert_sink, nullptr);
   gst_element_link(probe_converter, probe_sink);


### PR DESCRIPTION
This fixes the track change hang as described in https://github.com/clementine-player/Clementine/pull/6103 which is the correct fix for the problem.
Additionally setting properties on the queue2 element so it does not cause pause to hang.
Default max-size-bytes for queue2 is 2097152, which is lower than 10485760 for queue. We also set it to unlimited on the main queue before the tee, which might be the main cause for the track change hang.
I also set max-size-buffers and max-size-time to unlimited since we set the limit on the queue element on the queue before the tee anyway.
I have tested to pause over night and it does not get stuck anymore.

Fixes #6408
Fixes #6358
Fixes #6320
Fixes #6289
Fixes #5556
Fixes #6062
Fixes #5501
Fixes #4748
Fixes #1679
