### PR TITLE
Early detect device removal

### DIFF
--- a/src/core/metatypes.cpp
+++ b/src/core/metatypes.cpp
@@ -70,6 +70,7 @@ void RegisterMetaTypes() {
   qRegisterMetaType<GstElement*>("GstElement*");
   qRegisterMetaType<GstEngine::OutputDetails>("GstEngine::OutputDetails");
   qRegisterMetaType<GstEnginePipeline*>("GstEnginePipeline*");
+  qRegisterMetaType<const MountInfo*>("const MountInfo*");
   qRegisterMetaType<PlaylistItemList>("PlaylistItemList");
   qRegisterMetaType<PlaylistItemPtr>("PlaylistItemPtr");
   qRegisterMetaType<PodcastEpisodeList>("PodcastEpisodeList");

--- a/src/devices/connecteddevice.h
+++ b/src/devices/connecteddevice.h
@@ -33,6 +33,7 @@ class DeviceLister;
 class DeviceManager;
 class LibraryBackend;
 class LibraryModel;
+struct MountInfo;
 
 class ConnectedDevice : public QObject,
                         public virtual MusicStorage,
@@ -85,6 +86,7 @@ signals:
   DeviceManager* manager_;
 
   std::shared_ptr<LibraryBackend> backend_;
+  std::shared_ptr<MountInfo> mount_info_;
   LibraryModel* model_;
 
   int song_count_;

--- a/src/library/directory.h
+++ b/src/library/directory.h
@@ -24,13 +24,21 @@
 
 class QSqlQuery;
 
+struct MountInfo {
+  MountInfo() : removable_(false) {}
+  bool removable_;
+};
+Q_DECLARE_METATYPE(MountInfo)
+
 struct Directory {
   Directory() : id(-1) {}
+  Directory(const MountInfo& info) : mount_info_(info), id(-1) {}
 
   bool operator==(const Directory& other) const {
     return path == other.path && id == other.id;
   }
 
+  MountInfo mount_info_;
   QString path;
   int id;
 };

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -17,14 +17,15 @@
 
 #include "library.h"
 
-#include "librarymodel.h"
-#include "librarybackend.h"
 #include "core/application.h"
 #include "core/database.h"
 #include "core/player.h"
 #include "core/tagreaderclient.h"
 #include "core/taskmanager.h"
 #include "core/thread.h"
+#include "librarybackend.h"
+#include "librarydirectorymodel.h"
+#include "librarymodel.h"
 #include "smartplaylists/generator.h"
 #include "smartplaylists/querygenerator.h"
 #include "smartplaylists/search.h"
@@ -38,6 +39,7 @@ Library::Library(Application* app, QObject* parent)
     : QObject(parent),
       app_(app),
       backend_(nullptr),
+      mount_info_(new MountInfo),
       model_(nullptr),
       watcher_(nullptr),
       watcher_thread_(nullptr),
@@ -56,6 +58,7 @@ Library::Library(Application* app, QObject* parent)
   using smart_playlists::SearchTerm;
 
   model_ = new LibraryModel(backend_, app_, this);
+  model_->directory_model()->SetMountInfo(mount_info_);
   model_->set_show_smart_playlists(true);
   model_->set_default_smart_playlists(
       LibraryModel::DefaultGenerators()
@@ -168,7 +171,7 @@ void Library::Init() {
   connect(app_->player(), SIGNAL(Stopped()), SLOT(Stopped()));
 
   // This will start the watcher checking for updates
-  backend_->LoadDirectoriesAsync();
+  backend_->LoadDirectoriesAsync(mount_info_.get());
 }
 
 void Library::IncrementalScan() { watcher_->IncrementalScanAsync(); }

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -33,6 +33,7 @@ class LibraryModel;
 class LibraryWatcher;
 class TaskManager;
 class Thread;
+struct MountInfo;
 
 class Library : public QObject {
   Q_OBJECT
@@ -79,6 +80,7 @@ class Library : public QObject {
  private:
   Application* app_;
   std::shared_ptr<LibraryBackend> backend_;
+  std::shared_ptr<MountInfo> mount_info_;
   LibraryModel* model_;
 
   LibraryWatcher* watcher_;

--- a/src/library/librarybackend.h
+++ b/src/library/librarybackend.h
@@ -69,14 +69,14 @@ class LibraryBackendInterface : public QObject {
   virtual QString songs_table() const = 0;
 
   // Get a list of directories in the library.  Emits DirectoriesDiscovered.
-  virtual void LoadDirectoriesAsync() = 0;
+  virtual void LoadDirectoriesAsync(const MountInfo* mount_info) = 0;
 
   // Counts the songs in the library.  Emits TotalSongCountUpdated
   virtual void UpdateTotalSongCountAsync() = 0;
 
   virtual SongList FindSongsInDirectory(int id) = 0;
   virtual SubdirectoryList SubdirsInDirectory(int id) = 0;
-  virtual DirectoryList GetAllDirectories() = 0;
+  virtual DirectoryList GetAllDirectories(const MountInfo* info) = 0;
   virtual void ChangeDirPath(int id, const QString& old_path,
                              const QString& new_path) = 0;
 
@@ -118,7 +118,8 @@ class LibraryBackendInterface : public QObject {
   // songs.
   virtual Song GetSongByUrl(const QUrl& url, qint64 beginning = 0) = 0;
 
-  virtual void AddDirectory(const QString& path) = 0;
+  virtual void AddDirectory(const MountInfo* mount_info,
+                            const QString& path) = 0;
   virtual void RemoveDirectory(const Directory& dir) = 0;
 
   virtual bool ExecQuery(LibraryQuery* q) = 0;
@@ -141,14 +142,14 @@ class LibraryBackend : public LibraryBackendInterface {
   QString subdirs_table() const { return subdirs_table_; }
 
   // Get a list of directories in the library.  Emits DirectoriesDiscovered.
-  void LoadDirectoriesAsync();
+  void LoadDirectoriesAsync(const MountInfo* mount_info);
 
   // Counts the songs in the library.  Emits TotalSongCountUpdated
   void UpdateTotalSongCountAsync();
 
   SongList FindSongsInDirectory(int id);
   SubdirectoryList SubdirsInDirectory(int id);
-  DirectoryList GetAllDirectories();
+  DirectoryList GetAllDirectories(const MountInfo* info);
   void ChangeDirPath(int id, const QString& old_path, const QString& new_path);
 
   QStringList GetAll(const QString& column,
@@ -185,7 +186,7 @@ class LibraryBackend : public LibraryBackendInterface {
   SongList GetSongsByUrl(const QUrl& url);
   Song GetSongByUrl(const QUrl& url, qint64 beginning = 0);
 
-  void AddDirectory(const QString& path);
+  void AddDirectory(const MountInfo* mount_info, const QString& path);
   void RemoveDirectory(const Directory& dir);
 
   bool ExecQuery(LibraryQuery* q);
@@ -202,7 +203,7 @@ class LibraryBackend : public LibraryBackendInterface {
   void DeleteAll();
 
  public slots:
-  void LoadDirectories();
+  void LoadDirectories(const MountInfo* mount_info);
   void UpdateTotalSongCount();
   void AddOrUpdateSongs(const SongList& songs);
   void UpdateMTimesOnly(const SongList& songs);

--- a/src/library/librarydirectorymodel.cpp
+++ b/src/library/librarydirectorymodel.cpp
@@ -65,7 +65,7 @@ void LibraryDirectoryModel::DirectoryDeleted(const Directory& dir) {
 void LibraryDirectoryModel::AddDirectory(const QString& path) {
   if (!backend_) return;
 
-  backend_->AddDirectory(path);
+  backend_->AddDirectory(mount_info_.get(), path);
 }
 
 void LibraryDirectoryModel::RemoveDirectory(const QModelIndex& index) {

--- a/src/library/librarydirectorymodel.h
+++ b/src/library/librarydirectorymodel.h
@@ -35,6 +35,10 @@ class LibraryDirectoryModel : public QStandardItemModel {
   LibraryDirectoryModel(LibraryBackend* backend, QObject* parent = nullptr);
   ~LibraryDirectoryModel();
 
+  void SetMountInfo(std::shared_ptr<MountInfo> mount_info) {
+    mount_info_ = mount_info;
+  }
+
   // To be called by GUIs
   void AddDirectory(const QString& path);
   void RemoveDirectory(const QModelIndex& index);
@@ -51,6 +55,7 @@ class LibraryDirectoryModel : public QStandardItemModel {
 
   QIcon dir_icon_;
   LibraryBackend* backend_;
+  std::shared_ptr<MountInfo> mount_info_;
   QList<std::shared_ptr<MusicStorage> > storage_;
 };
 

--- a/src/library/librarywatcher.cpp
+++ b/src/library/librarywatcher.cpp
@@ -429,6 +429,15 @@ void LibraryWatcher::ScanSubdirectory(const QString& path,
     }
   }
 
+  // If this is a removable device, make sure the directory still exists before
+  // assembling a delete list.
+  if (t->dir().mount_info_.removable_) {
+    if (!QFileInfo::exists(t->dir().path)) {
+      qLog(Debug) << t->dir().path << "no longer exists.";
+      return;
+    }
+  }
+
   // Look for deleted songs
   for (const Song& song : songs_in_db) {
     if (!song.is_unavailable() &&

--- a/src/library/librarywatcher.h
+++ b/src/library/librarywatcher.h
@@ -114,6 +114,7 @@ class LibraryWatcher : public QObject {
     void AddToProgress(int n = 1);
     void AddToProgressMax(int n);
 
+    const Directory& dir() const { return dir_; }
     int dir_id() const { return dir_.id; }
     bool is_incremental() const { return incremental_; }
     bool ignores_mtime() const { return ignores_mtime_; }


### PR DESCRIPTION
These two changes fix a remaining timing hole that exists when a device is removed. They also create a mechanism to provide some device information to the watcher, library backend, etc.