### PR TITLE
Fix smartplaylist crash

### DIFF
--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -62,8 +62,8 @@ const char* PlaylistView::kSettingBackgroundImageFilename =
 const int PlaylistView::kDefaultBlurRadius = 0;
 const int PlaylistView::kDefaultOpacityLevel = 40;
 
-PlaylistProxyStyle::PlaylistProxyStyle(QStyle* base)
-    : QProxyStyle(base), common_style_(new QCommonStyle) {}
+PlaylistProxyStyle::PlaylistProxyStyle()
+    : QProxyStyle(), common_style_(new QCommonStyle) {}
 
 void PlaylistProxyStyle::drawControl(ControlElement element,
                                      const QStyleOption* option,
@@ -107,7 +107,7 @@ void PlaylistProxyStyle::drawPrimitive(PrimitiveElement element,
 PlaylistView::PlaylistView(QWidget* parent)
     : QTreeView(parent),
       app_(nullptr),
-      style_(new PlaylistProxyStyle(style())),
+      style_(new PlaylistProxyStyle),
       playlist_(nullptr),
       header_(new PlaylistHeader(Qt::Horizontal, this, this)),
       setting_initial_header_layout_(false),

--- a/src/playlist/playlistview.h
+++ b/src/playlist/playlistview.h
@@ -44,7 +44,7 @@ class QTimeLine;
 // This class is used by the global search view as well.
 class PlaylistProxyStyle : public QProxyStyle {
  public:
-  PlaylistProxyStyle(QStyle* base);
+  PlaylistProxyStyle();
   void drawControl(ControlElement element, const QStyleOption* option,
                    QPainter* painter, const QWidget* widget) const;
   void drawPrimitive(PrimitiveElement element, const QStyleOption* option,

--- a/src/smartplaylists/wizard.cpp
+++ b/src/smartplaylists/wizard.cpp
@@ -15,10 +15,11 @@
    along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "core/logging.h"
 #include "querywizardplugin.h"
+#include "ui_wizardfinishpage.h"
 #include "wizard.h"
 #include "wizardplugin.h"
-#include "ui_wizardfinishpage.h"
 
 #include <QLabel>
 #include <QRadioButton>
@@ -105,6 +106,11 @@ void Wizard::SetGenerator(GeneratorPtr gen) {
   // Set the name
   finish_page_->ui_->name->setText(gen->name());
   finish_page_->ui_->dynamic->setChecked(gen->is_dynamic());
+
+  if (type_index_ == -1) {
+    qLog(Error) << "Plugin was not found for generator type" << gen->type();
+    return;
+  }
 
   // Tell the plugin to load
   plugins_[type_index_]->SetGenerator(gen);


### PR DESCRIPTION
This is a fix for https://github.com/clementine-player/Clementine/issues/6434

Another option would be to use a static instance of PlaylistProxyStyle that we create the first time a PlaylistView is instanciated, but I think that makes some assumptions about lifetimes of QStyle objects that might cause pain in the future.

It's also possible that the bug sited in c83394b6b4 no longer exists.
