### PR TITLE
Gpodder login cleanup.

### DIFF
--- a/src/internet/podcasts/gpoddersync.cpp
+++ b/src/internet/podcasts/gpoddersync.cpp
@@ -103,9 +103,8 @@ void GPodderSync::ReloadSettings() {
   }
 }
 
-QNetworkReply* GPodderSync::Login(const QString& username,
-                                  const QString& password,
-                                  const QString& device_name) {
+void GPodderSync::Login(const QString& username, const QString& password,
+                        const QString& device_name) {
   api_.reset(new mygpo::ApiRequest(username, password, network_));
 
   QNetworkReply* reply = api_->renameDevice(
@@ -114,7 +113,6 @@ QNetworkReply* GPodderSync::Login(const QString& username,
   NewClosure(reply, SIGNAL(finished()), this,
              SLOT(LoginFinished(QNetworkReply*, QString, QString)), reply,
              username, password);
-  return reply;
 }
 
 void GPodderSync::LoginFinished(QNetworkReply* reply, const QString& username,
@@ -131,8 +129,10 @@ void GPodderSync::LoginFinished(QNetworkReply* reply, const QString& username,
     s.setValue("gpodder_password", password);
 
     DoInitialSync();
+    emit LoginSuccess();
   } else {
     api_.reset();
+    emit LoginFailure(reply->errorString());
   }
 }
 

--- a/src/internet/podcasts/gpoddersync.h
+++ b/src/internet/podcasts/gpoddersync.h
@@ -59,14 +59,17 @@ class GPodderSync : public QObject {
   bool is_logged_in() const;
 
   // Tries to login using the given username and password.  Also sets the
-  // device name and type on gpodder.net.  You do NOT need to deleteLater()
-  // the QNetworkReply returned from this function.
+  // device name and type on gpodder.net.
   // If login succeeds the username and password will be saved in QSettings.
-  QNetworkReply* Login(const QString& username, const QString& password,
-                       const QString& device_name);
+  void Login(const QString& username, const QString& password,
+             const QString& device_name);
 
   // Clears any saved username and password from QSettings.
   void Logout();
+
+ signals:
+  void LoginSuccess();
+  void LoginFailure(const QString& error);
 
  public slots:
   void GetUpdatesNow();

--- a/src/internet/podcasts/podcastsettingspage.h
+++ b/src/internet/podcasts/podcastsettingspage.h
@@ -24,8 +24,6 @@
 
 class Ui_PodcastSettingsPage;
 
-class QNetworkReply;
-
 class PodcastSettingsPage : public SettingsPage {
   Q_OBJECT
 
@@ -40,8 +38,10 @@ class PodcastSettingsPage : public SettingsPage {
 
  private slots:
   void LoginClicked();
-  void LoginFinished(QNetworkReply* reply);
   void LogoutClicked();
+
+  void GpodderLoginSuccess();
+  void GpodderLoginFailure(const QString& error);
 
   void DownloadDirBrowse();
 


### PR DESCRIPTION
It's not necessary for the PodcastSettingsPage class to have knowledge of
GPodderSync's login implementation. Handling the network reply in a single
location sightly simplifies the code. It also makes the handling order
more deterministic.