### PR TITLE
Fix resuming playback position on startup

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1342,7 +1342,19 @@ void MainWindow::ResumePlayback() {
 
   app_->player()->Play();
 
-  app_->player()->SeekTo(saved_playback_position_);
+  connect(track_position_timer_, SIGNAL(timeout()),
+          SLOT(ResumePlaybackPosition()));
+}
+
+void MainWindow::ResumePlaybackPosition() {
+  // We must wait until the song has a length because
+  // seeking a song without length does not work
+  if (app_->player()->engine()->length_nanosec() > 0) {
+    disconnect(track_position_timer_, SIGNAL(timeout()), this,
+               SLOT(ResumePlaybackPosition()));
+
+    app_->player()->SeekTo(saved_playback_position_);
+  }
 }
 
 void MainWindow::PlayIndex(const QModelIndex& index) {

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -271,6 +271,7 @@ signals:
   void SavePlaybackStatus(QSettings* settings);
   void LoadPlaybackStatus();
   void ResumePlayback();
+  void ResumePlaybackPosition();
 
   void AddSongInfoGenerator(smart_playlists::GeneratorPtr gen);
 


### PR DESCRIPTION
Resuming the playback position on startup has not worked for a while. See issues like #6363 

The reason it did not work is because the song to be resumed does not have a length yet when the seek is requested. My solution is to add a slot that waits until the song has a length so that the seek will work.