### PR TITLE
Replace use of QString::sprintf with QString::asprintf

### DIFF
--- a/src/core/utilities.cpp
+++ b/src/core/utilities.cpp
@@ -99,9 +99,10 @@ QString PrettyTime(int seconds, bool always_show_hours) {
   QString ret;
   if (hours || always_show_hours)
     ret = QString::asprintf("%d:%02d:%02d", hours, minutes,
-                seconds);  // NOLINT(runtime/printf)
+                            seconds);  // NOLINT(runtime/printf)
   else
-    ret = QString::asprintf("%d:%02d", minutes, seconds);  // NOLINT(runtime/printf)
+    ret = QString::asprintf("%d:%02d", minutes,
+                            seconds);  // NOLINT(runtime/printf)
 
   return ret;
 }
@@ -165,15 +166,18 @@ QString PrettySize(quint64 bytes) {
     if (bytes <= 1000)
       ret = QString::number(bytes) + " bytes";
     else if (bytes <= 1000 * 1000)
-      ret = QString::asprintf("%.1f KB",
-                  static_cast<float>(bytes) / 1000);  // NOLINT(runtime/printf)
+      ret = QString::asprintf(
+          "%.1f KB",
+          static_cast<float>(bytes) / 1000);  // NOLINT(runtime/printf)
     else if (bytes <= 1000 * 1000 * 1000)
-      ret = QString::asprintf("%.1f MB", static_cast<float>(bytes) /
-                                 (1000 * 1000));  // NOLINT(runtime/printf)
+      ret = QString::asprintf(
+          "%.1f MB",
+          static_cast<float>(bytes) / (1000 * 1000));  // NOLINT(runtime/printf)
     else
-      ret = QString::asprintf("%.1f GB",
-                  static_cast<float>(bytes) /
-                      (1000 * 1000 * 1000));  // NOLINT(runtime/printf)
+      ret = QString::asprintf(
+          "%.1f GB",
+          static_cast<float>(bytes) /
+              (1000 * 1000 * 1000));  // NOLINT(runtime/printf)
   }
   return ret;
 }

--- a/src/core/utilities.cpp
+++ b/src/core/utilities.cpp
@@ -98,10 +98,10 @@ QString PrettyTime(int seconds, bool always_show_hours) {
 
   QString ret;
   if (hours || always_show_hours)
-    ret.sprintf("%d:%02d:%02d", hours, minutes,
+    ret = QString::asprintf("%d:%02d:%02d", hours, minutes,
                 seconds);  // NOLINT(runtime/printf)
   else
-    ret.sprintf("%d:%02d", minutes, seconds);  // NOLINT(runtime/printf)
+    ret = QString::asprintf("%d:%02d", minutes, seconds);  // NOLINT(runtime/printf)
 
   return ret;
 }
@@ -165,13 +165,13 @@ QString PrettySize(quint64 bytes) {
     if (bytes <= 1000)
       ret = QString::number(bytes) + " bytes";
     else if (bytes <= 1000 * 1000)
-      ret.sprintf("%.1f KB",
+      ret = QString::asprintf("%.1f KB",
                   static_cast<float>(bytes) / 1000);  // NOLINT(runtime/printf)
     else if (bytes <= 1000 * 1000 * 1000)
-      ret.sprintf("%.1f MB", static_cast<float>(bytes) /
+      ret = QString::asprintf("%.1f MB", static_cast<float>(bytes) /
                                  (1000 * 1000));  // NOLINT(runtime/printf)
     else
-      ret.sprintf("%.1f GB",
+      ret = QString::asprintf("%.1f GB",
                   static_cast<float>(bytes) /
                       (1000 * 1000 * 1000));  // NOLINT(runtime/printf)
   }

--- a/src/devices/macdevicelister.mm
+++ b/src/devices/macdevicelister.mm
@@ -700,7 +700,7 @@ QList<QUrl> MacDeviceLister::MakeDeviceUrls(const QString& serial) {
   if (IsMTPSerial(serial)) {
     const MTPDevice& device = mtp_devices_[serial];
     QString str;
-    str.sprintf("gphoto2://usb-%d-%d/", device.bus, device.address);
+    str = QString::asprintf("gphoto2://usb-%d-%d/", device.bus, device.address);
     QUrlQuery url_query;
     url_query.addQueryItem("vendor", device.vendor);
     url_query.addQueryItem("vendor_id", QString::number(device.vendor_id));

--- a/src/ui/playbacksettingspage.cpp
+++ b/src/ui/playbacksettingspage.cpp
@@ -159,7 +159,7 @@ void PlaybackSettingsPage::Save() {
 void PlaybackSettingsPage::RgPreampChanged(int value) {
   float db = float(value) / 10 - 15;
   QString db_str;
-  db_str.sprintf("%+.1f dB", db);
+  db_str = QString::asprintf("%+.1f dB", db);
   ui_->replaygain_preamp_label->setText(db_str);
 }
 

--- a/src/widgets/stylehelper.cpp
+++ b/src/widgets/stylehelper.cpp
@@ -138,8 +138,8 @@ void StyleHelper::verticalGradient(QPainter* painter, const QRect& spanRect,
     QString key;
     QColor keyColor = baseColor(lightColored);
     key = QString::asprintf("mh_vertical %d %d %d %d %d", spanRect.width(),
-                spanRect.height(), clipRect.width(), clipRect.height(),
-                keyColor.rgb());
+                            spanRect.height(), clipRect.width(),
+                            clipRect.height(), keyColor.rgb());
     ;
 
     QPixmap pixmap;

--- a/src/widgets/stylehelper.cpp
+++ b/src/widgets/stylehelper.cpp
@@ -137,7 +137,7 @@ void StyleHelper::verticalGradient(QPainter* painter, const QRect& spanRect,
   if (StyleHelper::usePixmapCache()) {
     QString key;
     QColor keyColor = baseColor(lightColored);
-    key.sprintf("mh_vertical %d %d %d %d %d", spanRect.width(),
+    key = QString::asprintf("mh_vertical %d %d %d %d %d", spanRect.width(),
                 spanRect.height(), clipRect.width(), clipRect.height(),
                 keyColor.rgb());
     ;


### PR DESCRIPTION
QString::sprintf is obsolete and QString::asprintf is available since Qt 5.5 and should be used instead.
See https://doc.qt.io/qt-5/qstring-obsolete.html#sprintf