### PR TITLE
Fix hung progress indicator on device disconnect.

### DIFF
--- a/src/library/librarywatcher.cpp
+++ b/src/library/librarywatcher.cpp
@@ -102,7 +102,10 @@ LibraryWatcher::ScanTransaction::ScanTransaction(LibraryWatcher* watcher,
 
 LibraryWatcher::ScanTransaction::~ScanTransaction() {
   // If we're stopping then don't commit the transaction
-  if (watcher_->stop_requested_) return;
+  if (watcher_->stop_requested_) {
+    watcher_->task_manager_->SetTaskFinished(task_id_);
+    return;
+  }
 
   if (!new_songs.isEmpty()) emit watcher_->NewOrUpdatedSongs(new_songs);
 


### PR DESCRIPTION
When a device is removed during a scan, the scan is cancelled, but the task is
not set to finished.