### PR TITLE
Guess title and artist from filename

### DIFF
--- a/src/core/song.h
+++ b/src/core/song.h
@@ -241,6 +241,7 @@ class Song {
   // Pretty accessors
   QString PrettyRating() const;
   QString PrettyTitle() const;
+  QString PrettyArtist() const;
   QString PrettyTitleWithArtist() const;
   QString PrettyLength() const;
   QString PrettyYear() const;

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -303,7 +303,7 @@ QVariant Playlist::data(const QModelIndex& index, int role) const {
         case Column_Title:
           return song.PrettyTitle();
         case Column_Artist:
-          return song.artist();
+          return song.PrettyArtist();
         case Column_Album:
           return song.album();
         case Column_Length:

--- a/src/ui/edittagdialog.cpp
+++ b/src/ui/edittagdialog.cpp
@@ -299,8 +299,8 @@ void EditTagDialog::SetSongListVisibility(bool visible) {
 }
 
 QVariant EditTagDialog::Data::value(const Song& song, const QString& id) {
-  if (id == "title") return song.title();
-  if (id == "artist") return song.artist();
+  if (id == "title") return song.PrettyTitle();
+  if (id == "artist") return song.PrettyArtist();
   if (id == "album") return song.album();
   if (id == "albumartist") return song.albumartist();
   if (id == "composer") return song.composer();


### PR DESCRIPTION
I have many files named like Led_Zeppelin_-_Dazed_and_Confused.mp3 with no id3 tags.
This change makes the playlist look much nicer by grabbing the artist from before the dash
and the title from after.  Handles spaces or underscores. Additionally when you click on Edit Track Information the filename artist and title are there as default so you can just click [Save] to update the id3 tag - saves typing.

