### PR TITLE
icecast: free backend on exit

### DIFF
--- a/src/globalsearch/icecastsearchprovider.cpp
+++ b/src/globalsearch/icecastsearchprovider.cpp
@@ -16,11 +16,12 @@
 */
 
 #include "icecastsearchprovider.h"
+
 #include "internet/icecast/icecastbackend.h"
 #include "ui/iconloader.h"
 
-IcecastSearchProvider::IcecastSearchProvider(IcecastBackend* backend,
-                                             Application* app, QObject* parent)
+IcecastSearchProvider::IcecastSearchProvider(
+    std::shared_ptr<IcecastBackend> backend, Application* app, QObject* parent)
     : BlockingSearchProvider(app, parent), backend_(backend) {
   Init("Icecast", "icecast", IconLoader::Load("icon_radio", IconLoader::Lastfm),
        DisabledByDefault);

--- a/src/globalsearch/icecastsearchprovider.h
+++ b/src/globalsearch/icecastsearchprovider.h
@@ -18,19 +18,21 @@
 #ifndef ICECASTSEARCHPROVIDER_H
 #define ICECASTSEARCHPROVIDER_H
 
+#include <memory>
+
 #include "searchprovider.h"
 
 class IcecastBackend;
 
 class IcecastSearchProvider : public BlockingSearchProvider {
  public:
-  IcecastSearchProvider(IcecastBackend* backend, Application* app,
-                        QObject* parent);
+  IcecastSearchProvider(std::shared_ptr<IcecastBackend> backend,
+                        Application* app, QObject* parent);
 
   ResultList Search(int id, const QString& query);
 
  private:
-  IcecastBackend* backend_;
+  std::shared_ptr<IcecastBackend> backend_;
 };
 
 #endif  // ICECASTSEARCHPROVIDER_H

--- a/src/internet/icecast/icecastmodel.cpp
+++ b/src/internet/icecast/icecastmodel.cpp
@@ -23,7 +23,8 @@
 #include "playlist/songmimedata.h"
 #include "ui/iconloader.h"
 
-IcecastModel::IcecastModel(IcecastBackend* backend, QObject* parent)
+IcecastModel::IcecastModel(std::shared_ptr<IcecastBackend> backend,
+                           QObject* parent)
     : SimpleTreeModel<IcecastItem>(new IcecastItem(this), parent),
       backend_(backend),
       sort_mode_(SortMode_GenreByPopularity),
@@ -35,7 +36,7 @@ IcecastModel::IcecastModel(IcecastBackend* backend, QObject* parent)
 IcecastModel::~IcecastModel() { delete root_; }
 
 void IcecastModel::Init() {
-  connect(backend_, SIGNAL(DatabaseReset()), SLOT(Reset()));
+  connect(backend_.get(), SIGNAL(DatabaseReset()), SLOT(Reset()));
 
   Reset();
 }

--- a/src/internet/icecast/icecastmodel.h
+++ b/src/internet/icecast/icecastmodel.h
@@ -20,11 +20,12 @@
 #ifndef INTERNET_ICECAST_ICECASTMODEL_H_
 #define INTERNET_ICECAST_ICECASTMODEL_H_
 
-#include "icecastitem.h"
-#include "core/simpletreemodel.h"
-#include "library/librarymodel.h"
-
 #include <QIcon>
+#include <memory>
+
+#include "core/simpletreemodel.h"
+#include "icecastitem.h"
+#include "library/librarymodel.h"
 
 class IcecastBackend;
 
@@ -32,7 +33,8 @@ class IcecastModel : public SimpleTreeModel<IcecastItem> {
   Q_OBJECT
 
  public:
-  explicit IcecastModel(IcecastBackend* backend, QObject* parent = nullptr);
+  explicit IcecastModel(std::shared_ptr<IcecastBackend> backend,
+                        QObject* parent = nullptr);
   ~IcecastModel();
 
   // These values get saved in QSettings - don't change them
@@ -45,8 +47,6 @@ class IcecastModel : public SimpleTreeModel<IcecastItem> {
   enum Role {
     Role_IsDivider = LibraryModel::Role_IsDivider,
   };
-
-  IcecastBackend* backend() const { return backend_; }
 
   Song GetSong(const QModelIndex& index) const;
 
@@ -76,7 +76,7 @@ class IcecastModel : public SimpleTreeModel<IcecastItem> {
   static QString DividerDisplayText(const QChar& key);
 
  private:
-  IcecastBackend* backend_;
+  std::shared_ptr<IcecastBackend> backend_;
 
   QString filter_;
   SortMode sort_mode_;

--- a/src/internet/icecast/icecastservice.cpp
+++ b/src/internet/icecast/icecastservice.cpp
@@ -57,10 +57,9 @@ IcecastService::IcecastService(Application* app, InternetModel* parent)
     : InternetService(kServiceName, app, parent, parent),
       network_(new NetworkAccessManager(this)),
       context_menu_(nullptr),
-      backend_(nullptr),
+      backend_(new IcecastBackend),
       model_(nullptr),
       filter_(new IcecastFilterWidget(0)) {
-  backend_ = new IcecastBackend;
   backend_->moveToThread(app_->database()->thread());
   backend_->Init(app_->database());
 

--- a/src/internet/icecast/icecastservice.h
+++ b/src/internet/icecast/icecastservice.h
@@ -23,6 +23,7 @@
 
 #include "internet/core/internetservice.h"
 
+#include <memory>
 #include <QXmlStreamReader>
 
 #include "icecastbackend.h"
@@ -75,7 +76,7 @@ class IcecastService : public InternetService {
   NetworkAccessManager* network_;
   QMenu* context_menu_;
 
-  IcecastBackend* backend_;
+  std::shared_ptr<IcecastBackend> backend_;
   IcecastModel* model_;
   IcecastFilterWidget* filter_;
 };


### PR DESCRIPTION
Use a shared pointer since the model and search provider both hold pointers to
the backend object. Also removed unused accessor method.