### PR TITLE
Use reference on a const loop var to avoid copy

### DIFF
--- a/src/playlist/playlistlistcontainer.cpp
+++ b/src/playlist/playlistlistcontainer.cpp
@@ -286,7 +286,7 @@ void PlaylistListContainer::AddPlaylist(int id, const QString& name,
   QStandardItem* playlist_item = model_->NewPlaylist(name, id);
   QStandardItem* parent_folder = model_->FolderByPath(*ui_path);
   parent_folder->appendRow(playlist_item);
-  for (const Song s : app_->playlist_backend()->GetPlaylistSongs(id)) {
+  for (const Song& s : app_->playlist_backend()->GetPlaylistSongs(id)) {
     QStandardItem* track_item = model_->NewTrack(s);
     track_item->setDragEnabled(false);
     playlist_item->appendRow(track_item);


### PR DESCRIPTION
Clang 10 warns that ``s`` might be copied. Use a reference to avoid copying.