### PR TITLE
Replace all uses of QDesktopWidget with QScreen

### DIFF
--- a/src/ui/albumcoverchoicecontroller.cpp
+++ b/src/ui/albumcoverchoicecontroller.cpp
@@ -29,8 +29,10 @@
 #include "ui/coverfromurldialog.h"
 #include "ui/iconloader.h"
 
+#include <QGuiApplication>
+#include <QScreen>
+#include <QWindow>
 #include <QAction>
-#include <QDesktopWidget>
 #include <QDialog>
 #include <QDragEnterEvent>
 #include <QFileDialog>
@@ -244,10 +246,15 @@ QDialog* AlbumCoverChoiceController::ShowCoverPrivate(const Song& song) {
 
   // if the cover is larger than the screen, resize the window
   // 85% seems to be enough to account for title bar and taskbar etc.
-  QDesktopWidget desktop;
-  int current_screen = desktop.screenNumber(this);
-  int desktop_height = desktop.screenGeometry(current_screen).height();
-  int desktop_width = desktop.screenGeometry(current_screen).width();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+  QScreen *screen = screen();
+#else
+  QScreen *screen = (window() && window()->windowHandle() ? window()->windowHandle()->screen() : QGuiApplication::primaryScreen());
+#endif
+
+  QRect screenGeometry = screen->availableGeometry();
+  int desktop_height = screenGeometry.height();
+  int desktop_width = screenGeometry.width();
 
   // resize differently if monitor is in portrait mode
   if (desktop_width < desktop_height) {

--- a/src/ui/albumcoverchoicecontroller.cpp
+++ b/src/ui/albumcoverchoicecontroller.cpp
@@ -29,19 +29,19 @@
 #include "ui/coverfromurldialog.h"
 #include "ui/iconloader.h"
 
-#include <QGuiApplication>
-#include <QScreen>
-#include <QWindow>
 #include <QAction>
 #include <QDialog>
 #include <QDragEnterEvent>
 #include <QFileDialog>
+#include <QGuiApplication>
 #include <QImageWriter>
 #include <QLabel>
 #include <QList>
 #include <QMenu>
-#include <QUrl>
 #include <QMimeData>
+#include <QScreen>
+#include <QUrl>
+#include <QWindow>
 
 const char* AlbumCoverChoiceController::kLoadImageFileFilter = QT_TR_NOOP(
     "Images (*.png *.jpg *.jpeg *.bmp *.gif *.xpm *.pbm *.pgm *.ppm *.xbm)");
@@ -247,9 +247,11 @@ QDialog* AlbumCoverChoiceController::ShowCoverPrivate(const Song& song) {
   // if the cover is larger than the screen, resize the window
   // 85% seems to be enough to account for title bar and taskbar etc.
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-  QScreen *screen = screen();
+  QScreen* screen = screen();
 #else
-  QScreen *screen = (window() && window()->windowHandle() ? window()->windowHandle()->screen() : QGuiApplication::primaryScreen());
+  QScreen* screen =
+      (window() && window()->windowHandle() ? window()->windowHandle()->screen()
+                                            : QGuiApplication::primaryScreen());
 #endif
 
   QRect screenGeometry = screen->availableGeometry();

--- a/src/ui/notificationssettingspage.cpp
+++ b/src/ui/notificationssettingspage.cpp
@@ -220,7 +220,7 @@ void NotificationsSettingsPage::Save() {
   s.setValue("foreground_color", pretty_popup_->foreground_color());
   s.setValue("background_color", pretty_popup_->background_color());
   s.setValue("background_opacity", pretty_popup_->background_opacity());
-  s.setValue("popup_display", pretty_popup_->popup_display());
+  s.setValue("popup_screen", pretty_popup_->popup_screen());
   s.setValue("popup_pos", pretty_popup_->popup_pos());
   s.setValue("font", pretty_popup_->font().toString());
   s.setValue("disable_duration",

--- a/src/ui/settingsdialog.cpp
+++ b/src/ui/settingsdialog.cpp
@@ -81,12 +81,12 @@
 #include "internet/spotify/spotifysettingspage.h"
 #endif
 
-#include <QScreen>
-#include <QWindow>
 #include <QAbstractButton>
 #include <QPainter>
 #include <QPushButton>
+#include <QScreen>
 #include <QScrollArea>
+#include <QWindow>
 
 SettingsItemDelegate::SettingsItemDelegate(QObject* parent)
     : QStyledItemDelegate(parent) {}
@@ -306,9 +306,11 @@ void SettingsDialog::showEvent(QShowEvent* e) {
 
   // Resize the dialog if it's too big
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-    QScreen *screen = screen();
+  QScreen* screen = screen();
 #else
-    QScreen *screen = (window() && window()->windowHandle() ? window()->windowHandle()->screen() : QGuiApplication::primaryScreen());
+  QScreen* screen =
+      (window() && window()->windowHandle() ? window()->windowHandle()->screen()
+                                            : QGuiApplication::primaryScreen());
 #endif
   if (screen) {
     const QRect available = screen->availableGeometry();

--- a/src/ui/settingsdialog.cpp
+++ b/src/ui/settingsdialog.cpp
@@ -81,8 +81,9 @@
 #include "internet/spotify/spotifysettingspage.h"
 #endif
 
+#include <QScreen>
+#include <QWindow>
 #include <QAbstractButton>
-#include <QDesktopWidget>
 #include <QPainter>
 #include <QPushButton>
 #include <QScrollArea>
@@ -304,10 +305,16 @@ void SettingsDialog::showEvent(QShowEvent* e) {
   loading_settings_ = false;
 
   // Resize the dialog if it's too big
-  const QSize available =
-      QApplication::desktop()->availableGeometry(this).size();
-  if (available.height() < height()) {
-    resize(width(), sizeHint().height());
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    QScreen *screen = screen();
+#else
+    QScreen *screen = (window() && window()->windowHandle() ? window()->windowHandle()->screen() : QGuiApplication::primaryScreen());
+#endif
+  if (screen) {
+    const QRect available = screen->availableGeometry();
+    if (available.height() < height()) {
+      resize(width(), sizeHint().height());
+    }
   }
 
   QDialog::showEvent(e);

--- a/src/widgets/nowplayingwidget.cpp
+++ b/src/widgets/nowplayingwidget.cpp
@@ -17,7 +17,9 @@
 
 #include "nowplayingwidget.h"
 
-#include <QDesktopWidget>
+#include <QGuiApplication>
+#include <QScreen>
+#include <QWindow>
 #include <QMenu>
 #include <QMovie>
 #include <QPainter>
@@ -647,10 +649,13 @@ void NowPlayingWidget::SearchCoverAutomatically() {
 }
 
 void NowPlayingWidget::Bask() {
-  QDesktopWidget desktop;
-  int current_screen = desktop.screenNumber(this);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+  QScreen *screen = screen();
+#else
+  QScreen *screen = (window() && window()->windowHandle() ? window()->windowHandle()->screen() : QGuiApplication::primaryScreen());
+#endif
   big_hypnotoad_.reset(new FullscreenHypnotoad);
-  big_hypnotoad_->setGeometry(desktop.screenGeometry(current_screen));
+  if (screen) big_hypnotoad_->setGeometry(screen->availableGeometry());
   big_hypnotoad_->showFullScreen();
 }
 

--- a/src/widgets/nowplayingwidget.cpp
+++ b/src/widgets/nowplayingwidget.cpp
@@ -18,15 +18,15 @@
 #include "nowplayingwidget.h"
 
 #include <QGuiApplication>
-#include <QScreen>
-#include <QWindow>
 #include <QMenu>
 #include <QMovie>
-#include <QPainter>
 #include <QPaintEvent>
+#include <QPainter>
+#include <QScreen>
 #include <QSettings>
 #include <QTextDocument>
 #include <QTimeLine>
+#include <QWindow>
 #include <QtDebug>
 
 #include "fullscreenhypnotoad.h"
@@ -650,9 +650,11 @@ void NowPlayingWidget::SearchCoverAutomatically() {
 
 void NowPlayingWidget::Bask() {
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-  QScreen *screen = screen();
+  QScreen* screen = screen();
 #else
-  QScreen *screen = (window() && window()->windowHandle() ? window()->windowHandle()->screen() : QGuiApplication::primaryScreen());
+  QScreen* screen =
+      (window() && window()->windowHandle() ? window()->windowHandle()->screen()
+                                            : QGuiApplication::primaryScreen());
 #endif
   big_hypnotoad_.reset(new FullscreenHypnotoad);
   if (screen) big_hypnotoad_->setGeometry(screen->availableGeometry());

--- a/src/widgets/osdpretty.cpp
+++ b/src/widgets/osdpretty.cpp
@@ -20,17 +20,17 @@
 #include "ui_osdpretty.h"
 
 #include <QApplication>
-#include <QGuiApplication>
-#include <QScreen>
-#include <QWindow>
 #include <QBitmap>
 #include <QColor>
+#include <QGuiApplication>
 #include <QLayout>
 #include <QMouseEvent>
 #include <QPainter>
+#include <QScreen>
 #include <QSettings>
-#include <QTimer>
 #include <QTimeLine>
+#include <QTimer>
+#include <QWindow>
 
 #ifdef HAVE_X11
 #include <QX11Info>
@@ -125,25 +125,23 @@ OSDPretty::OSDPretty(Mode mode, QWidget* parent)
   int margin = l->margin() + kDropShadowSize;
   l->setMargin(margin);
 
-  connect(qApp, SIGNAL(screenAdded(QScreen*)), this, SLOT(ScreenAdded(QScreen*)));
-  connect(qApp, SIGNAL(screenRemoved(QScreen*)), this, SLOT(ScreenRemoved(QScreen*)));
+  connect(qApp, SIGNAL(screenAdded(QScreen*)), this,
+          SLOT(ScreenAdded(QScreen*)));
+  connect(qApp, SIGNAL(screenRemoved(QScreen*)), this,
+          SLOT(ScreenRemoved(QScreen*)));
 
   // Don't load settings here, they will be reloaded anyway on creation
 }
 
 OSDPretty::~OSDPretty() { delete ui_; }
 
-void OSDPretty::ScreenAdded(QScreen *screen) {
-
+void OSDPretty::ScreenAdded(QScreen* screen) {
   screens_.insert(screen->name(), screen);
-
 }
 
-void OSDPretty::ScreenRemoved(QScreen *screen) {
-
+void OSDPretty::ScreenRemoved(QScreen* screen) {
   if (screens_.contains(screen->name())) screens_.remove(screen->name());
   if (screen == popup_screen_) popup_screen_ = current_screen();
-
 }
 
 bool OSDPretty::IsTransparencyAvailable() {
@@ -154,7 +152,6 @@ bool OSDPretty::IsTransparencyAvailable() {
 }
 
 void OSDPretty::Load() {
-
   QSettings s;
   s.beginGroup(kSettingsGroup);
   foreground_color_ = QColor(s.value("foreground_color", 0).toInt());
@@ -167,28 +164,26 @@ void OSDPretty::Load() {
     popup_screen_name_ = s.value("popup_screen").toString();
     if (screens_.contains(popup_screen_name_)) {
       popup_screen_ = screens_[popup_screen_name_];
-    }
-    else {
+    } else {
       popup_screen_ = current_screen();
-      if (current_screen()) popup_screen_name_ = current_screen()->name();
-      else popup_screen_name_.clear();
+      if (current_screen())
+        popup_screen_name_ = current_screen()->name();
+      else
+        popup_screen_name_.clear();
     }
-  }
-  else {
+  } else {
     popup_screen_ = current_screen();
     if (current_screen()) popup_screen_name_ = current_screen()->name();
   }
 
   if (s.contains("popup_pos")) {
     popup_pos_ = s.value("popup_pos").toPoint();
-  }
-  else {
+  } else {
     if (popup_screen_) {
       QRect geometry = popup_screen_->availableGeometry();
       popup_pos_.setX(geometry.width() - width());
       popup_pos_.setY(0);
-    }
-    else {
+    } else {
       popup_pos_.setX(0);
       popup_pos_.setY(0);
     }
@@ -198,7 +193,6 @@ void OSDPretty::Load() {
   set_foreground_color(foreground_color());
 
   s.endGroup();
-
 }
 
 void OSDPretty::ReloadSettings() {
@@ -307,9 +301,9 @@ void OSDPretty::ShowMessage(const QString& summary, const QString& message,
   }
 }
 
-void OSDPretty::showEvent(QShowEvent *e) {
+void OSDPretty::showEvent(QShowEvent* e) {
   screens_.clear();
-  for(QScreen *screen : qApp->screens()) {
+  for (QScreen* screen : qApp->screens()) {
     screens_.insert(screen->name(), screen);
   }
 
@@ -368,11 +362,10 @@ void OSDPretty::Reposition() {
   // Work out where to place the OSD.  -1 for x or y means "on the right or
   // bottom edge".
   if (popup_screen_) {
-
     QRect geometry = popup_screen_->availableGeometry();
 
     int x = popup_pos_.x() < 0 ? geometry.right() - width()
-                             : geometry.left() + popup_pos_.x();
+                               : geometry.left() + popup_pos_.x();
     int y = popup_pos_.y() < 0 ? geometry.bottom() - height()
                                : geometry.top() + popup_pos_.y();
 
@@ -431,9 +424,11 @@ void OSDPretty::mouseMoveEvent(QMouseEvent* e) {
 
     // Keep it to the bounds of the desktop
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
-    QScreen *screen = QGuiApplication::screenAt(e->globalPos());
+    QScreen* screen = QGuiApplication::screenAt(e->globalPos());
 #else
-    QScreen *screen = (window() && window()->windowHandle() ? window()->windowHandle()->screen() : QGuiApplication::primaryScreen());
+    QScreen* screen = (window() && window()->windowHandle()
+                           ? window()->windowHandle()->screen()
+                           : QGuiApplication::primaryScreen());
 #endif
     if (!screen) return;
     QRect geometry = screen->availableGeometry();
@@ -455,32 +450,33 @@ void OSDPretty::mouseMoveEvent(QMouseEvent* e) {
     popup_screen_ = screen;
     popup_screen_name_ = screen->name();
   }
-
 }
 
-QScreen *OSDPretty::current_screen() const {
+QScreen* OSDPretty::current_screen() const {
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
   return QGuiApplication::screenAt(pos());
 #else
-  return (window() && window()->windowHandle() ? window()->windowHandle()->screen() : QGuiApplication::primaryScreen());
+  return (window() && window()->windowHandle()
+              ? window()->windowHandle()->screen()
+              : QGuiApplication::primaryScreen());
 #endif
 }
 
 QPoint OSDPretty::current_pos() const {
-
   if (current_screen()) {
     QRect geometry = current_screen()->availableGeometry();
 
-    int x = pos().x() >= geometry.right() - width() ? -1
-                                                  : pos().x() - geometry.left();
-    int y = pos().y() >= geometry.bottom() - height() ? -1 : pos().y() -
-                                                               geometry.top();
+    int x = pos().x() >= geometry.right() - width()
+                ? -1
+                : pos().x() - geometry.left();
+    int y = pos().y() >= geometry.bottom() - height()
+                ? -1
+                : pos().y() - geometry.top();
 
     return QPoint(x, y);
   }
 
   return QPoint(0, 0);
-
 }
 
 void OSDPretty::set_background_color(QRgb color) {

--- a/src/widgets/osdpretty.h
+++ b/src/widgets/osdpretty.h
@@ -19,9 +19,11 @@
 #define OSDPRETTY_H
 
 #include <QWidget>
+#include <QMap>
 
 class Ui_OSDPretty;
 
+class QScreen;
 class QTimeLine;
 
 class OSDPretty : public QWidget {
@@ -66,7 +68,7 @@ class OSDPretty : public QWidget {
   QRgb foreground_color() const { return foreground_color_.rgb(); }
   QRgb background_color() const { return background_color_.rgb(); }
   qreal background_opacity() const { return background_opacity_; }
-  int popup_display() const { return popup_display_; }
+  QString popup_screen() const { return popup_screen_name_; }
   QPoint popup_pos() const { return popup_pos_; }
   QFont font() const { return font_; }
   bool disable_duration() const { return disable_duration_; }
@@ -74,7 +76,7 @@ class OSDPretty : public QWidget {
   // When the user has been moving the popup, use these to get its current
   // position and screen.  Note that these return invalid values if the popup
   // is hidden.
-  int current_display() const;
+  QScreen *current_screen() const;
   QPoint current_pos() const;
 
   // QWidget
@@ -104,6 +106,8 @@ class OSDPretty : public QWidget {
  private slots:
   void FaderValueChanged(qreal value);
   void FaderFinished();
+  void ScreenAdded(QScreen* screen);
+  void ScreenRemoved(QScreen* screen);
 
  private:
   Ui_OSDPretty* ui_;
@@ -114,8 +118,9 @@ class OSDPretty : public QWidget {
   QColor foreground_color_;
   QColor background_color_;
   float background_opacity_;
-  int popup_display_;  // -1 for default
+  QString popup_screen_name_;
   QPoint popup_pos_;
+  QScreen* popup_screen_;
   QFont font_;
   // The OSD is kept always on top until you click (no timer)
   bool disable_duration_;
@@ -138,6 +143,9 @@ class OSDPretty : public QWidget {
 
   // Toggling requested, we have to show or hide the OSD
   bool toggle_mode_;
+
+  QMap<QString, QScreen*> screens_;
+
 };
 
 #endif  // OSDPRETTY_H

--- a/src/widgets/osdpretty.h
+++ b/src/widgets/osdpretty.h
@@ -18,8 +18,8 @@
 #ifndef OSDPRETTY_H
 #define OSDPRETTY_H
 
-#include <QWidget>
 #include <QMap>
+#include <QWidget>
 
 class Ui_OSDPretty;
 
@@ -76,7 +76,7 @@ class OSDPretty : public QWidget {
   // When the user has been moving the popup, use these to get its current
   // position and screen.  Note that these return invalid values if the popup
   // is hidden.
-  QScreen *current_screen() const;
+  QScreen* current_screen() const;
   QPoint current_pos() const;
 
   // QWidget
@@ -145,7 +145,6 @@ class OSDPretty : public QWidget {
   bool toggle_mode_;
 
   QMap<QString, QScreen*> screens_;
-
 };
 
 #endif  // OSDPRETTY_H

--- a/src/widgets/prettyimage.cpp
+++ b/src/widgets/prettyimage.cpp
@@ -18,8 +18,6 @@
 #include "prettyimage.h"
 
 #include <QApplication>
-#include <QScreen>
-#include <QWindow>
 #include <QContextMenuEvent>
 #include <QDir>
 #include <QFileDialog>
@@ -29,8 +27,10 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QPainter>
+#include <QScreen>
 #include <QScrollArea>
 #include <QSettings>
+#include <QWindow>
 #include <QtConcurrentRun>
 
 #include "core/closure.h"
@@ -198,9 +198,11 @@ void PrettyImage::ShowFullsize() {
 
   // Work out how large to make the window, based on the size of the screen
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-    QScreen *screen = screen();
+  QScreen* screen = screen();
 #else
-    QScreen *screen = (window() && window()->windowHandle() ? window()->windowHandle()->screen() : QGuiApplication::primaryScreen());
+  QScreen* screen =
+      (window() && window()->windowHandle() ? window()->windowHandle()->screen()
+                                            : QGuiApplication::primaryScreen());
 #endif
   if (screen) {
     QRect desktop_rect(screen->availableGeometry());

--- a/src/widgets/prettyimage.cpp
+++ b/src/widgets/prettyimage.cpp
@@ -18,8 +18,9 @@
 #include "prettyimage.h"
 
 #include <QApplication>
+#include <QScreen>
+#include <QWindow>
 #include <QContextMenuEvent>
-#include <QDesktopWidget>
 #include <QDir>
 #include <QFileDialog>
 #include <QFuture>
@@ -189,25 +190,33 @@ void PrettyImage::contextMenuEvent(QContextMenuEvent* e) {
 }
 
 void PrettyImage::ShowFullsize() {
-  // Work out how large to make the window, based on the size of the screen
-  QRect desktop_rect(QApplication::desktop()->availableGeometry(this));
-  QSize window_size(qMin(desktop_rect.width() - 20, image_.width()),
-                    qMin(desktop_rect.height() - 20, image_.height()));
 
   // Create the window
-  QScrollArea* window = new QScrollArea;
-  window->setAttribute(Qt::WA_DeleteOnClose, true);
-  window->setWindowTitle(tr("Clementine image viewer"));
-  window->resize(window_size);
+  QScrollArea* pwindow = new QScrollArea;
+  pwindow->setAttribute(Qt::WA_DeleteOnClose, true);
+  pwindow->setWindowTitle(tr("Clementine image viewer"));
+
+  // Work out how large to make the window, based on the size of the screen
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    QScreen *screen = screen();
+#else
+    QScreen *screen = (window() && window()->windowHandle() ? window()->windowHandle()->screen() : QGuiApplication::primaryScreen());
+#endif
+  if (screen) {
+    QRect desktop_rect(screen->availableGeometry());
+    QSize window_size(qMin(desktop_rect.width() - 20, image_.width()),
+                      qMin(desktop_rect.height() - 20, image_.height()));
+    pwindow->resize(window_size);
+  }
 
   // Create the label that displays the image
-  QLabel* label = new QLabel(window);
+  QLabel* label = new QLabel(pwindow);
   label->setPixmap(QPixmap::fromImage(image_));
 
   // Show the label in the window
-  window->setWidget(label);
-  window->setFrameShape(QFrame::NoFrame);
-  window->show();
+  pwindow->setWidget(label);
+  pwindow->setFrameShape(QFrame::NoFrame);
+  pwindow->show();
 }
 
 void PrettyImage::SaveAs() {


### PR DESCRIPTION
QDesktopWidget is deprecated. This replaces all uses of it with QScreen.
OSDPretty will use screen name instead of display number in the settings.
