### PR TITLE
Fix songs stuck in various artists

### DIFF
--- a/src/library/librarybackend.cpp
+++ b/src/library/librarybackend.cpp
@@ -823,8 +823,7 @@ void LibraryBackend::UpdateCompilations(const QSqlDatabase& db,
   QSqlQuery find_song(db);
   find_song.prepare(QString("SELECT ROWID, " + Song::kColumnSpec +
                             " FROM %1"
-                            " WHERE filename = :filename AND sampler = "
-                            ":sampler AND unavailable = 0")
+                            " WHERE filename = :filename AND unavailable = 0")
                         .arg(songs_table_));
 
   QSqlQuery update_song(db);
@@ -838,7 +837,6 @@ void LibraryBackend::UpdateCompilations(const QSqlDatabase& db,
 
   // Get song, so we can tell the model its updated
   find_song.bindValue(":filename", url.toEncoded());
-  find_song.bindValue(":sampler", int(!sampler));
   find_song.exec();
   while (find_song.next()) {
     Song song;


### PR DESCRIPTION
All songs that belong to a compilation album where a song is updated needs to be removed and readded to the model, otherwise they all still have the various artists compilation node.
This fixes a bug where the songs are stuck in various artists, even though it's correctly updated to the DB, the model isn't updated immediately.
