### PR TITLE
Fix LibraryModel async query crash.

### DIFF
--- a/src/devices/connecteddevice.h
+++ b/src/devices/connecteddevice.h
@@ -84,7 +84,7 @@ signals:
   int database_id_;
   DeviceManager* manager_;
 
-  LibraryBackend* backend_;
+  std::shared_ptr<LibraryBackend> backend_;
   LibraryModel* model_;
 
   int song_count_;

--- a/src/devices/filesystemdevice.cpp
+++ b/src/devices/filesystemdevice.cpp
@@ -43,24 +43,25 @@ FilesystemDevice::FilesystemDevice(const QUrl& url, DeviceLister* lister,
           ->data(manager->ItemToIndex(manager->FindDeviceById(unique_id)),
                  DeviceManager::Role_FriendlyName)
           .toString());
-  watcher_->set_backend(backend_);
+  watcher_->set_backend(backend_.get());
   watcher_->set_task_manager(app_->task_manager());
 
-  connect(backend_, SIGNAL(DirectoryDiscovered(Directory, SubdirectoryList)),
-          watcher_, SLOT(AddDirectory(Directory, SubdirectoryList)));
-  connect(backend_, SIGNAL(DirectoryDeleted(Directory)), watcher_,
+  connect(backend_.get(),
+          SIGNAL(DirectoryDiscovered(Directory, SubdirectoryList)), watcher_,
+          SLOT(AddDirectory(Directory, SubdirectoryList)));
+  connect(backend_.get(), SIGNAL(DirectoryDeleted(Directory)), watcher_,
           SLOT(RemoveDirectory(Directory)));
-  connect(watcher_, SIGNAL(NewOrUpdatedSongs(SongList)), backend_,
+  connect(watcher_, SIGNAL(NewOrUpdatedSongs(SongList)), backend_.get(),
           SLOT(AddOrUpdateSongs(SongList)));
-  connect(watcher_, SIGNAL(SongsMTimeUpdated(SongList)), backend_,
+  connect(watcher_, SIGNAL(SongsMTimeUpdated(SongList)), backend_.get(),
           SLOT(UpdateMTimesOnly(SongList)));
-  connect(watcher_, SIGNAL(SongsDeleted(SongList)), backend_,
+  connect(watcher_, SIGNAL(SongsDeleted(SongList)), backend_.get(),
           SLOT(DeleteSongs(SongList)));
-  connect(watcher_, SIGNAL(SubdirsDiscovered(SubdirectoryList)), backend_,
+  connect(watcher_, SIGNAL(SubdirsDiscovered(SubdirectoryList)), backend_.get(),
           SLOT(AddOrUpdateSubdirs(SubdirectoryList)));
-  connect(watcher_, SIGNAL(SubdirsMTimeUpdated(SubdirectoryList)), backend_,
-          SLOT(AddOrUpdateSubdirs(SubdirectoryList)));
-  connect(watcher_, SIGNAL(CompilationsNeedUpdating()), backend_,
+  connect(watcher_, SIGNAL(SubdirsMTimeUpdated(SubdirectoryList)),
+          backend_.get(), SLOT(AddOrUpdateSubdirs(SubdirectoryList)));
+  connect(watcher_, SIGNAL(CompilationsNeedUpdating()), backend_.get(),
           SLOT(UpdateCompilations()));
   connect(watcher_, SIGNAL(ScanStarted(int)), SIGNAL(TaskStarted(int)));
 }

--- a/src/devices/gpodloader.cpp
+++ b/src/devices/gpodloader.cpp
@@ -28,7 +28,7 @@
 #include <QtDebug>
 
 GPodLoader::GPodLoader(const QString& mount_point, TaskManager* task_manager,
-                       LibraryBackend* backend,
+                       std::shared_ptr<LibraryBackend> backend,
                        std::shared_ptr<ConnectedDevice> device)
     : QObject(nullptr),
       device_(device),

--- a/src/devices/gpodloader.h
+++ b/src/devices/gpodloader.h
@@ -35,7 +35,8 @@ class GPodLoader : public QObject {
 
  public:
   GPodLoader(const QString& mount_point, TaskManager* task_manager,
-             LibraryBackend* backend, std::shared_ptr<ConnectedDevice> device);
+             std::shared_ptr<LibraryBackend> backend,
+             std::shared_ptr<ConnectedDevice> device);
   ~GPodLoader();
 
   void set_music_path_prefix(const QString& prefix) { path_prefix_ = prefix; }
@@ -57,7 +58,7 @@ signals:
   QString path_prefix_;
   Song::FileType type_;
   TaskManager* task_manager_;
-  LibraryBackend* backend_;
+  std::shared_ptr<LibraryBackend> backend_;
 };
 
 #endif  // GPODLOADER_H

--- a/src/devices/mtploader.cpp
+++ b/src/devices/mtploader.cpp
@@ -26,7 +26,7 @@
 #include "library/librarybackend.h"
 
 MtpLoader::MtpLoader(const QUrl& url, TaskManager* task_manager,
-                     LibraryBackend* backend,
+                     std::shared_ptr<LibraryBackend> backend,
                      std::shared_ptr<ConnectedDevice> device)
     : QObject(nullptr),
       device_(device),

--- a/src/devices/mtploader.h
+++ b/src/devices/mtploader.h
@@ -31,7 +31,8 @@ class MtpLoader : public QObject {
   Q_OBJECT
 
  public:
-  MtpLoader(const QUrl& url, TaskManager* task_manager, LibraryBackend* backend,
+  MtpLoader(const QUrl& url, TaskManager* task_manager,
+            std::shared_ptr<LibraryBackend> backend,
             std::shared_ptr<ConnectedDevice> device);
   ~MtpLoader();
 
@@ -52,7 +53,7 @@ signals:
 
   QUrl url_;
   TaskManager* task_manager_;
-  LibraryBackend* backend_;
+  std::shared_ptr<LibraryBackend> backend_;
 };
 
 #endif  // MTPLOADER_H

--- a/src/internet/core/cloudfileservice.h
+++ b/src/internet/core/cloudfileservice.h
@@ -79,7 +79,7 @@ signals:
   QStandardItem* root_;
   NetworkAccessManager* network_;
 
-  LibraryBackend* library_backend_;
+  std::shared_ptr<LibraryBackend> library_backend_;
   LibraryModel* library_model_;
   QSortFilterProxyModel* library_sort_model_;
 

--- a/src/internet/jamendo/jamendoservice.h
+++ b/src/internet/jamendo/jamendoservice.h
@@ -53,7 +53,7 @@ class JamendoService : public InternetService {
 
   QWidget* HeaderWidget() const;
 
-  LibraryBackend* library_backend() const { return library_backend_; }
+  LibraryBackend* library_backend() const { return library_backend_.get(); }
 
   static const char* kServiceName;
   static const char* kDirectoryUrl;
@@ -110,7 +110,7 @@ class JamendoService : public InternetService {
   QAction* album_info_;
   QAction* download_album_;
 
-  LibraryBackend* library_backend_;
+  std::shared_ptr<LibraryBackend> library_backend_;
   LibraryFilterWidget* library_filter_;
   LibraryModel* library_model_;
   QSortFilterProxyModel* library_sort_model_;

--- a/src/internet/magnatune/magnatuneservice.h
+++ b/src/internet/magnatune/magnatuneservice.h
@@ -20,6 +20,8 @@
 #ifndef INTERNET_MAGNATUNE_MAGNATUNESERVICE_H_
 #define INTERNET_MAGNATUNE_MAGNATUNESERVICE_H_
 
+#include <memory>
+
 #include <QXmlStreamReader>
 
 #include "internet/core/internetservice.h"
@@ -84,7 +86,7 @@ class MagnatuneService : public InternetService {
   PreferredFormat preferred_format() const { return format_; }
   QString username() const { return username_; }
   QString password() const { return password_; }
-  LibraryBackend* library_backend() const { return library_backend_; }
+  LibraryBackend* library_backend() const { return library_backend_.get(); }
 
   QUrl ModifyUrl(const QUrl& url) const;
 
@@ -113,7 +115,7 @@ class MagnatuneService : public InternetService {
 
   QAction* download_;
 
-  LibraryBackend* library_backend_;
+  std::shared_ptr<LibraryBackend> library_backend_;
   LibraryModel* library_model_;
   LibraryFilterWidget* library_filter_;
   QSortFilterProxyModel* library_sort_model_;

--- a/src/internet/subsonic/subsonicservice.cpp
+++ b/src/internet/subsonic/subsonicservice.cpp
@@ -81,11 +81,12 @@ SubsonicService::SubsonicService(Application* app, InternetModel* parent)
 
   connect(scanner_, SIGNAL(ScanFinished()), SLOT(ReloadDatabaseFinished()));
 
-  library_backend_ = new LibraryBackend;
+  library_backend_.reset(new LibraryBackend,
+                         [](QObject* obj) { obj->deleteLater(); });
   library_backend_->moveToThread(app_->database()->thread());
   library_backend_->Init(app_->database(), kSongsTable, QString(), QString(),
                          kFtsTable);
-  connect(library_backend_, SIGNAL(TotalSongCountUpdated(int)),
+  connect(library_backend_.get(), SIGNAL(TotalSongCountUpdated(int)),
           SLOT(UpdateTotalSongCount(int)));
 
   using smart_playlists::Generator;
@@ -147,7 +148,7 @@ SubsonicService::SubsonicService(Application* app, InternetModel* parent)
   library_filter_->AddMenuAction(config_action);
 
   app_->global_search()->AddProvider(new LibrarySearchProvider(
-      library_backend_, tr("Subsonic"), "subsonic",
+      library_backend_.get(), tr("Subsonic"), "subsonic",
       IconLoader::Load("subsonic", IconLoader::Provider), true, app_, this));
 }
 

--- a/src/internet/subsonic/subsonicservice.h
+++ b/src/internet/subsonic/subsonicservice.h
@@ -22,6 +22,8 @@
 #ifndef INTERNET_SUBSONIC_SUBSONICSERVICE_H_
 #define INTERNET_SUBSONIC_SUBSONICSERVICE_H_
 
+#include <memory>
+
 #include <QQueue>
 
 #include "internet/core/internetmodel.h"
@@ -143,7 +145,7 @@ signals:
   QMenu* context_menu_;
   QStandardItem* root_;
 
-  LibraryBackend* library_backend_;
+  std::shared_ptr<LibraryBackend> library_backend_;
   LibraryModel* library_model_;
   LibraryFilterWidget* library_filter_;
   QSortFilterProxyModel* library_sort_model_;

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -18,6 +18,8 @@
 #ifndef LIBRARY_H
 #define LIBRARY_H
 
+#include <memory>
+
 #include <QHash>
 #include <QObject>
 #include <QUrl>
@@ -46,7 +48,7 @@ class Library : public QObject {
 
   void Init();
 
-  LibraryBackend* backend() const { return backend_; }
+  LibraryBackend* backend() const { return backend_.get(); }
   LibraryModel* model() const { return model_; }
 
   QString full_rescan_reason(int schema_version) const {
@@ -76,7 +78,7 @@ class Library : public QObject {
 
  private:
   Application* app_;
-  LibraryBackend* backend_;
+  std::shared_ptr<LibraryBackend> backend_;
   LibraryModel* model_;
 
   LibraryWatcher* watcher_;

--- a/src/library/librarymodel.cpp
+++ b/src/library/librarymodel.cpp
@@ -74,12 +74,12 @@ static bool IsCompilationArtistNode(const LibraryItem* node) {
   return node == node->parent->compilation_artist_node_;
 }
 
-LibraryModel::LibraryModel(LibraryBackend* backend, Application* app,
-                           QObject* parent)
+LibraryModel::LibraryModel(std::shared_ptr<LibraryBackend> backend,
+                           Application* app, QObject* parent)
     : SimpleTreeModel<LibraryItem>(new LibraryItem(this), parent),
       backend_(backend),
       app_(app),
-      dir_model_(new LibraryDirectoryModel(backend, this)),
+      dir_model_(new LibraryDirectoryModel(backend.get(), this)),
       show_smart_playlists_(false),
       show_various_artists_(true),
       total_song_count_(0),
@@ -115,16 +115,16 @@ LibraryModel::LibraryModel(LibraryBackend* backend, Application* app,
                            Qt::KeepAspectRatio,
                            Qt::SmoothTransformation);
 
-  connect(backend_, SIGNAL(SongsDiscovered(SongList)),
+  connect(backend_.get(), SIGNAL(SongsDiscovered(SongList)),
           SLOT(SongsDiscovered(SongList)));
-  connect(backend_, SIGNAL(SongsDeleted(SongList)),
+  connect(backend_.get(), SIGNAL(SongsDeleted(SongList)),
           SLOT(SongsDeleted(SongList)));
-  connect(backend_, SIGNAL(SongsStatisticsChanged(SongList)),
+  connect(backend_.get(), SIGNAL(SongsStatisticsChanged(SongList)),
           SLOT(SongsSlightlyChanged(SongList)));
-  connect(backend_, SIGNAL(SongsRatingChanged(SongList)),
+  connect(backend_.get(), SIGNAL(SongsRatingChanged(SongList)),
           SLOT(SongsSlightlyChanged(SongList)));
-  connect(backend_, SIGNAL(DatabaseReset()), SLOT(Reset()));
-  connect(backend_, SIGNAL(TotalSongCountUpdated(int)),
+  connect(backend_.get(), SIGNAL(DatabaseReset()), SLOT(Reset()));
+  connect(backend_.get(), SIGNAL(TotalSongCountUpdated(int)),
           SLOT(TotalSongCountUpdatedSlot(int)));
 
   backend_->UpdateTotalSongCountAsync();
@@ -1269,7 +1269,7 @@ QMimeData* LibraryModel::mimeData(const QModelIndexList& indexes) const {
   QList<QUrl> urls;
   QSet<int> song_ids;
 
-  data->backend = backend_;
+  data->backend = backend_.get();
 
   for (const QModelIndex& index : indexes) {
     GetChildSongs(IndexToItem(index), &urls, &data->songs, &song_ids);

--- a/src/library/librarymodel.h
+++ b/src/library/librarymodel.h
@@ -18,6 +18,8 @@
 #ifndef LIBRARYMODEL_H
 #define LIBRARYMODEL_H
 
+#include <memory>
+
 #include <QAbstractItemModel>
 #include <QIcon>
 #include <QNetworkDiskCache>
@@ -49,7 +51,7 @@ class LibraryModel : public SimpleTreeModel<LibraryItem> {
   Q_ENUMS(GroupBy)
 
  public:
-  LibraryModel(LibraryBackend* backend, Application* app,
+  LibraryModel(std::shared_ptr<LibraryBackend> backend, Application* app,
                QObject* parent = nullptr);
   ~LibraryModel();
 
@@ -117,7 +119,7 @@ class LibraryModel : public SimpleTreeModel<LibraryItem> {
     bool create_va;
   };
 
-  LibraryBackend* backend() const { return backend_; }
+  LibraryBackend* backend() const { return backend_.get(); }
   LibraryDirectoryModel* directory_model() const { return dir_model_; }
 
   typedef QList<smart_playlists::GeneratorPtr> GeneratorList;
@@ -259,7 +261,7 @@ signals:
   bool CompareItems(const LibraryItem* a, const LibraryItem* b) const;
 
  private:
-  LibraryBackend* backend_;
+  std::shared_ptr<LibraryBackend> backend_;
   Application* app_;
   LibraryDirectoryModel* dir_model_;
   bool show_smart_playlists_;


### PR DESCRIPTION
A LibraryBackend may be deleted while an associated LibraryModel object is using
it. An example is an async query running while a connected device is removed.
To prevent this, use a share pointer for the LibraryBackend.

This fixes one case where LibraryBackend is used after deletion. However, the
raw pointer is still passed around in several other places. These should be
evaluated on a case-by-case basis to insure that circular depencencies aren't
introduced.