### PR TITLE
Fix edit tag dialog

### DIFF
--- a/src/ui/edittagdialog.ui
+++ b/src/ui/edittagdialog.ui
@@ -2,6 +2,14 @@
 <ui version="4.0">
  <class>EditTagDialog</class>
  <widget class="QDialog" name="EditTagDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>780</width>
+    <height>840</height>
+   </rect>
+  </property>
   <property name="sizePolicy">
    <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
     <horstretch>0</horstretch>


### PR DESCRIPTION
Fixes a bug in the splitter of the edit tag dialog, when you open it, it only shows the left side of the splitter (files).
