### PR TITLE
Add a common LibraryBackend::Init method.

### DIFF
--- a/src/internet/core/cloudfileservice.cpp
+++ b/src/internet/core/cloudfileservice.cpp
@@ -59,8 +59,7 @@ CloudFileService::CloudFileService(Application* app, InternetModel* parent,
   QString songs_table = service_id + "_songs";
   QString songs_fts_table = service_id + "_songs_fts";
 
-  library_backend_->Init(app->database(), songs_table, QString(), QString(),
-                         songs_fts_table);
+  library_backend_->Init(app->database(), songs_table, songs_fts_table);
   library_model_ = new LibraryModel(library_backend_, app_, this);
 
   library_sort_model_->setSourceModel(library_model_);

--- a/src/internet/jamendo/jamendoservice.cpp
+++ b/src/internet/jamendo/jamendoservice.cpp
@@ -93,8 +93,7 @@ JamendoService::JamendoService(Application* app, InternetModel* parent)
   library_backend_.reset(new LibraryBackend,
                          [](QObject* obj) { obj->deleteLater(); });
   library_backend_->moveToThread(app_->database()->thread());
-  library_backend_->Init(app_->database(), kSongsTable, QString(), QString(),
-                         kFtsTable);
+  library_backend_->Init(app_->database(), kSongsTable, kFtsTable);
   connect(library_backend_.get(), SIGNAL(TotalSongCountUpdated(int)),
           SLOT(UpdateTotalSongCount(int)));
 

--- a/src/internet/magnatune/magnatuneservice.cpp
+++ b/src/internet/magnatune/magnatuneservice.cpp
@@ -92,8 +92,7 @@ MagnatuneService::MagnatuneService(Application* app, InternetModel* parent)
   library_backend_.reset(new LibraryBackend,
                          [](QObject* obj) { obj->deleteLater(); });
   library_backend_->moveToThread(app_->database()->thread());
-  library_backend_->Init(app_->database(), kSongsTable, QString(), QString(),
-                         kFtsTable);
+  library_backend_->Init(app_->database(), kSongsTable, kFtsTable);
   library_model_ = new LibraryModel(library_backend_, app_, this);
 
   connect(library_backend_.get(), SIGNAL(TotalSongCountUpdated(int)),

--- a/src/internet/subsonic/subsonicservice.cpp
+++ b/src/internet/subsonic/subsonicservice.cpp
@@ -84,8 +84,7 @@ SubsonicService::SubsonicService(Application* app, InternetModel* parent)
   library_backend_.reset(new LibraryBackend,
                          [](QObject* obj) { obj->deleteLater(); });
   library_backend_->moveToThread(app_->database()->thread());
-  library_backend_->Init(app_->database(), kSongsTable, QString(), QString(),
-                         kFtsTable);
+  library_backend_->Init(app_->database(), kSongsTable, kFtsTable);
   connect(library_backend_.get(), SIGNAL(TotalSongCountUpdated(int)),
           SLOT(UpdateTotalSongCount(int)));
 

--- a/src/library/librarybackend.cpp
+++ b/src/library/librarybackend.cpp
@@ -47,14 +47,19 @@ LibraryBackend::LibraryBackend(QObject* parent)
       save_ratings_in_file_(false) {}
 
 void LibraryBackend::Init(Database* db, const QString& songs_table,
-                          const QString& dirs_table,
-                          const QString& subdirs_table,
                           const QString& fts_table) {
   db_ = db;
   songs_table_ = songs_table;
+  fts_table_ = fts_table;
+}
+
+void LibraryBackend::Init(Database* db, const QString& songs_table,
+                          const QString& dirs_table,
+                          const QString& subdirs_table,
+                          const QString& fts_table) {
+  Init(db, songs_table, fts_table);
   dirs_table_ = dirs_table;
   subdirs_table_ = subdirs_table;
-  fts_table_ = fts_table;
 }
 
 void LibraryBackend::LoadDirectoriesAsync() {

--- a/src/library/librarybackend.h
+++ b/src/library/librarybackend.h
@@ -131,6 +131,7 @@ class LibraryBackend : public LibraryBackendInterface {
   static const char* kSettingsGroup;
 
   Q_INVOKABLE LibraryBackend(QObject* parent = nullptr);
+  void Init(Database* db, const QString& songs_table, const QString& fts_table);
   void Init(Database* db, const QString& songs_table, const QString& dirs_table,
             const QString& subdirs_table, const QString& fts_table);
 


### PR DESCRIPTION
Most users of LibraryBackend pass empty strings for directory and subdirectory
tables, so add a second Init method that omits those.