### PR TITLE
Name all threads created by Application

### DIFF
--- a/src/core/application.cpp
+++ b/src/core/application.cpp
@@ -226,6 +226,8 @@ Application::~Application() {
 
 void Application::MoveToNewThread(QObject* object) {
   QThread* thread = new QThread(this);
+  if (!object->objectName().isEmpty())
+    thread->setObjectName(object->objectName() + " thread");
 
   MoveToThread(object, thread);
 

--- a/src/core/database.cpp
+++ b/src/core/database.cpp
@@ -215,6 +215,7 @@ Database::Database(Application* app, QObject* parent,
       injected_database_name_(database_name),
       query_hash_(0),
       startup_schema_version_(-1) {
+  setObjectName("Database");
   {
     QMutexLocker l(&sNextConnectionIdMutex);
     connection_id_ = sNextConnectionId++;

--- a/src/core/tagreaderclient.cpp
+++ b/src/core/tagreaderclient.cpp
@@ -34,6 +34,7 @@ TagReaderClient* TagReaderClient::sInstance = nullptr;
 TagReaderClient::TagReaderClient(QObject* parent)
     : QObject(parent), worker_pool_(new WorkerPool<HandlerType>(this)) {
   sInstance = this;
+  setObjectName("Tag reader client");
 
   QSettings s;
   s.beginGroup(Player::kSettingsGroup);

--- a/src/covers/albumcoverloader.cpp
+++ b/src/covers/albumcoverloader.cpp
@@ -43,7 +43,9 @@ AlbumCoverLoader::AlbumCoverLoader(QObject* parent)
       stop_requested_(false),
       next_id_(1),
       network_(new NetworkAccessManager(this)),
-      connected_spotify_(false) {}
+      connected_spotify_(false) {
+  setObjectName("Album cover loader");
+}
 
 QString AlbumCoverLoader::ImageCacheDir() {
   return Utilities::GetConfigPath(Utilities::Path_AlbumCovers);

--- a/src/internet/podcasts/podcastdeleter.cpp
+++ b/src/internet/podcasts/podcastdeleter.cpp
@@ -42,6 +42,7 @@ PodcastDeleter::PodcastDeleter(Application* app, QObject* parent)
       backend_(app_->podcast_backend()),
       delete_after_secs_(0),
       auto_delete_timer_(new QTimer(this)) {
+  setObjectName("Podcast deleter");
   ReloadSettings();
   auto_delete_timer_->setSingleShot(true);
   AutoDelete();

--- a/src/networkremote/networkremote.cpp
+++ b/src/networkremote/networkremote.cpp
@@ -35,7 +35,9 @@ const quint16 NetworkRemote::kDefaultServerPort = 5500;
 const char* NetworkRemote::kTranscoderSettingPostfix = "/NetworkRemote";
 
 NetworkRemote::NetworkRemote(Application* app, QObject* parent)
-    : QObject(parent), signals_connected_(false), app_(app) {}
+    : QObject(parent), signals_connected_(false), app_(app) {
+  setObjectName("Network remote");
+}
 
 NetworkRemote::~NetworkRemote() { StopServer(); }
 


### PR DESCRIPTION
In Application::MoveToNewThread, name the new thread after the object being
moved. Give those objects names as well.

The thread names display in gdb with "info threads".