### PR TITLE
Prevent runaway cover art searches.

### DIFF
--- a/src/library/librarywatcher.cpp
+++ b/src/library/librarywatcher.cpp
@@ -48,6 +48,8 @@ static const char *kNoMediaFile = ".nomedia";
 static const char *kNoMusicFile   = ".nomusic";
 }
 
+static const int kUnfilteredImageLimit = 10;
+
 QStringList LibraryWatcher::sValidImages;
 
 const char* LibraryWatcher::kSettingsGroup = "LibraryWatcher";
@@ -714,6 +716,15 @@ QString LibraryWatcher::PickBestImage(const QStringList& images) {
   }
 
   if (filtered.isEmpty()) {
+    // If we're scanning a device, we may hit a directory that contains
+    // multiple types of media. An example is a camera directory on a smart
+    // phone that contains JPG and MP4. We don't want to cycle through hundreds
+    // of images for each audio file found, so we've set a threshold to try to
+    // detect this case.
+    if (images.count() > kUnfilteredImageLimit) {
+      return "";
+    }
+
     // the filter was too restrictive, just use the original list
     filtered = images;
   }


### PR DESCRIPTION
When scanning a device such as a mobile phone, it's likely that a directory
containing both image and audio files will be found. Besides the appearance of a
hung scan, it's unlikely that a relevant image will be found.

In the case where filters for relevant filenames don't yield results, set a
sanity limit on the number of images. If the list size is beyond than that
threshold, return an empty path.