### PR TITLE
Prevent deletion of LibraryModel object while async query is running.

### DIFF
--- a/src/library/librarymodel.h
+++ b/src/library/librarymodel.h
@@ -21,6 +21,7 @@
 #include <QAbstractItemModel>
 #include <QIcon>
 #include <QNetworkDiskCache>
+#include <QThreadPool>
 
 #include "libraryitem.h"
 #include "libraryquery.h"
@@ -291,6 +292,8 @@ signals:
   QIcon playlist_icon_;
 
   QNetworkDiskCache* icon_cache_;
+
+  QThreadPool thread_pool_;
 
   int init_task_id_;
 


### PR DESCRIPTION
Create a thread pool for each LibraryModel object and block destruction until
all threads that are operating on this object are complete.

Note that this is not a complete solution. The async query also uses the library
backend which may still be deleted before the thread exits. This will be
addressed in a future change.