### PR TITLE
Fix itunes search.

### DIFF
--- a/src/internet/podcasts/itunessearchpage.cpp
+++ b/src/internet/podcasts/itunessearchpage.cpp
@@ -88,7 +88,7 @@ void ITunesSearchPage::SearchFinished(QNetworkReply* reply) {
   QJsonObject json_data = json_document.object();
 
   // Was there an error message in the JSON?
-  if (!json_data["errorMessage"].isUndefined()) {
+  if (json_data.contains("errorMessage")) {
     QMessageBox::warning(this, tr("Failed to fetch podcasts"),
                          json_data["errorMessage"].toString());
     return;


### PR DESCRIPTION
Using the [] operator on a non-const QJsonObject inserts an item. The test for an error message was always positive. Use the contains method instead.