### PR TITLE
Fix songs in dynamic subsonic playlist

### DIFF
--- a/src/internet/subsonic/subsonicdynamicplaylist.cpp
+++ b/src/internet/subsonic/subsonicdynamicplaylist.cpp
@@ -219,7 +219,10 @@ void SubsonicDynamicPlaylist::GetAlbum(SubsonicService* service,
     qint64 length = reader.attributes().value("duration").toString().toInt();
     length *= kNsecPerSec;
     song.set_length_nanosec(length);
-    QUrl url = QUrl(QString("subsonic://%1").arg(id));
+    QUrl url = QUrl(QString("subsonic://"));
+    QUrlQuery song_query(url.query());
+    song_query.addQueryItem("id", id);
+    url.setQuery(song_query);
     QUrl cover_url = service->BuildRequestUrl("getCoverArt");
     QUrlQuery cover_url_query(cover_url.query());
     cover_url_query.addQueryItem("id", id);


### PR DESCRIPTION
This PR changes how dynamic subsonic playlists build the song URL. A similar issue (#6080) has been fixed for playing subsonic songs directly, but dynamic playlists currently don't have a song ID at all leading to a "This appears to be a text file" error when trying to play any song from a dynamic playlist.