### PR TITLE
Debug console

### DIFF
--- a/src/core/application.cpp
+++ b/src/core/application.cpp
@@ -192,6 +192,7 @@ class ApplicationImpl {
 
 Application::Application(QObject* parent)
     : QObject(parent), p_(new ApplicationImpl(this)) {
+  setObjectName("Clementine Application");
   // This must be before library_->Init();
   // In the constructor the helper waits for the signal
   // PlaylistManagerInitialized

--- a/src/ui/console.cpp
+++ b/src/ui/console.cpp
@@ -8,17 +8,24 @@
 
 #include "core/application.h"
 #include "core/database.h"
+#include "core/logging.h"
 
 Console::Console(Application* app, QWidget* parent)
     : QDialog(parent), app_(app) {
   ui_.setupUi(this);
   connect(ui_.database_run, SIGNAL(clicked()), SLOT(RunQuery()));
+  connect(ui_.qt_dump_button, SIGNAL(clicked()), SLOT(Dump()));
 
   QFont font("Monospace");
   font.setStyleHint(QFont::TypeWriter);
 
   ui_.database_output->setFont(font);
   ui_.database_query->setFont(font);
+
+  QList<QObject*> objs = GetTopLevelObjects();
+  for (QObject* obj : objs)
+    ui_.qt_dump_box->addItem(obj->objectName() + " object tree",
+                             obj->objectName());
 }
 
 void Console::RunQuery() {
@@ -44,4 +51,29 @@ void Console::RunQuery() {
 
   ui_.database_output->verticalScrollBar()->setValue(
       ui_.database_output->verticalScrollBar()->maximum());
+}
+
+void Console::Dump() {
+  QString item = ui_.qt_dump_box->currentData().toString();
+  QObject* obj = FindTopLevelObject(item);
+  if (obj == nullptr) {
+    qLog(Error) << "Object not found" << item;
+    return;
+  }
+  obj->dumpObjectTree();
+}
+
+QList<QObject*> Console::GetTopLevelObjects() {
+  QList<QObject*> objs;
+  objs << app_;
+  // The parent should be the main window.
+  if (parent() != nullptr) objs << parent();
+
+  return objs;
+}
+
+QObject* Console::FindTopLevelObject(QString& name) {
+  for (QObject* obj : GetTopLevelObjects())
+    if (obj->objectName() == name) return obj;
+  return nullptr;
 }

--- a/src/ui/console.cpp
+++ b/src/ui/console.cpp
@@ -12,21 +12,21 @@
 Console::Console(Application* app, QWidget* parent)
     : QDialog(parent), app_(app) {
   ui_.setupUi(this);
-  connect(ui_.run, SIGNAL(clicked()), SLOT(RunQuery()));
+  connect(ui_.database_run, SIGNAL(clicked()), SLOT(RunQuery()));
 
   QFont font("Monospace");
   font.setStyleHint(QFont::TypeWriter);
 
-  ui_.output->setFont(font);
-  ui_.query->setFont(font);
+  ui_.database_output->setFont(font);
+  ui_.database_query->setFont(font);
 }
 
 void Console::RunQuery() {
   QSqlDatabase db = app_->database()->Connect();
-  QSqlQuery query = db.exec(ui_.query->text());
-  ui_.query->clear();
+  QSqlQuery query = db.exec(ui_.database_query->text());
+  ui_.database_query->clear();
 
-  ui_.output->append("<b>&gt; " + query.executedQuery() + "</b>");
+  ui_.database_output->append("<b>&gt; " + query.executedQuery() + "</b>");
 
   query.next();
 
@@ -37,11 +37,11 @@ void Console::RunQuery() {
       values.append(record.value(i).toString());
     }
 
-    ui_.output->append(values.join("|"));
+    ui_.database_output->append(values.join("|"));
 
     query.next();
   }
 
-  ui_.output->verticalScrollBar()->setValue(
-      ui_.output->verticalScrollBar()->maximum());
+  ui_.database_output->verticalScrollBar()->setValue(
+      ui_.database_output->verticalScrollBar()->maximum());
 }

--- a/src/ui/console.h
+++ b/src/ui/console.h
@@ -13,9 +13,14 @@ class Console : public QDialog {
   Console(Application* app, QWidget* parent = nullptr);
 
  private slots:
+  // Database
   void RunQuery();
+  // Qt
+  void Dump();
 
  private:
+  QList<QObject*> GetTopLevelObjects();
+  QObject* FindTopLevelObject(QString& name);
   Ui::Console ui_;
   Application* app_;
 };

--- a/src/ui/console.ui
+++ b/src/ui/console.ui
@@ -48,6 +48,51 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="qt_tab">
+      <attribute name="title">
+       <string>Qt</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QGroupBox" name="qt_dump_group">
+         <property name="title">
+          <string>Dump To Logs</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <widget class="QComboBox" name="qt_dump_box"/>
+          </item>
+          <item>
+           <widget class="QPushButton" name="qt_dump_button">
+            <property name="maximumSize">
+             <size>
+              <width>100</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>dump</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/src/ui/console.ui
+++ b/src/ui/console.ui
@@ -13,35 +13,45 @@
   <property name="windowTitle">
    <string>Console</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <layout class="QVBoxLayout" name="verticalLayout">
-     <item>
-      <widget class="QTextBrowser" name="output"/>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="database_tab">
+      <attribute name="title">
+       <string>Database</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
-        <widget class="QLineEdit" name="query"/>
+        <widget class="QTextBrowser" name="database_output"/>
        </item>
        <item>
-        <widget class="QPushButton" name="run">
-         <property name="text">
-          <string>Run</string>
+        <widget class="QGroupBox" name="database_command_group">
+         <property name="title">
+          <string>Command</string>
          </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_4">
+          <item>
+           <widget class="QLineEdit" name="database_query"/>
+          </item>
+          <item>
+           <widget class="QPushButton" name="database_run">
+            <property name="text">
+             <string>Run</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
       </layout>
-     </item>
-    </layout>
+     </widget>
+    </widget>
    </item>
   </layout>
  </widget>
- <tabstops>
-  <tabstop>query</tabstop>
-  <tabstop>run</tabstop>
-  <tabstop>output</tabstop>
- </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -154,6 +154,7 @@ void qt_mac_set_dock_menu(QMenu*);
 
 const char* MainWindow::kSettingsGroup = "MainWindow";
 const char* MainWindow::kAllFilesFilterSpec = QT_TR_NOOP("All Files (*)");
+const char* MainWindow::kShowDebugConsoleKey = "CLEMENTINE_DEBUG_CONSOLE";
 
 namespace {
 const int kTrackSliderUpdateTimeMs = 500;
@@ -919,8 +920,12 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
           SLOT(EnableKittens(bool)));
   connect(ui_->action_kittens, SIGNAL(toggled(bool)), app_->network_remote(),
           SLOT(EnableKittens(bool)));
-  // Hide the console
-  // connect(ui_->action_console, SIGNAL(triggered()), SLOT(ShowConsole()));
+  QString showConsole =
+      QProcessEnvironment::systemEnvironment().value(kShowDebugConsoleKey, "0");
+  if (showConsole == "1")
+    connect(ui_->action_console, SIGNAL(triggered()), SLOT(ShowConsole()));
+  else
+    ui_->action_console->setVisible(false);
   NowPlayingWidgetPositionChanged(ui_->now_playing->show_above_status_bar());
 
   // Load theme

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -97,6 +97,7 @@ class MainWindow : public QMainWindow, public PlatformInterface {
 
   static const char* kSettingsGroup;
   static const char* kAllFilesFilterSpec;
+  static const char* kShowDebugConsoleKey;
 
   // Don't change the values
   enum StartupBehaviour {

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -536,6 +536,7 @@
     <addaction name="action_hypnotoad"/>
     <addaction name="action_enterprise"/>
     <addaction name="action_kittens"/>
+    <addaction name="action_console"/>
     <addaction name="separator"/>
    </widget>
    <widget class="QMenu" name="menu_tools">


### PR DESCRIPTION
These changes re-enable the console menu option for more general debug usage. The option is only available if the environment variable CLEMENTINE_DEBUG_CONSOLE=1. A new tab in the dialog provides options to dump the application and main window objects trees.

Thoughts on future use:
- Query information on an object based on name.
- Adjust logging classes and levels.
- Dump gstreamer pipeline info.