### PR TITLE
Remove album from pixmap cache when song is removed from library model

### DIFF
--- a/src/library/librarymodel.cpp
+++ b/src/library/librarymodel.cpp
@@ -803,8 +803,6 @@ void LibraryModel::BeginReset() {
   divider_nodes_.clear();
   pending_art_.clear();
   pending_cache_keys_.clear();
-  QPixmapCache::clear();
-  icon_cache_->clear();
   smart_playlist_node_ = nullptr;
 
   root_ = new LibraryItem(this);

--- a/src/library/librarymodel.cpp
+++ b/src/library/librarymodel.cpp
@@ -409,7 +409,8 @@ void LibraryModel::SongsDeleted(const SongList& songs) {
       const QString cache_key = AlbumIconPixmapCacheKey(idx);
       QPixmapCache::remove(cache_key);
       icon_cache_->remove(QUrl(cache_key));
-      if (pending_cache_keys_.contains(cache_key)) pending_cache_keys_.remove(cache_key);
+      if (pending_cache_keys_.contains(cache_key))
+        pending_cache_keys_.remove(cache_key);
 
       // Remove from pending art loading
       QMapIterator<quint64, ItemAndCacheKey> i(pending_art_);

--- a/src/library/librarymodel.cpp
+++ b/src/library/librarymodel.cpp
@@ -403,7 +403,25 @@ void LibraryModel::SongsDeleted(const SongList& songs) {
 
       if (node->parent != root_) parents << node->parent;
 
-      beginRemoveRows(ItemToIndex(node->parent), node->row, node->row);
+      QModelIndex idx = ItemToIndex(node->parent);
+
+      // Remove from pixmap cache
+      const QString cache_key = AlbumIconPixmapCacheKey(idx);
+      QPixmapCache::remove(cache_key);
+      icon_cache_->remove(QUrl(cache_key));
+      if (pending_cache_keys_.contains(cache_key)) pending_cache_keys_.remove(cache_key);
+
+      // Remove from pending art loading
+      QMapIterator<quint64, ItemAndCacheKey> i(pending_art_);
+      while (i.hasNext()) {
+        i.next();
+        if (i.value().first == node) {
+          pending_art_.remove(i.key());
+          break;
+        }
+      }
+
+      beginRemoveRows(idx, node->row, node->row);
       node->parent->Delete(node->row);
       song_nodes_.remove(song.id());
       endRemoveRows();
@@ -783,6 +801,9 @@ void LibraryModel::BeginReset() {
   container_nodes_[2].clear();
   divider_nodes_.clear();
   pending_art_.clear();
+  pending_cache_keys_.clear();
+  QPixmapCache::clear();
+  icon_cache_->clear();
   smart_playlist_node_ = nullptr;
 
   root_ = new LibraryItem(this);


### PR DESCRIPTION
This removes the album cover from pixmap cache when the song is removed from the model.
It fixes a bug where the album cover in the library is stuck to the old one when a new cover is fetched.
Also remove the entry from pending_art_ since it otherwise will contain a dangling pointer to the item.

