### PR TITLE
Handle redirects when downloading Spotify blob.

### DIFF
--- a/src/internet/spotify/spotifyblobdownloader.cpp
+++ b/src/internet/spotify/spotifyblobdownloader.cpp
@@ -95,7 +95,13 @@ void SpotifyBlobDownloader::Start() {
                    filename);
     qLog(Info) << "Downloading" << url;
 
-    QNetworkReply* reply = network_->get(QNetworkRequest(url));
+    QNetworkRequest req(url);
+    // This policy will work as long as there isn't a redirect from https to
+    // http.
+    req.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
+                     QNetworkRequest::NoLessSafeRedirectPolicy);
+
+    QNetworkReply* reply = network_->get(req);
     connect(reply, SIGNAL(finished()), SLOT(ReplyFinished()));
     connect(reply, SIGNAL(downloadProgress(qint64, qint64)),
             SLOT(ReplyProgress()));


### PR DESCRIPTION
Use the NoLessSafeRedirectPolicy policy which will redirect as long as
it isn't from https to http.

This should fix #6569 and #6623