### PR TITLE
Display message to user when IntergalacticFM channel list fails.

### DIFF
--- a/src/internet/intergalacticfm/intergalacticfmservice.cpp
+++ b/src/internet/intergalacticfm/intergalacticfmservice.cpp
@@ -129,8 +129,8 @@ void IntergalacticFMServiceBase::RefreshStreamsFinished(QNetworkReply* reply,
   reply->deleteLater();
 
   if (reply->error() != QNetworkReply::NoError) {
-    // TODO(David Sansome): Error handling
-    qLog(Error) << reply->errorString();
+    app_->AddError(
+        tr("Failed to get channel list:\n%1").arg(reply->errorString()));
     return;
   }
 


### PR DESCRIPTION
At the time of this commit, the channel list from intergalactic.fm is
unavailable. To the user, this is failing silently. Add an error message for
this failure. If this issue persists, then the service should be removed or a
hardcoded station list should be used.