### PR TITLE
Fix cd playback

### DIFF
--- a/src/devices/cddadevice.h
+++ b/src/devices/cddadevice.h
@@ -45,6 +45,17 @@ class CddaDevice : public ConnectedDevice {
 
   static QStringList url_schemes() { return QStringList() << "cdda"; }
 
+  // QUrl interprets a single number as an ip address, so the QString cdda://1
+  // would become the QUrl cdda://0.0.0.1. For this reason, we append a single
+  // character to strings when converting to URLs and strip that character
+  // when doing the reverse conversion.
+  static QUrl TrackStrToUrl(const QString& name) { return QUrl(name + "a"); }
+  static QString TrackUrlToStr(const QUrl& url) {
+    QString str = url.toString();
+    str.remove(str.lastIndexOf(QChar('a')), 1);
+    return str;
+  }
+
 signals:
   void SongsDiscovered(const SongList& songs);
 

--- a/src/devices/cddasongloader.cpp
+++ b/src/devices/cddasongloader.cpp
@@ -23,6 +23,7 @@
 #include "core/logging.h"
 #include "core/timeconstants.h"
 
+#include "cddadevice.h"
 #include "cddasongloader.h"
 
 CddaSongLoader::CddaSongLoader(const QUrl& url, QObject* parent)
@@ -36,11 +37,13 @@ CddaSongLoader::~CddaSongLoader() {
 }
 
 QUrl CddaSongLoader::GetUrlFromTrack(int track_number) const {
+  QString track;
   if (url_.isEmpty()) {
-    return QUrl(QString("cdda://%1a").arg(track_number));
+    track = QString("cdda://%1").arg(track_number);
   } else {
-    return QUrl(QString("cdda://%1/%2").arg(url_.path()).arg(track_number));
+    track = QString("cdda://%1/%2").arg(url_.path()).arg(track_number);
   }
+  return CddaDevice::TrackStrToUrl(track);
 }
 
 void CddaSongLoader::LoadSongs() {

--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -34,6 +34,7 @@
 #include "core/mac_startup.h"
 #include "core/signalchecker.h"
 #include "core/utilities.h"
+#include "devices/cddadevice.h"
 #include "internet/core/internetmodel.h"
 #ifdef HAVE_SPOTIFY
 #  include "internet/spotify/spotifyserver.h"
@@ -203,9 +204,7 @@ GstElement* GstEnginePipeline::CreateDecodeBinFromUrl(const QUrl& url) {
 #endif
     QByteArray uri;
     if (url.scheme() == "cdda") {
-      QString str = url.toString();
-      str.remove(str.lastIndexOf(QChar('a')), 1);
-      uri = str.toUtf8();
+      uri = CddaDevice::TrackUrlToStr(url).toUtf8();
     } else {
       uri = Utilities::GetUriForGstreamer(url);
     }

--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -524,20 +524,21 @@ bool GstEnginePipeline::InitFromReq(const MediaPlaybackRequest& req,
   pipeline_ = gst_pipeline_new("pipeline");
 
   current_ = req;
-  if (current_.url_.scheme() == "cdda" && !current_.url_.path().isEmpty()) {
+  QUrl url = current_.url_;
+  if (url.scheme() == "cdda" && !url.path().isEmpty()) {
     // Currently, Gstreamer can't handle input CD devices inside cdda URL. So
     // we handle them ourself: we extract the track number and re-create an
     // URL with only cdda:// + the track number (which can be handled by
     // Gstreamer). We keep the device in mind, and we will set it later using
     // SourceSetupCallback
-    QStringList path = current_.url_.path().split('/');
-    current_.url_ = QUrl(QString("cdda://%1").arg(path.takeLast()));
+    QStringList path = url.path().split('/');
+    url = QUrl(QString("cdda://%1").arg(path.takeLast()));
     source_device_ = path.join("/");
   }
   end_offset_nanosec_ = end_nanosec;
 
   // Decode bin
-  if (!ReplaceDecodeBin(current_.url_)) return false;
+  if (!ReplaceDecodeBin(url)) return false;
 
   return Init();
 }

--- a/src/engines/gstenginepipeline.h
+++ b/src/engines/gstenginepipeline.h
@@ -141,6 +141,8 @@ signals:
                                   gpointer);
   static void TaskEnterCallback(GstTask*, GThread*, gpointer);
 
+  static QByteArray GstUriFromUrl(const QUrl& url);
+
   void TagMessageReceived(GstMessage*);
   void ErrorMessageReceived(GstMessage*);
   void ElementMessageReceived(GstMessage*);


### PR DESCRIPTION
This is a follow-on to change 335bc89. That changed fixed cdda URLs without paths but broke the schemes on URLs with paths.