### PR TITLE
Enable debug logging for GstEnginePipeline by default.

### DIFF
--- a/ext/libclementine-common/core/logging.cpp
+++ b/ext/libclementine-common/core/logging.cpp
@@ -42,7 +42,7 @@ static Level sDefaultLevel = Level_Debug;
 static QMap<QString, Level>* sClassLevels = nullptr;
 static QIODevice* sNullDevice = nullptr;
 
-const char* kDefaultLogLevels = "GstEnginePipeline:2,*:3";
+const char* kDefaultLogLevels = "GstEnginePipelineCallbacks:2,*:3";
 
 static const char* kMessageHandlerMagic = "__logging_message__";
 static const int kMessageHandlerMagicLength = strlen(kMessageHandlerMagic);

--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -549,7 +549,8 @@ gboolean GstEnginePipeline::BusCallback(GstBus*, GstMessage* msg,
                                         gpointer self) {
   GstEnginePipeline* instance = reinterpret_cast<GstEnginePipeline*>(self);
 
-  qLog(Debug) << instance->id() << "bus message" << GST_MESSAGE_TYPE_NAME(msg);
+  qLogCat(Debug, "GstEnginePipelineCallbacks")
+      << instance->id() << "bus message" << GST_MESSAGE_TYPE_NAME(msg);
 
   switch (GST_MESSAGE_TYPE(msg)) {
     case GST_MESSAGE_ERROR:
@@ -575,8 +576,8 @@ GstBusSyncReply GstEnginePipeline::BusCallbackSync(GstBus*, GstMessage* msg,
                                                    gpointer self) {
   GstEnginePipeline* instance = reinterpret_cast<GstEnginePipeline*>(self);
 
-  qLog(Debug) << instance->id() << "sync bus message"
-              << GST_MESSAGE_TYPE_NAME(msg);
+  qLogCat(Debug, "GstEnginePipelineCallbacks")
+      << instance->id() << "sync bus message" << GST_MESSAGE_TYPE_NAME(msg);
 
   switch (GST_MESSAGE_TYPE(msg)) {
     case GST_MESSAGE_EOS:
@@ -959,7 +960,8 @@ GstPadProbeReturn GstEnginePipeline::EventHandoffCallback(GstPad*,
   GstEnginePipeline* instance = reinterpret_cast<GstEnginePipeline*>(self);
   GstEvent* e = gst_pad_probe_info_get_event(info);
 
-  qLog(Debug) << instance->id() << "event" << GST_EVENT_TYPE_NAME(e);
+  qLogCat(Debug, "GstEnginePipelineCallbacks")
+      << instance->id() << "event" << GST_EVENT_TYPE_NAME(e);
 
   switch (GST_EVENT_TYPE(e)) {
     case GST_EVENT_SEGMENT:


### PR DESCRIPTION
Use qLogCat to put verbose GStreamer callback messages into a new
GstEnginePipelineCallbacks category. Filter that category instead of
the entire class by default.