### PR TITLE
Fix setting mtime/btime in tagreader

### DIFF
--- a/ext/libclementine-tagreader/tagreader.cpp
+++ b/ext/libclementine-tagreader/tagreader.cpp
@@ -128,7 +128,10 @@ void TagReader::ReadFile(const QString& filename,
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
   qint64 mtime = info.lastModified().toSecsSinceEpoch();
-  qint64 btime = info.birthTime().toSecsSinceEpoch();
+  qint64 btime = mtime;
+  if (info.birthTime().isValid()) {
+    btime = info.birthTime().toSecsSinceEpoch();
+  }
 #elif QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
   qint64 mtime = info.lastModified().toSecsSinceEpoch();
   qint64 btime = info.created().toSecsSinceEpoch();

--- a/ext/libclementine-tagreader/tagreader.cpp
+++ b/ext/libclementine-tagreader/tagreader.cpp
@@ -126,10 +126,10 @@ void TagReader::ReadFile(const QString& filename,
   song->set_url(url.constData(), url.size());
   song->set_filesize(info.size());
 
-#if QT_VERSION >= 0x051000
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
   qint64 mtime = info.lastModified().toSecsSinceEpoch();
-  qint64 btime = info.birthtime().toSecsSinceEpoch();
-#elif QT_VERSION >= 0x050800
+  qint64 btime = info.birthTime().toSecsSinceEpoch();
+#elif QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
   qint64 mtime = info.lastModified().toSecsSinceEpoch();
   qint64 btime = info.created().toSecsSinceEpoch();
 #else


### PR DESCRIPTION
Because the version is in hex, 0x051000 is not the same as Qt 5.10. So this code will never be used.
Even if it was, it won't compile because it's called birthTime() not birthtime().

Fixes #6423