### PR TITLE
Changed rgb() to rgba()

### DIFF
--- a/src/playlist/dynamicplaylistcontrols.ui
+++ b/src/playlist/dynamicplaylistcontrols.ui
@@ -14,7 +14,7 @@
    <string notr="true">#container {
 	background: rgba(200, 200, 200, 50%);
     border-radius: 10px;
-    border: 1px solid rgb(200, 200, 200, 75%);
+    border: 1px solid rgba(200, 200, 200, 75%);
 }
 
 #label1 {


### PR DESCRIPTION
Avoids message:   
QCssParser::parseColorValue: Specified color without alpha value but alpha given: 'rgb 200, 200, 200, 75%'