### PR TITLE
Settings cleanup

### DIFF
--- a/src/ui/settingsdialog.cpp
+++ b/src/ui/settingsdialog.cpp
@@ -269,21 +269,17 @@ void SettingsDialog::AddPage(Page id, SettingsPage* page,
   pages_[id] = data;
 }
 
-void SettingsDialog::Save() {
-  for (const PageData& data : pages_.values()) {
-    data.page_->Save();
-  }
-}
-
 void SettingsDialog::accept() {
-  Save();
+  for (const PageData& data : pages_.values()) {
+    data.page_->Accept();
+  }
   QDialog::accept();
 }
 
 void SettingsDialog::reject() {
   // Notify each page that user clicks on Cancel
   for (const PageData& data : pages_.values()) {
-    data.page_->Cancel();
+    data.page_->Reject();
   }
 
   QDialog::reject();
@@ -292,7 +288,9 @@ void SettingsDialog::reject() {
 void SettingsDialog::DialogButtonClicked(QAbstractButton* button) {
   // While we only connect Apply at the moment, this might change in the future
   if (ui_->buttonBox->button(QDialogButtonBox::Apply) == button) {
-    Save();
+    for (const PageData& data : pages_.values()) {
+      data.page_->Apply();
+    }
   }
 }
 

--- a/src/ui/settingsdialog.h
+++ b/src/ui/settingsdialog.h
@@ -133,8 +133,6 @@ class SettingsDialog : public QDialog {
   QTreeWidgetItem* AddCategory(const QString& name);
   void AddPage(Page id, SettingsPage* page, QTreeWidgetItem* parent = nullptr);
 
-  void Save();
-
  private:
   Application* app_;
   LibraryDirectoryModel* model_;

--- a/src/ui/settingspage.cpp
+++ b/src/ui/settingspage.cpp
@@ -20,3 +20,15 @@
 
 SettingsPage::SettingsPage(SettingsDialog* dialog)
     : QWidget(dialog), dialog_(dialog) {}
+
+void SettingsPage::Apply() {
+  Save();
+}
+
+void SettingsPage::Accept() {
+  Save();
+}
+
+void SettingsPage::Reject() {
+  Cancel();
+}

--- a/src/ui/settingspage.cpp
+++ b/src/ui/settingspage.cpp
@@ -17,18 +17,35 @@
 
 #include "settingsdialog.h"
 #include "settingspage.h"
+#include "core/logging.h"
 
 SettingsPage::SettingsPage(SettingsDialog* dialog)
-    : QWidget(dialog), dialog_(dialog) {}
+    : QWidget(dialog), maybe_changed_(false), dialog_(dialog) {}
+
+void SettingsPage::showEvent(QShowEvent* event) {
+  QWidget::showEvent(event);
+  maybe_changed_ = true;
+}
 
 void SettingsPage::Apply() {
-  Save();
+  if (maybe_changed_) {
+    qLog(Debug) << "Saving" << windowTitle();
+    Save();
+    if (!isVisible())
+      // Don't expect additional changes until the page is visible again.
+      maybe_changed_ = false;
+  }
 }
 
 void SettingsPage::Accept() {
-  Save();
+  if (maybe_changed_) {
+    qLog(Debug) << "Saving" << windowTitle();
+    Save();
+    maybe_changed_ = false;
+  }
 }
 
 void SettingsPage::Reject() {
   Cancel();
+  maybe_changed_ = false;
 }

--- a/src/ui/settingspage.h
+++ b/src/ui/settingspage.h
@@ -45,9 +45,14 @@ class SettingsPage : public QWidget {
   // The dialog that this page belongs to.
   SettingsDialog* dialog() const { return dialog_; }
 
-signals:
+ signals:
   void NotificationPreview(OSD::Behaviour, QString, QString);
   void SetWiimotedevInterfaceActived(bool);
+
+ protected:
+  void showEvent(QShowEvent* event);
+
+  bool maybe_changed_;
 
  private:
   virtual void Save() = 0;

--- a/src/ui/settingspage.h
+++ b/src/ui/settingspage.h
@@ -33,11 +33,14 @@ class SettingsPage : public QWidget {
   // Return false to grey out the page's item in the list.
   virtual bool IsEnabled() const { return true; }
 
-  // Load is called when the dialog is shown, Save when the user clicks OK, and
-  // Cancel when the user clicks on Cancel
+  // Called when the dialog is shown.
   virtual void Load() = 0;
-  virtual void Save() = 0;
-  virtual void Cancel() {}
+  // Called when Apply is selected.
+  virtual void Apply();
+  // Called when OK is selected.
+  virtual void Accept();
+  // Called when Cancel is selected.
+  virtual void Reject();
 
   // The dialog that this page belongs to.
   SettingsDialog* dialog() const { return dialog_; }
@@ -47,6 +50,9 @@ signals:
   void SetWiimotedevInterfaceActived(bool);
 
  private:
+  virtual void Save() = 0;
+  virtual void Cancel() {}
+
   SettingsDialog* dialog_;
 };
 


### PR DESCRIPTION
Current settings behavior calls Save for all pages, which can take several seconds. This change calls Save only on pages that have been shown.