### PR TITLE
Discontinue use of deprecated QSqlError constructor.

### DIFF
--- a/3rdparty/qsqlite/qsql_sqlite.cpp
+++ b/3rdparty/qsqlite/qsql_sqlite.cpp
@@ -103,7 +103,7 @@ static QSqlError qMakeError(sqlite3 *access, const QString &descr, QSqlError::Er
 {
     return QSqlError(descr,
                      QString(reinterpret_cast<const QChar *>(sqlite3_errmsg16(access))),
-                     type, errorCode);
+                     type, QString(errorCode));
 }
 
 class QSQLiteDriverPrivate


### PR DESCRIPTION
See: https://doc.qt.io/qt-5/qsqlerror-obsolete.html#QSqlError

Note that development on qsqlite was discontinued after the Qt 3.3 release, which
contained native sqlite drivers. Long term, Clementine should migrate to these.