### PR TITLE
Fix undeclared void MainWindow::Love()

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1586,7 +1586,6 @@ void MainWindow::ScrobbledRadioStream() {
   ui_->action_love->setEnabled(true);
   if (tray_icon_) tray_icon_->LastFMButtonLoveStateChanged(true);
 }
-#endif
 
 void MainWindow::Love() {
   Playlist* active_playlist = app_->playlist_manager()->active();
@@ -1609,6 +1608,7 @@ void MainWindow::Love() {
     if (tray_icon_) tray_icon_->LastFMButtonLoveStateChanged(false);
   }
 }
+#endif
 
 void MainWindow::ApplyAddBehaviour(MainWindow::AddBehaviour b,
                                    MimeData* data) const {


### PR DESCRIPTION
Error from compilation:
```
/home/dev/AUR/clementine-git/src/Clementine/src/ui/mainwindow.cpp:1583:6: error: no declaration matches ‘void MainWindow::Love()’
 1583 | void MainWindow::Love() {
      |      ^~~~~~~~~~
/home/dev/AUR/clementine-git/src/Clementine/src/ui/mainwindow.cpp:1583:6: note: no functions named ‘void MainWindow::Love()’
In file included from /home/dev/AUR/clementine-git/src/Clementine/src/ui/mainwindow.cpp:18:
/home/dev/AUR/clementine-git/src/Clementine/src/ui/mainwindow.h:91:7: note: ‘class MainWindow’ defined here
   91 | class MainWindow : public QMainWindow, public PlatformInterface {
      |       ^~~~~~~~~~
cc1plus: note: unrecognized command-line option ‘-Wno-unknown-warning-option’ may have been intended to silence earlier diagnostics
cc1plus: note: unrecognized command-line option ‘-Wno-unused-private-field’ may have been intended to silence earlier diagnostics
make[2]: *** [src/CMakeFiles/clementine_lib.dir/build.make:7017: src/CMakeFiles/clementine_lib.dir/ui/mainwindow.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:875: src/CMakeFiles/clementine_lib.dir/all] Error 2
make: *** [Makefile:149: all] Error 2
==> ERROR: A failure occurred in build().
    Aborting...
```

In mainwindow.h L224
```
#ifdef HAVE_LIBLASTFM
  void ScrobblingEnabledChanged(bool value);
  void Love();
  void ScrobbledRadioStream();
#endif
```