### PR TITLE
Library playlist baseclass

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -528,6 +528,7 @@ set(HEADERS
   playlist/playlistdelegates.h
   playlist/playlistfilter.h
   playlist/playlistheader.h
+  playlist/playlistitem.h
   playlist/playlistitemmimedata.h
   playlist/playlistlistcontainer.h
   playlist/playlistlistmodel.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -221,6 +221,7 @@ set(SOURCES
   networkremote/songsender.cpp
   networkremote/zeroconf.cpp
 
+  playlist/dbplaylistitem.cpp
   playlist/dynamicplaylistcontrols.cpp
   playlist/playlist.cpp
   playlist/playlistbackend.cpp
@@ -521,6 +522,7 @@ set(HEADERS
   networkremote/remoteclient.h
   networkremote/songsender.h
 
+  playlist/dbplaylistitem.h
   playlist/dynamicplaylistcontrols.h
   playlist/playlist.h
   playlist/playlistbackend.h

--- a/src/internet/jamendo/jamendoplaylistitem.cpp
+++ b/src/internet/jamendo/jamendoplaylistitem.cpp
@@ -20,12 +20,10 @@
 #include "jamendoplaylistitem.h"
 
 JamendoPlaylistItem::JamendoPlaylistItem(const QString& type)
-    : LibraryPlaylistItem(type) {}
+    : DbPlaylistItem(type) {}
 
 JamendoPlaylistItem::JamendoPlaylistItem(const Song& song)
-    : LibraryPlaylistItem("Jamendo") {
-  song_ = song;
-}
+    : DbPlaylistItem("Jamendo", song) {}
 
 bool JamendoPlaylistItem::InitFromQuery(const SqlRow& query) {
   // Rows from the songs tables come first
@@ -33,5 +31,3 @@ bool JamendoPlaylistItem::InitFromQuery(const SqlRow& query) {
 
   return song_.is_valid();
 }
-
-QUrl JamendoPlaylistItem::Url() const { return song_.url(); }

--- a/src/internet/jamendo/jamendoplaylistitem.h
+++ b/src/internet/jamendo/jamendoplaylistitem.h
@@ -20,16 +20,14 @@
 #ifndef INTERNET_JAMENDO_JAMENDOPLAYLISTITEM_H_
 #define INTERNET_JAMENDO_JAMENDOPLAYLISTITEM_H_
 
-#include "library/libraryplaylistitem.h"
+#include "playlist/dbplaylistitem.h"
 
-class JamendoPlaylistItem : public LibraryPlaylistItem {
+class JamendoPlaylistItem : public DbPlaylistItem {
  public:
   explicit JamendoPlaylistItem(const QString& type);
   explicit JamendoPlaylistItem(const Song& song);
 
   bool InitFromQuery(const SqlRow& query);
-
-  QUrl Url() const;
 };
 
 #endif  // INTERNET_JAMENDO_JAMENDOPLAYLISTITEM_H_

--- a/src/internet/magnatune/magnatuneplaylistitem.cpp
+++ b/src/internet/magnatune/magnatuneplaylistitem.cpp
@@ -21,12 +21,10 @@
 #include "internet/core/internetmodel.h"
 
 MagnatunePlaylistItem::MagnatunePlaylistItem(const QString& type)
-    : LibraryPlaylistItem(type) {}
+    : DbPlaylistItem(type) {}
 
 MagnatunePlaylistItem::MagnatunePlaylistItem(const Song& song)
-    : LibraryPlaylistItem("Magnatune") {
-  song_ = song;
-}
+    : DbPlaylistItem("Magnatune", song) {}
 
 bool MagnatunePlaylistItem::InitFromQuery(const SqlRow& query) {
   // Rows from the songs tables come first
@@ -34,5 +32,3 @@ bool MagnatunePlaylistItem::InitFromQuery(const SqlRow& query) {
 
   return song_.is_valid();
 }
-
-QUrl MagnatunePlaylistItem::Url() const { return song_.url(); }

--- a/src/internet/magnatune/magnatuneplaylistitem.h
+++ b/src/internet/magnatune/magnatuneplaylistitem.h
@@ -20,16 +20,14 @@
 #ifndef INTERNET_MAGNATUNE_MAGNATUNEPLAYLISTITEM_H_
 #define INTERNET_MAGNATUNE_MAGNATUNEPLAYLISTITEM_H_
 
-#include "library/libraryplaylistitem.h"
+#include "playlist/dbplaylistitem.h"
 
-class MagnatunePlaylistItem : public LibraryPlaylistItem {
+class MagnatunePlaylistItem : public DbPlaylistItem {
  public:
   explicit MagnatunePlaylistItem(const QString& type);
   explicit MagnatunePlaylistItem(const Song& song);
 
   bool InitFromQuery(const SqlRow& query);
-
-  QUrl Url() const;
 };
 
 #endif  // INTERNET_MAGNATUNE_MAGNATUNEPLAYLISTITEM_H_

--- a/src/library/libraryplaylistitem.cpp
+++ b/src/library/libraryplaylistitem.cpp
@@ -21,12 +21,10 @@
 #include <QSettings>
 
 LibraryPlaylistItem::LibraryPlaylistItem(const QString& type)
-    : PlaylistItem(type) {}
+    : DbPlaylistItem(type) {}
 
 LibraryPlaylistItem::LibraryPlaylistItem(const Song& song)
-    : PlaylistItem("Library"), song_(song) {}
-
-QUrl LibraryPlaylistItem::Url() const { return song_.url(); }
+    : DbPlaylistItem("Library", song) {}
 
 void LibraryPlaylistItem::Reload() {
   TagReaderClient::Instance()->ReadFileBlocking(song_.url().toLocalFile(),
@@ -38,18 +36,4 @@ bool LibraryPlaylistItem::InitFromQuery(const SqlRow& query) {
   song_.InitFromQuery(query, true);
 
   return song_.is_valid();
-}
-
-QVariant LibraryPlaylistItem::DatabaseValue(DatabaseColumn column) const {
-  switch (column) {
-    case Column_LibraryId:
-      return song_.id();
-    default:
-      return PlaylistItem::DatabaseValue(column);
-  }
-}
-
-Song LibraryPlaylistItem::Metadata() const {
-  if (HasTemporaryMetadata()) return temp_metadata_;
-  return song_;
 }

--- a/src/playlist/dbplaylistitem.cpp
+++ b/src/playlist/dbplaylistitem.cpp
@@ -1,5 +1,6 @@
 /* This file is part of Clementine.
    Copyright 2010, David Sansome <me@davidsansome.com>
+   Copyright 2020, Jim Broadus <jbroadus@gmail.com>
 
    Clementine is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -15,21 +16,27 @@
    along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef LIBRARYPLAYLISTITEM_H
-#define LIBRARYPLAYLISTITEM_H
+#include "dbplaylistitem.h"
+#include "core/tagreaderclient.h"
 
-#include "core/song.h"
-#include "playlist/dbplaylistitem.h"
+DbPlaylistItem::DbPlaylistItem(const QString& type)
+    : PlaylistItem(type) {}
 
-class LibraryPlaylistItem : public DbPlaylistItem {
- public:
-  LibraryPlaylistItem(const QString& type);
-  LibraryPlaylistItem(const Song& song);
+DbPlaylistItem::DbPlaylistItem(const QString& type, const Song& song)
+    : PlaylistItem(type), song_(song) {}
 
-  bool InitFromQuery(const SqlRow& query);
-  void Reload();
+QUrl DbPlaylistItem::Url() const { return song_.url(); }
 
-  bool IsLocalLibraryItem() const { return true; }
-};
+QVariant DbPlaylistItem::DatabaseValue(DatabaseColumn column) const {
+  switch (column) {
+    case Column_LibraryId:
+      return song_.id();
+    default:
+      return PlaylistItem::DatabaseValue(column);
+  }
+}
 
-#endif  // LIBRARYPLAYLISTITEM_H
+Song DbPlaylistItem::Metadata() const {
+  if (HasTemporaryMetadata()) return temp_metadata_;
+  return song_;
+}

--- a/src/playlist/dbplaylistitem.h
+++ b/src/playlist/dbplaylistitem.h
@@ -1,5 +1,6 @@
 /* This file is part of Clementine.
    Copyright 2010, David Sansome <me@davidsansome.com>
+   Copyright 2020, Jim Broadus <jbroadus@gmail.com>
 
    Clementine is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -15,21 +16,27 @@
    along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef LIBRARYPLAYLISTITEM_H
-#define LIBRARYPLAYLISTITEM_H
+#ifndef DBPLAYLISTITEM_H
+#define DBPLAYLISTITEM_H
 
 #include "core/song.h"
-#include "playlist/dbplaylistitem.h"
+#include "playlist/playlistitem.h"
 
-class LibraryPlaylistItem : public DbPlaylistItem {
+class DbPlaylistItem : public PlaylistItem {
  public:
-  LibraryPlaylistItem(const QString& type);
-  LibraryPlaylistItem(const Song& song);
+  DbPlaylistItem(const QString& type);
+  DbPlaylistItem(const QString& type, const Song& song);
 
-  bool InitFromQuery(const SqlRow& query);
-  void Reload();
+  Song Metadata() const;
+  void SetMetadata(const Song& song) { song_ = song; }
 
-  bool IsLocalLibraryItem() const { return true; }
+  QUrl Url() const;
+
+ protected:
+  QVariant DatabaseValue(DatabaseColumn column) const;
+
+ protected:
+  Song song_;
 };
 
-#endif  // LIBRARYPLAYLISTITEM_H
+#endif  // DBPLAYLISTITEM_H


### PR DESCRIPTION
These changes remove LibraryPlaylistItem as a base class of Jamendo and Magnatune items. Removing the inherited implementation of IsLocalLibraryItem prevents song ratings from being set for local library items with the same database IDs.