### PR TITLE
Fix abort from Mtp loader thread.

### DIFF
--- a/src/devices/mtpdevice.cpp
+++ b/src/devices/mtpdevice.cpp
@@ -69,6 +69,7 @@ void MtpDevice::LoadFinished(bool success) {
   loader_->deleteLater();
   loader_ = nullptr;
   db_busy_.unlock();
+  loader_thread_->quit();
   emit ConnectFinished(unique_id_, success);
 }
 


### PR DESCRIPTION
A commit in qt 5.7 changes a qWarning to a qFatal if a QThread is still running
when it's deleted. When we get the LoadFinished signal in MtpDevice, stop
the loader thread's event loop to avoid this situation.

See qtbase commit c8277b6e532