### PR TITLE
Prevent accidental usage of /usr/bin/data

### DIFF
--- a/src/core/application.cpp
+++ b/src/core/application.cpp
@@ -66,6 +66,9 @@
 #endif
 
 bool Application::kIsPortable = false;
+const char* Application::kLegacyPortableDataDir = "data";
+const char* Application::kDefaultPortableDataDir = "clementine-data";
+const char* Application::kPortableDataDir = nullptr;
 
 class ApplicationImpl {
  public:

--- a/src/core/application.h
+++ b/src/core/application.h
@@ -63,6 +63,10 @@ class Application : public QObject {
 
  public:
   static bool kIsPortable;
+  static const char* kPortableDataDir;
+  static const char* kLegacyPortableDataDir;
+  static const char* kDefaultPortableDataDir;
+  static bool IsPortable() { return kIsPortable; }
 
   explicit Application(QObject* parent = nullptr);
   ~Application();

--- a/src/core/utilities.cpp
+++ b/src/core/utilities.cpp
@@ -342,8 +342,9 @@ QString ColorToRgba(const QColor& c) {
 QString GetConfigPath(ConfigPath config) {
   switch (config) {
     case Path_Root: {
-      if (Application::kIsPortable) {
-        return QString("%1/data").arg(QCoreApplication::applicationDirPath());
+      if (Application::IsPortable()) {
+        QDir d(QCoreApplication::applicationDirPath());
+        return d.filePath(Application::kPortableDataDir);
       }
 #ifdef Q_OS_DARWIN
       return mac::GetApplicationSupportPath() + "/" +

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -197,15 +197,33 @@ void ParseAProto() {
 }
 
 void CheckPortable() {
-  QFile f(QApplication::applicationDirPath() + QDir::separator() + "data");
-  if (f.exists()) {
+  QDir appDir(QApplication::applicationDirPath());
+  // First look for legacy data location.
+  QDir d(appDir.filePath(Application::kLegacyPortableDataDir));
+  // Key off of database file since config name may vary depending on platform.
+  if (d.exists("clementine.db")) {
     // We are portable. Set the bool and change the qsettings path
+    qLog(Info) << "Using legacy portable data location:" << d.path();
     Application::kIsPortable = true;
+    Application::kPortableDataDir = Application::kLegacyPortableDataDir;
 
     QSettings::setDefaultFormat(QSettings::IniFormat);
-    QSettings::setPath(QSettings::IniFormat, QSettings::UserScope,
-                       f.fileName());
+    QSettings::setPath(QSettings::IniFormat, QSettings::UserScope, d.path());
+    return;
   }
+
+  d = appDir.filePath(Application::kDefaultPortableDataDir);
+  if (d.exists()) {
+    // We are portable. Set the bool and change the qsettings path
+    qLog(Info) << "Using portable data location:" << d.path();
+    Application::kIsPortable = true;
+    Application::kPortableDataDir = Application::kDefaultPortableDataDir;
+
+    QSettings::setDefaultFormat(QSettings::IniFormat);
+    QSettings::setPath(QSettings::IniFormat, QSettings::UserScope, d.path());
+    return;
+  }
+  qLog(Info) << "Using default config locations.";
 }
 
 }  // namespace


### PR DESCRIPTION
Clementine detects a data directory in the same directory as the executable to
determine portable configuration. But there are some packages that create
/usr/bin/data, causing Clementine to run in portable mode.

Use a more unique data directory name, clementine-data, as the portable data
directory. For backwards compatibility, use the legacy data directory if the
already exists there.


This is a response to #6583. I don't see the portable mode documented in the readme or the wiki.