### PR TITLE
Fix gpodder sync memory leaks in success cases.

### DIFF
--- a/src/internet/podcasts/gpoddersync.h
+++ b/src/internet/podcasts/gpoddersync.h
@@ -77,7 +77,8 @@ class GPodderSync : public QObject {
                      const QString& password);
 
   void DeviceUpdatesFinished(mygpo::DeviceUpdatesPtr reply);
-  void DeviceUpdatesFailed(mygpo::DeviceUpdatesPtr reply);
+  void DeviceUpdatesParseError();
+  void DeviceUpdatesRequestError(QNetworkReply::NetworkError error);
 
   void NewPodcastLoaded(PodcastUrlLoaderReply* reply, const QUrl& url,
                         const QList<mygpo::EpisodePtr>& actions);
@@ -91,7 +92,8 @@ class GPodderSync : public QObject {
 
   void AddRemoveFinished(mygpo::AddRemoveResultPtr reply,
                          const QList<QUrl>& affected_urls);
-  void AddRemoveFailed(mygpo::AddRemoveResultPtr reply);
+  void AddRemoveParseError();
+  void AddRemoveRequestError(QNetworkReply::NetworkError error);
 
  private:
   void LoadQueue();


### PR DESCRIPTION
A closure created by NewClosure that handles Qt signals is destroyed if the
signal object is destroyed, the slot object is destroyed, or the signal is
invoked. In the case where the sender is passed as a shared pointer, the
reference prevents the sender from being destroyed before the closure.

So for closures built to handle responses returned from ApiRequest in
GPodderSync, the closure object and the response object will only be destroyed
after the signal is invoked. In some cases, separate closures are built for
error signals as well. For these, only one closure will be destroyed. The other
closures and the response object will be leaked.

A simple fix for the success cases is to remove the unnecessary error case
closures and directly connect the signals to slots. This is low hanging fruit
and still leaves leaks in the error cases. Those cases will require a more
complete solution to properly manage the life cycle of the response object.