### PR TITLE
udisks2lister: enable ipod recognition

### DIFF
--- a/src/devices/udisks2lister.cpp
+++ b/src/devices/udisks2lister.cpp
@@ -39,7 +39,12 @@ QStringList Udisks2Lister::DeviceUniqueIDs() {
 }
 
 QVariantList Udisks2Lister::DeviceIcons(const QString& id) {
-  return QVariantList();
+  QReadLocker locker(&device_data_lock_);
+  if (!device_data_.contains(id)) return QVariantList();
+  QString path = device_data_[id].mount_paths.at(0);
+  return QVariantList() << GuessIconForPath(path)
+                        << GuessIconForModel(DeviceManufacturer(id),
+                                             DeviceModel(id));
 }
 
 QString Udisks2Lister::DeviceManufacturer(const QString& id) {
@@ -91,7 +96,7 @@ QString Udisks2Lister::MakeFriendlyName(const QString& id) {
 QList<QUrl> Udisks2Lister::MakeDeviceUrls(const QString& id) {
   QReadLocker locker(&device_data_lock_);
   if (!device_data_.contains(id)) return QList<QUrl>();
-  return QList<QUrl>() << QUrl::fromLocalFile(
+  return QList<QUrl>() << MakeUrlFromLocalPath(
              device_data_[id].mount_paths.at(0));
 }
 


### PR DESCRIPTION
The extends two functions:
- Recognize iPods as iPods, check for them in MakeDeviceUrls
- Give them a nice Icon in DeviceIcons (code taken from devicekitlister)

Before this commit, the iPod is recognized as normal device like an USB stick etc. when udisks is used for device mounting.
I haven't searched for related bugs, maybe this closes one or more of them.