### PR TITLE
Replace QModelIndex::child() with QAbstractItemModel::index()

### DIFF
--- a/src/globalsearch/globalsearchmodel.cpp
+++ b/src/globalsearch/globalsearchmodel.cpp
@@ -255,7 +255,7 @@ void GlobalSearchModel::GetChildResults(
     // Yes - visit all the children, but do so through the proxy so we get them
     // in the right order.
     for (int i = 0; i < item->rowCount(); ++i) {
-      const QModelIndex proxy_index = parent_proxy_index.child(i, 0);
+      const QModelIndex proxy_index = parent_proxy_index.model()->index(i, 0, parent_proxy_index);
       const QModelIndex index = proxy_->mapToSource(proxy_index);
       GetChildResults(itemFromIndex(index), results, visited);
     }

--- a/src/globalsearch/globalsearchmodel.cpp
+++ b/src/globalsearch/globalsearchmodel.cpp
@@ -255,7 +255,8 @@ void GlobalSearchModel::GetChildResults(
     // Yes - visit all the children, but do so through the proxy so we get them
     // in the right order.
     for (int i = 0; i < item->rowCount(); ++i) {
-      const QModelIndex proxy_index = parent_proxy_index.model()->index(i, 0, parent_proxy_index);
+      const QModelIndex proxy_index =
+          parent_proxy_index.model()->index(i, 0, parent_proxy_index);
       const QModelIndex index = proxy_->mapToSource(proxy_index);
       GetChildResults(itemFromIndex(index), results, visited);
     }

--- a/src/internet/core/internetmodel.cpp
+++ b/src/internet/core/internetmodel.cpp
@@ -273,7 +273,6 @@ QMimeData* InternetModel::mimeData(const QModelIndexList& indexes) const {
 
   QModelIndex last_valid_index;
   for (const QModelIndex& index : indexes) {
-
     if (!IsPlayable(index)) continue;
 
     last_valid_index = index;

--- a/src/internet/core/internetmodel.cpp
+++ b/src/internet/core/internetmodel.cpp
@@ -273,6 +273,7 @@ QMimeData* InternetModel::mimeData(const QModelIndexList& indexes) const {
 
   QModelIndex last_valid_index;
   for (const QModelIndex& index : indexes) {
+
     if (!IsPlayable(index)) continue;
 
     last_valid_index = index;
@@ -280,11 +281,12 @@ QMimeData* InternetModel::mimeData(const QModelIndexList& indexes) const {
       // Get children
       int row = 0;
       int column = 0;
-      QModelIndex child = index.child(row, column);
+      QModelIndex child = index.model()->index(row, column, index);
       while (child.isValid()) {
         new_indexes << child;
         urls << child.data(Role_Url).toUrl();
-        child = index.child(++row, column);
+        QModelIndex child_prev = child;
+        child = index.model()->index(++row, column, child_prev);
       }
     } else {
       new_indexes = indexes;

--- a/src/internet/podcasts/podcastservice.cpp
+++ b/src/internet/podcasts/podcastservice.cpp
@@ -170,7 +170,7 @@ void PodcastService::CopyToDevice(const QModelIndexList& episode_indexes,
 
   for (const QModelIndex& podcast : podcast_indexes) {
     for (int i = 0; i < podcast.model()->rowCount(podcast); ++i) {
-      const QModelIndex& index = podcast.child(i, 0);
+      const QModelIndex& index = podcast.model()->index(i, 0, podcast);
       episode_tmp = index.data(Role_Episode).value<PodcastEpisode>();
       if (episode_tmp.downloaded() && !episode_tmp.listened())
         episodes << episode_tmp;
@@ -204,7 +204,7 @@ void PodcastService::CancelDownload(const QModelIndexList& episode_indexes,
 
   for (const QModelIndex& podcast : podcast_indexes) {
     for (int i = 0; i < podcast.model()->rowCount(podcast); ++i) {
-      const QModelIndex& index = podcast.child(i, 0);
+      const QModelIndex& index = podcast.model()->index(i, 0, podcast);
       episode_tmp = index.data(Role_Episode).value<PodcastEpisode>();
       episodes << episode_tmp;
     }
@@ -803,7 +803,7 @@ void PodcastService::SetListened(const QModelIndexList& episode_indexes,
 
   for (const QModelIndex& podcast : podcast_indexes) {
     for (int i = 0; i < podcast.model()->rowCount(podcast); ++i) {
-      const QModelIndex& index = podcast.child(i, 0);
+      const QModelIndex& index = podcast.model()->index(i, 0, podcast);
       episodes << index.data(Role_Episode).value<PodcastEpisode>();
     }
   }

--- a/src/internet/podcasts/podcastservicemodel.cpp
+++ b/src/internet/podcasts/podcastservicemodel.cpp
@@ -79,7 +79,7 @@ void PodcastServiceModel::MimeDataForPodcast(const QModelIndex& index,
   const int children = index.model()->rowCount(index);
   for (int i = 0; i < children; ++i) {
     QVariant episode_variant =
-        index.child(i, 0).data(PodcastService::Role_Episode);
+        index.model()->index(i, 0, index).data(PodcastService::Role_Episode);
     if (!episode_variant.isValid()) continue;
 
     PodcastEpisode episode(episode_variant.value<PodcastEpisode>());

--- a/src/playlist/playlistlistcontainer.cpp
+++ b/src/playlist/playlistlistcontainer.cpp
@@ -452,7 +452,7 @@ void PlaylistListContainer::RecursivelyFindPlaylists(const QModelIndex& parent,
 
     case PlaylistListModel::Type_Folder:
       for (int i = 0; i < parent.model()->rowCount(parent); ++i) {
-        RecursivelyFindPlaylists(parent.child(i, 0), ids);
+        RecursivelyFindPlaylists(parent.model()->index(i, 0, parent), ids);
       }
       break;
   }


### PR DESCRIPTION
QModelIndex::child() is obsolete. See: https://doc.qt.io/qt-5/qmodelindex-obsolete.html
