### PR TITLE
Fix closure timing hole.

### DIFF
--- a/ext/libclementine-common/core/closure.cpp
+++ b/ext/libclementine-common/core/closure.cpp
@@ -37,8 +37,15 @@ ObjectHelper* ClosureBase::helper() const { return helper_; }
 ObjectHelper::ObjectHelper(QObject* sender, const char* signal,
                            ClosureBase* closure)
     : closure_(closure) {
-  connect(sender, signal, SLOT(Invoked()));
-  connect(sender, SIGNAL(destroyed()), SLOT(deleteLater()));
+  connection_ = connect(sender, signal, SLOT(Invoked()));
+  connect(sender, SIGNAL(destroyed()), SLOT(TearDown()));
+}
+
+void ObjectHelper::TearDown() {
+  // For the case that the receiver has been destroyed, disconnect the signal
+  // so that Invoke isn't called.
+  disconnect(connection_);
+  deleteLater();
 }
 
 void ObjectHelper::Invoked() {


### PR DESCRIPTION
When a closure involves an ObjectHelper, a connection is made from the
receiver's destroyed signal and the helper object's deleteLater slot. Since
the signal between the sender and the helper object isn't disconnected until
either object is actually destroyed, this leaves a hole where the helper
holds a pointer to an invalid receiver object, but is still able to receive
the signal connected to its Invoke slot.

Instead of connecting the destroyed signal to deleteLater, connect it to a new
TearDown slot that immediately disconnects the signal then calls deleteLater.