### PR TITLE
Minor smart playlist UI improvements

### DIFF
--- a/src/smartplaylists/querysortpage.ui
+++ b/src/smartplaylists/querysortpage.ui
@@ -14,7 +14,16 @@
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
@@ -82,6 +91,12 @@
       </item>
       <item row="1" column="1">
        <widget class="QSpinBox" name="limit_value">
+        <property name="minimumSize">
+         <size>
+          <width>150</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="suffix">
          <string> songs</string>
         </property>

--- a/src/smartplaylists/wizard.cpp
+++ b/src/smartplaylists/wizard.cpp
@@ -106,6 +106,9 @@ void Wizard::SetGenerator(GeneratorPtr gen) {
   // Set the name
   finish_page_->ui_->name->setText(gen->name());
   finish_page_->ui_->dynamic->setChecked(gen->is_dynamic());
+  if (!gen->name().isEmpty()) {
+    setWindowTitle(windowTitle() + " - " + gen->name());
+  }
 
   if (type_index_ == -1) {
     qLog(Error) << "Plugin was not found for generator type" << gen->type();


### PR DESCRIPTION
- Displays the name of the smart playlist in the wizard title when you are editing

- Specified a minimum width for the number-of-songs spinner since it wasn't displaying nicely for me (Linux)