### PR TITLE
Replace QTime with QElapsedTimer

### DIFF
--- a/src/musicbrainz/chromaprinter.cpp
+++ b/src/musicbrainz/chromaprinter.cpp
@@ -19,10 +19,10 @@
 
 #include <QCoreApplication>
 #include <QDir>
+#include <QElapsedTimer>
 #include <QEventLoop>
 #include <QThread>
 #include <QtDebug>
-#include <QElapsedTimer>
 
 #include <chromaprint.h>
 

--- a/src/musicbrainz/chromaprinter.cpp
+++ b/src/musicbrainz/chromaprinter.cpp
@@ -22,7 +22,7 @@
 #include <QEventLoop>
 #include <QThread>
 #include <QtDebug>
-#include <QTime>
+#include <QElapsedTimer>
 
 #include <chromaprint.h>
 
@@ -109,7 +109,7 @@ QString Chromaprinter::CreateFingerprint() {
                    GST_SEEK_TYPE_SET, 0 * GST_SECOND, GST_SEEK_TYPE_SET,
                    kPlayLengthSecs * GST_SECOND);
 
-  QTime time;
+  QElapsedTimer time;
   time.start();
 
   // Start playing


### PR DESCRIPTION
Use of QTime::start - elapsed is deprecated in Qt 5.14 and QElapsedTimer does the same.
