### PR TITLE
Gdrive get file

### DIFF
--- a/src/internet/googledrive/googledriveclient.cpp
+++ b/src/internet/googledrive/googledriveclient.cpp
@@ -72,7 +72,7 @@ QStringList File::parent_ids() const {
 ConnectResponse::ConnectResponse(QObject* parent) : QObject(parent) {}
 
 GetFileResponse::GetFileResponse(const QString& file_id, QObject* parent)
-    : QObject(parent), file_id_(file_id) {}
+    : QObject(parent), file_id_(file_id), had_error_(false) {}
 
 ListChangesResponse::ListChangesResponse(const QString& cursor, QObject* parent)
     : QObject(parent), cursor_(cursor) {}
@@ -165,6 +165,7 @@ void Client::GetFileFinished(GetFileResponse* response, QNetworkReply* reply) {
   QJsonDocument document = QJsonDocument::fromJson(reply->readAll(), &error);
   if (error.error != QJsonParseError::NoError) {
     qLog(Error) << "Failed to fetch file with ID" << response->file_id_;
+    response->had_error_ = true;
     emit response->Finished();
     return;
   }

--- a/src/internet/googledrive/googledriveclient.cpp
+++ b/src/internet/googledrive/googledriveclient.cpp
@@ -126,9 +126,7 @@ void Client::FetchUserInfoFinished(ConnectResponse* response,
       return;
     }
 
-    qLog(Debug) << document;
     response->user_email_ = document.object()["email"].toString();
-    qLog(Debug) << response->user_email_;
   }
   emit response->Finished();
   emit Authenticated();

--- a/src/internet/googledrive/googledriveclient.h
+++ b/src/internet/googledrive/googledriveclient.h
@@ -103,6 +103,7 @@ class GetFileResponse : public QObject {
  public:
   const QString& file_id() const { return file_id_; }
   const File& file() const { return file_; }
+  bool had_error() { return had_error_; }
 
  signals:
   void Finished();
@@ -111,6 +112,7 @@ class GetFileResponse : public QObject {
   GetFileResponse(const QString& file_id, QObject* parent);
   QString file_id_;
   File file_;
+  bool had_error_;
 };
 
 class ListChangesResponse : public QObject {

--- a/src/internet/googledrive/googledriveservice.cpp
+++ b/src/internet/googledrive/googledriveservice.cpp
@@ -204,6 +204,11 @@ QUrl GoogleDriveService::GetStreamingUrlFromSongId(const QString& id) {
   connect(response.data(), SIGNAL(Finished()), &loop, SLOT(quit()));
   loop.exec();
 
+  if (response->had_error()) {
+    app_->AddError(tr("Could not find Google Drive file."));
+    return QUrl();
+  }
+
   QUrl url(response->file().download_url());
   QUrlQuery url_query(url);
   url_query.addQueryItem("access_token", client_->access_token());

--- a/src/internet/googledrive/googledriveurlhandler.cpp
+++ b/src/internet/googledrive/googledriveurlhandler.cpp
@@ -25,7 +25,7 @@ GoogleDriveUrlHandler::GoogleDriveUrlHandler(GoogleDriveService* service,
     : UrlHandler(parent), service_(service) {}
 
 UrlHandler::LoadResult GoogleDriveUrlHandler::StartLoading(const QUrl& url) {
-  QString file_id = url.path();
+  QString file_id = url.path().remove(QChar('/'));
   QUrl real_url = service_->GetStreamingUrlFromSongId(file_id);
   LoadResult::Type type = real_url.isValid() ? LoadResult::TrackAvailable
                                              : LoadResult::NoMoreTracks;

--- a/src/internet/googledrive/googledriveurlhandler.cpp
+++ b/src/internet/googledrive/googledriveurlhandler.cpp
@@ -27,5 +27,7 @@ GoogleDriveUrlHandler::GoogleDriveUrlHandler(GoogleDriveService* service,
 UrlHandler::LoadResult GoogleDriveUrlHandler::StartLoading(const QUrl& url) {
   QString file_id = url.path();
   QUrl real_url = service_->GetStreamingUrlFromSongId(file_id);
-  return LoadResult(url, LoadResult::TrackAvailable, real_url);
+  LoadResult::Type type = real_url.isValid() ? LoadResult::TrackAvailable
+                                             : LoadResult::NoMoreTracks;
+  return LoadResult(url, type, real_url);
 }


### PR DESCRIPTION
 This fixes GetStreamingUrlFromSongId for Google Drive. 

With this change, playback is still broken due to an API change:
https://cloud.google.com/blog/products/application-development/upcoming-changes-to-the-google-drive-api-and-google-picker-api

I'm looking at solutions for that.