### PR TITLE
Reset gpodder session cookies on logout.

### DIFF
--- a/src/internet/podcasts/gpoddersync.cpp
+++ b/src/internet/podcasts/gpoddersync.cpp
@@ -22,6 +22,7 @@
 #include <QCoreApplication>
 #include <QHostInfo>
 #include <QNetworkAccessManager>
+#include <QNetworkCookieJar>
 #include <QSettings>
 #include <QTimer>
 
@@ -143,6 +144,10 @@ void GPodderSync::Logout() {
   s.remove("gpodder_last_get");
 
   api_.reset();
+
+  // Remove session cookies. QNetworkAccessManager takes ownership of the new
+  // object and frees the previous.
+  network_->setCookieJar(new QNetworkCookieJar());
 }
 
 void GPodderSync::GetUpdatesNow() {


### PR DESCRIPTION
A sessionid cookie is stored when logging in to gpodder. After logging out, a
subsequent login with the same user name but incorrect password will succeed,
ignoring the authorization header. The incorrect password will be stored for
future use.

To fix this, reset the cookie jar for GPodderSync's network access manager at
logout.