### PR TITLE
Support  for XDG_CONFIG_HOME and XDG_CACHE_HOME

### DIFF
--- a/src/core/utilities.cpp
+++ b/src/core/utilities.cpp
@@ -345,9 +345,9 @@ QString GetConfigPath(ConfigPath config) {
       return mac::GetApplicationSupportPath() + "/" +
              QCoreApplication::organizationName();
 #else
-      return QString("%1/%2")
-          .arg(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation),
-               QCoreApplication::organizationName());
+      return QString("%1/%2").arg(
+          QStandardPaths::writableLocation(QStandardPaths::ConfigLocation),
+          QCoreApplication::organizationName());
 #endif
     } break;
 
@@ -356,9 +356,9 @@ QString GetConfigPath(ConfigPath config) {
         return GetConfigPath(Path_Root) + "/cache";
       }
 #if defined(Q_OS_UNIX) && !defined(Q_OS_DARWIN)
-      return QString("%1/%2")
-          .arg(QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation),
-               QCoreApplication::organizationName());
+      return QString("%1/%2").arg(QStandardPaths::writableLocation(
+                                      QStandardPaths::GenericCacheLocation),
+                                  QCoreApplication::organizationName());
 #else
       return GetConfigPath(Path_Root);
 #endif

--- a/src/core/utilities.cpp
+++ b/src/core/utilities.cpp
@@ -376,6 +376,9 @@ QString GetConfigPath(ConfigPath config) {
     case Path_MoodbarCache:
       return GetConfigPath(Path_CacheRoot) + "/moodbarcache";
 
+    case Path_PixmapCache:
+      return GetConfigPath(Path_CacheRoot) + "/pixmapcache";
+
     case Path_GstreamerRegistry:
       return GetConfigPath(Path_Root) +
              QString("/gst-registry-%1-bin")

--- a/src/core/utilities.cpp
+++ b/src/core/utilities.cpp
@@ -345,8 +345,9 @@ QString GetConfigPath(ConfigPath config) {
       return mac::GetApplicationSupportPath() + "/" +
              QCoreApplication::organizationName();
 #else
-      return QString("%1/.config/%2")
-          .arg(QDir::homePath(), QCoreApplication::organizationName());
+      return QString("%1/%2")
+          .arg(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation),
+               QCoreApplication::organizationName());
 #endif
     } break;
 
@@ -355,13 +356,9 @@ QString GetConfigPath(ConfigPath config) {
         return GetConfigPath(Path_Root) + "/cache";
       }
 #if defined(Q_OS_UNIX) && !defined(Q_OS_DARWIN)
-      char* xdg = getenv("XDG_CACHE_HOME");
-      if (!xdg || !*xdg) {
-        return QString("%1/.cache/%2")
-            .arg(QDir::homePath(), QCoreApplication::organizationName());
-      } else {
-        return QString("%1/%2").arg(xdg, QCoreApplication::organizationName());
-      }
+      return QString("%1/%2")
+          .arg(QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation),
+               QCoreApplication::organizationName());
 #else
       return GetConfigPath(Path_Root);
 #endif

--- a/src/core/utilities.h
+++ b/src/core/utilities.h
@@ -132,6 +132,7 @@ enum ConfigPath {
   Path_DefaultMusicLibrary,
   Path_LocalSpotifyBlob,
   Path_MoodbarCache,
+  Path_PixmapCache,
   Path_CacheRoot,
 };
 QString GetConfigPath(ConfigPath config);

--- a/src/library/librarymodel.cpp
+++ b/src/library/librarymodel.cpp
@@ -105,7 +105,7 @@ LibraryModel::LibraryModel(LibraryBackend* backend, Application* app,
           SLOT(AlbumArtLoaded(quint64, QImage)));
 
   icon_cache_->setCacheDirectory(
-      Utilities::GetConfigPath(Utilities::Path_CacheRoot) + "/pixmapcache");
+      Utilities::GetConfigPath(Utilities::Path_PixmapCache));
   icon_cache_->setMaximumCacheSize(LibraryModel::kIconCacheSize);
 
   QIcon nocover = IconLoader::Load("nocover", IconLoader::Other);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -302,14 +302,6 @@ int main(int argc, char* argv[]) {
     }
   }
 
-#ifdef Q_OS_DARWIN
-  // Must happen after QCoreApplication::setOrganizationName().
-  setenv(
-      "XDG_CONFIG_HOME",
-      Utilities::GetConfigPath(Utilities::Path_Root).toLocal8Bit().constData(),
-      1);
-#endif
-
   // Output the version, so when people attach log output to bug reports they
   // don't have to tell us which version they're using.
   qLog(Info) << "Clementine-qt5" << CLEMENTINE_VERSION_DISPLAY;


### PR DESCRIPTION
Fixes #6471 

This will honor the XDG_CONFIG_HOME and XDG_CACHE_HOME defined in XDG standard:
https://specifications.freedesktop.org/basedir-spec/basedir-spec-0.6.html.

It uses Qt that already provided a facility to get configuration directories that support XDG:
https://doc.qt.io/qt-5/qstandardpaths.html#writableLocation

Additionally a workaround for macOS that was needed in 2011 has been removed since libimobiledevice doesn't need the workaround anymore.