### PR TITLE
Short-term fix for shortcut crash

### DIFF
--- a/src/core/qxtglobalshortcutbackend.cpp
+++ b/src/core/qxtglobalshortcutbackend.cpp
@@ -23,12 +23,17 @@
 #include "core/logging.h"
 
 #include <QAction>
+#include <QGuiApplication>
 #include <QtDebug>
 
 QxtGlobalShortcutBackend::QxtGlobalShortcutBackend(GlobalShortcuts* parent)
     : GlobalShortcutBackend(parent) {}
 
 bool QxtGlobalShortcutBackend::DoRegister() {
+  if (QGuiApplication::platformName() == "wayland") {
+    qLog(Warning) << "No support for Wayland in qxt.";
+    return false;
+  }
   qLog(Debug) << "registering";
   for (const GlobalShortcuts::Shortcut& shortcut :
        manager_->shortcuts().values()) {


### PR DESCRIPTION
The 3rd party qxt library assumes X11 on Linux systems. Don't register
QxtGlobalShortcutBackend when using Wayland.