### PR TITLE
Support compiling with Boost 1.69

### DIFF
--- a/src/networkremote/incomingdataparser.cpp
+++ b/src/networkremote/incomingdataparser.cpp
@@ -268,7 +268,7 @@ void IncomingDataParser::InsertUrls(const pb::remote::Message& msg) {
   const pb::remote::RequestInsertUrls& request = msg.request_insert_urls();
 
   // Insert plain urls without metadata
-  if (!request.urls().empty()) {
+  if (request.urls().size() > 0) {
     QList<QUrl> urls;
     for (auto it = request.urls().begin(); it != request.urls().end(); ++it) {
       std::string s = *it;
@@ -281,7 +281,7 @@ void IncomingDataParser::InsertUrls(const pb::remote::Message& msg) {
   }
 
   // Add songs with metadata if present
-  if (!request.songs().empty()) {
+  if (request.songs().size() > 0) {
     SongList songs;
     for (int i = 0; i < request.songs().size(); i++) {
       songs << CreateSongFromProtobuf(request.songs(i));


### PR DESCRIPTION
This allows compilation on RHEL/CentOS 7 on which the latest available Boost version is 1.69.