### PR TITLE
Add a logging category to log all network requests.

### DIFF
--- a/ext/libclementine-common/core/logging.cpp
+++ b/ext/libclementine-common/core/logging.cpp
@@ -42,7 +42,10 @@ static Level sDefaultLevel = Level_Debug;
 static QMap<QString, Level>* sClassLevels = nullptr;
 static QIODevice* sNullDevice = nullptr;
 
-const char* kDefaultLogLevels = "GstEnginePipelineCallbacks:2,*:3";
+const char* kDefaultLogLevels =
+    "GstEnginePipelineCallbacks:2,"
+    "NetworkRequests:2,"
+    "*:3";
 
 static const char* kMessageHandlerMagic = "__logging_message__";
 static const int kMessageHandlerMagicLength = strlen(kMessageHandlerMagic);

--- a/src/core/network.cpp
+++ b/src/core/network.cpp
@@ -17,6 +17,7 @@
    along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "core/logging.h"
 #include "network.h"
 
 #include <QCoreApplication>
@@ -95,6 +96,7 @@ NetworkAccessManager::NetworkAccessManager(int timeout, QObject* parent)
 
 QNetworkReply* NetworkAccessManager::createRequest(
     Operation op, const QNetworkRequest& request, QIODevice* outgoingData) {
+  qLogCat(Debug, "NetworkRequests") << request.url();
   QByteArray user_agent = QString("%1 %2")
                               .arg(QCoreApplication::applicationName(),
                                    QCoreApplication::applicationVersion())


### PR DESCRIPTION
New logging class NetworkRequests disabled by default, but can be enabled with
the command line option.