### PR TITLE
Remove watch for removed subdirectories

### DIFF
--- a/src/library/librarywatcher.cpp
+++ b/src/library/librarywatcher.cpp
@@ -119,6 +119,12 @@ LibraryWatcher::ScanTransaction::~ScanTransaction() {
 
   watcher_->task_manager_->SetTaskFinished(task_id_);
 
+  for (const Subdirectory &subdir : deleted_subdirs) {
+    if (watcher_->watched_dirs_.contains(dir_)) {
+      watcher_->RemoveWatch(watcher_->watched_dirs_[dir_], subdir);
+    }
+  }
+
   if (watcher_->monitor_) {
     // Watch the new subdirectories
     for (const Subdirectory& subdir : new_subdirs) {
@@ -411,6 +417,10 @@ void LibraryWatcher::ScanSubdirectory(const QString& path,
   else
     t->touched_subdirs << updated_subdir;
 
+  if (updated_subdir.mtime == 0) { // Subdirectory deleted, mark it for removal from the watcher.
+    t->deleted_subdirs << updated_subdir;
+  }
+
   t->AddToProgress(1);
 
   // Recurse into the new subdirs that we found
@@ -583,6 +593,17 @@ void LibraryWatcher::AddWatch(const Directory& dir, const QString& path) {
           SLOT(DirectoryChanged(const QString&)), Qt::UniqueConnection);
   fs_watcher_->AddPath(path);
   subdir_mapping_[path] = dir;
+}
+
+void LibraryWatcher::RemoveWatch(const Directory &dir, const Subdirectory &subdir) {
+
+  for (const QString &subdir_path : subdir_mapping_.keys(dir)) {
+    if (subdir_path != subdir.path) continue;
+    fs_watcher_->RemovePath(subdir_path);
+    subdir_mapping_.remove(subdir_path);
+    break;
+  }
+
 }
 
 void LibraryWatcher::RemoveDirectory(const Directory& dir) {

--- a/src/library/librarywatcher.cpp
+++ b/src/library/librarywatcher.cpp
@@ -119,7 +119,7 @@ LibraryWatcher::ScanTransaction::~ScanTransaction() {
 
   watcher_->task_manager_->SetTaskFinished(task_id_);
 
-  for (const Subdirectory &subdir : deleted_subdirs) {
+  for (const Subdirectory& subdir : deleted_subdirs) {
     if (watcher_->watched_dirs_.contains(dir_)) {
       watcher_->RemoveWatch(watcher_->watched_dirs_[dir_], subdir);
     }
@@ -417,7 +417,8 @@ void LibraryWatcher::ScanSubdirectory(const QString& path,
   else
     t->touched_subdirs << updated_subdir;
 
-  if (updated_subdir.mtime == 0) { // Subdirectory deleted, mark it for removal from the watcher.
+  if (updated_subdir.mtime ==
+      0) {  // Subdirectory deleted, mark it for removal from the watcher.
     t->deleted_subdirs << updated_subdir;
   }
 
@@ -595,15 +596,14 @@ void LibraryWatcher::AddWatch(const Directory& dir, const QString& path) {
   subdir_mapping_[path] = dir;
 }
 
-void LibraryWatcher::RemoveWatch(const Directory &dir, const Subdirectory &subdir) {
-
-  for (const QString &subdir_path : subdir_mapping_.keys(dir)) {
+void LibraryWatcher::RemoveWatch(const Directory& dir,
+                                 const Subdirectory& subdir) {
+  for (const QString& subdir_path : subdir_mapping_.keys(dir)) {
     if (subdir_path != subdir.path) continue;
     fs_watcher_->RemovePath(subdir_path);
     subdir_mapping_.remove(subdir_path);
     break;
   }
-
 }
 
 void LibraryWatcher::RemoveDirectory(const Directory& dir) {

--- a/src/library/librarywatcher.h
+++ b/src/library/librarywatcher.h
@@ -156,7 +156,7 @@ signals:
   QString ImageForSong(const QString& path,
                        QMap<QString, QStringList>& album_art);
   void AddWatch(const Directory& dir, const QString& path);
-  void RemoveWatch(const Directory &dir, const Subdirectory &subdir);
+  void RemoveWatch(const Directory& dir, const Subdirectory& subdir);
   uint GetMtimeForCue(const QString& cue_path);
   void PerformScan(bool incremental, bool ignore_mtimes);
 

--- a/src/library/librarywatcher.h
+++ b/src/library/librarywatcher.h
@@ -109,6 +109,7 @@ signals:
     SongList touched_songs;
     SubdirectoryList new_subdirs;
     SubdirectoryList touched_subdirs;
+    SubdirectoryList deleted_subdirs;
 
    private:
     ScanTransaction(const ScanTransaction&) {}
@@ -155,6 +156,7 @@ signals:
   QString ImageForSong(const QString& path,
                        QMap<QString, QStringList>& album_art);
   void AddWatch(const Directory& dir, const QString& path);
+  void RemoveWatch(const Directory &dir, const Subdirectory &subdir);
   uint GetMtimeForCue(const QString& cue_path);
   void PerformScan(bool incremental, bool ignore_mtimes);
 


### PR DESCRIPTION
This fixes a bug where the library watcher is no longer updating the sub directory (album) after rename when the parent directory (artist) is renamed first.  Even though the new artist directory is updated to the songs, the new album directory is not.
It's because we are still watcher the old directory names.
Fixed by removing watches on the removed subdirectories of the library directory before watching the new directory names.
