### PR TITLE
Fix UNC paths.

### DIFF
--- a/src/core/songloader.cpp
+++ b/src/core/songloader.cpp
@@ -404,7 +404,8 @@ SongLoader::Result SongLoader::LoadRemote() {
 
   // Create the source element automatically based on the URL
   GstElement* source = gst_element_make_from_uri(
-      GST_URI_SRC, url_.toEncoded().constData(), nullptr, nullptr);
+      GST_URI_SRC, Utilities::GetUriForGstreamer(url_).constData(),
+      nullptr, nullptr);
   if (!source) {
     qLog(Warning) << "Couldn't create gstreamer source element for"
                   << url_.toString();

--- a/src/core/utilities.cpp
+++ b/src/core/utilities.cpp
@@ -741,6 +741,17 @@ QString FiddleFileExtension(const QString& filename,
   return PathWithoutFilenameExtension(filename) + "." + new_extension;
 }
 
+QByteArray GetUriForGstreamer(const QUrl& url) {
+  if (url.scheme() == "file") {
+    QString local_file = url.toLocalFile();
+    if (local_file.indexOf("//") == 0) {
+      // Exclude / from encoding.
+      return QByteArray("file://") + QUrl::toPercentEncoding(local_file, "/");
+    }
+  }
+  return url.toEncoded();
+}
+
 }  // namespace Utilities
 
 ScopedWCharArray::ScopedWCharArray(const QString& str)

--- a/src/core/utilities.h
+++ b/src/core/utilities.h
@@ -123,6 +123,10 @@ QString PathWithoutFilenameExtension(const QString& filename);
 QString FiddleFileExtension(const QString& filename,
                             const QString& new_extension);
 
+// Fix URLs for Gstreamer, specifically those for network file paths that begin
+// with //.
+QByteArray GetUriForGstreamer(const QUrl& url);
+
 enum ConfigPath {
   Path_Root,
   Path_Icons,

--- a/src/engines/gstengine.h
+++ b/src/engines/gstengine.h
@@ -169,8 +169,6 @@ class GstEngine : public Engine::Base, public BufferConsumer {
 
   int AddBackgroundStream(std::shared_ptr<GstEnginePipeline> pipeline);
 
-  static QUrl FixupUrl(const QUrl& url);
-
  private:
   static const qint64 kTimerIntervalNanosec = 1000 * kNsecPerMsec;  // 1s
   static const qint64 kPreloadGapNanosec = 2000 * kNsecPerMsec;     // 2s

--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -204,7 +204,7 @@ GstElement* GstEnginePipeline::CreateDecodeBinFromUrl(const QUrl& url) {
       str.remove(str.lastIndexOf(QChar('a')), 1);
       uri = str.toUtf8();
     } else {
-      uri = url.toEncoded();
+      uri = Utilities::GetUriForGstreamer(url);
     }
     new_bin = engine_->CreateElement("uridecodebin");
     if (!new_bin) return nullptr;

--- a/src/moodbar/moodbarpipeline.cpp
+++ b/src/moodbar/moodbarpipeline.cpp
@@ -103,8 +103,8 @@ void MoodbarPipeline::Start() {
   builder_.reset(new MoodbarBuilder);
 
   // Set properties
-  g_object_set(decodebin, "uri", local_filename_.toEncoded().constData(),
-               nullptr);
+  QByteArray uri = Utilities::GetUriForGstreamer(local_filename_);
+  g_object_set(decodebin, "uri", uri.constData(), nullptr);
   g_object_set(spectrum, "bands", kBands, nullptr);
 
   GstFastSpectrum* fast_spectrum = GST_FASTSPECTRUM(spectrum);


### PR DESCRIPTION
The fix-up for URLs for files that that begin with // no longer works since the
QUrl class determines that these modifications are invalid, resulting in an
empty string when converted. Instead of attempting to modify the QUrl, add a
utility function that makes the correction on the encoded byte array at time of
usage.