### PR TITLE
Fix assertion when deleting multiple queued items from playlist.

### DIFF
--- a/src/playlist/queue.h
+++ b/src/playlist/queue.h
@@ -86,6 +86,7 @@ class Queue : public QAbstractProxyModel {
   QList<QPersistentModelIndex> source_indexes_;
   const Playlist* playlist_;
   quint64 total_length_ns_;
+  QMetaObject::Connection count_changed_;
 };
 
 #endif  // QUEUE_H


### PR DESCRIPTION
Removal of items from a playlist is done with a single transaction. When
Queue::SourceLayoutChanged is called after this, the items in the queue are
checked one at a time. When an item is removed, it triggers dataChanged signal
from the model, connected to the SourceDataChanged slot. There, ItemCountChanged
is emitted which calls UpdateTotalLength. This method will assert when it finds
an item that is in the queue, but not in the playlist.

To solve this, disconnect the ItemCountChanged signal at the beginning of
SourceLayoutChanged and re-enable it after cleaning the queue. The method emits
the signal before returning.