### PR TITLE
Fix crash when searching playlist.

### DIFF
--- a/src/playlist/playlistlistcontainer.cpp
+++ b/src/playlist/playlistlistcontainer.cpp
@@ -67,7 +67,13 @@ class PlaylistListFilterProxyModel : public QSortFilterProxyModel {
 
   void refreshExpanded(QTreeView *tree) {
     tree->collapseAll();
-    for(QModelIndex sourceIndex : expandList ) {
+    // The call to setExpanded causes expendList to be appended via
+    // the filterAcceptsRow overload. Since QList's implementation is an array,
+    // when the reserved space is exhausted, it must be reallocated. When this
+    // happens, iterators are likely to break. But because of this implemention,
+    // indexing is safe and efficient.
+    for (int i = 0; i < expandList.count(); i++) {
+      const QModelIndex& sourceIndex = expandList[i];
       QModelIndex mappedIndex = mapFromSource( sourceIndex );
       tree->setExpanded( mappedIndex, true );
     }


### PR DESCRIPTION
While iterating over expandList in refreshExpanded, calls to setExpanded cause
the list to be appended. Since a QList uses and array implementation that must
resize when reserved space is exhausted, iterators are unsafe for this case.
Use indexes, which are O(1) in QLists, instead of iterators for this case.