### PR TITLE
Change text for Original Year

### DIFF
--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -1388,7 +1388,7 @@ QString Playlist::column_name(Column column) {
     case Column_Year:
       return tr("Year");
     case Column_OriginalYear:
-      return tr("Original year");
+      return tr("Year - original"); // Done like this so sorts beside "Year" when editing smart playlists
     case Column_Genre:
       return tr("Genre");
     case Column_AlbumArtist:

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -1388,7 +1388,7 @@ QString Playlist::column_name(Column column) {
     case Column_Year:
       return tr("Year");
     case Column_OriginalYear:
-      return tr("Year - original"); // Done like this so sorts beside "Year" when editing smart playlists
+      return tr("Year - original"); //: Done like this so sorts beside "Year" when editing smart playlists
     case Column_Genre:
       return tr("Genre");
     case Column_AlbumArtist:


### PR DESCRIPTION
When editing a smart playlist "Original Year" comes before "Year" alphabetically (of course).
But the user might want Year.  So I changed the text to "Year - original" so the user
sees both kinds of year beside each other in the list and can make a better choice.