### PR TITLE
Organize dialog filenames

### DIFF
--- a/src/core/organiseformat.cpp
+++ b/src/core/organiseformat.cpp
@@ -179,9 +179,9 @@ QString OrganiseFormat::ParseBlock(QString block, const Song& song,
 QString OrganiseFormat::TagValue(const QString& tag, const Song& song) const {
   QString value;
 
-  // TODO(sobkas): What about nice switch statement?
-
-  if (tag == "title")
+  if (tag_overrides_.contains(tag))
+    value = tag_overrides_.value(tag);
+  else if (tag == "title")
     value = song.title();
   else if (tag == "album")
     value = song.album();

--- a/src/core/organiseformat.h
+++ b/src/core/organiseformat.h
@@ -48,6 +48,11 @@ class OrganiseFormat {
   void set_replace_spaces(bool v) { replace_spaces_ = v; }
   void set_replace_the(bool v) { replace_the_ = v; }
 
+  void add_tag_override(const QString& tag, const QString& v) {
+    tag_overrides_[tag] = v;
+  }
+  void reset_tag_overrides() { tag_overrides_.clear(); }
+
   bool IsValid() const;
   QString GetFilenameForSong(const Song& song) const;
 
@@ -76,6 +81,8 @@ class OrganiseFormat {
   QString ParseBlock(QString block, const Song& song,
                      bool* any_empty = nullptr) const;
   QString TagValue(const QString& tag, const Song& song) const;
+
+  QMap<QString, QString> tag_overrides_;
 
   QString format_;
   bool replace_non_ascii_;

--- a/src/ui/organisedialog.cpp
+++ b/src/ui/organisedialog.cpp
@@ -113,6 +113,13 @@ void OrganiseDialog::SetDestinationModel(QAbstractItemModel* model,
   ui_->destination->setModel(model);
 
   ui_->eject_after->setVisible(devices);
+
+  // In case this is called more than once, disconnect old model.
+  if (model_connection_) disconnect(model_connection_);
+  // If a device changes, transcoding options may have changed.
+  model_connection_ =
+      connect(model, SIGNAL(dataChanged(QModelIndex, QModelIndex)), this,
+              SLOT(DestDataChanged(QModelIndex, QModelIndex)));
 }
 
 bool OrganiseDialog::SetSongs(const SongList& songs) {
@@ -303,6 +310,16 @@ void OrganiseDialog::UpdatePreviews() {
 
   if (!resized_by_user_) {
     adjustSize();
+  }
+}
+
+void OrganiseDialog::DestDataChanged(const QModelIndex& begin,
+                                     const QModelIndex& end) {
+  const QModelIndex destination =
+      ui_->destination->model()->index(ui_->destination->currentIndex(), 0);
+  if (QItemSelection(begin, end).contains(destination)) {
+    qLog(Debug) << "Destination data changed";
+    UpdatePreviews();
   }
 }
 

--- a/src/ui/organisedialog.h
+++ b/src/ui/organisedialog.h
@@ -64,7 +64,7 @@ class OrganiseDialog : public QDialog {
 
   void SetCopy(bool copy);
 
-signals:
+ signals:
   void FileCopied(int);
 
  public slots:
@@ -80,6 +80,8 @@ signals:
   void InsertTag(const QString& tag);
   void UpdatePreviews();
 
+  void DestDataChanged(const QModelIndex& begin, const QModelIndex& end);
+
   void OrganiseFinished(const QStringList& files_with_errors);
 
  private:
@@ -92,6 +94,8 @@ signals:
   Ui_OrganiseDialog* ui_;
   TaskManager* task_manager_;
   LibraryBackend* backend_;
+
+  QMetaObject::Connection model_connection_;
 
   OrganiseFormat format_;
 


### PR DESCRIPTION
This is a follow-up to the previous change. In the case that a user has chosen a transcode format, it will display the file extensions properly. If the files are transcoded for other reasons, the dialog doesn't have any way of knowing. There could be a tighter coupling between the two classes to correct this.