### PR TITLE
Add KGlobalAccel global shortcuts backend

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,6 +82,7 @@ set(SOURCES
   core/globalshortcutbackend.cpp
   core/globalshortcuts.cpp
   core/gnomeglobalshortcutbackend.cpp
+  core/kglobalaccelglobalshortcutbackend.cpp
   core/mergedproxymodel.cpp
   core/metatypes.cpp
   core/multisortfilterproxy.cpp
@@ -413,6 +414,7 @@ set(HEADERS
   core/globalshortcuts.h
   core/globalshortcutbackend.h
   core/gnomeglobalshortcutbackend.h
+  core/kglobalaccelglobalshortcutbackend.h
   core/mergedproxymodel.h
   core/mimedata.h
   core/network.h
@@ -936,6 +938,15 @@ if(UNIX AND HAVE_DBUS)
   qt5_add_dbus_interface(SOURCES
       dbus/org.gnome.SettingsDaemon.MediaKeys.xml
       dbus/gnomesettingsdaemon)
+
+  # org.kde.KGlobalAccel interfaces
+  # these are taken from the KGlobalAccel sources (LGPL 2.1)
+  qt5_add_dbus_interface(SOURCES
+          dbus/org.kde.KGlobalAccel.xml
+          dbus/kglobalaccel)
+  qt5_add_dbus_interface(SOURCES
+          dbus/org.kde.kglobalaccel.Component.xml
+          dbus/kglobalaccelcomponent)
 
   # org.freedesktop.Avahi.Server interface
   add_custom_command(

--- a/src/core/globalshortcuts.cpp
+++ b/src/core/globalshortcuts.cpp
@@ -43,7 +43,8 @@ GlobalShortcuts::GlobalShortcuts(QWidget* parent)
       gnome_backend_(nullptr),
       system_backend_(nullptr),
       use_gnome_(false),
-      have_kglobalaccel_(KGlobalAccelShortcutBackend::isKGlobalAccelAvailable()) {
+      have_kglobalaccel_(
+          KGlobalAccelShortcutBackend::isKGlobalAccelAvailable()) {
   settings_.beginGroup(kSettingsGroup);
 
   // Create actions
@@ -166,7 +167,7 @@ void GlobalShortcuts::Unregister() {
 }
 
 void GlobalShortcuts::Register() {
-  if(have_kglobalaccel_ && kglobalaccel_backend_->Register()) return;
+  if (have_kglobalaccel_ && kglobalaccel_backend_->Register()) return;
   if (use_gnome_ && gnome_backend_->Register()) return;
   system_backend_->Register();
 }

--- a/src/core/globalshortcuts.cpp
+++ b/src/core/globalshortcuts.cpp
@@ -44,7 +44,7 @@ GlobalShortcuts::GlobalShortcuts(QWidget* parent)
       system_backend_(nullptr),
       use_gnome_(false),
       have_kglobalaccel_(
-          KGlobalAccelShortcutBackend::isKGlobalAccelAvailable()) {
+          KGlobalAccelShortcutBackend::IsKGlobalAccelAvailable()) {
   settings_.beginGroup(kSettingsGroup);
 
   // Create actions

--- a/src/core/globalshortcuts.h
+++ b/src/core/globalshortcuts.h
@@ -93,12 +93,14 @@ signals:
 
  private:
   GlobalShortcutBackend* gnome_backend_;
+  GlobalShortcutBackend* kglobalaccel_backend_;
   GlobalShortcutBackend* system_backend_;
 
   QMap<QString, Shortcut> shortcuts_;
   QSettings settings_;
 
   bool use_gnome_;
+  bool have_kglobalaccel_;
 };
 
 #endif  // CORE_GLOBALSHORTCUTS_H_

--- a/src/core/kglobalaccelglobalshortcutbackend.cpp
+++ b/src/core/kglobalaccelglobalshortcutbackend.cpp
@@ -18,8 +18,8 @@ namespace {
 #ifdef HAVE_DBUS
 QString ComponentDisplayName() {
   return QGuiApplication::applicationDisplayName().isEmpty()
-         ? QCoreApplication::applicationName()
-         : QGuiApplication::applicationDisplayName();
+             ? QCoreApplication::applicationName()
+             : QGuiApplication::applicationDisplayName();
 }
 
 QString ComponentUniqueName() { return QCoreApplication::applicationName(); }
@@ -46,9 +46,7 @@ bool IsCorrectMediaKeyShortcut(const GlobalShortcuts::Shortcut& shortcut) {
 
 KGlobalAccelShortcutBackend::KGlobalAccelShortcutBackend(
     GlobalShortcuts* parent)
-    : GlobalShortcutBackend(parent),
-      iface_(nullptr),
-      component_(nullptr) {}
+    : GlobalShortcutBackend(parent), iface_(nullptr), component_(nullptr) {}
 
 #else   // HAVE_DBUS
 KGlobalAccelShortcutBackend::KGlobalAccelShortcutBackend(
@@ -102,9 +100,9 @@ void KGlobalAccelShortcutBackend::DoUnregister() {
   for (const GlobalShortcuts::Shortcut& shortcut : manager_->shortcuts())
     UnregisterAction(shortcut.id, shortcut.action);
 
-  QObject::disconnect(component_,
-                      &OrgKdeKglobalaccelComponentInterface::globalShortcutPressed,
-                      this, &KGlobalAccelShortcutBackend::OnShortcutPressed);
+  QObject::disconnect(
+      component_, &OrgKdeKglobalaccelComponentInterface::globalShortcutPressed,
+      this, &KGlobalAccelShortcutBackend::OnShortcutPressed);
 #endif  // HAVE_DBUS
 }
 
@@ -118,7 +116,8 @@ bool KGlobalAccelShortcutBackend::AcquireComponent() {
 
   if (component_) return true;
 
-  QDBusReply<QDBusObjectPath> reply = iface_->getComponent(ComponentUniqueName());
+  QDBusReply<QDBusObjectPath> reply =
+      iface_->getComponent(ComponentUniqueName());
   if (!reply.isValid()) {
     if (reply.error().name() ==
         QLatin1String("org.kde.kglobalaccel.NoSuchComponent"))

--- a/src/core/kglobalaccelglobalshortcutbackend.cpp
+++ b/src/core/kglobalaccelglobalshortcutbackend.cpp
@@ -1,8 +1,5 @@
-#include "config.h"
-#include "core/closure.h"
-#include "core/logging.h"
-#include "globalshortcuts.h"
 #include "kglobalaccelglobalshortcutbackend.h"
+#include "core/logging.h"
 
 #include <QAction>
 #include <QGuiApplication>
@@ -17,57 +14,51 @@
 // Most of this file is based on the KGlobalAccel sources
 // (https://phabricator.kde.org/source/kglobalaccel)
 
-
 namespace {
-  QString compDisplayName() {
-    if (!QGuiApplication::applicationDisplayName().isEmpty()) {
-      return QGuiApplication::applicationDisplayName();
-    }
-    return QCoreApplication::applicationName();
+QString compDisplayName() {
+  if (!QGuiApplication::applicationDisplayName().isEmpty()) {
+    return QGuiApplication::applicationDisplayName();
   }
+  return QCoreApplication::applicationName();
+}
 
-  QString compUniqueName() {
-    return QCoreApplication::applicationName();
-  }
+QString compUniqueName() { return QCoreApplication::applicationName(); }
 
-  const QString &id_ActionUnique(const QStringList &id) {
-    return id.at(1);
-  }
+const QString &id_ActionUnique(const QStringList &id) { return id.at(1); }
 
-  bool isCorrectMediaKeyShortcut(const GlobalShortcuts::Shortcut& shortcut) {
-    if(shortcut.id == QStringLiteral("play_pause")) {
-      return shortcut.action->shortcut() == QKeySequence(Qt::Key_MediaPlay);
-    } else if(shortcut.id == QStringLiteral("stop")) {
-      return shortcut.action->shortcut() == QKeySequence(Qt::Key_MediaStop);
-    } else if(shortcut.id == QStringLiteral("next_track")) {
-      return shortcut.action->shortcut() == QKeySequence(Qt::Key_MediaNext);
-    } else if(shortcut.id == QStringLiteral("prev_track")) {
-      return shortcut.action->shortcut() == QKeySequence(Qt::Key_MediaPrevious);
-    } else {
-      return false;
-    }
+bool isCorrectMediaKeyShortcut(const GlobalShortcuts::Shortcut &shortcut) {
+  if (shortcut.id == QStringLiteral("play_pause")) {
+    return shortcut.action->shortcut() == QKeySequence(Qt::Key_MediaPlay);
+  } else if (shortcut.id == QStringLiteral("stop")) {
+    return shortcut.action->shortcut() == QKeySequence(Qt::Key_MediaStop);
+  } else if (shortcut.id == QStringLiteral("next_track")) {
+    return shortcut.action->shortcut() == QKeySequence(Qt::Key_MediaNext);
+  } else if (shortcut.id == QStringLiteral("prev_track")) {
+    return shortcut.action->shortcut() == QKeySequence(Qt::Key_MediaPrevious);
+  } else {
+    return false;
   }
 }
+} // namespace
 
 #ifdef HAVE_DBUS
 
 KGlobalAccelShortcutBackend::KGlobalAccelShortcutBackend(
     GlobalShortcuts *parent)
-    : GlobalShortcutBackend(parent),
-      iface_(nullptr),
-      component_(nullptr),
+    : GlobalShortcutBackend(parent), iface_(nullptr), component_(nullptr),
       nameToAction_() {}
 
-#else // HAVE_DBUS
-KGlobalAccelShortcutBackend::KGlobalAccelShortcutBackend(GlobalShortcuts *parent)
-  : GlobalShortcutBackend(parent) {}
+#else  // HAVE_DBUS
+KGlobalAccelShortcutBackend::KGlobalAccelShortcutBackend(
+    GlobalShortcuts *parent)
+    : GlobalShortcutBackend(parent) {}
 #endif // HAVE_DBUS
 
 bool KGlobalAccelShortcutBackend::isKGlobalAccelAvailable() {
 #ifdef HAVE_DBUS
   return QDBusConnection::sessionBus().interface()->isServiceRegistered(
       Service);
-#else // HAVE_DBUS
+#else  // HAVE_DBUS
   return false;
 #endif // HAVE_DBUS
 }
@@ -80,8 +71,9 @@ bool KGlobalAccelShortcutBackend::DoRegister() {
     return false;
 
   bool complete = true;
-  for (const GlobalShortcuts::Shortcut &shortcut : manager_->shortcuts().values()) {
-    if(shortcut.action->shortcut().isEmpty())
+  for (const GlobalShortcuts::Shortcut &shortcut :
+       manager_->shortcuts().values()) {
+    if (shortcut.action->shortcut().isEmpty())
       continue;
 
     if (!registerShortcut(shortcut))
@@ -93,11 +85,10 @@ bool KGlobalAccelShortcutBackend::DoRegister() {
 
   QObject::connect(component_,
                    &OrgKdeKglobalaccelComponentInterface::globalShortcutPressed,
-                   this,
-                   &KGlobalAccelShortcutBackend::onShortcutPressed);
+                   this, &KGlobalAccelShortcutBackend::onShortcutPressed);
 
   return complete;
-#else // HAVE_DBUS
+#else  // HAVE_DBUS
   qLog(Warning) << "dbus not available";
   return false;
 #endif // HAVE_DBUS
@@ -133,10 +124,8 @@ bool KGlobalAccelShortcutBackend::acquireComponent() {
     return false;
   }
 
-  component_ = new org::kde::kglobalaccel::Component(Service,
-                                                     reply.value().path(),
-                                                     QDBusConnection::sessionBus(),
-                                                     iface_);
+  component_ = new org::kde::kglobalaccel::Component(
+      Service, reply.value().path(), QDBusConnection::sessionBus(), iface_);
 
   if (!component_->isValid()) {
     qLog(Warning) << "Failed to get KGlobalAccel component:"
@@ -154,9 +143,8 @@ bool KGlobalAccelShortcutBackend::acquireInterface() {
     return true;
 
   if (isKGlobalAccelAvailable()) {
-    iface_ = new OrgKdeKGlobalAccelInterface(Service, Path,
-                                             QDBusConnection::sessionBus(),
-                                             this);
+    iface_ = new OrgKdeKGlobalAccelInterface(
+        Service, Path, QDBusConnection::sessionBus(), this);
   }
 
   if (iface_ && iface_->isValid())
@@ -183,8 +171,8 @@ QStringList KGlobalAccelShortcutBackend::id(const QString &name,
   return ret;
 }
 
-QList<int> KGlobalAccelShortcutBackend::intList(
-    const QList<QKeySequence> &seq) {
+QList<int>
+KGlobalAccelShortcutBackend::intList(const QList<QKeySequence> &seq) {
   QList<int> ret;
   for (const QKeySequence &sequence : seq) {
     ret.append(sequence[0]);
@@ -200,9 +188,9 @@ bool KGlobalAccelShortcutBackend::registerAction(const QString &name,
                                                  QStringList &actionId) {
   Q_ASSERT(action);
 
-  if (name.isEmpty() && (action->objectName().isEmpty() ||
-                         action->objectName().startsWith(
-                             QLatin1String("unnamed-")))) {
+  if (name.isEmpty() &&
+      (action->objectName().isEmpty() ||
+       action->objectName().startsWith(QLatin1String("unnamed-")))) {
     qLog(Warning) << "Cannot register shortcut for unnamed action";
     return false;
   }
@@ -214,7 +202,8 @@ bool KGlobalAccelShortcutBackend::registerAction(const QString &name,
   return true;
 }
 
-bool KGlobalAccelShortcutBackend::registerShortcut(const GlobalShortcuts::Shortcut &shortcut) {
+bool KGlobalAccelShortcutBackend::registerShortcut(
+    const GlobalShortcuts::Shortcut &shortcut) {
   QStringList actionId;
   if (!registerAction(shortcut.id, shortcut.action, actionId))
     return false;
@@ -222,9 +211,8 @@ bool KGlobalAccelShortcutBackend::registerShortcut(const GlobalShortcuts::Shortc
   QList<QKeySequence> activeShortcut;
   activeShortcut << shortcut.action->shortcut();
 
-  const QList<int> result = iface_->setShortcut(actionId,
-                                                intList(activeShortcut),
-                                                SetShortcutFlag::SetPresent);
+  const QList<int> result = iface_->setShortcut(
+      actionId, intList(activeShortcut), SetShortcutFlag::SetPresent);
 
   const QList<QKeySequence> resultSequence = shortcutList(result);
   if (resultSequence != activeShortcut) {
@@ -232,7 +220,7 @@ bool KGlobalAccelShortcutBackend::registerShortcut(const GlobalShortcuts::Shortc
                   << "but KGlobalAccel returned" << resultSequence;
 
     if (!resultSequence.isEmpty()) {
-      if(!isCorrectMediaKeyShortcut(shortcut)) {
+      if (!isCorrectMediaKeyShortcut(shortcut)) {
         // there is some conflict with our preferred shortcut so we use
         // the new shortcut that kglobalaccel suggests
         shortcut.action->setShortcut(resultSequence[0]);
@@ -247,8 +235,8 @@ bool KGlobalAccelShortcutBackend::registerShortcut(const GlobalShortcuts::Shortc
   return true;
 }
 
-QList<QKeySequence> KGlobalAccelShortcutBackend::shortcutList(
-    const QList<int> &seq) {
+QList<QKeySequence>
+KGlobalAccelShortcutBackend::shortcutList(const QList<int> &seq) {
   QList<QKeySequence> ret;
   for (int i : seq) {
     ret.append(i);
@@ -266,8 +254,7 @@ void KGlobalAccelShortcutBackend::unregisterAction(const QString &name,
 }
 
 void KGlobalAccelShortcutBackend::onShortcutPressed(
-    const QString &componentUnique,
-    const QString &actionUnique,
+    const QString &componentUnique, const QString &actionUnique,
     qlonglong timestamp) const {
   QAction *action = nullptr;
   const QList<QAction *> candidates = nameToAction_.values(actionUnique);

--- a/src/core/kglobalaccelglobalshortcutbackend.cpp
+++ b/src/core/kglobalaccelglobalshortcutbackend.cpp
@@ -1,0 +1,284 @@
+#include "config.h"
+#include "core/closure.h"
+#include "core/logging.h"
+#include "globalshortcuts.h"
+#include "kglobalaccelglobalshortcutbackend.h"
+
+#include <QAction>
+#include <QGuiApplication>
+
+#ifdef HAVE_DBUS
+
+#include <dbus/kglobalaccel.h>
+#include <dbus/kglobalaccelcomponent.h>
+
+#endif
+
+// Most of this file is based on the KGlobalAccel sources
+// (https://phabricator.kde.org/source/kglobalaccel)
+
+
+namespace {
+  QString compDisplayName() {
+    if (!QGuiApplication::applicationDisplayName().isEmpty()) {
+      return QGuiApplication::applicationDisplayName();
+    }
+    return QCoreApplication::applicationName();
+  }
+
+  QString compUniqueName() {
+    return QCoreApplication::applicationName();
+  }
+
+  const QString &id_ActionUnique(const QStringList &id) {
+    return id.at(1);
+  }
+
+  bool isCorrectMediaKeyShortcut(const GlobalShortcuts::Shortcut& shortcut) {
+    if(shortcut.id == QStringLiteral("play_pause")) {
+      return shortcut.action->shortcut() == QKeySequence(Qt::Key_MediaPlay);
+    } else if(shortcut.id == QStringLiteral("stop")) {
+      return shortcut.action->shortcut() == QKeySequence(Qt::Key_MediaStop);
+    } else if(shortcut.id == QStringLiteral("next_track")) {
+      return shortcut.action->shortcut() == QKeySequence(Qt::Key_MediaNext);
+    } else if(shortcut.id == QStringLiteral("prev_track")) {
+      return shortcut.action->shortcut() == QKeySequence(Qt::Key_MediaPrevious);
+    } else {
+      return false;
+    }
+  }
+}
+
+#ifdef HAVE_DBUS
+
+KGlobalAccelShortcutBackend::KGlobalAccelShortcutBackend(
+    GlobalShortcuts *parent)
+    : GlobalShortcutBackend(parent),
+      iface_(nullptr),
+      component_(nullptr),
+      nameToAction_() {}
+
+#else // HAVE_DBUS
+KGlobalAccelShortcutBackend::KGlobalAccelShortcutBackend(GlobalShortcuts *parent)
+  : GlobalShortcutBackend(parent) {}
+#endif // HAVE_DBUS
+
+bool KGlobalAccelShortcutBackend::isKGlobalAccelAvailable() {
+#ifdef HAVE_DBUS
+  return QDBusConnection::sessionBus().interface()->isServiceRegistered(
+      Service);
+#else // HAVE_DBUS
+  return false;
+#endif // HAVE_DBUS
+}
+
+bool KGlobalAccelShortcutBackend::DoRegister() {
+#ifdef HAVE_DBUS
+  qLog(Debug) << "Registering shortcuts";
+
+  if (!acquireInterface())
+    return false;
+
+  bool complete = true;
+  for (const GlobalShortcuts::Shortcut &shortcut : manager_->shortcuts().values()) {
+    if(shortcut.action->shortcut().isEmpty())
+      continue;
+
+    if (!registerShortcut(shortcut))
+      complete = false;
+  }
+
+  if (!acquireComponent())
+    return false;
+
+  QObject::connect(component_,
+                   &OrgKdeKglobalaccelComponentInterface::globalShortcutPressed,
+                   this,
+                   &KGlobalAccelShortcutBackend::onShortcutPressed);
+
+  return complete;
+#else // HAVE_DBUS
+  qLog(Warning) << "dbus not available";
+  return false;
+#endif // HAVE_DBUS
+}
+
+void KGlobalAccelShortcutBackend::DoUnregister() {
+  if (!acquireInterface())
+    return;
+
+  if (!acquireComponent())
+    return;
+
+  for (const GlobalShortcuts::Shortcut &shortcut : manager_->shortcuts())
+    unregisterAction(shortcut.id, shortcut.action);
+}
+
+#ifdef HAVE_DBUS
+
+const char *KGlobalAccelShortcutBackend::Service = "org.kde.kglobalaccel";
+const char *KGlobalAccelShortcutBackend::Path = "/kglobalaccel";
+
+bool KGlobalAccelShortcutBackend::acquireComponent() {
+  Q_ASSERT(iface_ && iface_->isValid());
+
+  QString componentName = compUniqueName();
+  QDBusReply<QDBusObjectPath> reply = iface_->getComponent(compUniqueName());
+  if (!reply.isValid()) {
+    if (reply.error().name() ==
+        QLatin1String("org.kde.kglobalaccel.NoSuchComponent"))
+      return false;
+
+    qLog(Warning) << "Failed to get DBus path for KGlobalAccel component";
+    return false;
+  }
+
+  component_ = new org::kde::kglobalaccel::Component(Service,
+                                                     reply.value().path(),
+                                                     QDBusConnection::sessionBus(),
+                                                     iface_);
+
+  if (!component_->isValid()) {
+    qLog(Warning) << "Failed to get KGlobalAccel component:"
+                  << QDBusConnection::sessionBus().lastError();
+    delete component_;
+    component_ = nullptr;
+    return false;
+  }
+
+  return true;
+}
+
+bool KGlobalAccelShortcutBackend::acquireInterface() {
+  if (iface_ && iface_->isValid())
+    return true;
+
+  if (isKGlobalAccelAvailable()) {
+    iface_ = new OrgKdeKGlobalAccelInterface(Service, Path,
+                                             QDBusConnection::sessionBus(),
+                                             this);
+  }
+
+  if (iface_ && iface_->isValid())
+    return true;
+
+  if (!iface_)
+    qLog(Warning) << "KGlobalAccel daemon not registered";
+  else if (!iface_->isValid())
+    qLog(Warning) << "KGlobalAccel daemon is not valid";
+  return false;
+}
+
+QStringList KGlobalAccelShortcutBackend::id(const QString &name,
+                                            const QAction *action) {
+  Q_ASSERT(action);
+
+  QStringList ret;
+  ret << compUniqueName();
+  ret << name;
+  ret << compDisplayName();
+  ret << action->text().replace(QLatin1Char('&'), QStringLiteral(""));
+  if (ret.back().isEmpty())
+    ret.back() = name;
+  return ret;
+}
+
+QList<int> KGlobalAccelShortcutBackend::intList(
+    const QList<QKeySequence> &seq) {
+  QList<int> ret;
+  for (const QKeySequence &sequence : seq) {
+    ret.append(sequence[0]);
+  }
+  while (!ret.isEmpty() && ret.last() == 0) {
+    ret.removeLast();
+  }
+  return ret;
+}
+
+bool KGlobalAccelShortcutBackend::registerAction(const QString &name,
+                                                 QAction *action,
+                                                 QStringList &actionId) {
+  Q_ASSERT(action);
+
+  if (name.isEmpty() && (action->objectName().isEmpty() ||
+                         action->objectName().startsWith(
+                             QLatin1String("unnamed-")))) {
+    qLog(Warning) << "Cannot register shortcut for unnamed action";
+    return false;
+  }
+
+  actionId = id(name, action);
+  nameToAction_.insertMulti(id_ActionUnique(actionId), action);
+  iface_->doRegister(actionId);
+
+  return true;
+}
+
+bool KGlobalAccelShortcutBackend::registerShortcut(const GlobalShortcuts::Shortcut &shortcut) {
+  QStringList actionId;
+  if (!registerAction(shortcut.id, shortcut.action, actionId))
+    return false;
+
+  QList<QKeySequence> activeShortcut;
+  activeShortcut << shortcut.action->shortcut();
+
+  const QList<int> result = iface_->setShortcut(actionId,
+                                                intList(activeShortcut),
+                                                SetShortcutFlag::SetPresent);
+
+  const QList<QKeySequence> resultSequence = shortcutList(result);
+  if (resultSequence != activeShortcut) {
+    qLog(Warning) << "Tried setting global shortcut" << activeShortcut
+                  << "but KGlobalAccel returned" << resultSequence;
+
+    if (!resultSequence.isEmpty()) {
+      if(!isCorrectMediaKeyShortcut(shortcut)) {
+        // there is some conflict with our preferred shortcut so we use
+        // the new shortcut that kglobalaccel suggests
+        shortcut.action->setShortcut(resultSequence[0]);
+      } else {
+        // media keys are properly handled by plasma through the
+        // media player plasmoid so we don't do anything in those cases
+        qLog(Debug) << "Leaving media key shortcuts unchanged";
+      }
+    }
+  }
+
+  return true;
+}
+
+QList<QKeySequence> KGlobalAccelShortcutBackend::shortcutList(
+    const QList<int> &seq) {
+  QList<QKeySequence> ret;
+  for (int i : seq) {
+    ret.append(i);
+  }
+  return ret;
+}
+
+void KGlobalAccelShortcutBackend::unregisterAction(const QString &name,
+                                                   QAction *action) {
+  Q_ASSERT(action);
+
+  QStringList actionId = id(name, action);
+  nameToAction_.remove(id_ActionUnique(actionId), action);
+  iface_->unRegister(actionId);
+}
+
+void KGlobalAccelShortcutBackend::onShortcutPressed(
+    const QString &componentUnique,
+    const QString &actionUnique,
+    qlonglong timestamp) const {
+  QAction *action = nullptr;
+  const QList<QAction *> candidates = nameToAction_.values(actionUnique);
+  for (QAction *a : candidates) {
+    if (compUniqueName() == componentUnique) {
+      action = a;
+    }
+  }
+
+  if (action && action->isEnabled())
+    action->trigger();
+}
+
+#endif // HAVE_DBUS

--- a/src/core/kglobalaccelglobalshortcutbackend.cpp
+++ b/src/core/kglobalaccelglobalshortcutbackend.cpp
@@ -83,7 +83,8 @@ bool KGlobalAccelShortcutBackend::DoRegister() {
 
   QObject::connect(component_,
                    &OrgKdeKglobalaccelComponentInterface::globalShortcutPressed,
-                   this, &KGlobalAccelShortcutBackend::OnShortcutPressed);
+                   this, &KGlobalAccelShortcutBackend::OnShortcutPressed,
+                   Qt::UniqueConnection);
 
   return complete;
 #else   // HAVE_DBUS
@@ -100,6 +101,10 @@ void KGlobalAccelShortcutBackend::DoUnregister() {
 
   for (const GlobalShortcuts::Shortcut& shortcut : manager_->shortcuts())
     UnregisterAction(shortcut.id, shortcut.action);
+
+  QObject::disconnect(component_,
+                      &OrgKdeKglobalaccelComponentInterface::globalShortcutPressed,
+                      this, &KGlobalAccelShortcutBackend::OnShortcutPressed);
 #endif  // HAVE_DBUS
 }
 
@@ -110,6 +115,8 @@ const char* KGlobalAccelShortcutBackend::kPath = "/kglobalaccel";
 
 bool KGlobalAccelShortcutBackend::AcquireComponent() {
   Q_ASSERT(iface_ && iface_->isValid());
+
+  if (component_) return true;
 
   QDBusReply<QDBusObjectPath> reply = iface_->getComponent(ComponentUniqueName());
   if (!reply.isValid()) {

--- a/src/core/kglobalaccelglobalshortcutbackend.cpp
+++ b/src/core/kglobalaccelglobalshortcutbackend.cpp
@@ -15,6 +15,7 @@
 // (https://phabricator.kde.org/source/kglobalaccel)
 
 namespace {
+#ifdef HAVE_DBUS
 QString compDisplayName() {
   if (!QGuiApplication::applicationDisplayName().isEmpty()) {
     return QGuiApplication::applicationDisplayName();
@@ -39,6 +40,7 @@ bool isCorrectMediaKeyShortcut(const GlobalShortcuts::Shortcut &shortcut) {
     return false;
   }
 }
+#endif // HAVE_DBUS
 } // namespace
 
 #ifdef HAVE_DBUS
@@ -95,6 +97,7 @@ bool KGlobalAccelShortcutBackend::DoRegister() {
 }
 
 void KGlobalAccelShortcutBackend::DoUnregister() {
+#ifdef HAVE_DBUS
   if (!acquireInterface())
     return;
 
@@ -103,6 +106,7 @@ void KGlobalAccelShortcutBackend::DoUnregister() {
 
   for (const GlobalShortcuts::Shortcut &shortcut : manager_->shortcuts())
     unregisterAction(shortcut.id, shortcut.action);
+#endif // HAVE_DBUS
 }
 
 #ifdef HAVE_DBUS

--- a/src/core/kglobalaccelglobalshortcutbackend.cpp
+++ b/src/core/kglobalaccelglobalshortcutbackend.cpp
@@ -1,5 +1,5 @@
-#include "kglobalaccelglobalshortcutbackend.h"
 #include "core/logging.h"
+#include "kglobalaccelglobalshortcutbackend.h"
 
 #include <QAction>
 #include <QGuiApplication>
@@ -25,9 +25,9 @@ QString compDisplayName() {
 
 QString compUniqueName() { return QCoreApplication::applicationName(); }
 
-const QString &id_ActionUnique(const QStringList &id) { return id.at(1); }
+const QString& id_ActionUnique(const QStringList& id) { return id.at(1); }
 
-bool isCorrectMediaKeyShortcut(const GlobalShortcuts::Shortcut &shortcut) {
+bool isCorrectMediaKeyShortcut(const GlobalShortcuts::Shortcut& shortcut) {
   if (shortcut.id == QStringLiteral("play_pause")) {
     return shortcut.action->shortcut() == QKeySequence(Qt::Key_MediaPlay);
   } else if (shortcut.id == QStringLiteral("stop")) {
@@ -40,79 +40,75 @@ bool isCorrectMediaKeyShortcut(const GlobalShortcuts::Shortcut &shortcut) {
     return false;
   }
 }
-#endif // HAVE_DBUS
-} // namespace
+#endif  // HAVE_DBUS
+}  // namespace
 
 #ifdef HAVE_DBUS
 
 KGlobalAccelShortcutBackend::KGlobalAccelShortcutBackend(
-    GlobalShortcuts *parent)
-    : GlobalShortcutBackend(parent), iface_(nullptr), component_(nullptr),
+    GlobalShortcuts* parent)
+    : GlobalShortcutBackend(parent),
+      iface_(nullptr),
+      component_(nullptr),
       nameToAction_() {}
 
-#else  // HAVE_DBUS
+#else   // HAVE_DBUS
 KGlobalAccelShortcutBackend::KGlobalAccelShortcutBackend(
-    GlobalShortcuts *parent)
+    GlobalShortcuts* parent)
     : GlobalShortcutBackend(parent) {}
-#endif // HAVE_DBUS
+#endif  // HAVE_DBUS
 
 bool KGlobalAccelShortcutBackend::isKGlobalAccelAvailable() {
 #ifdef HAVE_DBUS
   return QDBusConnection::sessionBus().interface()->isServiceRegistered(
       Service);
-#else  // HAVE_DBUS
+#else   // HAVE_DBUS
   return false;
-#endif // HAVE_DBUS
+#endif  // HAVE_DBUS
 }
 
 bool KGlobalAccelShortcutBackend::DoRegister() {
 #ifdef HAVE_DBUS
   qLog(Debug) << "Registering shortcuts";
 
-  if (!acquireInterface())
-    return false;
+  if (!acquireInterface()) return false;
 
   bool complete = true;
-  for (const GlobalShortcuts::Shortcut &shortcut :
+  for (const GlobalShortcuts::Shortcut& shortcut :
        manager_->shortcuts().values()) {
-    if (shortcut.action->shortcut().isEmpty())
-      continue;
+    if (shortcut.action->shortcut().isEmpty()) continue;
 
-    if (!registerShortcut(shortcut))
-      complete = false;
+    if (!registerShortcut(shortcut)) complete = false;
   }
 
-  if (!acquireComponent())
-    return false;
+  if (!acquireComponent()) return false;
 
   QObject::connect(component_,
                    &OrgKdeKglobalaccelComponentInterface::globalShortcutPressed,
                    this, &KGlobalAccelShortcutBackend::onShortcutPressed);
 
   return complete;
-#else  // HAVE_DBUS
+#else   // HAVE_DBUS
   qLog(Warning) << "dbus not available";
   return false;
-#endif // HAVE_DBUS
+#endif  // HAVE_DBUS
 }
 
 void KGlobalAccelShortcutBackend::DoUnregister() {
 #ifdef HAVE_DBUS
-  if (!acquireInterface())
-    return;
+  if (!acquireInterface()) return;
 
-  if (!acquireComponent())
-    return;
+  if (!acquireComponent()) return;
 
-  for (const GlobalShortcuts::Shortcut &shortcut : manager_->shortcuts())
+  for (const GlobalShortcuts::Shortcut& shortcut : manager_->shortcuts())
     unregisterAction(shortcut.id, shortcut.action);
-#endif // HAVE_DBUS
+#endif  // HAVE_DBUS
 }
 
 #ifdef HAVE_DBUS
 
-const char *KGlobalAccelShortcutBackend::Service = "org.kde.kglobalaccel";
-const char *KGlobalAccelShortcutBackend::Path = "/kglobalaccel";
+const char* KGlobalAccelShortcutBackend::Service = "org.kde.kglobalaccel";
+const char* KGlobalAccelShortcutBackend::Path = "/kglobalaccel";
 
 bool KGlobalAccelShortcutBackend::acquireComponent() {
   Q_ASSERT(iface_ && iface_->isValid());
@@ -143,16 +139,14 @@ bool KGlobalAccelShortcutBackend::acquireComponent() {
 }
 
 bool KGlobalAccelShortcutBackend::acquireInterface() {
-  if (iface_ && iface_->isValid())
-    return true;
+  if (iface_ && iface_->isValid()) return true;
 
   if (isKGlobalAccelAvailable()) {
     iface_ = new OrgKdeKGlobalAccelInterface(
         Service, Path, QDBusConnection::sessionBus(), this);
   }
 
-  if (iface_ && iface_->isValid())
-    return true;
+  if (iface_ && iface_->isValid()) return true;
 
   if (!iface_)
     qLog(Warning) << "KGlobalAccel daemon not registered";
@@ -161,8 +155,8 @@ bool KGlobalAccelShortcutBackend::acquireInterface() {
   return false;
 }
 
-QStringList KGlobalAccelShortcutBackend::id(const QString &name,
-                                            const QAction *action) {
+QStringList KGlobalAccelShortcutBackend::id(const QString& name,
+                                            const QAction* action) {
   Q_ASSERT(action);
 
   QStringList ret;
@@ -170,15 +164,14 @@ QStringList KGlobalAccelShortcutBackend::id(const QString &name,
   ret << name;
   ret << compDisplayName();
   ret << action->text().replace(QLatin1Char('&'), QStringLiteral(""));
-  if (ret.back().isEmpty())
-    ret.back() = name;
+  if (ret.back().isEmpty()) ret.back() = name;
   return ret;
 }
 
-QList<int>
-KGlobalAccelShortcutBackend::intList(const QList<QKeySequence> &seq) {
+QList<int> KGlobalAccelShortcutBackend::intList(
+    const QList<QKeySequence>& seq) {
   QList<int> ret;
-  for (const QKeySequence &sequence : seq) {
+  for (const QKeySequence& sequence : seq) {
     ret.append(sequence[0]);
   }
   while (!ret.isEmpty() && ret.last() == 0) {
@@ -187,9 +180,9 @@ KGlobalAccelShortcutBackend::intList(const QList<QKeySequence> &seq) {
   return ret;
 }
 
-bool KGlobalAccelShortcutBackend::registerAction(const QString &name,
-                                                 QAction *action,
-                                                 QStringList &actionId) {
+bool KGlobalAccelShortcutBackend::registerAction(const QString& name,
+                                                 QAction* action,
+                                                 QStringList& actionId) {
   Q_ASSERT(action);
 
   if (name.isEmpty() &&
@@ -207,10 +200,9 @@ bool KGlobalAccelShortcutBackend::registerAction(const QString &name,
 }
 
 bool KGlobalAccelShortcutBackend::registerShortcut(
-    const GlobalShortcuts::Shortcut &shortcut) {
+    const GlobalShortcuts::Shortcut& shortcut) {
   QStringList actionId;
-  if (!registerAction(shortcut.id, shortcut.action, actionId))
-    return false;
+  if (!registerAction(shortcut.id, shortcut.action, actionId)) return false;
 
   QList<QKeySequence> activeShortcut;
   activeShortcut << shortcut.action->shortcut();
@@ -239,8 +231,8 @@ bool KGlobalAccelShortcutBackend::registerShortcut(
   return true;
 }
 
-QList<QKeySequence>
-KGlobalAccelShortcutBackend::shortcutList(const QList<int> &seq) {
+QList<QKeySequence> KGlobalAccelShortcutBackend::shortcutList(
+    const QList<int>& seq) {
   QList<QKeySequence> ret;
   for (int i : seq) {
     ret.append(i);
@@ -248,8 +240,8 @@ KGlobalAccelShortcutBackend::shortcutList(const QList<int> &seq) {
   return ret;
 }
 
-void KGlobalAccelShortcutBackend::unregisterAction(const QString &name,
-                                                   QAction *action) {
+void KGlobalAccelShortcutBackend::unregisterAction(const QString& name,
+                                                   QAction* action) {
   Q_ASSERT(action);
 
   QStringList actionId = id(name, action);
@@ -258,18 +250,17 @@ void KGlobalAccelShortcutBackend::unregisterAction(const QString &name,
 }
 
 void KGlobalAccelShortcutBackend::onShortcutPressed(
-    const QString &componentUnique, const QString &actionUnique,
+    const QString& componentUnique, const QString& actionUnique,
     qlonglong timestamp) const {
-  QAction *action = nullptr;
-  const QList<QAction *> candidates = nameToAction_.values(actionUnique);
-  for (QAction *a : candidates) {
+  QAction* action = nullptr;
+  const QList<QAction*> candidates = nameToAction_.values(actionUnique);
+  for (QAction* a : candidates) {
     if (compUniqueName() == componentUnique) {
       action = a;
     }
   }
 
-  if (action && action->isEnabled())
-    action->trigger();
+  if (action && action->isEnabled()) action->trigger();
 }
 
-#endif // HAVE_DBUS
+#endif  // HAVE_DBUS

--- a/src/core/kglobalaccelglobalshortcutbackend.h
+++ b/src/core/kglobalaccelglobalshortcutbackend.h
@@ -1,0 +1,71 @@
+#ifndef CORE_KGLOBALACCELGLOBALSHORTCUTBACKEND_H_
+#define CORE_KGLOBALACCELGLOBALSHORTCUTBACKEND_H_
+
+#include "globalshortcutbackend.h"
+
+#include <QSet>
+#include <QStringList>
+
+class QAction;
+
+class OrgKdeKGlobalAccelInterface;
+
+class OrgKdeKglobalaccelComponentInterface;
+
+
+class KGlobalAccelShortcutBackend : public GlobalShortcutBackend {
+  Q_OBJECT
+
+  public:
+    explicit KGlobalAccelShortcutBackend(GlobalShortcuts *parent);
+
+
+    static bool isKGlobalAccelAvailable();
+
+  protected:
+    bool DoRegister() override;
+
+    void DoUnregister() override;
+
+  private:
+#ifdef HAVE_DBUS
+    enum SetShortcutFlag {
+      SetPresent = 2,
+      NoAutoloading = 4,
+      IsDefault = 8
+    };
+
+    bool acquireComponent();
+
+    bool acquireInterface();
+
+    static QStringList id(const QString &name, const QAction *action);
+
+    static QList<int> intList(const QList<QKeySequence> &seq);
+
+    bool registerAction(const QString &name, QAction *action,
+                        QStringList &actionId);
+
+    bool registerShortcut(const GlobalShortcuts::Shortcut &shortcut);
+
+    static QList<QKeySequence> shortcutList(const QList<int> &seq);
+
+    void unregisterAction(const QString &name, QAction *action);
+
+  private slots:
+
+    void onShortcutPressed(const QString &componentUnique,
+                           const QString &actionUnique,
+                           qlonglong timestamp) const;
+
+  private:
+    static const char *Service;
+    static const char *Path;
+
+    OrgKdeKGlobalAccelInterface *iface_;
+    OrgKdeKglobalaccelComponentInterface *component_;
+    QMultiHash<QString, QAction *> nameToAction_;
+#endif // HAVE_DBUS
+};
+
+#endif //CORE_KGLOBALACCELGLOBALSHORTCUTBACKEND_H_

--- a/src/core/kglobalaccelglobalshortcutbackend.h
+++ b/src/core/kglobalaccelglobalshortcutbackend.h
@@ -20,7 +20,7 @@ class KGlobalAccelShortcutBackend : public GlobalShortcutBackend {
  public:
   explicit KGlobalAccelShortcutBackend(GlobalShortcuts* parent);
 
-  static bool isKGlobalAccelAvailable();
+  static bool IsKGlobalAccelAvailable();
 
  protected:
   bool DoRegister() override;
@@ -31,36 +31,35 @@ class KGlobalAccelShortcutBackend : public GlobalShortcutBackend {
 #ifdef HAVE_DBUS
   enum SetShortcutFlag { SetPresent = 2, NoAutoloading = 4, IsDefault = 8 };
 
-  bool acquireComponent();
+  bool AcquireComponent();
 
-  bool acquireInterface();
+  bool AcquireInterface();
 
-  static QStringList id(const QString& name, const QAction* action);
+  static QStringList GetId(const QString& name, const QAction* action);
 
-  static QList<int> intList(const QList<QKeySequence>& seq);
+  static QList<int> ToIntList(const QList<QKeySequence>& seq);
 
-  bool registerAction(const QString& name, QAction* action,
-                      QStringList& actionId);
+  bool RegisterAction(const QString& name, QAction* action);
 
-  bool registerShortcut(const GlobalShortcuts::Shortcut& shortcut);
+  bool RegisterShortcut(const GlobalShortcuts::Shortcut& shortcut);
 
-  static QList<QKeySequence> shortcutList(const QList<int>& seq);
+  static QList<QKeySequence> ToKeySequenceList(const QList<int>& seq);
 
-  void unregisterAction(const QString& name, QAction* action);
+  void UnregisterAction(const QString& name, QAction* action);
 
  private slots:
 
-  void onShortcutPressed(const QString& componentUnique,
-                         const QString& actionUnique,
+  void OnShortcutPressed(const QString& component_unique,
+                         const QString& action_unique,
                          qlonglong timestamp) const;
 
  private:
-  static const char* Service;
-  static const char* Path;
+  static const char* kService;
+  static const char* kPath;
 
   OrgKdeKGlobalAccelInterface* iface_;
   OrgKdeKglobalaccelComponentInterface* component_;
-  QMultiHash<QString, QAction*> nameToAction_;
+  QMultiHash<QString, QAction*> name_to_action_;
 #endif  // HAVE_DBUS
 };
 

--- a/src/core/kglobalaccelglobalshortcutbackend.h
+++ b/src/core/kglobalaccelglobalshortcutbackend.h
@@ -17,17 +17,17 @@ class OrgKdeKglobalaccelComponentInterface;
 class KGlobalAccelShortcutBackend : public GlobalShortcutBackend {
   Q_OBJECT
 
-public:
-  explicit KGlobalAccelShortcutBackend(GlobalShortcuts *parent);
+ public:
+  explicit KGlobalAccelShortcutBackend(GlobalShortcuts* parent);
 
   static bool isKGlobalAccelAvailable();
 
-protected:
+ protected:
   bool DoRegister() override;
 
   void DoUnregister() override;
 
-private:
+ private:
 #ifdef HAVE_DBUS
   enum SetShortcutFlag { SetPresent = 2, NoAutoloading = 4, IsDefault = 8 };
 
@@ -35,33 +35,33 @@ private:
 
   bool acquireInterface();
 
-  static QStringList id(const QString &name, const QAction *action);
+  static QStringList id(const QString& name, const QAction* action);
 
-  static QList<int> intList(const QList<QKeySequence> &seq);
+  static QList<int> intList(const QList<QKeySequence>& seq);
 
-  bool registerAction(const QString &name, QAction *action,
-                      QStringList &actionId);
+  bool registerAction(const QString& name, QAction* action,
+                      QStringList& actionId);
 
-  bool registerShortcut(const GlobalShortcuts::Shortcut &shortcut);
+  bool registerShortcut(const GlobalShortcuts::Shortcut& shortcut);
 
-  static QList<QKeySequence> shortcutList(const QList<int> &seq);
+  static QList<QKeySequence> shortcutList(const QList<int>& seq);
 
-  void unregisterAction(const QString &name, QAction *action);
+  void unregisterAction(const QString& name, QAction* action);
 
-private slots:
+ private slots:
 
-  void onShortcutPressed(const QString &componentUnique,
-                         const QString &actionUnique,
+  void onShortcutPressed(const QString& componentUnique,
+                         const QString& actionUnique,
                          qlonglong timestamp) const;
 
-private:
-  static const char *Service;
-  static const char *Path;
+ private:
+  static const char* Service;
+  static const char* Path;
 
-  OrgKdeKGlobalAccelInterface *iface_;
-  OrgKdeKglobalaccelComponentInterface *component_;
-  QMultiHash<QString, QAction *> nameToAction_;
-#endif // HAVE_DBUS
+  OrgKdeKGlobalAccelInterface* iface_;
+  OrgKdeKglobalaccelComponentInterface* component_;
+  QMultiHash<QString, QAction*> nameToAction_;
+#endif  // HAVE_DBUS
 };
 
-#endif // CORE_KGLOBALACCELGLOBALSHORTCUTBACKEND_H_
+#endif  // CORE_KGLOBALACCELGLOBALSHORTCUTBACKEND_H_

--- a/src/core/kglobalaccelglobalshortcutbackend.h
+++ b/src/core/kglobalaccelglobalshortcutbackend.h
@@ -1,7 +1,9 @@
 #ifndef CORE_KGLOBALACCELGLOBALSHORTCUTBACKEND_H_
 #define CORE_KGLOBALACCELGLOBALSHORTCUTBACKEND_H_
 
+#include "config.h"
 #include "globalshortcutbackend.h"
+#include "globalshortcuts.h"
 
 #include <QSet>
 #include <QStringList>
@@ -12,60 +14,54 @@ class OrgKdeKGlobalAccelInterface;
 
 class OrgKdeKglobalaccelComponentInterface;
 
-
 class KGlobalAccelShortcutBackend : public GlobalShortcutBackend {
   Q_OBJECT
 
-  public:
-    explicit KGlobalAccelShortcutBackend(GlobalShortcuts *parent);
+public:
+  explicit KGlobalAccelShortcutBackend(GlobalShortcuts *parent);
 
+  static bool isKGlobalAccelAvailable();
 
-    static bool isKGlobalAccelAvailable();
+protected:
+  bool DoRegister() override;
 
-  protected:
-    bool DoRegister() override;
+  void DoUnregister() override;
 
-    void DoUnregister() override;
-
-  private:
+private:
 #ifdef HAVE_DBUS
-    enum SetShortcutFlag {
-      SetPresent = 2,
-      NoAutoloading = 4,
-      IsDefault = 8
-    };
+  enum SetShortcutFlag { SetPresent = 2, NoAutoloading = 4, IsDefault = 8 };
 
-    bool acquireComponent();
+  bool acquireComponent();
 
-    bool acquireInterface();
+  bool acquireInterface();
 
-    static QStringList id(const QString &name, const QAction *action);
+  static QStringList id(const QString &name, const QAction *action);
 
-    static QList<int> intList(const QList<QKeySequence> &seq);
+  static QList<int> intList(const QList<QKeySequence> &seq);
 
-    bool registerAction(const QString &name, QAction *action,
-                        QStringList &actionId);
+  bool registerAction(const QString &name, QAction *action,
+                      QStringList &actionId);
 
-    bool registerShortcut(const GlobalShortcuts::Shortcut &shortcut);
+  bool registerShortcut(const GlobalShortcuts::Shortcut &shortcut);
 
-    static QList<QKeySequence> shortcutList(const QList<int> &seq);
+  static QList<QKeySequence> shortcutList(const QList<int> &seq);
 
-    void unregisterAction(const QString &name, QAction *action);
+  void unregisterAction(const QString &name, QAction *action);
 
-  private slots:
+private slots:
 
-    void onShortcutPressed(const QString &componentUnique,
-                           const QString &actionUnique,
-                           qlonglong timestamp) const;
+  void onShortcutPressed(const QString &componentUnique,
+                         const QString &actionUnique,
+                         qlonglong timestamp) const;
 
-  private:
-    static const char *Service;
-    static const char *Path;
+private:
+  static const char *Service;
+  static const char *Path;
 
-    OrgKdeKGlobalAccelInterface *iface_;
-    OrgKdeKglobalaccelComponentInterface *component_;
-    QMultiHash<QString, QAction *> nameToAction_;
+  OrgKdeKGlobalAccelInterface *iface_;
+  OrgKdeKglobalaccelComponentInterface *component_;
+  QMultiHash<QString, QAction *> nameToAction_;
 #endif // HAVE_DBUS
 };
 
-#endif //CORE_KGLOBALACCELGLOBALSHORTCUTBACKEND_H_
+#endif // CORE_KGLOBALACCELGLOBALSHORTCUTBACKEND_H_

--- a/src/dbus/org.kde.KGlobalAccel.xml
+++ b/src/dbus/org.kde.KGlobalAccel.xml
@@ -1,0 +1,72 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+    <interface name="org.kde.KGlobalAccel">
+        <signal name="yourShortcutGotChanged">
+            <arg name="actionId" type="as" direction="out"/>
+            <arg name="newKeys" type="ai" direction="out"/>
+            <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QList&lt;int&gt;"/>
+        </signal>
+        <method name="allComponents">
+            <arg type="ao" direction="out"/>
+        </method>
+        <method name="allMainComponents">
+            <arg type="aas" direction="out"/>
+            <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QList&lt;QStringList&gt;"/>
+        </method>
+        <method name="allActionsForComponent">
+            <arg type="aas" direction="out"/>
+            <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QList&lt;QStringList&gt;"/>
+            <arg name="actionId" type="as" direction="in"/>
+        </method>
+        <method name="action">
+            <arg type="as" direction="out"/>
+            <arg name="key" type="i" direction="in"/>
+        </method>
+        <method name="getComponent">
+            <arg type="o" direction="out"/>
+            <arg name="componentUnique" type="s" direction="in"/>
+        </method>
+        <method name="shortcut">
+            <arg type="ai" direction="out"/>
+            <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QList&lt;int&gt;"/>
+            <arg name="actionId" type="as" direction="in"/>
+        </method>
+        <method name="defaultShortcut">
+            <arg type="ai" direction="out"/>
+            <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QList&lt;int&gt;"/>
+            <arg name="actionId" type="as" direction="in"/>
+        </method>
+        <method name="setShortcut">
+            <arg type="ai" direction="out"/>
+            <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QList&lt;int&gt;"/>
+            <arg name="actionId" type="as" direction="in"/>
+            <arg name="keys" type="ai" direction="in"/>
+            <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QList&lt;int&gt;"/>
+            <arg name="flags" type="u" direction="in"/>
+        </method>
+        <method name="setForeignShortcut">
+            <arg name="actionId" type="as" direction="in"/>
+            <arg name="keys" type="ai" direction="in"/>
+            <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QList&lt;int&gt;"/>
+        </method>
+        <method name="setInactive">
+            <arg name="actionId" type="as" direction="in"/>
+        </method>
+        <method name="doRegister">
+            <arg name="actionId" type="as" direction="in"/>
+        </method>
+        <method name="unRegister">
+            <arg name="actionId" type="as" direction="in"/>
+        </method>
+        <method name="activateGlobalShortcutContext">
+            <arg name="component" type="s" direction="in"/>
+            <arg name="context" type="s" direction="in"/>
+        </method>
+        <method name="isGlobalShortcutAvailable">
+            <arg type="b" direction="out"/>
+            <arg name="key" type="i" direction="in"/>
+            <arg name="component" type="s" direction="in"/>
+        </method>
+    </interface>
+</node>

--- a/src/dbus/org.kde.kglobalaccel.Component.xml
+++ b/src/dbus/org.kde.kglobalaccel.Component.xml
@@ -1,0 +1,32 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+    <interface name="org.kde.kglobalaccel.Component">
+        <property name="friendlyName" type="s" access="read"/>
+        <property name="uniqueName" type="s" access="read"/>
+        <signal name="globalShortcutPressed">
+            <arg name="componentUnique" type="s" direction="out"/>
+            <arg name="actionUnique" type="s" direction="out"/>
+            <arg name="timestamp" type="x" direction="out"/>
+        </signal>
+        <method name="cleanUp">
+            <arg type="b" direction="out"/>
+        </method>
+        <method name="isActive">
+            <arg type="b" direction="out"/>
+        </method>
+        <method name="shortcutNames">
+            <arg type="as" direction="out"/>
+            <arg name="context" type="s" direction="in"/>
+        </method>
+        <method name="shortcutNames">
+            <arg type="as" direction="out"/>
+        </method>
+        <method name="getShortcutContexts">
+            <arg type="as" direction="out"/>
+        </method>
+        <method name="invokeShortcut">
+            <arg name="actionName" type="s" direction="in"/>
+        </method>
+    </interface>
+</node>


### PR DESCRIPTION
This fixes #6469.

It seems to work for both a Wayland session and a X11 session on KDE Plasma 5.17.4 (on gentoo). However, the media keys behave a bit erratically probably because they are reserved by the Media Player plasmoid.