### PR TITLE
Remove pixmap cache and pending art when removing parent nodes instead

### DIFF
--- a/src/library/librarymodel.cpp
+++ b/src/library/librarymodel.cpp
@@ -455,8 +455,7 @@ void LibraryModel::SongsDeleted(const SongList& songs) {
       while (i != pending_art_.end()) {
         if (i.value().first == node) {
           i = pending_art_.erase(i);
-        }
-        else {
+        } else {
           ++i;
         }
       }

--- a/src/library/librarymodel.cpp
+++ b/src/library/librarymodel.cpp
@@ -403,26 +403,7 @@ void LibraryModel::SongsDeleted(const SongList& songs) {
 
       if (node->parent != root_) parents << node->parent;
 
-      QModelIndex idx = ItemToIndex(node->parent);
-
-      // Remove from pixmap cache
-      const QString cache_key = AlbumIconPixmapCacheKey(idx);
-      QPixmapCache::remove(cache_key);
-      icon_cache_->remove(QUrl(cache_key));
-      if (pending_cache_keys_.contains(cache_key))
-        pending_cache_keys_.remove(cache_key);
-
-      // Remove from pending art loading
-      QMapIterator<quint64, ItemAndCacheKey> i(pending_art_);
-      while (i.hasNext()) {
-        i.next();
-        if (i.value().first == node) {
-          pending_art_.remove(i.key());
-          break;
-        }
-      }
-
-      beginRemoveRows(idx, node->row, node->row);
+      beginRemoveRows(ItemToIndex(node->parent), node->row, node->row);
       node->parent->Delete(node->row);
       song_nodes_.remove(song.id());
       endRemoveRows();
@@ -460,6 +441,25 @@ void LibraryModel::SongsDeleted(const SongList& songs) {
         node->parent->compilation_artist_node_ = nullptr;
       else
         container_nodes_[node->container_level].remove(node->key);
+
+      // Remove from pixmap cache
+      const QString cache_key = AlbumIconPixmapCacheKey(ItemToIndex(node));
+      QPixmapCache::remove(cache_key);
+      icon_cache_->remove(QUrl(cache_key));
+      if (pending_cache_keys_.contains(cache_key)) {
+        pending_cache_keys_.remove(cache_key);
+      }
+
+      // Remove from pending art loading
+      QMap<quint64, ItemAndCacheKey>::iterator i = pending_art_.begin();
+      while (i != pending_art_.end()) {
+        if (i.value().first == node) {
+          i = pending_art_.erase(i);
+        }
+        else {
+          ++i;
+        }
+      }
 
       // It was empty - delete it
       beginRemoveRows(ItemToIndex(node->parent), node->row, node->row);


### PR DESCRIPTION
My previous fix had a bug, it worked for removing pixmap cache itself, but not the pending art: The following line `if (i.value().first == node) {` should have been `if (i.value().first == node->parent) {`
But it's actually better to just remove it when removing the parent nodes since the album is always the parent anyway.
