### PR TITLE
Fix window visibility state & active show from tray

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1037,10 +1037,8 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
   // Force the window to show in case somehow the config has tray and window set
   // to hide
   if (hidden && (!QSystemTrayIcon::isSystemTrayAvailable() || !tray_icon_ ||
-                 !tray_icon_->IsVisible())) {
-    settings_.setValue("hidden", false);
+                 !tray_icon_->IsVisible()))
     show();
-  }
 #endif
 
   QShortcut* close_window_shortcut = new QShortcut(this);
@@ -1432,6 +1430,7 @@ void MainWindow::VolumeWheelEvent(int delta) {
 void MainWindow::ToggleShowHide() {
   if (settings_.value("hidden").toBool()) {
     show();
+    activateWindow();
     SetHiddenInTray(false);
   } else if (isActiveWindow()) {
     hide();
@@ -1466,9 +1465,17 @@ void MainWindow::closeEvent(QCloseEvent* event) {
   QMainWindow::closeEvent(event);
 }
 
-void MainWindow::SetHiddenInTray(bool hidden) {
-  settings_.setValue("hidden", hidden);
+void MainWindow::hideEvent(QHideEvent* event) {
+  settings_.setValue("hidden", true);
+  QMainWindow::hideEvent(event);
+}
 
+void MainWindow::showEvent(QShowEvent* event) {
+  settings_.setValue("hidden", false);
+  QMainWindow::showEvent(event);
+}
+
+void MainWindow::SetHiddenInTray(bool hidden) {
   // Some window managers don't remember maximized state between calls to
   // hide() and show(), so we have to remember it ourself.
   if (hidden) {

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -131,10 +131,12 @@ class MainWindow : public QMainWindow, public PlatformInterface {
   void CommandlineOptionsReceived(const CommandlineOptions& options);
 
  protected:
-  void keyPressEvent(QKeyEvent* event);
+  void keyPressEvent(QKeyEvent*);
   void changeEvent(QEvent*);
   void resizeEvent(QResizeEvent*);
-  void closeEvent(QCloseEvent* event);
+  void closeEvent(QCloseEvent*);
+  void hideEvent(QHideEvent*);
+  void showEvent(QShowEvent*);
 
 #ifdef Q_OS_WIN32
   bool winEvent(MSG* message, long* result);


### PR DESCRIPTION
In 2bac3626 I removed `SetHiddenInTray` from closeEvent because it would have been a double hide when calling the default handler. This caused a regression in that the window at startup no longer remembered if it was hidden only if the window was closed via the window manager to hide it last.

This cleans up the state tracking of showing and hiding the main window by changing the config setting on all show and hide events so it gets set regardless of event spontaneity. It also fixes having to click the tray icon twice to raise the window with focus if you had another active focus window already.