### PR TITLE
database: Add ftsyear to jamendo.songs_fts

### DIFF
--- a/data/schema/jamendo.sql
+++ b/data/schema/jamendo.sql
@@ -53,7 +53,7 @@ CREATE TABLE jamendo.songs (
 );
 
 CREATE VIRTUAL TABLE jamendo.songs_fts USING fts3(
-  ftstitle, ftsalbum, ftsartist, ftsalbumartist, ftscomposer, ftsperformer, ftsgrouping, ftsgenre, ftscomment,
+  ftstitle, ftsalbum, ftsartist, ftsalbumartist, ftscomposer, ftsperformer, ftsgrouping, ftsgenre, ftscomment, ftsyear,
   tokenize=unicode
 );
 


### PR DESCRIPTION
A previous change added ftsyear to all songs_fts tables, but the base jamendo
schema, which is used when recreating the database, was not updated. This
resulted in thousands of sql errors when reloading the catalog.