### PR TITLE
Scrub debug urls

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -132,8 +132,10 @@ void Player::HandleLoadResult(const UrlHandler::LoadResult& result) {
       break;
 
     case UrlHandler::LoadResult::TrackAvailable: {
+      // The media URL may contain an auth token.
       qLog(Debug) << "URL handler for" << result.original_url_ << "returned"
-                  << result.media_url_;
+                  << result.media_url_.toString(QUrl::RemoveQuery)
+                  << "(query removed)";
 
       // If there was no length info in song's metadata, use the one provided by
       // URL handler, if there is one

--- a/src/core/utilities.cpp
+++ b/src/core/utilities.cpp
@@ -760,6 +760,13 @@ QByteArray GetUriForGstreamer(const QUrl& url) {
   return url.toEncoded();
 }
 
+QString ScrubUrlQueries(const QString& str) {
+  // If the URL isn't followed by whitespace, this will eat extra characters.
+  QRegExp rx("((?:http|https)://\\S*\\?)\\S*");
+  // QString::replace is non const, so operate on a copy.
+  return QString(str).replace(rx, "\\1 (query removed)");
+}
+
 }  // namespace Utilities
 
 ScopedWCharArray::ScopedWCharArray(const QString& str)

--- a/src/core/utilities.h
+++ b/src/core/utilities.h
@@ -164,6 +164,9 @@ int GetThreadId();
 bool IsLaptop();
 
 QString SystemLanguageName();
+
+// Scrub messages for to remove queries, which may include auth info, from URLs.
+QString ScrubUrlQueries(const QString& str);
 }  // namespace Utilities
 
 class ScopedWCharArray {

--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -685,7 +685,10 @@ void GstEnginePipeline::ErrorMessageReceived(GstMessage* msg) {
     return;
   }
 
-  qLog(Error) << id() << debugstr;
+  for (const QString& l : debugstr.split("\n")) {
+    // Messages may contain URLs with auth info in query strings.
+    qLog(Error) << id() << Utilities::ScrubUrlQueries(l);
+  }
 
   emit Error(id(), message, domain, code);
 }


### PR DESCRIPTION
While debugging an issue, I came across a couple places where auth tokens were being logged in url query strings.