### PR TITLE
add CLI play-playlist option, to play given playlist name.

### DIFF
--- a/src/core/commandlineoptions.cpp
+++ b/src/core/commandlineoptions.cpp
@@ -39,37 +39,38 @@ const char* CommandlineOptions::kHelpText =
     "%1: clementine [%2] [%3]\n"
     "\n"
     "%4:\n"
-    "  -p, --play                %5\n"
-    "  -t, --play-pause          %6\n"
-    "  -u, --pause               %7\n"
-    "  -s, --stop                %8\n"
-    "  -q, --stop-after-current  %9\n"
-    "  -r, --previous            %10\n"
-    "  -f, --next                %11\n"
-    "  -v, --volume <value>      %12\n"
-    "  --volume-up               %13\n"
-    "  --volume-down             %14\n"
-    "  --volume-increase-by      %15\n"
-    "  --volume-decrease-by      %16\n"
-    "  --seek-to <seconds>       %17\n"
-    "  --seek-by <seconds>       %18\n"
-    "  --restart-or-previous     %19\n"
+    "  -p, --play                  %5\n"
+    "  -t, --play-pause            %6\n"
+    "  -u, --pause                 %7\n"
+    "  -s, --stop                  %8\n"
+    "  -q, --stop-after-current    %9\n"
+    "  -r, --previous              %10\n"
+    "  -f, --next                  %11\n"
+    "  -v, --volume <value>        %12\n"
+    "  --volume-up                 %13\n"
+    "  --volume-down               %14\n"
+    "  --volume-increase-by        %15\n"
+    "  --volume-decrease-by        %16\n"
+    "  --seek-to <seconds>         %17\n"
+    "  --seek-by <seconds>         %18\n"
+    "  --restart-or-previous       %19\n"
     "\n"
     "%20:\n"
-    "  -c, --create <name>       %21\n"
-    "  -a, --append              %22\n"
-    "  -l, --load                %23\n"
-    "  -k, --play-track <n>      %24\n"
+    "  -c, --create <name>         %21\n"
+    "  -a, --append                %22\n"
+    "  -l, --load                  %23\n"
+    "  -k, --play-track <n>        %24\n"
+    "  -i, --play-playlist <name>  %25\n"
     "\n"
-    "%25:\n"
-    "  -o, --show-osd            %26\n"
-    "  -y, --toggle-pretty-osd   %27\n"
-    "  -g, --language <lang>     %28\n"
-    "      --quiet               %29\n"
-    "      --verbose             %30\n"
-    "      --log-levels <levels> %31\n"
-    "      --version             %32\n"
-    "  -x, --delete-current      %33\n";
+    "%26:\n"
+    "  -o, --show-osd              %27\n"
+    "  -y, --toggle-pretty-osd     %28\n"
+    "  -g, --language <lang>       %29\n"
+    "      --quiet                 %30\n"
+    "      --verbose               %31\n"
+    "      --log-levels <levels>   %32\n"
+    "      --version               %33\n"
+    "  -x, --delete-current        %34\n";
 
 const char* CommandlineOptions::kVersionText = "Clementine %1";
 
@@ -131,6 +132,7 @@ bool CommandlineOptions::Parse() {
       {"append", no_argument, 0, 'a'},
       {"load", no_argument, 0, 'l'},
       {"play-track", required_argument, 0, 'k'},
+      {"play-playlist", required_argument, 0, 'i'},
       {"show-osd", no_argument, 0, 'o'},
       {"toggle-pretty-osd", no_argument, 0, 'y'},
       {"language", required_argument, 0, 'g'},
@@ -145,7 +147,7 @@ bool CommandlineOptions::Parse() {
   bool ok = false;
   forever {
     int c =
-        getopt_long(argc_, argv_, "xhptusqrfv:c:alk:oyg:", kOptions, nullptr);
+        getopt_long(argc_, argv_, "xhptusqrfv:c:i:alk:oyg:", kOptions, nullptr);
 
     // End of the options
     if (c == -1) break;
@@ -177,7 +179,8 @@ bool CommandlineOptions::Parse() {
                      tr("Create a new playlist with files/URLs"),
                      tr("Append files/URLs to the playlist"),
                      tr("Loads files/URLs, replacing current playlist"),
-                     tr("Play the <n>th track in the playlist"))
+                     tr("Play the <n>th track in the playlist"),
+                     tr("Play given playlist"))
                 .arg(tr("Other options"), tr("Display the on-screen-display"),
                      tr("Toggle visibility for the pretty on-screen-display"),
                      tr("Change the language"),
@@ -211,6 +214,10 @@ bool CommandlineOptions::Parse() {
         break;
       case 'f':
         player_action_ = Player_Next;
+        break;
+      case 'i':
+        player_action_ = Player_PlayPlaylist;
+        playlist_name_ = QString(optarg);
         break;
       case 'c':
         url_list_action_ = UrlList_CreateNew;
@@ -349,7 +356,7 @@ QDataStream& operator<<(QDataStream& s, const CommandlineOptions& a) {
   s << qint32(a.player_action_) << qint32(a.url_list_action_) << a.set_volume_
     << a.volume_modifier_ << a.seek_to_ << a.seek_by_ << a.play_track_at_
     << a.show_osd_ << a.urls_ << a.log_levels_ << a.toggle_pretty_osd_
-    << a.delete_current_track_;
+    << a.delete_current_track_ << a.playlist_name_;
 
   return s;
 }
@@ -360,7 +367,7 @@ QDataStream& operator>>(QDataStream& s, CommandlineOptions& a) {
   s >> player_action >> url_list_action >> a.set_volume_ >>
       a.volume_modifier_ >> a.seek_to_ >> a.seek_by_ >> a.play_track_at_ >>
       a.show_osd_ >> a.urls_ >> a.log_levels_ >> a.toggle_pretty_osd_ >>
-      a.delete_current_track_;
+      a.delete_current_track_ >> a.playlist_name_;
   a.player_action_ = CommandlineOptions::PlayerAction(player_action);
   a.url_list_action_ = CommandlineOptions::UrlListAction(url_list_action);
 

--- a/src/core/commandlineoptions.h
+++ b/src/core/commandlineoptions.h
@@ -56,6 +56,7 @@ class CommandlineOptions {
     Player_Next = 6,
     Player_RestartOrPrevious = 7,
     Player_StopAfterCurrent = 8,
+    Player_PlayPlaylist = 9,
   };
 
   bool Parse();

--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -225,31 +225,31 @@ void Player::NextItem(Engine::TrackChangeFlags change) {
 }
 
 void Player::PlayPlaylist(const QString& playlistName) {
-    PlayPlaylistInternal(Engine::Manual, playlistName);
+  PlayPlaylistInternal(Engine::Manual, playlistName);
 }
 
-void Player::PlayPlaylistInternal(Engine::TrackChangeFlags change, const QString& playlistName) {
-    Playlist* playlist = NULL;
-    for (Playlist* p : app_->playlist_manager()->GetAllPlaylists()) {
-      if (playlistName == app_->playlist_manager()->GetPlaylistName(p->id())) {
-          playlist = p;
-          break;
-      }
+void Player::PlayPlaylistInternal(Engine::TrackChangeFlags change,
+                                  const QString& playlistName) {
+  Playlist* playlist = NULL;
+  for (Playlist* p : app_->playlist_manager()->GetAllPlaylists()) {
+    if (playlistName == app_->playlist_manager()->GetPlaylistName(p->id())) {
+      playlist = p;
+      break;
     }
+  }
 
-    if (playlist != NULL) {
-      app_->playlist_manager()->SetActivePlaylist(playlist->id());
-      if (playlist->rowCount() == 0) return;
+  if (playlist != NULL) {
+    app_->playlist_manager()->SetActivePlaylist(playlist->id());
+    if (playlist->rowCount() == 0) return;
 
-      int i = app_->playlist_manager()->active()->current_row();
-      if (i == -1) i = app_->playlist_manager()->active()->last_played_row();
-      if (i == -1) i = 0;
+    int i = app_->playlist_manager()->active()->current_row();
+    if (i == -1) i = app_->playlist_manager()->active()->last_played_row();
+    if (i == -1) i = 0;
 
-      PlayAt(i, Engine::First, true);
-    }
-    else {
-      qLog(Warning) << "Playlist '" << playlistName << "' not found.";
-    }
+    PlayAt(i, Engine::First, true);
+  } else {
+    qLog(Warning) << "Playlist '" << playlistName << "' not found.";
+  }
 }
 
 bool Player::HandleStopAfter() {

--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -224,6 +224,34 @@ void Player::NextItem(Engine::TrackChangeFlags change) {
   PlayAt(i, change, false);
 }
 
+void Player::PlayPlaylist(const QString& playlistName) {
+    PlayPlaylistInternal(Engine::Manual, playlistName);
+}
+
+void Player::PlayPlaylistInternal(Engine::TrackChangeFlags change, const QString& playlistName) {
+    Playlist* playlist = NULL;
+    for (Playlist* p : app_->playlist_manager()->GetAllPlaylists()) {
+      if (playlistName == app_->playlist_manager()->GetPlaylistName(p->id())) {
+          playlist = p;
+          break;
+      }
+    }
+
+    if (playlist != NULL) {
+      app_->playlist_manager()->SetActivePlaylist(playlist->id());
+      if (playlist->rowCount() == 0) return;
+
+      int i = app_->playlist_manager()->active()->current_row();
+      if (i == -1) i = app_->playlist_manager()->active()->last_played_row();
+      if (i == -1) i = 0;
+
+      PlayAt(i, Engine::First, true);
+    }
+    else {
+      qLog(Warning) << "Playlist '" << playlistName << "' not found.";
+    }
+}
+
 bool Player::HandleStopAfter() {
   if (app_->playlist_manager()->active()->stop_after_current()) {
     // Find what the next track would've been, and mark that one as current

--- a/src/core/player.h
+++ b/src/core/player.h
@@ -151,6 +151,7 @@ class Player : public PlayerInterface {
   void RestartOrPrevious();
   void Next();
   void Previous();
+  void PlayPlaylist(const QString& playlistName);
   void SetVolume(int value);
   void VolumeUp() { SetVolume(GetVolume() + 5); }
   void VolumeDown() { SetVolume(GetVolume() - 5); }
@@ -180,6 +181,7 @@ class Player : public PlayerInterface {
   void PreviousItem(Engine::TrackChangeFlags change);
 
   void NextInternal(Engine::TrackChangeFlags);
+  void PlayPlaylistInternal(Engine::TrackChangeFlags, const QString& playlistName);
 
   void ValidSongRequested(const QUrl&);
   void InvalidSongRequested(const QUrl&);

--- a/src/core/player.h
+++ b/src/core/player.h
@@ -181,7 +181,8 @@ class Player : public PlayerInterface {
   void PreviousItem(Engine::TrackChangeFlags change);
 
   void NextInternal(Engine::TrackChangeFlags);
-  void PlayPlaylistInternal(Engine::TrackChangeFlags, const QString& playlistName);
+  void PlayPlaylistInternal(Engine::TrackChangeFlags,
+                            const QString& playlistName);
 
   void ValidSongRequested(const QUrl&);
   void InvalidSongRequested(const QUrl&);

--- a/src/playlist/playlistmanager.cpp
+++ b/src/playlist/playlistmanager.cpp
@@ -90,6 +90,17 @@ void PlaylistManager::Init(LibraryBackend* library_backend,
   emit PlaylistManagerInitialized();
 }
 
+/*
+Playlist* PlaylistManager::GetPlaylistByName(const QString& playlistName) const {
+  for (const Data& data : playlists_.values()) {
+      if (playlistName->compare(data->name) == 0) {
+          return data;
+      }
+  }
+  return NULL;
+}
+*/
+
 QList<Playlist*> PlaylistManager::GetAllPlaylists() const {
   QList<Playlist*> result;
 

--- a/src/playlist/playlistmanager.cpp
+++ b/src/playlist/playlistmanager.cpp
@@ -90,17 +90,6 @@ void PlaylistManager::Init(LibraryBackend* library_backend,
   emit PlaylistManagerInitialized();
 }
 
-/*
-Playlist* PlaylistManager::GetPlaylistByName(const QString& playlistName) const {
-  for (const Data& data : playlists_.values()) {
-      if (playlistName->compare(data->name) == 0) {
-          return data;
-      }
-  }
-  return NULL;
-}
-*/
-
 QList<Playlist*> PlaylistManager::GetAllPlaylists() const {
   QList<Playlist*> result;
 

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2272,10 +2272,10 @@ void MainWindow::CommandlineOptionsReceived(const CommandlineOptions& options) {
       app_->player()->Next();
       break;
     case CommandlineOptions::Player_PlayPlaylist:
-      if (options.playlist_name().isNull() || options.playlist_name().isEmpty()) {
+      if (options.playlist_name().isNull() ||
+          options.playlist_name().isEmpty()) {
         qLog(Error) << "ERROR: playlist name missing";
-      }
-      else {
+      } else {
         app_->player()->PlayPlaylist(options.playlist_name());
       }
       break;

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2239,8 +2239,9 @@ void MainWindow::CommandlineOptionsReceived(const QString& string_options) {
   if (options.is_empty()) {
     show();
     activateWindow();
-  } else
+  } else {
     CommandlineOptionsReceived(options);
+  }
 }
 
 void MainWindow::CommandlineOptionsReceived(const CommandlineOptions& options) {
@@ -2269,6 +2270,14 @@ void MainWindow::CommandlineOptionsReceived(const CommandlineOptions& options) {
       break;
     case CommandlineOptions::Player_Next:
       app_->player()->Next();
+      break;
+    case CommandlineOptions::Player_PlayPlaylist:
+      if (options.playlist_name().isNull() || options.playlist_name().isEmpty()) {
+        qLog(Error) << "ERROR: playlist name missing";
+      }
+      else {
+        app_->player()->PlayPlaylist(options.playlist_name());
+      }
       break;
     case CommandlineOptions::Player_RestartOrPrevious:
       app_->player()->RestartOrPrevious();


### PR DESCRIPTION
Adding a command line option to start playing the playlist given as argument.

I reused the command line argument `playlist_name_`  from the *create_playlist* option - I had to add it to the [De]Serialize functions to make it work, meaning -unless I missed something- that the create playlist could not be working before.
And this "create playlist" is still not working for me, but I did not dig further.