### PR TITLE
Convert remaining QJsonValue::isUndefined usage.

### DIFF
--- a/src/internet/digitally/digitallyimportedclient.cpp
+++ b/src/internet/digitally/digitallyimportedclient.cpp
@@ -85,7 +85,7 @@ DigitallyImportedClient::AuthReply DigitallyImportedClient::ParseAuthReply(
 
   QJsonObject json_root_object = QJsonDocument::fromJson(reply->readAll()).object();
 
-  if (json_root_object["subscriptions"].isUndefined()) {
+  if (!json_root_object.contains("subscriptions")) {
     return ret;
   }
 
@@ -96,9 +96,10 @@ DigitallyImportedClient::AuthReply DigitallyImportedClient::ParseAuthReply(
     return ret;
   }
 
-  if (json_root_object["first_name"].isUndefined() || json_root_object["last_name"].isUndefined() ||
-      json_subscriptions[0].toObject()["expires_on"].isUndefined() ||
-      json_root_object["listen_key"].isUndefined())
+  if (!json_root_object.contains("first_name") ||
+      !json_root_object.contains("last_name") ||
+      !json_subscriptions[0].toObject().contains("expires_on") ||
+      !json_root_object.contains("listen_key"))
     return ret;
 
   ret.success_ = true;
@@ -124,7 +125,7 @@ DigitallyImportedClient::ChannelList DigitallyImportedClient::ParseChannelList(
 
   QJsonObject json_root_object = QJsonDocument::fromJson(reply->readAll()).object();
 
-  if (json_root_object["channel_filters"].isUndefined()) return ret;
+  if (!json_root_object.contains("channel_filters")) return ret;
 
   QJsonArray json_filters = json_root_object["channel_filters"].toArray();
 

--- a/src/musicbrainz/acoustidclient.cpp
+++ b/src/musicbrainz/acoustidclient.cpp
@@ -129,11 +129,11 @@ void AcoustidClient::RequestFinished(QNetworkReply* reply, int request_id) {
 
   for (const QJsonValue& v : json_results) {
     QJsonObject r = v.toObject();
-    if (!r["recordings"].isUndefined()) {
+    if (r.contains("recordings")) {
       QJsonArray json_recordings = r["recordings"].toArray();
       for (const QJsonValue& recording : json_recordings) {
         QJsonObject o = recording.toObject();
-        if (!o["id"].isUndefined()) {
+        if (o.contains("id")) {
           id_source_list << IdSource(o["id"].toString(), o["sources"].toInt());
         }
       }

--- a/src/songinfo/songkickconcerts.cpp
+++ b/src/songinfo/songkickconcerts.cpp
@@ -133,7 +133,8 @@ void SongkickConcerts::CalendarRequestFinished(QNetworkReply* reply, int id) {
 
     // Try to get the lat/lng coordinates of the venue.
     QJsonObject json_venue = json_event["venue"].toObject();
-    const bool valid_latlng = !json_venue["lng"].isUndefined() && !json_venue["lat"].isUndefined();
+    const bool valid_latlng =
+        json_venue.contains("lng") && json_venue.contains("lat");
 
     if (valid_latlng && latlng_.IsValid()) {
       static const int kFilterDistanceMetres = 250 * 1e3;  // 250km


### PR DESCRIPTION
Noted previously, using the [] operator on a non-const QJsonObject causes the
creation of the key and does not work for checking existence. Convert the
remaining isUndefined call sites to use QJsonObect::contains.