### PR TITLE
Fix updating compilations

### DIFF
--- a/src/library/librarybackend.cpp
+++ b/src/library/librarybackend.cpp
@@ -770,12 +770,12 @@ void LibraryBackend::UpdateCompilations() {
 
     // Find the directory the song is in
     QUrl url = QUrl::fromEncoded(filename.toUtf8());
-    QString directory = url.toString(QUrl::PreferLocalFile|QUrl::RemoveFilename);
+    QString directory =
+        url.toString(QUrl::PreferLocalFile | QUrl::RemoveFilename);
 
     CompilationInfo& info = compilation_info[directory + album];
     info.urls << url;
-    if (!info.artists.contains(artist))
-      info.artists << artist;
+    if (!info.artists.contains(artist)) info.artists << artist;
     if (sampler)
       ++info.has_samplers;
     else
@@ -794,15 +794,14 @@ void LibraryBackend::UpdateCompilations() {
   for (; it != compilation_info.constEnd(); ++it) {
     const CompilationInfo& info = it.value();
 
-    // If there were more then one 'effective album artist' for this album directory
-    // then it's a compilation
+    // If there were more then one 'effective album artist' for this album
+    // directory then it's a compilation
 
-    for (const QUrl &url : info.urls) {
-      if (info.artists.count() > 1) { // This directory+album is a compilation.
+    for (const QUrl& url : info.urls) {
+      if (info.artists.count() > 1) {  // This directory+album is a compilation.
         if (info.has_not_samplers > 0)
           UpdateCompilations(db, deleted_songs, added_songs, url, true);
-      }
-      else {
+      } else {
         if (info.has_samplers > 0)
           UpdateCompilations(db, deleted_songs, added_songs, url, false);
       }
@@ -818,25 +817,24 @@ void LibraryBackend::UpdateCompilations() {
 }
 
 void LibraryBackend::UpdateCompilations(const QSqlDatabase& db,
-                                        SongList& deleted_songs, SongList& added_songs,
-                                        const QUrl& url, const bool sampler) {
-
+                                        SongList& deleted_songs,
+                                        SongList& added_songs, const QUrl& url,
+                                        const bool sampler) {
   QSqlQuery find_song(db);
-  find_song.prepare(
-      QString(
-          "SELECT ROWID, " + Song::kColumnSpec +
-          " FROM %1"
-          " WHERE filename = :filename AND sampler = :sampler AND unavailable = 0")
-          .arg(songs_table_));
+  find_song.prepare(QString("SELECT ROWID, " + Song::kColumnSpec +
+                            " FROM %1"
+                            " WHERE filename = :filename AND sampler = "
+                            ":sampler AND unavailable = 0")
+                        .arg(songs_table_));
 
   QSqlQuery update_song(db);
   update_song.prepare(
-      QString(
-          "UPDATE %1"
-          " SET sampler = :sampler,"
-          "     effective_compilation = ((compilation OR :sampler OR "
-          "forced_compilation_on) AND NOT forced_compilation_off) + 0"
-          " WHERE filename = :filename AND unavailable = 0").arg(songs_table_));
+      QString("UPDATE %1"
+              " SET sampler = :sampler,"
+              "     effective_compilation = ((compilation OR :sampler OR "
+              "forced_compilation_on) AND NOT forced_compilation_off) + 0"
+              " WHERE filename = :filename AND unavailable = 0")
+          .arg(songs_table_));
 
   // Get song, so we can tell the model its updated
   find_song.bindValue(":filename", url.toEncoded());

--- a/src/library/librarybackend.h
+++ b/src/library/librarybackend.h
@@ -237,20 +237,20 @@ signals:
 
  private:
   struct CompilationInfo {
-    CompilationInfo() : has_samplers(false), has_not_samplers(false) {}
+    CompilationInfo() : has_samplers(0), has_not_samplers(0) {}
 
-    QSet<QString> artists;
-    QSet<QString> directories;
+    QList<QUrl> urls;
+    QStringList artists;
 
-    bool has_samplers;
-    bool has_not_samplers;
+    int has_samplers;
+    int has_not_samplers;
   };
 
   static const char* kNewScoreSql;
 
-  void UpdateCompilations(QSqlQuery& find_songs, QSqlQuery& update,
+  void UpdateCompilations(const QSqlDatabase& db,
                           SongList& deleted_songs, SongList& added_songs,
-                          const QString& album, int sampler);
+                          const QUrl& url, const bool sampler);
   AlbumList GetAlbums(const QString& artist, const QString& album_artist,
                       bool compilation = false,
                       const QueryOptions& opt = QueryOptions());

--- a/src/library/librarybackend.h
+++ b/src/library/librarybackend.h
@@ -248,9 +248,9 @@ signals:
 
   static const char* kNewScoreSql;
 
-  void UpdateCompilations(const QSqlDatabase& db,
-                          SongList& deleted_songs, SongList& added_songs,
-                          const QUrl& url, const bool sampler);
+  void UpdateCompilations(const QSqlDatabase& db, SongList& deleted_songs,
+                          SongList& added_songs, const QUrl& url,
+                          const bool sampler);
   AlbumList GetAlbums(const QString& artist, const QString& album_artist,
                       bool compilation = false,
                       const QueryOptions& opt = QueryOptions());


### PR DESCRIPTION
Updating compilations does not handle cases where there are albums with the same name by different artists. If you have one album with the same effective album artist for all songs, and one album with various effective album artists, both of those albums will go into various artists when updating compilations for the compilation album.
This changes the logic to work on directory + album, instead of just album.
There is also a bug always setting sampler to true when updating the model, even though its updated correctly to the db:
https://github.com/clementine-player/Clementine/blob/master/src/library/librarybackend.cpp#L849
This fixes that too.

