### PR TITLE
Add timeouts for gpodder requests.

### DIFF
--- a/src/core/network.h
+++ b/src/core/network.h
@@ -51,10 +51,12 @@ class NetworkAccessManager : public QNetworkAccessManager {
 
  public:
   explicit NetworkAccessManager(QObject* parent = nullptr);
+  explicit NetworkAccessManager(int timeout, QObject* parent = nullptr);
 
  protected:
   QNetworkReply* createRequest(Operation op, const QNetworkRequest& request,
                                QIODevice* outgoingData);
+  int timeout_msec_;
 };
 
 class RedirectFollower : public QObject {

--- a/src/internet/podcasts/gpoddersync.cpp
+++ b/src/internet/podcasts/gpoddersync.cpp
@@ -38,11 +38,12 @@ const char* GPodderSync::kSettingsGroup = "Podcasts";
 const int GPodderSync::kFlushUpdateQueueDelay = 30 * kMsecPerSec;  // 30 seconds
 const int GPodderSync::kGetUpdatesInterval =
     30 * 60 * kMsecPerSec;  // 30 minutes
+const int GPodderSync::kRequestTimeout = 30 * kMsecPerSec;  // 30 seconds
 
 GPodderSync::GPodderSync(Application* app, QObject* parent)
     : QObject(parent),
       app_(app),
-      network_(new NetworkAccessManager(this)),
+      network_(new NetworkAccessManager(kRequestTimeout, this)),
       backend_(app_->podcast_backend()),
       loader_(new PodcastUrlLoader(this)),
       get_updates_timer_(new QTimer(this)),

--- a/src/internet/podcasts/gpoddersync.h
+++ b/src/internet/podcasts/gpoddersync.h
@@ -51,6 +51,7 @@ class GPodderSync : public QObject {
   static const char* kSettingsGroup;
   static const int kFlushUpdateQueueDelay;
   static const int kGetUpdatesInterval;
+  static const int kRequestTimeout;
 
   static QString DefaultDeviceName();
   static QString DeviceId();


### PR DESCRIPTION
Found this issue while I was playing with my own gpodder instance that wasn't behaving properly. A request that fails to return can cause GPodderSync be stuck in the flushing state.

The alternative to this would be to modify the libmygpo-qt to expose the QNetworkReply instance and use the NetworkTimeouts class in the same manner that it's used elsewhere.
