### PR TITLE
Fix tranlations test.

### DIFF
--- a/tests/translations_test.cpp
+++ b/tests/translations_test.cpp
@@ -29,8 +29,8 @@ TEST(Translations, Basic) {
   PoTranslator t;
   t.load("clementine_es.qm", ":/translations");
 
-  EXPECT_EQ(QString::fromUtf8("Colección"),
+  EXPECT_EQ(QString::fromUtf8("Fonoteca"),
             t.translate("MainWindow", "Library"));
-  EXPECT_EQ(QString::fromUtf8("Colección"),
+  EXPECT_EQ(QString::fromUtf8("Fonoteca"),
             t.translate("", "Library"));
 }


### PR DESCRIPTION
Hello there :-)

When packaging clementine for guix, we run the unittests. I noticed the pre-release was failing this test because of an out-dated translation so here's a fix!

Thanks,
Pierre