### PR TITLE
Use effective album artist for Repeat Album logic

### DIFF
--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -525,7 +525,7 @@ int Playlist::NextVirtualIndex(int i, bool ignore_repeat_track) const {
     }
     Song this_song = item_at(virtual_items_[j])->Metadata();
     if (((last_song.is_compilation() && this_song.is_compilation()) ||
-         last_song.artist() == this_song.artist()) &&
+         last_song.effective_albumartist() == this_song.effective_albumartist()) &&
         last_song.album() == this_song.album() &&
         FilterContainsVirtualIndex(j)) {
       return j;  // Found one


### PR DESCRIPTION
When there is album artist information available for a track, the user would
probably expect that "Repeat Album" should cycle through all songs with the same
album artist and album title, not only all songs with the same artist and album
title.