### PR TITLE
Add an option to specify a gpodder server.

### DIFF
--- a/src/internet/podcasts/gpoddersync.h
+++ b/src/internet/podcasts/gpoddersync.h
@@ -64,6 +64,9 @@ class GPodderSync : public QObject {
   void Login(const QString& username, const QString& password,
              const QString& device_name);
 
+  void Login(const QString& username, const QString& password,
+             const QString& device_name, const QUrl& custom_url);
+
   // Clears any saved username and password from QSettings.
   void Logout();
 
@@ -77,7 +80,7 @@ class GPodderSync : public QObject {
  private slots:
   void ReloadSettings();
   void LoginFinished(QNetworkReply* reply, const QString& username,
-                     const QString& password);
+                     const QString& password, const QUrl& custom_url);
 
   void DeviceUpdatesFinished(mygpo::DeviceUpdatesPtr reply);
   void DeviceUpdatesParseError();
@@ -104,6 +107,8 @@ class GPodderSync : public QObject {
 
   void DoInitialSync();
 
+  void UpdateBaseUrl(const QUrl& custom_base_url);
+
  private:
   Application* app_;
   QNetworkAccessManager* network_;
@@ -116,6 +121,7 @@ class GPodderSync : public QObject {
   QString password_;
   QDateTime last_successful_get_;
   QTimer* get_updates_timer_;
+  QUrl default_base_url_;
 
   QTimer* flush_queue_timer_;
   QSet<QUrl> queued_add_subscriptions_;

--- a/src/internet/podcasts/podcastsettingspage.cpp
+++ b/src/internet/podcasts/podcastsettingspage.cpp
@@ -44,6 +44,8 @@ PodcastSettingsPage::PodcastSettingsPage(SettingsDialog* dialog)
   connect(ui_->login_state, SIGNAL(LogoutClicked()), SLOT(LogoutClicked()));
   connect(ui_->download_dir_browse, SIGNAL(clicked()),
           SLOT(DownloadDirBrowse()));
+  connect(ui_->gpodder_advanced, SIGNAL(stateChanged(int)),
+          SLOT(GpodderAdvancedChanged(int)));
 
   GPodderSync* gsync = dialog->app()->gpodder_sync();
   connect(gsync, SIGNAL(LoginSuccess()), SLOT(GpodderLoginSuccess()));
@@ -89,6 +91,16 @@ void PodcastSettingsPage::Load() {
       s.value("gpodder_device_name", GPodderSync::DefaultDeviceName())
           .toString());
 
+  QUrl base_url = s.value("gpodder_base_url").toUrl();
+  if (base_url.isEmpty()) {
+    ui_->gpodder_advanced->setCheckState(Qt::Unchecked);
+    ui_->gpodder_advanced_group->setEnabled(false);
+  } else {
+    ui_->gpodder_advanced->setCheckState(Qt::Checked);
+    ui_->gpodder_advanced_group->setEnabled(true);
+  }
+  ui_->gpodder_base_url->setText(base_url.toString());
+
   if (dialog()->app()->gpodder_sync()->is_logged_in()) {
     ui_->login_state->SetLoggedIn(LoginStateWidget::LoggedIn,
                                   ui_->username->text());
@@ -115,8 +127,19 @@ void PodcastSettingsPage::Save() {
 void PodcastSettingsPage::LoginClicked() {
   ui_->login_state->SetLoggedIn(LoginStateWidget::LoginInProgress);
 
-  dialog()->app()->gpodder_sync()->Login(
-      ui_->username->text(), ui_->password->text(), ui_->device_name->text());
+  if (ui_->gpodder_advanced->checkState()) {
+    QUrl url(ui_->gpodder_base_url->text());
+    if (url.isEmpty() || !url.isValid()) {
+      GpodderLoginFailure("Invalid URL");
+      return;
+    }
+    dialog()->app()->gpodder_sync()->Login(ui_->username->text(),
+                                           ui_->password->text(),
+                                           ui_->device_name->text(), url);
+  } else {
+    dialog()->app()->gpodder_sync()->Login(
+        ui_->username->text(), ui_->password->text(), ui_->device_name->text());
+  }
 }
 
 void PodcastSettingsPage::GpodderLoginSuccess() {
@@ -144,4 +167,8 @@ void PodcastSettingsPage::DownloadDirBrowse() {
   if (directory.isEmpty()) return;
 
   ui_->download_dir->setText(QDir::toNativeSeparators(directory));
+}
+
+void PodcastSettingsPage::GpodderAdvancedChanged(int state) {
+  ui_->gpodder_advanced_group->setEnabled(state != Qt::Unchecked);
 }

--- a/src/internet/podcasts/podcastsettingspage.h
+++ b/src/internet/podcasts/podcastsettingspage.h
@@ -45,6 +45,8 @@ class PodcastSettingsPage : public SettingsPage {
 
   void DownloadDirBrowse();
 
+  void GpodderAdvancedChanged(int state);
+
  private:
   Ui_PodcastSettingsPage* ui_;
 };

--- a/src/internet/podcasts/podcastsettingspage.ui
+++ b/src/internet/podcasts/podcastsettingspage.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>616</width>
-    <height>656</height>
+    <height>672</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -174,7 +174,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox_3">
+    <widget class="QGroupBox" name="gpodder_groupBox">
      <property name="title">
       <string>gpodder.net</string>
      </property>
@@ -198,7 +198,16 @@
       <item>
        <widget class="QWidget" name="login_group" native="true">
         <layout class="QFormLayout" name="formLayout_3">
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <item row="0" column="0">
@@ -236,15 +245,44 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="0">
+         <item row="3" column="0">
           <widget class="QLabel" name="label_7">
            <property name="text">
             <string>Device name</string>
            </property>
           </widget>
          </item>
-         <item row="2" column="1">
+         <item row="3" column="1">
           <widget class="QLineEdit" name="device_name"/>
+         </item>
+         <item row="5" column="0" colspan="2">
+          <widget class="QGroupBox" name="gpodder_advanced_group">
+           <property name="title">
+            <string/>
+           </property>
+           <layout class="QGridLayout" name="gridLayout">
+            <item row="0" column="1">
+             <widget class="QLineEdit" name="gpodder_base_url"/>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="gpodder_base_url_label">
+              <property name="text">
+               <string>Base URL</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item row="4" column="0" colspan="2">
+          <widget class="QCheckBox" name="gpodder_advanced">
+           <property name="text">
+            <string>Advanced Settings</string>
+           </property>
+           <property name="tristate">
+            <bool>false</bool>
+           </property>
+          </widget>
          </item>
         </layout>
        </widget>
@@ -286,5 +324,6 @@
   <tabstop>device_name</tabstop>
   <tabstop>login</tabstop>
  </tabstops>
+ <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
Add an "Advanced Settings" option to the gpodder sign in. If selected, a fully
qualified URL must be specified as the gpodder base. Upon successful login, the
URL is saved along with username and password. If advanced settings are not
selected, an empty URL is stored and the default will be used.