### PR TITLE
Add MediaPlaybackRequest class.

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -146,9 +146,10 @@ void Player::HandleLoadResult(const UrlHandler::LoadResult& result) {
         item->SetTemporaryMetadata(song);
         app_->playlist_manager()->active()->InformOfCurrentSongChange();
       }
-      engine_->Play(
-          result.media_url_, stream_change_type_, item->Metadata().has_cue(),
-          item->Metadata().beginning_nanosec(), item->Metadata().end_nanosec());
+      MediaPlaybackRequest req(result.media_url_);
+      engine_->Play(req, stream_change_type_, item->Metadata().has_cue(),
+                    item->Metadata().beginning_nanosec(),
+                    item->Metadata().end_nanosec());
 
       current_item_ = item;
       loading_async_ = QUrl();
@@ -420,8 +421,8 @@ void Player::PlayAt(int index, Engine::TrackChangeFlags change,
     HandleLoadResult(url_handlers_[url.scheme()]->StartLoading(url));
   } else {
     loading_async_ = QUrl();
-    engine_->Play(current_item_->Url(), change,
-                  current_item_->Metadata().has_cue(),
+    MediaPlaybackRequest req(current_item_->Url());
+    engine_->Play(req, change, current_item_->Metadata().has_cue(),
                   current_item_->Metadata().beginning_nanosec(),
                   current_item_->Metadata().end_nanosec());
 
@@ -604,7 +605,8 @@ void Player::TrackAboutToEnd() {
         break;
     }
   }
-  engine_->StartPreloading(url, next_item->Metadata().has_cue(),
+  MediaPlaybackRequest req(url);
+  engine_->StartPreloading(req, next_item->Metadata().has_cue(),
                            next_item->Metadata().beginning_nanosec(),
                            next_item->Metadata().end_nanosec());
 }

--- a/src/engines/enginebase.cpp
+++ b/src/engines/enginebase.cpp
@@ -43,12 +43,12 @@ Engine::Base::Base()
 
 Engine::Base::~Base() {}
 
-bool Engine::Base::Load(const QUrl& url, TrackChangeFlags,
+bool Engine::Base::Load(const MediaPlaybackRequest& req, TrackChangeFlags,
                         bool force_stop_at_end, quint64 beginning_nanosec,
                         qint64 end_nanosec) {
   Q_UNUSED(force_stop_at_end);
 
-  url_ = url;
+  playback_req_ = req;
   beginning_nanosec_ = beginning_nanosec;
   end_nanosec_ = end_nanosec;
 
@@ -92,10 +92,10 @@ void Engine::Base::EmitAboutToEnd() {
 
 int Engine::Base::AddBackgroundStream(const QUrl& url) { return -1; }
 
-bool Engine::Base::Play(const QUrl& u, TrackChangeFlags c,
+bool Engine::Base::Play(const MediaPlaybackRequest& req, TrackChangeFlags c,
                         bool force_stop_at_end, quint64 beginning_nanosec,
                         qint64 end_nanosec) {
-  if (!Load(u, c, force_stop_at_end, beginning_nanosec, end_nanosec))
+  if (!Load(req, c, force_stop_at_end, beginning_nanosec, end_nanosec))
     return false;
 
   return Play(0);

--- a/src/engines/enginebase.h
+++ b/src/engines/enginebase.h
@@ -32,6 +32,7 @@
 #include <QUrl>
 
 #include "engine_fwd.h"
+#include "playbackrequest.h"
 
 namespace Engine {
 
@@ -45,7 +46,8 @@ class Base : public QObject {
 
   virtual bool Init() = 0;
 
-  virtual void StartPreloading(const QUrl&, bool, qint64, qint64) {}
+  virtual void StartPreloading(const MediaPlaybackRequest&, bool, qint64,
+                               qint64) {}
   virtual bool Play(quint64 offset_nanosec) = 0;
   virtual void Stop(bool stop_after = false) = 0;
   virtual void Pause() = 0;
@@ -62,7 +64,7 @@ class Base : public QObject {
 
   // Subclasses should respect given markers (beginning and end) which are
   // in milliseconds.
-  virtual bool Load(const QUrl& url, TrackChangeFlags change,
+  virtual bool Load(const MediaPlaybackRequest& req, TrackChangeFlags change,
                     bool force_stop_at_end, quint64 beginning_nanosec,
                     qint64 end_nanosec);
   // Sets new values for the beginning and end markers of the currently playing
@@ -78,8 +80,9 @@ class Base : public QObject {
   // to the given 'end' (usually from 0 to a song's length). Both markers
   // should be passed in nanoseconds. 'end' can be negative, indicating that the
   // real length of 'u' stream is unknown.
-  bool Play(const QUrl& u, TrackChangeFlags c, bool force_stop_at_end,
-            quint64 beginning_nanosec, qint64 end_nanosec);
+  bool Play(const MediaPlaybackRequest& req, TrackChangeFlags c,
+            bool force_stop_at_end, quint64 beginning_nanosec,
+            qint64 end_nanosec);
 
   void SetVolume(uint value);
 
@@ -139,7 +142,7 @@ signals:
   uint volume_;
   quint64 beginning_nanosec_;
   qint64 end_nanosec_;
-  QUrl url_;
+  MediaPlaybackRequest playback_req_;
   Scope scope_;
 
   bool fadeout_enabled_;

--- a/src/engines/gstengine.h
+++ b/src/engines/gstengine.h
@@ -95,9 +95,9 @@ class GstEngine : public Engine::Base, public BufferConsumer {
   void ConsumeBuffer(GstBuffer* buffer, int pipeline_id);
 
  public slots:
-  void StartPreloading(const QUrl& url, bool force_stop_at_end,
+  void StartPreloading(const MediaPlaybackRequest& req, bool force_stop_at_end,
                        qint64 beginning_nanosec, qint64 end_nanosec);
-  bool Load(const QUrl&, Engine::TrackChangeFlags change,
+  bool Load(const MediaPlaybackRequest&, Engine::TrackChangeFlags change,
             bool force_stop_at_end, quint64 beginning_nanosec,
             qint64 end_nanosec);
   bool Play(quint64 offset_nanosec);
@@ -162,8 +162,8 @@ class GstEngine : public Engine::Base, public BufferConsumer {
   void StopTimers();
 
   std::shared_ptr<GstEnginePipeline> CreatePipeline();
-  std::shared_ptr<GstEnginePipeline> CreatePipeline(const QUrl& url,
-                                                    qint64 end_nanosec);
+  std::shared_ptr<GstEnginePipeline> CreatePipeline(
+      const MediaPlaybackRequest& req, qint64 end_nanosec);
 
   void UpdateScope(int chunk_length);
 

--- a/src/engines/gstenginepipeline.h
+++ b/src/engines/gstenginepipeline.h
@@ -31,6 +31,7 @@
 #include <gst/gst.h>
 
 #include "engine_fwd.h"
+#include "playbackrequest.h"
 
 class GstElementDeleter;
 class GstEngine;
@@ -58,7 +59,7 @@ class GstEnginePipeline : public QObject {
   void set_sample_rate(int rate);
 
   // Creates the pipeline, returns false on error
-  bool InitFromUrl(const QUrl& url, qint64 end_nanosec);
+  bool InitFromReq(const MediaPlaybackRequest& req, qint64 end_nanosec);
   bool InitFromString(const QString& pipeline);
 
   // BufferConsumers get fed audio data.  Thread-safe.
@@ -80,12 +81,12 @@ class GstEnginePipeline : public QObject {
 
   // If this is set then it will be loaded automatically when playback finishes
   // for gapless playback
-  void SetNextUrl(const QUrl& url, qint64 beginning_nanosec,
+  void SetNextReq(const MediaPlaybackRequest& req, qint64 beginning_nanosec,
                   qint64 end_nanosec);
-  bool has_next_valid_url() const { return next_url_.isValid(); }
+  bool has_next_valid_url() const { return next_.url_.isValid(); }
 
   // Get information about the music playback
-  QUrl url() const { return url_; }
+  QUrl url() const { return current_.url_; }
   bool is_valid() const { return valid_; }
   // Please note that this method (unlike GstEngine's.position()) is
   // multiple-section media unaware.
@@ -226,8 +227,8 @@ signals:
 
   // The URL that is currently playing, and the URL that is to be preloaded
   // when the current track is close to finishing.
-  QUrl url_;
-  QUrl next_url_;
+  MediaPlaybackRequest current_;
+  MediaPlaybackRequest next_;
 
   // If this is > 0 then the pipeline will be forced to stop when playback goes
   // past this position.

--- a/src/engines/playbackrequest.h
+++ b/src/engines/playbackrequest.h
@@ -1,0 +1,31 @@
+/* This file is part of Clementine.
+   Copyright 2020, Jim Broadus <jbroadus@gmail.com>
+
+   Clementine is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Clementine is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef ENGINES_PLAYBACKREQUEST_H_
+#define ENGINES_PLAYBACKREQUEST_H_
+
+#include <QUrl>
+
+class MediaPlaybackRequest {
+ public:
+  MediaPlaybackRequest(const QUrl& url) : url_(url) {}
+  MediaPlaybackRequest() {}
+
+  QUrl url_;
+};
+
+#endif  // ENGINES_PLAYBACKREQUEST_H_


### PR DESCRIPTION
Add a class to wrap the URL in the playback engines. In the future, this will
contain authentication information for the specified URL. It can also include
the start and end time as well as other data that is currently specified along
with the URL.

This is the first commit for the #6581 RFC. I was originally going to use shared pointers, but that's an optimization that can be made later.