### PR TITLE
Make first smart playlist dialog fit on smaller screen

### DIFF
--- a/src/smartplaylists/querysearchpage.ui
+++ b/src/smartplaylists/querysearchpage.ui
@@ -25,16 +25,7 @@
 }</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout" stretch="0,5,1">
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
+   <property name="margin">
     <number>0</number>
    </property>
    <item>
@@ -102,7 +93,7 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>420</width>
+           <width>418</width>
            <height>182</height>
           </rect>
          </property>
@@ -113,16 +104,7 @@
           </sizepolicy>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_2">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
+          <property name="margin">
            <number>0</number>
           </property>
           <item>

--- a/src/smartplaylists/querysearchpage.ui
+++ b/src/smartplaylists/querysearchpage.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+   <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -24,8 +24,17 @@
   background: transparent;
 }</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="margin">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,5,1">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
@@ -67,7 +76,7 @@
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>300</height>
+       <height>200</height>
       </size>
      </property>
      <property name="title">
@@ -93,8 +102,8 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>418</width>
-           <height>251</height>
+           <width>420</width>
+           <height>182</height>
           </rect>
          </property>
          <property name="sizePolicy">
@@ -104,7 +113,16 @@
           </sizepolicy>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_2">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
            <number>0</number>
           </property>
           <item>

--- a/src/smartplaylists/querywizardplugin.cpp
+++ b/src/smartplaylists/querywizardplugin.cpp
@@ -152,24 +152,6 @@ int QueryWizardPlugin::CreatePages(QWizard* wizard, int finish_page_id) {
           SLOT(UpdateSortPreview()));
   connect(sort_ui_->random, SIGNAL(toggled(bool)), SLOT(UpdateSortPreview()));
 
-  // Adjust height, if necessary
-  /*
-  QScreen *scn = QGuiApplication::primaryScreen();
-  QRect scnGeo = scn->availableGeometry();
-  const int scnHeight = scnGeo.height();
-  //QRect pgeGeo = search_page_->geometry();
-  const int pgeHeight = search_page_->height();
-  printf("djm: pgeHeight=%d, scnHeight=%d\n", pgeHeight, scnHeight);
-  if (pgeHeight > scnHeight) {
-     printf("djm: too tall\n");
-     const int pgeWidth = search_page_->width();
-     search_page_->resize(pgeWidth, scnHeight);
-  }
-  else {
-     printf("djm: OK tall\n");
-  }
-  */
-
   // Configure the page text
   search_page_->setTitle(tr("Search terms"));
   search_page_->setSubTitle(

--- a/src/smartplaylists/querywizardplugin.cpp
+++ b/src/smartplaylists/querywizardplugin.cpp
@@ -118,6 +118,7 @@ int QueryWizardPlugin::CreatePages(QWizard* wizard, int finish_page_id) {
   search_page_->preview_ = new SearchPreview(search_page_);
   search_page_->preview_->set_application(app_);
   search_page_->preview_->set_library(library_);
+  search_page_->preview_->setMinimumHeight(100);
   terms_page_layout->addWidget(search_page_->preview_);
 
   // Add sort field texts
@@ -150,6 +151,24 @@ int QueryWizardPlugin::CreatePages(QWizard* wizard, int finish_page_id) {
   connect(sort_ui_->order, SIGNAL(currentIndexChanged(int)),
           SLOT(UpdateSortPreview()));
   connect(sort_ui_->random, SIGNAL(toggled(bool)), SLOT(UpdateSortPreview()));
+
+  // Adjust height, if necessary
+  /*
+  QScreen *scn = QGuiApplication::primaryScreen();
+  QRect scnGeo = scn->availableGeometry();
+  const int scnHeight = scnGeo.height();
+  //QRect pgeGeo = search_page_->geometry();
+  const int pgeHeight = search_page_->height();
+  printf("djm: pgeHeight=%d, scnHeight=%d\n", pgeHeight, scnHeight);
+  if (pgeHeight > scnHeight) {
+     printf("djm: too tall\n");
+     const int pgeWidth = search_page_->width();
+     search_page_->resize(pgeWidth, scnHeight);
+  }
+  else {
+     printf("djm: OK tall\n");
+  }
+  */
 
   // Configure the page text
   search_page_->setTitle(tr("Search terms"));


### PR DESCRIPTION
This dialog was falling off the bottom on a smaller screen.
The user (me) could not press the buttons at the bottom.
I reduced the minimum heights so its ok for smaller screens but added expanding
so it will be larger are on big screens.
I tested by manually making the dialog bigger and smaller as a user - to make
sure it made best use of the space.