### PR TITLE
Fix opml import crash

### DIFF
--- a/src/internet/podcasts/podcastparser.cpp
+++ b/src/internet/podcasts/podcastparser.cpp
@@ -279,8 +279,14 @@ bool PodcastParser::ParseOpml(QXmlStreamReader* reader,
   ParseOutline(reader, ret);
 
   // OPML files sometimes consist of a single top level container.
-  while (ret->feeds.count() == 0 && ret->containers.count() == 1) {
-    *ret = ret->containers[0];
+  OpmlContainer* top = ret;
+  while (top->feeds.count() == 0 && top->containers.count() == 1) {
+    top = &top->containers[0];
+  }
+  if (top != ret) {
+    // Copy the sub-container to a temporary location first.
+    OpmlContainer tmp = *top;
+    *ret = tmp;
   }
 
   return true;


### PR DESCRIPTION
The opml parsing code handles cases where there are extra levels in the xml file
by copying the child to the main container. This corrupts the source instance
during the copy, which leads to corruption in the destination, and ultimately a
crash when it is later used.

To fix, do the copy in two steps, copying the child container to a temporary
location before copying to the destination.

This is a fix for #6802 