### PR TITLE
Shortcut settings page cleanup.

### DIFF
--- a/src/ui/globalshortcutssettingspage.cpp
+++ b/src/ui/globalshortcutssettingspage.cpp
@@ -47,7 +47,7 @@ GlobalShortcutsSettingsPage::GlobalShortcutsSettingsPage(SettingsDialog* dialog)
 
   connect(ui_->list,
           SIGNAL(currentItemChanged(QTreeWidgetItem*, QTreeWidgetItem*)),
-          SLOT(ItemClicked(QTreeWidgetItem*)));
+          SLOT(CurrentItemChanged(QTreeWidgetItem*)));
   connect(ui_->radio_none, SIGNAL(clicked()), SLOT(NoneClicked()));
   connect(ui_->radio_default, SIGNAL(clicked()), SLOT(DefaultClicked()));
   connect(ui_->radio_custom, SIGNAL(clicked()), SLOT(ChangeClicked()));
@@ -86,7 +86,7 @@ void GlobalShortcutsSettingsPage::Load() {
     }
 
     ui_->list->sortItems(0, Qt::AscendingOrder);
-    ItemClicked(ui_->list->topLevelItem(0));
+    ui_->list->setCurrentItem(ui_->list->topLevelItem(0));
   }
 
   for (const Shortcut& s : shortcuts_.values()) {
@@ -121,7 +121,7 @@ void GlobalShortcutsSettingsPage::Save() {
   dialog()->global_shortcuts_manager()->ReloadSettings();
 }
 
-void GlobalShortcutsSettingsPage::ItemClicked(QTreeWidgetItem* item) {
+void GlobalShortcutsSettingsPage::CurrentItemChanged(QTreeWidgetItem* item) {
   current_id_ = item->data(0, Qt::UserRole).toString();
   Shortcut& shortcut = shortcuts_[current_id_];
 

--- a/src/ui/globalshortcutssettingspage.h
+++ b/src/ui/globalshortcutssettingspage.h
@@ -44,7 +44,7 @@ class GlobalShortcutsSettingsPage : public SettingsPage {
   void Save();
 
  private slots:
-  void ItemClicked(QTreeWidgetItem*);
+  void CurrentItemChanged(QTreeWidgetItem*);
   void NoneClicked();
   void DefaultClicked();
   void ChangeClicked();

--- a/src/ui/globalshortcutssettingspage.ui
+++ b/src/ui/globalshortcutssettingspage.ui
@@ -21,7 +21,16 @@
    <item>
     <widget class="QWidget" name="gnome_container" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout_2">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
        <number>0</number>
       </property>
       <item>
@@ -53,7 +62,16 @@
       <property name="spacing">
        <number>0</number>
       </property>
-      <property name="margin">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
        <number>0</number>
       </property>
       <item>
@@ -83,85 +101,97 @@
     </widget>
    </item>
    <item>
-    <widget class="QTreeWidget" name="list">
-     <property name="editTriggers">
-      <set>QAbstractItemView::NoEditTriggers</set>
+    <widget class="QWidget" name="list_container" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
      </property>
-     <property name="alternatingRowColors">
-      <bool>true</bool>
-     </property>
-     <property name="rootIsDecorated">
-      <bool>false</bool>
-     </property>
-     <property name="allColumnsShowFocus">
-      <bool>true</bool>
-     </property>
-     <column>
-      <property name="text">
-       <string comment="Category label">Action</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Shortcut</string>
-      </property>
-     </column>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="shortcut_options">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="title">
-      <string>Shortcut for %1</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
+     <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="QRadioButton" name="radio_none">
+       <widget class="QTreeWidget" name="list">
+        <property name="editTriggers">
+         <set>QAbstractItemView::NoEditTriggers</set>
+        </property>
+        <property name="alternatingRowColors">
+         <bool>true</bool>
+        </property>
+        <property name="rootIsDecorated">
+         <bool>false</bool>
+        </property>
+        <property name="allColumnsShowFocus">
+         <bool>true</bool>
+        </property>
+        <column>
+         <property name="text">
+          <string comment="Category label">Action</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Shortcut</string>
+         </property>
+        </column>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="shortcut_options">
         <property name="enabled">
          <bool>true</bool>
         </property>
-        <property name="text">
-         <string>&amp;None</string>
+        <property name="title">
+         <string>Shortcut for %1</string>
         </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="radio_default">
-        <property name="text">
-         <string>De&amp;fault</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="radio_custom">
-        <property name="text">
-         <string>&amp;Custom</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="change">
-        <property name="text">
-         <string>Change shortcut...</string>
-        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QRadioButton" name="radio_none">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="text">
+            <string>&amp;None</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="radio_default">
+           <property name="text">
+            <string>De&amp;fault</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="radio_custom">
+           <property name="text">
+            <string>&amp;Custom</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="change">
+           <property name="text">
+            <string>Change shortcut...</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
      </layout>
@@ -170,6 +200,9 @@
   </layout>
  </widget>
  <tabstops>
+  <tabstop>gnome_checkbox</tabstop>
+  <tabstop>gnome_open</tabstop>
+  <tabstop>mac_open</tabstop>
   <tabstop>list</tabstop>
   <tabstop>radio_none</tabstop>
   <tabstop>radio_default</tabstop>
@@ -183,7 +216,7 @@
   <connection>
    <sender>gnome_checkbox</sender>
    <signal>toggled(bool)</signal>
-   <receiver>list</receiver>
+   <receiver>list_container</receiver>
    <slot>setDisabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -191,24 +224,8 @@
      <y>25</y>
     </hint>
     <hint type="destinationlabel">
-     <x>82</x>
-     <y>63</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>gnome_checkbox</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>shortcut_options</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>244</x>
-     <y>26</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>122</x>
-     <y>298</y>
+     <x>253</x>
+     <y>247</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
- Group list and settings so they can be enabled/disabled together.
- Make default selection shortcut list. Previous behavior set options
  for the first item, but didn't highlight selection.
- Rename ItemClicked to CurrentItemChanged to reflect correct signal.