### PR TITLE
Properly handle connect errors when initiated from properties dialog.

### DIFF
--- a/src/devices/devicemanager.cpp
+++ b/src/devices/devicemanager.cpp
@@ -586,6 +586,7 @@ void DeviceManager::DeviceConnectFinished(const QString& id, bool success) {
     emit DeviceConnected(idx);
   } else {
     info->device_.reset();
+    emit dataChanged(idx, idx);
   }
 }
 

--- a/src/devices/devicemanager.h
+++ b/src/devices/devicemanager.h
@@ -87,6 +87,9 @@ class DeviceManager : public SimpleTreeModel<DeviceInfo> {
   void Disconnect(QModelIndex idx);
   void Forget(QModelIndex idx);
   void UnmountAsync(QModelIndex idx);
+  bool IsConnected(QModelIndex idx) {
+    return GetConnectedDevice(idx) != nullptr;
+  }
 
   void SetDeviceOptions(QModelIndex idx, const QString& friendly_name,
                         const QString& icon_name,

--- a/src/devices/deviceproperties.cpp
+++ b/src/devices/deviceproperties.cpp
@@ -264,6 +264,13 @@ void DeviceProperties::OpenDevice() { manager_->Connect(index_); }
 void DeviceProperties::UpdateFormatsFinished(QFuture<bool> future) {
   updating_formats_ = false;
 
+  // Check if the device was disconnected while the thread was running. In that
+  // case, ModelChanged would be called and the not connected page would be
+  // shown.
+  if (!manager_->IsConnected(index_)) {
+    return;
+  }
+
   if (!future.result()) {
     supported_formats_.clear();
   }


### PR DESCRIPTION
If connection fails when initiated from the device properties dialog, the
connected page is shown after the update formats worker thread completes.