### PR TITLE
Add dynamic playlist for playing random songs from subsonic

### DIFF
--- a/src/internet/subsonic/subsonicdynamicplaylist.cpp
+++ b/src/internet/subsonic/subsonicdynamicplaylist.cpp
@@ -93,14 +93,6 @@ PlaylistItemList SubsonicDynamicPlaylist::Generate() {
 
 PlaylistItemList SubsonicDynamicPlaylist::GenerateMoreSongs(int count) {
   SubsonicService* service = InternetModel::Service<SubsonicService>();
-  const int task_id =
-      service->app_->task_manager()->StartTask(tr("Fetching Playlist Items"));
-
-  BOOST_SCOPE_EXIT((service)(task_id)) {
-        // stop task when we're done
-        service->app_->task_manager()->SetTaskFinished(task_id);
-      }
-  BOOST_SCOPE_EXIT_END
 
   QUrl url = service->BuildRequestUrl("getRandomSongs");
   QNetworkAccessManager network;
@@ -165,14 +157,6 @@ PlaylistItemList SubsonicDynamicPlaylist::GenerateMoreSongs(int count) {
 
 PlaylistItemList SubsonicDynamicPlaylist::GenerateMoreAlbums(int count) {
   SubsonicService* service = InternetModel::Service<SubsonicService>();
-  const int task_id =
-      service->app_->task_manager()->StartTask(tr("Fetching Playlist Items"));
-
-  BOOST_SCOPE_EXIT((service)(task_id)) {
-    // stop task when we're done
-    service->app_->task_manager()->SetTaskFinished(task_id);
-  }
-  BOOST_SCOPE_EXIT_END
 
   QUrl url = service->BuildRequestUrl("getAlbumList");
   QNetworkAccessManager network;

--- a/src/internet/subsonic/subsonicdynamicplaylist.cpp
+++ b/src/internet/subsonic/subsonicdynamicplaylist.cpp
@@ -137,6 +137,7 @@ PlaylistItemList SubsonicDynamicPlaylist::GenerateMoreSongs(int count) {
     qLog(Warning) << "An error occurred fetching data.  Code: " << error
                   << " Message: "
                   << reader.attributes().value("message").toString();
+    return items;
   }
 
   reader.readNextStartElement();
@@ -147,8 +148,9 @@ PlaylistItemList SubsonicDynamicPlaylist::GenerateMoreSongs(int count) {
 
   while (reader.readNextStartElement()) {
     if (reader.name() != "song") {
-      qLog(Warning) << "song tag expected. Aborting playlist fetch";
-      return items;
+      qLog(Warning) << "song tag expected. Skipping song";
+      reader.skipCurrentElement();
+      continue;
     }
 
     Song song = ReadSong(service, reader);
@@ -209,6 +211,7 @@ PlaylistItemList SubsonicDynamicPlaylist::GenerateMoreAlbums(int count) {
     qLog(Warning) << "An error occurred fetching data.  Code: " << error
                   << " Message: "
                   << reader.attributes().value("message").toString();
+    return items;
   }
 
   reader.readNextStartElement();
@@ -219,8 +222,9 @@ PlaylistItemList SubsonicDynamicPlaylist::GenerateMoreAlbums(int count) {
 
   while (reader.readNextStartElement()) {
     if (reader.name() != "album") {
-      qLog(Warning) << "album tag expected. Aboring playlist fetch";
-      return items;
+      qLog(Warning) << "album tag expected. Skipping album";
+      reader.skipCurrentElement();
+      continue;
     }
 
     qLog(Debug) << "Getting album: "
@@ -279,8 +283,9 @@ void SubsonicDynamicPlaylist::GetAlbum(SubsonicService* service,
   // Read song information
   while (reader.readNextStartElement()) {
     if (reader.name() != "song") {
-      qLog(Warning) << "song tag expected. Aborting playlist fetch.";
-      return;
+      qLog(Warning) << "song tag expected. Skipping song";
+      reader.skipCurrentElement();
+      continue;
     }
 
     Song song = ReadSong(service, reader);

--- a/src/internet/subsonic/subsonicdynamicplaylist.cpp
+++ b/src/internet/subsonic/subsonicdynamicplaylist.cpp
@@ -87,7 +87,8 @@ PlaylistItemList SubsonicDynamicPlaylist::Generate() {
     case QueryType_Song:
       return GenerateMoreSongs(kDefaultSongCount);
     default:
-      return GenerateMoreAlbums(kDefaultAlbumCount);
+      qLog(Warning) << "Invalid playlist type";
+      return PlaylistItemList();
   }
 }
 

--- a/src/internet/subsonic/subsonicdynamicplaylist.cpp
+++ b/src/internet/subsonic/subsonicdynamicplaylist.cpp
@@ -96,6 +96,10 @@ PlaylistItemList SubsonicDynamicPlaylist::Generate() {
 }
 
 PlaylistItemList SubsonicDynamicPlaylist::GenerateMoreSongs(int count) {
+  const int task_id =
+      service_->app_->task_manager()->StartTask(tr("Fetching playlist items"));
+  TaskManager::ScopedTask task(task_id, service_->app_->task_manager());
+
   QUrl url = service_->BuildRequestUrl("getRandomSongs");
   QNetworkAccessManager network;
 
@@ -158,6 +162,10 @@ PlaylistItemList SubsonicDynamicPlaylist::GenerateMoreSongs(int count) {
 }
 
 PlaylistItemList SubsonicDynamicPlaylist::GenerateMoreAlbums(int count) {
+  const int task_id =
+      service_->app_->task_manager()->StartTask(tr("Fetching playlist items"));
+  TaskManager::ScopedTask task(task_id, service_->app_->task_manager());
+
   QUrl url = service_->BuildRequestUrl("getAlbumList");
   QNetworkAccessManager network;
 

--- a/src/internet/subsonic/subsonicdynamicplaylist.h
+++ b/src/internet/subsonic/subsonicdynamicplaylist.h
@@ -62,7 +62,7 @@ class SubsonicDynamicPlaylist : public smart_playlists::Generator {
   PlaylistItemList GenerateMoreAlbums(int count);
   PlaylistItemList GenerateMoreSongs(int count);
 
-  Song ReadSong(SubsonicService* service, QXmlStreamReader& reader);
+  Song ReadSong(QXmlStreamReader& reader);
 
   static const int kMaxCount;
   static const int kDefaultAlbumCount;
@@ -70,8 +70,8 @@ class SubsonicDynamicPlaylist : public smart_playlists::Generator {
   static const int kDefaultOffset;
 
  private:
-  void GetAlbum(SubsonicService* service, PlaylistItemList& list, QString id,
-                QNetworkAccessManager& network, const bool usesslv3);
+  void GetAlbum(PlaylistItemList& list, QString id, QNetworkAccessManager& network,
+                const bool usesslv3);
   // need our own one since we run in a different thread from service
   QNetworkReply* Send(QNetworkAccessManager& network, const QUrl& url,
                       const bool usesslv3);

--- a/src/internet/subsonic/subsonicdynamicplaylist.h
+++ b/src/internet/subsonic/subsonicdynamicplaylist.h
@@ -21,6 +21,7 @@
 #include "smartplaylists/generator.h"
 
 #include <QNetworkAccessManager>
+#include <QXmlStreamReader>
 
 class SubsonicService;
 
@@ -41,8 +42,13 @@ class SubsonicDynamicPlaylist : public smart_playlists::Generator {
     QueryStat_Random = 5,
   };
 
+  enum QueryType {
+      QueryType_Album = 0,
+      QueryType_Song = 1,
+  };
+
   SubsonicDynamicPlaylist();
-  SubsonicDynamicPlaylist(const QString& name, QueryStat stat);
+  SubsonicDynamicPlaylist(const QString& name, QueryType type, QueryStat stat);
 
   QString type() const { return "Subsonic"; }
 
@@ -53,10 +59,14 @@ class SubsonicDynamicPlaylist : public smart_playlists::Generator {
   PlaylistItemList Generate();
 
   bool is_dynamic() const { return true; }
-  PlaylistItemList GenerateMore(int count);
+  PlaylistItemList GenerateMoreAlbums(int count);
+  PlaylistItemList GenerateMoreSongs(int count);
+
+  Song ReadSong(SubsonicService* service, QXmlStreamReader& reader);
 
   static const int kMaxCount;
-  static const int kDefaultCount;
+  static const int kDefaultAlbumCount;
+  static const int kDefaultSongCount;
   static const int kDefaultOffset;
 
  private:
@@ -85,6 +95,7 @@ class SubsonicDynamicPlaylist : public smart_playlists::Generator {
   }
 
  private:
+  QueryType type_;
   QueryStat stat_;
   int offset_;
   SubsonicService* service_;

--- a/src/internet/subsonic/subsonicservice.cpp
+++ b/src/internet/subsonic/subsonicservice.cpp
@@ -98,23 +98,33 @@ SubsonicService::SubsonicService(Application* app, InternetModel* parent)
     LibraryModel::DefaultGenerators()
     << (LibraryModel::GeneratorList()
         << GeneratorPtr(new SubsonicDynamicPlaylist(
-                          tr("Newest"),
+                          tr("Newest Albums"),
+                          SubsonicDynamicPlaylist::QueryType_Album,
                           SubsonicDynamicPlaylist::QueryStat_Newest))
         << GeneratorPtr(new SubsonicDynamicPlaylist(
-                          tr("Random"),
+                          tr("Random Albums"),
+                          SubsonicDynamicPlaylist::QueryType_Album,
                           SubsonicDynamicPlaylist::QueryStat_Random))
         << GeneratorPtr(new SubsonicDynamicPlaylist(
-                          tr("Frequently Played"),
+                          tr("Frequently Played Albums"),
+                          SubsonicDynamicPlaylist::QueryType_Album,
                           SubsonicDynamicPlaylist::QueryStat_Frequent))
         << GeneratorPtr(new SubsonicDynamicPlaylist(
-                          tr("Top Rated"),
+                          tr("Top Rated Albums"),
+                          SubsonicDynamicPlaylist::QueryType_Album,
                           SubsonicDynamicPlaylist::QueryStat_Highest))
         << GeneratorPtr(new SubsonicDynamicPlaylist(
-                          tr("Recently Played"),
+                          tr("Recently Played Albums"),
+                          SubsonicDynamicPlaylist::QueryType_Album,
                           SubsonicDynamicPlaylist::QueryStat_Recent))
         << GeneratorPtr(new SubsonicDynamicPlaylist(
-                          tr("Starred"),
+                          tr("Starred Albums"),
+                          SubsonicDynamicPlaylist::QueryType_Album,
                           SubsonicDynamicPlaylist::QueryStat_Starred))
+        << GeneratorPtr(new SubsonicDynamicPlaylist(
+                          tr("Random Songs"),
+                          SubsonicDynamicPlaylist::QueryType_Song,
+                          SubsonicDynamicPlaylist::QueryStat_Random))
       ));
 
   library_filter_ = new LibraryFilterWidget(0);

--- a/src/internet/subsonic/subsonicservice.h
+++ b/src/internet/subsonic/subsonicservice.h
@@ -114,7 +114,8 @@ class SubsonicService : public InternetService {
   // boilerplate.
   QNetworkReply* Send(const QUrl& url);
 
-  friend PlaylistItemList SubsonicDynamicPlaylist::GenerateMore(int);
+  friend PlaylistItemList SubsonicDynamicPlaylist::GenerateMoreAlbums(int);
+  friend PlaylistItemList SubsonicDynamicPlaylist::GenerateMoreSongs(int);
 
   static const char* kServiceName;
   static const char* kSettingsGroup;


### PR DESCRIPTION
This PR adds a new dynamic playlist to subsonic that plays random songs instead of only random albums. The previous dynamic playlists have been renamed.

I had to remove the Clementine configuration to be able to see the changes to playlists, I guess there's a better way to change the dynamic playlists without deleting the entire configuration.

While this PR doesn't really depend on my other PR (#6631), this PR builds on top of that and is pretty useless without the previous PR.