### PR TITLE
Broken mtp

### DIFF
--- a/src/devices/giolister.cpp
+++ b/src/devices/giolister.cpp
@@ -352,6 +352,12 @@ QString GioLister::DeviceInfo::ConvertAndFree(char* str) {
   return ret;
 }
 
+QString GioLister::DeviceInfo::DecodeAndFree(char* str) {
+  QString ret = QByteArray::fromPercentEncoding(str);
+  g_free(str);
+  return ret;
+}
+
 void GioLister::DeviceInfo::ReadMountInfo(GMount* mount) {
   // Get basic information
   this->mount.reset_without_add(mount);
@@ -374,7 +380,7 @@ void GioLister::DeviceInfo::ReadMountInfo(GMount* mount) {
 
   // Get the mount path
   mount_path = ConvertAndFree(g_file_get_path(root));
-  mount_uri = ConvertAndFree(g_file_get_uri(root));
+  mount_uri = DecodeAndFree(g_file_get_uri(root));
 
   // Do a sanity check to make sure the root is actually this mount - when a
   // device is unmounted GIO sends a changed signal before the removed signal,

--- a/src/devices/giolister.cpp
+++ b/src/devices/giolister.cpp
@@ -73,6 +73,15 @@ void GioLister::VolumeMountFinished(GObject* object, GAsyncResult* result,
                              object, result);
 }
 
+GioLister::GioLister() {
+  // Direct usage of libmtp and libgphoto2 conflicts with gvfs's usage as both
+  // attempt to claim the interface via libusb. When these devices are mounted
+  // by gvfs, ignore the URIs with those schemes and use the file scheme
+  // instead.
+  scheme_blacklist_ << "mtp";
+  scheme_blacklist_ << "gphoto2";
+}
+
 void GioLister::Init() {
   monitor_.reset_without_add(g_volume_monitor_get());
 
@@ -198,7 +207,7 @@ QList<QUrl> GioLister::MakeDeviceUrls(const QString& id) {
     // to an ipod.
     if (url.scheme() == "file") {
       ret << MakeUrlFromLocalPath(url.path());
-    } else {
+    } else if (!scheme_blacklist_.contains(url.scheme())) {
       ret << url;
     }
   }

--- a/src/devices/giolister.h
+++ b/src/devices/giolister.h
@@ -72,7 +72,11 @@ class GioLister : public DeviceLister {
     QString unique_id() const;
     bool is_suitable() const;
 
+    // Convert a gio property string to a QString and free the original.
     static QString ConvertAndFree(char* str);
+    // Like ConvertAndFree, but perform url decoding.
+    static QString DecodeAndFree(char* str);
+
     void ReadDriveInfo(GDrive* drive);
     void ReadVolumeInfo(GVolume* volume);
     void ReadMountInfo(GMount* mount);

--- a/src/devices/giolister.h
+++ b/src/devices/giolister.h
@@ -35,7 +35,7 @@ class GioLister : public DeviceLister {
   Q_OBJECT
 
  public:
-  GioLister() {}
+  GioLister();
   ~GioLister();
 
   int priority() const { return 50; }
@@ -146,6 +146,8 @@ class GioLister : public DeviceLister {
 
   QMutex mutex_;
   QMap<QString, DeviceInfo> devices_;
+
+  QStringList scheme_blacklist_;
 };
 
 template <typename T>


### PR DESCRIPTION
Using libmtp or libgphoto2 to access a device that gvfs has mounted causes the connection to fail. libmtp is calling libusb_claim_interface which, according to libusb documentation, will return LIBUSB_ERROR_BUSY if claimed by a different program. For mtp and gphoto2 devices discovered by the GioLister, use the file scheme and access the device through the gvfs mount.
