### PR TITLE
Delete DeviceLister worker thread.

### DIFF
--- a/src/devices/devicelister.cpp
+++ b/src/devices/devicelister.cpp
@@ -34,6 +34,7 @@ DeviceLister::~DeviceLister() {
   if (thread_) {
     thread_->quit();
     thread_->wait(1000);
+    thread_->deleteLater();
   }
 }
 


### PR DESCRIPTION
This isn't a serious leak since the lister is only destroyed when Clementine
exits.