### PR TITLE
Fix macOS filesystem listener (library watcher)

### DIFF
--- a/src/core/macfslistener.h
+++ b/src/core/macfslistener.h
@@ -57,7 +57,7 @@ class MacFSListener : public FileSystemWatcherInterface {
   FSEventStreamRef stream_;
 
   QSet<QString> paths_;
-  QTimer *update_timer_;
+  QTimer* update_timer_;
 };
 
 #endif  // CORE_MACFSLISTENER_H_

--- a/src/core/macfslistener.h
+++ b/src/core/macfslistener.h
@@ -24,9 +24,10 @@
 
 #include <QObject>
 #include <QSet>
-#include <QTimer>
 
 #include "filesystemwatcherinterface.h"
+
+class QTimer;
 
 class MacFSListener : public FileSystemWatcherInterface {
   Q_OBJECT
@@ -56,7 +57,7 @@ class MacFSListener : public FileSystemWatcherInterface {
   FSEventStreamRef stream_;
 
   QSet<QString> paths_;
-  QTimer update_timer_;
+  QTimer *update_timer_;
 };
 
 #endif  // CORE_MACFSLISTENER_H_

--- a/src/core/macfslistener.mm
+++ b/src/core/macfslistener.mm
@@ -22,14 +22,16 @@
 #include <Foundation/NSArray.h>
 #include <Foundation/NSString.h>
 
+#include <QTimer>
+
 #include "core/logging.h"
 #include "core/scoped_nsobject.h"
 
 MacFSListener::MacFSListener(QObject* parent)
-    : FileSystemWatcherInterface(parent), run_loop_(nullptr), stream_(nullptr) {
-  update_timer_.setSingleShot(true);
-  update_timer_.setInterval(2000);
-  connect(&update_timer_, SIGNAL(timeout()), SLOT(UpdateStream()));
+    : FileSystemWatcherInterface(parent), run_loop_(nullptr), stream_(nullptr), update_timer_(new QTimer(this)) {
+  update_timer_->setSingleShot(true);
+  update_timer_->setInterval(2000);
+  connect(update_timer_, SIGNAL(timeout()), SLOT(UpdateStream()));
 }
 
 void MacFSListener::Init() { run_loop_ = CFRunLoopGetCurrent(); }
@@ -67,7 +69,7 @@ void MacFSListener::Clear() {
   UpdateStreamAsync();
 }
 
-void MacFSListener::UpdateStreamAsync() { update_timer_.start(); }
+void MacFSListener::UpdateStreamAsync() { update_timer_->start(); }
 
 void MacFSListener::UpdateStream() {
   if (stream_) {


### PR DESCRIPTION
The library watcher is broken on macOS because the QTimer doesn't start. Because it's allocated on the stack, the object isn't moved to the correct thread. Fixed by allocating on the heap.

This fixes the following errors logged:

```
__logging_message__08:33:22.414 WARN  unknown                          QObject::startTimer: Timers cannot be started from another thread
__logging_message__08:33:22.414 WARN  unknown                          QObject::killTimer: Timers cannot be stopped from another thread
__logging_message__08:33:22.414 WARN  unknown                          QObject::startTimer: Timers cannot be started from another thread


```