### PR TITLE
organise: Refresh filename after transcode

### DIFF
--- a/src/core/organise.cpp
+++ b/src/core/organise.cpp
@@ -149,6 +149,12 @@ void Organise::ProcessSomeFiles() {
       song.set_basefilename(Utilities::FiddleFileExtension(
           song.basefilename(), task.new_extension_));
 
+      // Adjust the destination filename. Don't use the OrganiseFormat object
+      // for this since that will remove any duplicate filename adjustments
+      // made by OrganiseDialog.
+      task.song_info_.new_filename_ = Utilities::FiddleFileExtension(
+          task.song_info_.new_filename_, task.new_extension_);
+
       // Have to set this to the size of the new file or else funny stuff
       // happens
       song.set_filesize(QFileInfo(task.transcoded_filename_).size());


### PR DESCRIPTION
This addresses #6715. However, there's still a still an issue with incorrect filenames displayed in the dialog that needs a bigger fix.