### PR TITLE
Allow Network Remote to browse the FileSystem from a defined root folder and then enqueue tracks from there

### DIFF
--- a/ext/libclementine-remote/remotecontrolmessages.proto
+++ b/ext/libclementine-remote/remotecontrolmessages.proto
@@ -87,23 +87,38 @@ enum MsgType {
 
 }
 
-message RequestFiles {
-  optional string relativePath = 1;
+message RequestListFiles {
+  optional string relative_path = 1;
 }
 
 message FileMetadata {
     optional string filename  = 1;
-    optional bool   isDir = 2;
+    optional bool   is_dir = 2;
 }
 
-// used by both Client (APPEND_FILES) and server (LIST_FILES)
-message ResponseFiles {
-  optional string relativePath = 1;
+// reply from server to LIST_FILES
+message ResponseListFiles {
+  enum Error {
+    NONE = 0;
+    ROOT_DIR_NOT_SET = 1;
+    DIR_NOT_ACCESSIBLE = 2;
+    DIR_NOT_EXIST = 3;
+    UNKNOWN = 4;
+  }
+  optional string relative_path = 1;
   repeated FileMetadata files  = 2;
 
-  optional string error = 3;
-  optional string musicExtentions = 4;
+  optional Error error = 3;
+  optional string music_extentions = 4;
 }
+
+// request to append files (APPEND_FILES)
+message RequestAppendFiles {
+  optional string relative_path = 1;
+  optional string new_playlist_name = 2;
+  repeated string files  = 3;
+}
+
 
 // Valid Engine states
 enum EngineState {
@@ -409,7 +424,8 @@ message Message {
   optional RequestDownloadSongs request_download_songs = 31;
   optional RequestRateSong request_rate_song = 35;
   optional RequestGlobalSearch request_global_search = 37;
-  optional RequestFiles request_files = 50;
+  optional RequestListFiles request_list_files = 50;
+  optional RequestAppendFiles request_append_files = 51;
 
   optional Repeat repeat = 13;
   optional Shuffle shuffle = 14;
@@ -430,5 +446,5 @@ message Message {
   optional ResponseGlobalSearch response_global_search = 38;
   optional ResponseTranscoderStatus response_transcoder_status = 39;
   optional ResponseGlobalSearchStatus response_global_search_status = 40;
-  optional ResponseFiles response_files = 51;
+  optional ResponseListFiles response_list_files = 52;
 }

--- a/ext/libclementine-remote/remotecontrolmessages.proto
+++ b/ext/libclementine-remote/remotecontrolmessages.proto
@@ -87,38 +87,6 @@ enum MsgType {
 
 }
 
-message RequestListFiles {
-  optional string relative_path = 1;
-}
-
-message FileMetadata {
-    optional string filename  = 1;
-    optional bool   is_dir = 2;
-}
-
-// reply from server to LIST_FILES
-message ResponseListFiles {
-  enum Error {
-    NONE = 0;
-    ROOT_DIR_NOT_SET = 1;
-    DIR_NOT_ACCESSIBLE = 2;
-    DIR_NOT_EXIST = 3;
-    UNKNOWN = 4;
-  }
-  optional string relative_path = 1;
-  repeated FileMetadata files  = 2;
-
-  optional Error error = 3;
-  optional string music_extentions = 4;
-}
-
-// request to append files (APPEND_FILES)
-message RequestAppendFiles {
-  optional string relative_path = 1;
-  optional string new_playlist_name = 2;
-  repeated string files  = 3;
-}
-
 
 // Valid Engine states
 enum EngineState {
@@ -405,6 +373,41 @@ message ResponseGlobalSearchStatus {
   optional string query = 2;
   optional GlobalSearchStatus status = 3;
 }
+
+
+// access the FileSystem remotely from a defined root directory
+message RequestListFiles {
+  optional string relative_path = 1;
+}
+
+message FileMetadata {
+    optional string filename  = 1;
+    optional bool   is_dir = 2;
+}
+
+message ResponseListFiles {
+  enum Error {
+    NONE = 0;
+    ROOT_DIR_NOT_SET = 1;
+    DIR_NOT_ACCESSIBLE = 2;
+    DIR_NOT_EXIST = 3;
+    UNKNOWN = 4;
+  }
+  optional string relative_path = 1;
+  repeated FileMetadata files  = 2;
+
+  optional Error error = 3;
+  optional string music_extentions = 4; // set on server
+}
+
+message RequestAppendFiles {
+  optional string relative_path = 1;
+  optional string new_playlist_name = 2;
+  repeated string files  = 3;
+  optional bool play_now = 4;
+  optional bool clear_first = 5;
+}
+
 
 // The message itself
 message Message {

--- a/ext/libclementine-remote/remotecontrolmessages.proto
+++ b/ext/libclementine-remote/remotecontrolmessages.proto
@@ -46,6 +46,9 @@ enum MsgType {
   GET_LIBRARY = 18;
   RATE_SONG = 19;
   GLOBAL_SEARCH = 100;
+  // access Files from remote control
+  REQUEST_FILES = 200;
+  APPEND_FILES = 201;
 
   // Messages send by both
   DISCONNECT = 2;
@@ -79,6 +82,27 @@ enum MsgType {
   GLOBAL_SEARCH_RESULT = 54;
   TRANSCODING_FILES = 55;
   GLOBAL_SEARCH_STATUS = 56;
+  // access Files from remote control
+  LIST_FILES = 202;
+
+}
+
+message RequestFiles {
+  optional string relativePath = 1;
+}
+
+message FileMetadata {
+    optional string filename  = 1;
+    optional bool   isDir = 2;
+}
+
+// used by both Client (APPEND_FILES) and server (LIST_FILES)
+message ResponseFiles {
+  optional string relativePath = 1;
+  repeated FileMetadata files  = 2;
+
+  optional string error = 3;
+  optional string musicExtentions = 4;
 }
 
 // Valid Engine states
@@ -385,7 +409,8 @@ message Message {
   optional RequestDownloadSongs request_download_songs = 31;
   optional RequestRateSong request_rate_song = 35;
   optional RequestGlobalSearch request_global_search = 37;
-  
+  optional RequestFiles request_files = 50;
+
   optional Repeat repeat = 13;
   optional Shuffle shuffle = 14;
   
@@ -405,4 +430,5 @@ message Message {
   optional ResponseGlobalSearch response_global_search = 38;
   optional ResponseTranscoderStatus response_transcoder_status = 39;
   optional ResponseGlobalSearchStatus response_global_search_status = 40;
+  optional ResponseFiles response_files = 51;
 }

--- a/ext/libclementine-remote/remotecontrolmessages.proto
+++ b/ext/libclementine-remote/remotecontrolmessages.proto
@@ -15,7 +15,7 @@
    limitations under the License.
 */
 
-// Note: this file is licensed under the Apache License instead of GPL, so 
+// Note: this file is licensed under the Apache License instead of GPL, so
 // 3rd party applications or libraries can use another license besides GPL.
 
 syntax = "proto2";
@@ -84,9 +84,7 @@ enum MsgType {
   GLOBAL_SEARCH_STATUS = 56;
   // access Files from remote control
   LIST_FILES = 202;
-
 }
-
 
 // Valid Engine states
 enum EngineState {
@@ -120,8 +118,8 @@ message SongMetadata {
     STREAM = 99;
   }
 
-  optional int32 id = 1; // unique id of the song
-  optional int32 index = 2; // Index of the current row of the active playlist
+  optional int32 id = 1;     // unique id of the song
+  optional int32 index = 2;  // Index of the current row of the active playlist
   optional string title = 3;
   optional string album = 4;
   optional string artist = 5;
@@ -137,7 +135,7 @@ message SongMetadata {
   optional bool is_local = 15;
   optional string filename = 16;
   optional int32 file_size = 17;
-  optional float rating = 18; // 0 (0 stars) to 1 (5 stars)
+  optional float rating = 18;  // 0 (0 stars) to 1 (5 stars)
   optional string url = 19;
   optional string art_automatic = 20;
   optional string art_manual = 21;
@@ -222,7 +220,7 @@ message ResponsePlaylists {
 // A list of songs in a playlist
 message ResponsePlaylistSongs {
   optional Playlist requested_playlist = 1;
-  
+
   // The songs that are in the playlist
   repeated SongMetadata songs = 2;
 }
@@ -233,7 +231,7 @@ message ResponseEngineStateChanged {
 }
 
 // Sends the current position of the track
-message ResponseUpdateTrackPosition {  
+message ResponseUpdateTrackPosition {
   optional int32 position = 1;
 }
 
@@ -269,9 +267,9 @@ message RequestInsertUrls {
   // In which playlist should the urls be inserted?
   optional int32 playlist_id = 1;
   repeated string urls = 2;
-  optional int32 position = 3 [default=-1];
-  optional bool play_now = 4 [default=false];
-  optional bool enqueue = 5 [default=false];
+  optional int32 position = 3 [default = -1];
+  optional bool play_now = 4 [default = false];
+  optional bool enqueue = 5 [default = false];
   repeated SongMetadata songs = 6;
 }
 
@@ -319,7 +317,7 @@ message ResponseSongFileChunk {
   optional int32 chunk_count = 2;
   optional int32 file_number = 3;
   optional int32 file_count = 4;
-  optional SongMetadata song_metadata = 6; // only sent with first chunk!
+  optional SongMetadata song_metadata = 6;  // only sent with first chunk!
   optional bytes data = 7;
   optional int32 size = 8;
   optional bytes file_hash = 9;
@@ -334,11 +332,11 @@ message ResponseLibraryChunk {
 }
 
 message ResponseSongOffer {
-  optional bool accepted = 1; // true = client wants to download item
+  optional bool accepted = 1;  // true = client wants to download item
 }
 
 message RequestRateSong {
-  optional float rating = 1; // 0 to 1
+  optional float rating = 1;  // 0 to 1
 }
 
 message ResponseDownloadTotalSize {
@@ -374,15 +372,14 @@ message ResponseGlobalSearchStatus {
   optional GlobalSearchStatus status = 3;
 }
 
-
 // access the FileSystem remotely from a defined root directory
 message RequestListFiles {
   optional string relative_path = 1;
 }
 
 message FileMetadata {
-    optional string filename  = 1;
-    optional bool   is_dir = 2;
+  optional string filename = 1;
+  optional bool is_dir = 2;
 }
 
 message ResponseListFiles {
@@ -394,25 +391,25 @@ message ResponseListFiles {
     UNKNOWN = 4;
   }
   optional string relative_path = 1;
-  repeated FileMetadata files  = 2;
+  repeated FileMetadata files = 2;
 
   optional Error error = 3;
-  optional string music_extentions = 4; // set on server
+  optional string music_extentions = 4;  // set on server
 }
 
 message RequestAppendFiles {
   optional string relative_path = 1;
   optional string new_playlist_name = 2;
-  repeated string files  = 3;
+  repeated string files = 3;
   optional bool play_now = 4;
   optional bool clear_first = 5;
 }
 
-
 // The message itself
 message Message {
-  optional int32 version = 1 [default=21];
-  optional MsgType type = 2 [default=UNKNOWN]; // What data is in the message?
+  optional int32 version = 1 [default = 21];
+  optional MsgType type = 2
+      [default = UNKNOWN];  // What data is in the message?
 
   optional RequestConnect request_connect = 21;
   optional RequestPlaylists request_playlists = 27;
@@ -432,7 +429,7 @@ message Message {
 
   optional Repeat repeat = 13;
   optional Shuffle shuffle = 14;
-  
+
   optional ResponseClementineInfo response_clementine_info = 15;
   optional ResponseCurrentMetadata response_current_metadata = 16;
   optional ResponsePlaylists response_playlists = 17;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -339,6 +339,7 @@ set(SOURCES
   ui/edittagdialog.cpp
   ui/lovedialog.cpp
   ui/equalizer.cpp
+  ui/filechooserwidget.cpp
   ui/flowlayout.cpp
   ui/globalshortcutgrabber.cpp
   ui/globalshortcutssettingspage.cpp
@@ -625,6 +626,7 @@ set(HEADERS
   ui/console.h
   ui/coverfromurldialog.h
   ui/edittagdialog.h
+  ui/filechooserwidget.h
   ui/lovedialog.h
   ui/equalizer.h
   ui/globalshortcutgrabber.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,7 @@ endif(BUILD_WERROR)
 include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(../3rdparty/gmock/gtest/include)
 
-# Activate fast QString concatenation
+#Activate fast QString concatenation
 add_definitions(-DQT_USE_QSTRINGBUILDER)
 add_definitions(-DQT_NO_URL_CAST_FROM_STRING)
 add_definitions(-DBOOST_BIND_NO_PLACEHOLDERS)
@@ -790,7 +790,7 @@ set(OTHER_SOURCES)
 if (HAVE_TRANSLATIONS)
   set(LINGUAS "All" CACHE STRING "A space-seperated list of translations to compile in to Clementine, or \"None\".")
   if (LINGUAS STREQUAL "All")
-    # build LANGUAGES from all existing .po files
+#build LANGUAGES from all existing.po files
     file(GLOB pofiles translations/*.po)
     foreach(pofile ${pofiles})
       get_filename_component(lang ${pofile} NAME_WE)

--- a/src/core/application.cpp
+++ b/src/core/application.cpp
@@ -69,6 +69,7 @@ bool Application::kIsPortable = false;
 const char* Application::kLegacyPortableDataDir = "data";
 const char* Application::kDefaultPortableDataDir = "clementine-data";
 const char* Application::kPortableDataDir = nullptr;
+const char* Application::kDefaultMusicExtensionsAllowedRemotely = "aac,alac,flac,m3u,m4a,mp3,ogg,wav,wmv";
 
 class ApplicationImpl {
  public:

--- a/src/core/application.cpp
+++ b/src/core/application.cpp
@@ -69,7 +69,8 @@ bool Application::kIsPortable = false;
 const char* Application::kLegacyPortableDataDir = "data";
 const char* Application::kDefaultPortableDataDir = "clementine-data";
 const char* Application::kPortableDataDir = nullptr;
-const char* Application::kDefaultMusicExtensionsAllowedRemotely = "aac,alac,flac,m3u,m4a,mp3,ogg,wav,wmv";
+const char* Application::kDefaultMusicExtensionsAllowedRemotely =
+    "aac,alac,flac,m3u,m4a,mp3,ogg,wav,wmv";
 
 class ApplicationImpl {
  public:

--- a/src/core/application.h
+++ b/src/core/application.h
@@ -65,6 +65,7 @@ class Application : public QObject {
   static const char* kPortableDataDir;
   static const char* kLegacyPortableDataDir;
   static const char* kDefaultPortableDataDir;
+  static const char* kDefaultMusicExtensionsAllowedRemotely;
   static bool IsPortable() { return kIsPortable; }
 
   explicit Application(QObject* parent = nullptr);

--- a/src/networkremote/incomingdataparser.cpp
+++ b/src/networkremote/incomingdataparser.cpp
@@ -17,8 +17,8 @@
 
 #include "incomingdataparser.h"
 
-#include <algorithm>
 #include <QDir>
+#include <algorithm>
 
 #include "core/logging.h"
 #include "core/mimedata.h"
@@ -194,12 +194,13 @@ void IncomingDataParser::Parse(const pb::remote::Message& msg) {
     case pb::remote::GLOBAL_SEARCH:
       GlobalSearch(client, msg);
       break;
-  case pb::remote::REQUEST_FILES:
-      emit SendListFiles(QString::fromStdString(msg.request_list_files().relative_path()));
-    break;
-  case pb::remote::APPEND_FILES:
+    case pb::remote::REQUEST_FILES:
+      emit SendListFiles(
+          QString::fromStdString(msg.request_list_files().relative_path()));
+      break;
+    case pb::remote::APPEND_FILES:
       AppendFilesToPlaylist(msg);
-    break;
+      break;
 
     default:
       break;
@@ -380,55 +381,56 @@ Song IncomingDataParser::CreateSongFromProtobuf(
   return song;
 }
 
-void IncomingDataParser::AppendFilesToPlaylist(const pb::remote::Message &msg) {
-    if (files_root_folder_.isEmpty()) {// should never happen...
-        qLog(Warning) << "Remote root dir is not set although receiving APPEND_FILES request...";
-        return;
-    }
-    QDir rootDir(files_root_folder_);
-    if (!rootDir.exists()) {
-        qLog(Warning) << "Remote root dir doesn't exist...";
-        return;
-    }
+void IncomingDataParser::AppendFilesToPlaylist(const pb::remote::Message& msg) {
+  if (files_root_folder_.isEmpty()) {  // should never happen...
+    qLog(Warning) << "Remote root dir is not set although receiving "
+                     "APPEND_FILES request...";
+    return;
+  }
+  QDir rootDir(files_root_folder_);
+  if (!rootDir.exists()) {
+    qLog(Warning) << "Remote root dir doesn't exist...";
+    return;
+  }
 
-    const pb::remote::RequestAppendFiles &reqAppend = msg.request_append_files();
-    QString relativePath = QString::fromStdString(reqAppend.relative_path());
-    if (relativePath.startsWith("/"))
-        relativePath.remove(0, 1);
+  const pb::remote::RequestAppendFiles& reqAppend = msg.request_append_files();
+  QString relativePath = QString::fromStdString(reqAppend.relative_path());
+  if (relativePath.startsWith("/")) relativePath.remove(0, 1);
 
-    QFileInfo fiFolder(rootDir, relativePath);
-    if (!fiFolder.exists())
-        qLog(Warning) << "Remote relative path "<< relativePath << " doesn't exist...";
-    else if (!fiFolder.isDir())
-        qLog(Warning) << "Remote relative path "<< relativePath << " is not a directory...";
-    else if (rootDir.relativeFilePath(fiFolder.absoluteFilePath()).startsWith("../"))
-        qLog(Warning) << "Remote relative path "<< relativePath << " should not be accessed...";
-    else {
-        QList<QUrl> urls;
-        QDir dir(fiFolder.absoluteFilePath());
-        for (auto it = reqAppend.files().cbegin(), itEnd = reqAppend.files().cend();
-             it != itEnd; ++it) {
-            QFileInfo fi(dir, it->c_str());
-            if (fi.exists())
-                urls << QUrl::fromLocalFile(fi.canonicalFilePath());
-        }
-        if (urls.size()) {
-            MimeData* data = new MimeData;
-            data->setUrls(urls);
-            if (reqAppend.has_play_now())
-                data->play_now_ = reqAppend.play_now();
-            if (reqAppend.has_clear_first())
-                data->clear_first_ = reqAppend.clear_first();
-            if (reqAppend.has_new_playlist_name())
-            {
-                QString playlistName = QString::fromStdString(reqAppend.new_playlist_name());
-                if (!playlistName.isEmpty())
-                {
-                    data->open_in_new_playlist_  = true;
-                    data->name_for_new_playlist_ = playlistName;
-                }
-            }
-            emit AddToPlaylistSignal(data);
-        }
+  QFileInfo fiFolder(rootDir, relativePath);
+  if (!fiFolder.exists())
+    qLog(Warning) << "Remote relative path " << relativePath
+                  << " doesn't exist...";
+  else if (!fiFolder.isDir())
+    qLog(Warning) << "Remote relative path " << relativePath
+                  << " is not a directory...";
+  else if (rootDir.relativeFilePath(fiFolder.absoluteFilePath())
+               .startsWith("../"))
+    qLog(Warning) << "Remote relative path " << relativePath
+                  << " should not be accessed...";
+  else {
+    QList<QUrl> urls;
+    QDir dir(fiFolder.absoluteFilePath());
+    for (auto it = reqAppend.files().cbegin(), itEnd = reqAppend.files().cend();
+         it != itEnd; ++it) {
+      QFileInfo fi(dir, it->c_str());
+      if (fi.exists()) urls << QUrl::fromLocalFile(fi.canonicalFilePath());
     }
+    if (urls.size()) {
+      MimeData* data = new MimeData;
+      data->setUrls(urls);
+      if (reqAppend.has_play_now()) data->play_now_ = reqAppend.play_now();
+      if (reqAppend.has_clear_first())
+        data->clear_first_ = reqAppend.clear_first();
+      if (reqAppend.has_new_playlist_name()) {
+        QString playlistName =
+            QString::fromStdString(reqAppend.new_playlist_name());
+        if (!playlistName.isEmpty()) {
+          data->open_in_new_playlist_ = true;
+          data->name_for_new_playlist_ = playlistName;
+        }
+      }
+      emit AddToPlaylistSignal(data);
+    }
+  }
 }

--- a/src/networkremote/incomingdataparser.cpp
+++ b/src/networkremote/incomingdataparser.cpp
@@ -387,11 +387,11 @@ Song IncomingDataParser::CreateSongFromProtobuf(
 
 void IncomingDataParser::AppendFilesToPlaylist(const pb::remote::Message &msg)
 {
-    if (remote_root_files_.isEmpty()) {// should never happen...
+    if (files_root_folder_.isEmpty()) {// should never happen...
         qLog(Warning) << "Remote root dir is not set although receiving APPEND_FILES request...";
         return;
     }
-    QDir rootDir(remote_root_files_);
+    QDir rootDir(files_root_folder_);
     if (!rootDir.exists()) {
         qLog(Warning) << "Remote root dir doesn't exist...";
         return;

--- a/src/networkremote/incomingdataparser.cpp
+++ b/src/networkremote/incomingdataparser.cpp
@@ -195,8 +195,8 @@ qLog(Debug) << "[MB_TRACE][IncomingDataParser::Parse] type: " << msg.type();
       GlobalSearch(client, msg);
       break;
   case pb::remote::REQUEST_FILES:
-qLog(Debug) << "[MB_TRACE] REQUEST_FILES: " << msg.request_files().relativepath().c_str();
-      emit SendListFiles(msg.request_files().relativepath().c_str());
+qLog(Debug) << "[MB_TRACE] REQUEST_FILES: " << msg.request_list_files().relative_path().c_str();
+      emit SendListFiles(msg.request_list_files().relative_path().c_str());
     break;
 
     default:

--- a/src/networkremote/incomingdataparser.cpp
+++ b/src/networkremote/incomingdataparser.cpp
@@ -104,8 +104,6 @@ void IncomingDataParser::Parse(const pb::remote::Message& msg) {
 
   RemoteClient* client = qobject_cast<RemoteClient*>(sender());
 
-qLog(Debug) << "[MB_TRACE][IncomingDataParser::Parse] type: " << msg.type();
-
   // Now check what's to do
   switch (msg.type()) {
     case pb::remote::CONNECT:
@@ -197,12 +195,9 @@ qLog(Debug) << "[MB_TRACE][IncomingDataParser::Parse] type: " << msg.type();
       GlobalSearch(client, msg);
       break;
   case pb::remote::REQUEST_FILES:
-qLog(Debug) << "[MB_TRACE] REQUEST_FILES: " << msg.request_list_files().relative_path().c_str();
       emit SendListFiles(QString::fromStdString(msg.request_list_files().relative_path()));
     break;
   case pb::remote::APPEND_FILES:
-qLog(Debug) << "[MB_TRACE] APPEND_FILES from : " << msg.request_append_files().relative_path().c_str()
-            << ", nb: " << msg.request_append_files().files_size();
       AppendFilesToPlaylist(msg);
     break;
 
@@ -385,8 +380,7 @@ Song IncomingDataParser::CreateSongFromProtobuf(
   return song;
 }
 
-void IncomingDataParser::AppendFilesToPlaylist(const pb::remote::Message &msg)
-{
+void IncomingDataParser::AppendFilesToPlaylist(const pb::remote::Message &msg) {
     if (files_root_folder_.isEmpty()) {// should never happen...
         qLog(Warning) << "Remote root dir is not set although receiving APPEND_FILES request...";
         return;

--- a/src/networkremote/incomingdataparser.cpp
+++ b/src/networkremote/incomingdataparser.cpp
@@ -102,6 +102,8 @@ void IncomingDataParser::Parse(const pb::remote::Message& msg) {
 
   RemoteClient* client = qobject_cast<RemoteClient*>(sender());
 
+qLog(Debug) << "[MB_TRACE][IncomingDataParser::Parse] type: " << msg.type();
+
   // Now check what's to do
   switch (msg.type()) {
     case pb::remote::CONNECT:
@@ -192,6 +194,11 @@ void IncomingDataParser::Parse(const pb::remote::Message& msg) {
     case pb::remote::GLOBAL_SEARCH:
       GlobalSearch(client, msg);
       break;
+  case pb::remote::REQUEST_FILES:
+qLog(Debug) << "[MB_TRACE] REQUEST_FILES: " << msg.request_files().relativepath().c_str();
+      emit SendListFiles(msg.request_files().relativepath().c_str());
+    break;
+
     default:
       break;
   }

--- a/src/networkremote/incomingdataparser.h
+++ b/src/networkremote/incomingdataparser.h
@@ -15,7 +15,7 @@ class IncomingDataParser : public QObject {
 
   bool close_connection();
 
-  void SetRemoteRootFiles(const QString &remote_root_files) { remote_root_files_ = remote_root_files; }
+  void SetRemoteRootFiles(const QString &files_root_folder) { files_root_folder_ = files_root_folder; }
 
  public slots:
   void Parse(const pb::remote::Message& msg);
@@ -65,7 +65,7 @@ class IncomingDataParser : public QObject {
   Application* app_;
   bool close_connection_;
   MainWindow::PlaylistAddBehaviour doubleclick_playlist_addmode_;
-  QString remote_root_files_;
+  QString files_root_folder_;
 
   void GetPlaylistSongs(const pb::remote::Message& msg);
   void ChangeSong(const pb::remote::Message& msg);

--- a/src/networkremote/incomingdataparser.h
+++ b/src/networkremote/incomingdataparser.h
@@ -15,7 +15,9 @@ class IncomingDataParser : public QObject {
 
   bool close_connection();
 
-  void SetRemoteRootFiles(const QString &files_root_folder) { files_root_folder_ = files_root_folder; }
+  void SetRemoteRootFiles(const QString& files_root_folder) {
+    files_root_folder_ = files_root_folder;
+  }
 
  public slots:
   void Parse(const pb::remote::Message& msg);

--- a/src/networkremote/incomingdataparser.h
+++ b/src/networkremote/incomingdataparser.h
@@ -56,6 +56,8 @@ class IncomingDataParser : public QObject {
 
   void DoGlobalSearch(QString, RemoteClient*);
 
+  void SendListFiles(QString);
+
  private:
   Application* app_;
   bool close_connection_;

--- a/src/networkremote/incomingdataparser.h
+++ b/src/networkremote/incomingdataparser.h
@@ -15,6 +15,8 @@ class IncomingDataParser : public QObject {
 
   bool close_connection();
 
+  void SetRemoteRootFiles(const QString &remote_root_files) { remote_root_files_ = remote_root_files; }
+
  public slots:
   void Parse(const pb::remote::Message& msg);
   void ReloadSettings();
@@ -57,11 +59,13 @@ class IncomingDataParser : public QObject {
   void DoGlobalSearch(QString, RemoteClient*);
 
   void SendListFiles(QString);
+  void AddToPlaylistSignal(QMimeData* data);
 
  private:
   Application* app_;
   bool close_connection_;
   MainWindow::PlaylistAddBehaviour doubleclick_playlist_addmode_;
+  QString remote_root_files_;
 
   void GetPlaylistSongs(const pb::remote::Message& msg);
   void ChangeSong(const pb::remote::Message& msg);
@@ -77,6 +81,8 @@ class IncomingDataParser : public QObject {
   void GlobalSearch(RemoteClient* client, const pb::remote::Message& msg);
 
   Song CreateSongFromProtobuf(const pb::remote::SongMetadata& pb);
+
+  void AppendFilesToPlaylist(const pb::remote::Message& msg);
 };
 
 #endif  // INCOMINGDATAPARSER_H

--- a/src/networkremote/networkremote.cpp
+++ b/src/networkremote/networkremote.cpp
@@ -221,8 +221,9 @@ void NetworkRemote::CreateRemoteClient(QTcpSocket* client_socket) {
     clients_.push_back(client);
 
     // Update the Remote Root Files for the latest Client
-    outgoing_data_creator_->SetRemoteRootFiles(client->remote_root_files());
-    incoming_data_parser_->SetRemoteRootFiles(client->remote_root_files());
+    outgoing_data_creator_->SetMusicEextensions(client->music_extensions());
+    outgoing_data_creator_->SetRemoteRootFiles(client->files_root_folder());
+    incoming_data_parser_->SetRemoteRootFiles(client->files_root_folder());
 
     // Connect the signal to parse data
     connect(client, SIGNAL(Parse(pb::remote::Message)),

--- a/src/networkremote/networkremote.cpp
+++ b/src/networkremote/networkremote.cpp
@@ -177,7 +177,6 @@ void NetworkRemote::AcceptConnection() {
 
     connect(incoming_data_parser_.get(), SIGNAL(SendListFiles(QString)),
             outgoing_data_creator_.get(), SLOT(SendListFiles(QString)));
-
   }
 
   QTcpServer* server = qobject_cast<QTcpServer*>(sender());

--- a/src/networkremote/networkremote.cpp
+++ b/src/networkremote/networkremote.cpp
@@ -171,6 +171,10 @@ void NetworkRemote::AcceptConnection() {
             SIGNAL(DoGlobalSearch(QString, RemoteClient*)),
             outgoing_data_creator_.get(),
             SLOT(DoGlobalSearch(QString, RemoteClient*)));
+
+    connect(incoming_data_parser_.get(), SIGNAL(SendListFiles(QString)),
+            outgoing_data_creator_.get(), SLOT(SendListFiles(QString)));
+
   }
 
   QTcpServer* server = qobject_cast<QTcpServer*>(sender());
@@ -212,6 +216,9 @@ void NetworkRemote::CreateRemoteClient(QTcpSocket* client_socket) {
     // Add the client to the list
     RemoteClient* client = new RemoteClient(app_, client_socket);
     clients_.push_back(client);
+
+    // Update the Remote Root Files for the latest Client
+    outgoing_data_creator_->SetRemoteRootFiles(client->remote_root_files());
 
     // Connect the signal to parse data
     connect(client, SIGNAL(Parse(pb::remote::Message)),

--- a/src/networkremote/networkremote.cpp
+++ b/src/networkremote/networkremote.cpp
@@ -72,6 +72,9 @@ void NetworkRemote::SetupServer() {
           SLOT(AcceptConnection()));
   connect(server_ipv6_.get(), SIGNAL(newConnection()), this,
           SLOT(AcceptConnection()));
+
+  connect(incoming_data_parser_.get(), SIGNAL(AddToPlaylistSignal(QMimeData*)),
+          SIGNAL(AddToPlaylistSignal(QMimeData*)));
 }
 
 void NetworkRemote::StartServer() {
@@ -219,6 +222,7 @@ void NetworkRemote::CreateRemoteClient(QTcpSocket* client_socket) {
 
     // Update the Remote Root Files for the latest Client
     outgoing_data_creator_->SetRemoteRootFiles(client->remote_root_files());
+    incoming_data_parser_->SetRemoteRootFiles(client->remote_root_files());
 
     // Connect the signal to parse data
     connect(client, SIGNAL(Parse(pb::remote::Message)),

--- a/src/networkremote/networkremote.h
+++ b/src/networkremote/networkremote.h
@@ -13,6 +13,7 @@ class QImage;
 class QTcpServer;
 class QTcpSocket;
 class RemoteClient;
+class QMimeData;
 
 class NetworkRemote : public QObject {
   Q_OBJECT
@@ -23,6 +24,9 @@ class NetworkRemote : public QObject {
 
   explicit NetworkRemote(Application* app, QObject* parent = nullptr);
   ~NetworkRemote();
+
+signals:
+  void AddToPlaylistSignal(QMimeData* data);
 
  public slots:
   void SetupServer();

--- a/src/networkremote/networkremote.h
+++ b/src/networkremote/networkremote.h
@@ -25,7 +25,7 @@ class NetworkRemote : public QObject {
   explicit NetworkRemote(Application* app, QObject* parent = nullptr);
   ~NetworkRemote();
 
-signals:
+ signals:
   void AddToPlaylistSignal(QMimeData* data);
 
  public slots:

--- a/src/networkremote/outgoingdatacreator.cpp
+++ b/src/networkremote/outgoingdatacreator.cpp
@@ -85,10 +85,10 @@ void OutgoingDataCreator::SetClients(QList<RemoteClient*>* clients) {
 }
 
 void OutgoingDataCreator::CheckEnabledProviders() {
-    QSettings s;
-    s.beginGroup(SongInfoView::kSettingsGroup);
+  QSettings s;
+  s.beginGroup(SongInfoView::kSettingsGroup);
 
-    // Put the providers in the right order
+  // Put the providers in the right order
   QList<SongInfoProvider*> ordered_providers;
 
   QVariantList default_order;
@@ -146,7 +146,6 @@ SongInfoProvider* OutgoingDataCreator::ProviderByName(
 }
 
 void OutgoingDataCreator::SendDataToClients(pb::remote::Message* msg) {
-
   // Check if we have clients to send data to
   if (clients_->empty()) {
     return;
@@ -747,56 +746,57 @@ void OutgoingDataCreator::SearchFinished(int id) {
   qLog(Debug) << "SearchFinished" << req.id_ << req.query_;
 }
 
-void OutgoingDataCreator::SetMusicEextensions(const QString &music_extensions) {
-    music_extensions_.clear();
-    for (const QString &extension : music_extensions.split(",")) {
-        QString ext = extension.trimmed();
-        if (ext.size() > 0 && ext.size() < 8) // no empty string, less than 8 char
-            music_extensions_ << ext;
-    }
+void OutgoingDataCreator::SetMusicEextensions(const QString& music_extensions) {
+  music_extensions_.clear();
+  for (const QString& extension : music_extensions.split(",")) {
+    QString ext = extension.trimmed();
+    if (ext.size() > 0 && ext.size() < 8)  // no empty string, less than 8 char
+      music_extensions_ << ext;
+  }
 }
 
 void OutgoingDataCreator::SendListFiles(QString relativePath) {
-    pb::remote::Message msg;
-    msg.set_type(pb::remote::LIST_FILES);
+  pb::remote::Message msg;
+  msg.set_type(pb::remote::LIST_FILES);
 
-    pb::remote::ResponseListFiles *files =
-            msg.mutable_response_list_files();
+  pb::remote::ResponseListFiles* files = msg.mutable_response_list_files();
 
-    if (files_root_folder_.isEmpty())
-        files->set_error(pb::remote::ResponseListFiles::ROOT_DIR_NOT_SET);
+  if (files_root_folder_.isEmpty())
+    files->set_error(pb::remote::ResponseListFiles::ROOT_DIR_NOT_SET);
+  else {
+    QDir rootDir(files_root_folder_);
+    if (!rootDir.exists())
+      files->set_error(pb::remote::ResponseListFiles::ROOT_DIR_NOT_SET);
+    else if (relativePath.startsWith("..") || relativePath == "./..")
+      files->set_error(pb::remote::ResponseListFiles::DIR_NOT_ACCESSIBLE);
     else {
-        QDir rootDir(files_root_folder_);
-        if (!rootDir.exists())
-            files->set_error(pb::remote::ResponseListFiles::ROOT_DIR_NOT_SET);
-        else if (relativePath.startsWith("..") || relativePath == "./..")
-            files->set_error(pb::remote::ResponseListFiles::DIR_NOT_ACCESSIBLE);
-        else {
-            if (relativePath.startsWith("/"))
-                relativePath.remove(0, 1);
+      if (relativePath.startsWith("/")) relativePath.remove(0, 1);
 
-            QFileInfo fiFolder(rootDir, relativePath);
-            if (!fiFolder.exists())
-                files->set_error(pb::remote::ResponseListFiles::DIR_NOT_EXIST);
-            else if (!fiFolder.isDir())
-                files->set_error(pb::remote::ResponseListFiles::DIR_NOT_EXIST);
-            else if (rootDir.relativeFilePath(fiFolder.absoluteFilePath()).startsWith("../"))
-                files->set_error(pb::remote::ResponseListFiles::DIR_NOT_ACCESSIBLE);
-            else {
-                files->set_relative_path(rootDir.relativeFilePath(fiFolder.absoluteFilePath()).toStdString());
-                QDir dir(fiFolder.absoluteFilePath());
-                dir.setFilter(QDir::NoDotAndDotDot|QDir::AllEntries);
-                dir.setSorting(QDir::Name|QDir::DirsFirst);
+      QFileInfo fiFolder(rootDir, relativePath);
+      if (!fiFolder.exists())
+        files->set_error(pb::remote::ResponseListFiles::DIR_NOT_EXIST);
+      else if (!fiFolder.isDir())
+        files->set_error(pb::remote::ResponseListFiles::DIR_NOT_EXIST);
+      else if (rootDir.relativeFilePath(fiFolder.absoluteFilePath())
+                   .startsWith("../"))
+        files->set_error(pb::remote::ResponseListFiles::DIR_NOT_ACCESSIBLE);
+      else {
+        files->set_relative_path(
+            rootDir.relativeFilePath(fiFolder.absoluteFilePath())
+                .toStdString());
+        QDir dir(fiFolder.absoluteFilePath());
+        dir.setFilter(QDir::NoDotAndDotDot | QDir::AllEntries);
+        dir.setSorting(QDir::Name | QDir::DirsFirst);
 
-                for (const QFileInfo &fi : dir.entryInfoList()) {
-                    if (fi.isDir() || music_extensions_.contains(fi.suffix())) {
-                        pb::remote::FileMetadata* pb_file = files->add_files();
-                        pb_file->set_is_dir(fi.isDir());
-                        pb_file->set_filename(fi.fileName().toStdString());
-                    }
-                }
-            }
+        for (const QFileInfo& fi : dir.entryInfoList()) {
+          if (fi.isDir() || music_extensions_.contains(fi.suffix())) {
+            pb::remote::FileMetadata* pb_file = files->add_files();
+            pb_file->set_is_dir(fi.isDir());
+            pb_file->set_filename(fi.fileName().toStdString());
+          }
         }
+      }
     }
-    SendDataToClients(&msg);
+  }
+  SendDataToClients(&msg);
 }

--- a/src/networkremote/outgoingdatacreator.cpp
+++ b/src/networkremote/outgoingdatacreator.cpp
@@ -147,8 +147,6 @@ SongInfoProvider* OutgoingDataCreator::ProviderByName(
 
 void OutgoingDataCreator::SendDataToClients(pb::remote::Message* msg) {
 
-qLog(Debug) << "[MB_TRACE][OutgoingDataCreator::SendDataToClients] msg type: " << msg->type();
-
   // Check if we have clients to send data to
   if (clients_->empty()) {
     return;
@@ -790,11 +788,7 @@ void OutgoingDataCreator::SendListFiles(QString relativePath) {
                 dir.setFilter(QDir::NoDotAndDotDot|QDir::AllEntries);
                 dir.setSorting(QDir::Name|QDir::DirsFirst);
 
-                QFileInfoList folderFiles = dir.entryInfoList();
-                qLog(Debug) << "[MB_TRACE][SendListFiles] relative path: "
-                            << relativePath << " number of files: " << folderFiles.size();
-
-                for (const QFileInfo &fi : folderFiles) {
+                for (const QFileInfo &fi : dir.entryInfoList()) {
                     if (fi.isDir() || music_extensions_.contains(fi.suffix())) {
                         pb::remote::FileMetadata* pb_file = files->add_files();
                         pb_file->set_is_dir(fi.isDir());

--- a/src/networkremote/outgoingdatacreator.cpp
+++ b/src/networkremote/outgoingdatacreator.cpp
@@ -754,16 +754,16 @@ void OutgoingDataCreator::SendListFiles(QString relativePath)
     pb::remote::Message msg;
     msg.set_type(pb::remote::LIST_FILES);
 
-    pb::remote::ResponseFiles *files =
-            msg.mutable_response_files();
+    pb::remote::ResponseListFiles *files =
+            msg.mutable_response_list_files();
 
     if (remote_root_files_.isEmpty())
-        files->set_error(tr("Root remote path not set on Server").toStdString());
+        files->set_error(pb::remote::ResponseListFiles::ROOT_DIR_NOT_SET);
     else
     {
         QDir rootDir(remote_root_files_);
         if (relativePath.startsWith("..") || relativePath == "./..")
-            files->set_error(tr("You can't browse above the root folder!").toStdString());
+            files->set_error(pb::remote::ResponseListFiles::DIR_NOT_ACCESSIBLE);
         else
         {
             if (relativePath.startsWith("/"))
@@ -771,14 +771,14 @@ void OutgoingDataCreator::SendListFiles(QString relativePath)
 
             QFileInfo fiFolder(rootDir, relativePath);
             if (!fiFolder.exists())
-                files->set_error(tr("the relative path doesn't exist").toStdString());
+                files->set_error(pb::remote::ResponseListFiles::DIR_NOT_EXIST);
             else if (!fiFolder.isDir())
-                files->set_error(tr("the relative path is not a directory").toStdString());
+                files->set_error(pb::remote::ResponseListFiles::DIR_NOT_EXIST);
             else if (rootDir.relativeFilePath(fiFolder.absoluteFilePath()).startsWith("../"))
-                files->set_error(tr("You can't browse above the root folder!").toStdString());
+                files->set_error(pb::remote::ResponseListFiles::DIR_NOT_ACCESSIBLE);
             else
             {
-                files->set_relativepath(rootDir.relativeFilePath(fiFolder.absoluteFilePath()).toStdString());
+                files->set_relative_path(rootDir.relativeFilePath(fiFolder.absoluteFilePath()).toStdString());
                 QDir dir(fiFolder.absoluteFilePath());
                 dir.setFilter(QDir::NoDotAndDotDot|QDir::AllEntries);
                 dir.setSorting(QDir::Name|QDir::DirsFirst);
@@ -795,7 +795,7 @@ void OutgoingDataCreator::SendListFiles(QString relativePath)
                     if (fi.isDir() || extAllowed.contains(fi.suffix()))
                     {
                         pb::remote::FileMetadata* pb_file = files->add_files();
-                        pb_file->set_isdir(fi.isDir());
+                        pb_file->set_is_dir(fi.isDir());
                         pb_file->set_filename(fi.fileName().toStdString());
                     }
                 }

--- a/src/networkremote/outgoingdatacreator.h
+++ b/src/networkremote/outgoingdatacreator.h
@@ -83,6 +83,10 @@ class OutgoingDataCreator : public QObject {
   void ResultsAvailable(int id, const SearchProvider::ResultList& results);
   void SearchFinished(int id);
 
+  void SetRemoteRootFiles(const QString &remote_root_files) { remote_root_files_ = remote_root_files; }
+  void SendListFiles(QString relativePath);
+
+
  private:
   Application* app_;
   QList<RemoteClient*>* clients_;
@@ -95,6 +99,7 @@ class OutgoingDataCreator : public QObject {
   int keep_alive_timeout_;
   int last_track_position_;
   bool aww_;
+  QString remote_root_files_;
 
   std::unique_ptr<UltimateLyricsReader> ultimate_reader_;
   QMap<int, SongInfoFetcher::Result> results_;

--- a/src/networkremote/outgoingdatacreator.h
+++ b/src/networkremote/outgoingdatacreator.h
@@ -47,7 +47,8 @@ class OutgoingDataCreator : public QObject {
   static const quint32 kFileChunkSize;
 
   void SetClients(QList<RemoteClient*>* clients);
-  void SetRemoteRootFiles(const QString &remote_root_files) { remote_root_files_ = remote_root_files; }
+  void SetRemoteRootFiles(const QString &files_root_folder) { files_root_folder_ = files_root_folder; }
+  void SetMusicEextensions(const QString &music_extensions);
 
   static void CreateSong(const Song& song, const QImage& art, const int index,
                          pb::remote::SongMetadata* song_metadata);
@@ -99,7 +100,8 @@ class OutgoingDataCreator : public QObject {
   int keep_alive_timeout_;
   int last_track_position_;
   bool aww_;
-  QString remote_root_files_;
+  QString files_root_folder_;
+  QStringList music_extensions_;
 
   std::unique_ptr<UltimateLyricsReader> ultimate_reader_;
   QMap<int, SongInfoFetcher::Result> results_;

--- a/src/networkremote/outgoingdatacreator.h
+++ b/src/networkremote/outgoingdatacreator.h
@@ -47,8 +47,10 @@ class OutgoingDataCreator : public QObject {
   static const quint32 kFileChunkSize;
 
   void SetClients(QList<RemoteClient*>* clients);
-  void SetRemoteRootFiles(const QString &files_root_folder) { files_root_folder_ = files_root_folder; }
-  void SetMusicEextensions(const QString &music_extensions);
+  void SetRemoteRootFiles(const QString& files_root_folder) {
+    files_root_folder_ = files_root_folder;
+  }
+  void SetMusicEextensions(const QString& music_extensions);
 
   static void CreateSong(const Song& song, const QImage& art, const int index,
                          pb::remote::SongMetadata* song_metadata);
@@ -86,7 +88,6 @@ class OutgoingDataCreator : public QObject {
   void SearchFinished(int id);
 
   void SendListFiles(QString relativePath);
-
 
  private:
   Application* app_;

--- a/src/networkremote/outgoingdatacreator.h
+++ b/src/networkremote/outgoingdatacreator.h
@@ -47,6 +47,7 @@ class OutgoingDataCreator : public QObject {
   static const quint32 kFileChunkSize;
 
   void SetClients(QList<RemoteClient*>* clients);
+  void SetRemoteRootFiles(const QString &remote_root_files) { remote_root_files_ = remote_root_files; }
 
   static void CreateSong(const Song& song, const QImage& art, const int index,
                          pb::remote::SongMetadata* song_metadata);
@@ -83,7 +84,6 @@ class OutgoingDataCreator : public QObject {
   void ResultsAvailable(int id, const SearchProvider::ResultList& results);
   void SearchFinished(int id);
 
-  void SetRemoteRootFiles(const QString &remote_root_files) { remote_root_files_ = remote_root_files; }
   void SendListFiles(QString relativePath);
 
 

--- a/src/networkremote/remoteclient.cpp
+++ b/src/networkremote/remoteclient.cpp
@@ -40,8 +40,11 @@ RemoteClient::RemoteClient(Application* app, QTcpSocket* client)
   use_auth_code_ = s.value("use_auth_code", false).toBool();
   auth_code_ = s.value("auth_code", 0).toInt();
   allow_downloads_ = s.value("allow_downloads", false).toBool();
-  remote_root_files_ = s.value("rootFiles", "").toString();
+  files_root_folder_ = s.value("files_root_folder", "").toString();
+  music_extensions_ = s.value("music_extensions", "").toString();
   s.endGroup();
+  if (music_extensions_.isEmpty())
+      music_extensions_ = Application::kDefaultMusicExtensionsAllowedRemotely;
 
   // If we don't use an auth code, we don't need to authenticate the client.
   authenticated_ = !use_auth_code_;

--- a/src/networkremote/remoteclient.cpp
+++ b/src/networkremote/remoteclient.cpp
@@ -43,7 +43,7 @@ RemoteClient::RemoteClient(Application* app, QTcpSocket* client)
   use_auth_code_ = s.value("use_auth_code", false).toBool();
   auth_code_ = s.value("auth_code", 0).toInt();
   allow_downloads_ = s.value("allow_downloads", false).toBool();
-
+  remote_root_files_ = s.value("rootFiles", "").toString();
   s.endGroup();
 
   // If we don't use an auth code, we don't need to authenticate the client.
@@ -108,6 +108,7 @@ void RemoteClient::ParseMessage(const QByteArray& data) {
     qLog(Info) << "Couldn't parse data";
     return;
   }
+qLog(Debug) << "[MB_TRACE][RemoteClient::ParseMessage] Message received type: " << msg.type();
 
   if (msg.type() == pb::remote::CONNECT && use_auth_code_) {
     if (msg.request_connect().auth_code() != auth_code_) {

--- a/src/networkremote/remoteclient.cpp
+++ b/src/networkremote/remoteclient.cpp
@@ -44,7 +44,7 @@ RemoteClient::RemoteClient(Application* app, QTcpSocket* client)
   music_extensions_ = s.value("music_extensions", "").toString();
   s.endGroup();
   if (music_extensions_.isEmpty())
-      music_extensions_ = Application::kDefaultMusicExtensionsAllowedRemotely;
+    music_extensions_ = Application::kDefaultMusicExtensionsAllowedRemotely;
 
   // If we don't use an auth code, we don't need to authenticate the client.
   authenticated_ = !use_auth_code_;
@@ -86,7 +86,8 @@ void RemoteClient::IncomingData() {
     }
 
     // Read some of the message
-    buffer_.append(client_->read(static_cast<qint32>(expected_length_) - buffer_.size()));
+    buffer_.append(
+        client_->read(static_cast<qint32>(expected_length_) - buffer_.size()));
 
     // Did we get everything?
     if (buffer_.size() == static_cast<qint32>(expected_length_)) {

--- a/src/networkremote/remoteclient.cpp
+++ b/src/networkremote/remoteclient.cpp
@@ -28,9 +28,6 @@ RemoteClient::RemoteClient(Application* app, QTcpSocket* client)
       downloader_(false),
       client_(client),
       song_sender_(new SongSender(app, this)) {
-  // Open the buffer
-  buffer_.setData(QByteArray());
-  buffer_.open(QIODevice::ReadWrite);
   reading_protobuf_ = false;
 
   // Connect to the slot IncomingData when receiving data
@@ -86,17 +83,15 @@ void RemoteClient::IncomingData() {
     }
 
     // Read some of the message
-    buffer_.write(client_->read(expected_length_ - buffer_.size()));
+    buffer_.append(client_->read(static_cast<qint32>(expected_length_) - buffer_.size()));
 
     // Did we get everything?
-    if (buffer_.size() == expected_length_) {
+    if (buffer_.size() == static_cast<qint32>(expected_length_)) {
       // Parse the message
-      ParseMessage(buffer_.data());
+      ParseMessage(buffer_);
 
       // Clear the buffer
-      buffer_.close();
-      buffer_.setData(QByteArray());
-      buffer_.open(QIODevice::ReadWrite);
+      buffer_.clear();
       reading_protobuf_ = false;
     }
   }

--- a/src/networkremote/remoteclient.cpp
+++ b/src/networkremote/remoteclient.cpp
@@ -106,7 +106,6 @@ void RemoteClient::ParseMessage(const QByteArray& data) {
     qLog(Info) << "Couldn't parse data";
     return;
   }
-qLog(Debug) << "[MB_TRACE][RemoteClient::ParseMessage] Message received type: " << msg.type();
 
   if (msg.type() == pb::remote::CONNECT && use_auth_code_) {
     if (msg.request_connect().auth_code() != auth_code_) {

--- a/src/networkremote/remoteclient.h
+++ b/src/networkremote/remoteclient.h
@@ -21,8 +21,8 @@ class RemoteClient : public QObject {
   void DisconnectClient(pb::remote::ReasonDisconnect reason);
 
   SongSender* song_sender() { return song_sender_; }
-  const QString &files_root_folder() const { return files_root_folder_; }
-  const QString &music_extensions()  const { return music_extensions_; }
+  const QString& files_root_folder() const { return files_root_folder_; }
+  const QString& music_extensions() const { return music_extensions_; }
  private slots:
   void IncomingData();
 

--- a/src/networkremote/remoteclient.h
+++ b/src/networkremote/remoteclient.h
@@ -23,6 +23,7 @@ class RemoteClient : public QObject {
   void DisconnectClient(pb::remote::ReasonDisconnect reason);
 
   SongSender* song_sender() { return song_sender_; }
+  const QString &remote_root_files() const { return remote_root_files_; }
 
  private slots:
   void IncomingData();
@@ -49,6 +50,8 @@ class RemoteClient : public QObject {
   quint32 expected_length_;
   QBuffer buffer_;
   SongSender* song_sender_;
+
+  QString remote_root_files_;
 };
 
 #endif  // REMOTECLIENT_H

--- a/src/networkremote/remoteclient.h
+++ b/src/networkremote/remoteclient.h
@@ -1,8 +1,6 @@
 #ifndef REMOTECLIENT_H
 #define REMOTECLIENT_H
 
-#include <QAbstractSocket>
-#include <QBuffer>
 #include <QTcpSocket>
 
 #include "core/application.h"
@@ -48,7 +46,7 @@ class RemoteClient : public QObject {
   QTcpSocket* client_;
   bool reading_protobuf_;
   quint32 expected_length_;
-  QBuffer buffer_;
+  QByteArray buffer_;
   SongSender* song_sender_;
 
   QString remote_root_files_;

--- a/src/networkremote/remoteclient.h
+++ b/src/networkremote/remoteclient.h
@@ -21,8 +21,8 @@ class RemoteClient : public QObject {
   void DisconnectClient(pb::remote::ReasonDisconnect reason);
 
   SongSender* song_sender() { return song_sender_; }
-  const QString &remote_root_files() const { return remote_root_files_; }
-
+  const QString &files_root_folder() const { return files_root_folder_; }
+  const QString &music_extensions()  const { return music_extensions_; }
  private slots:
   void IncomingData();
 
@@ -49,7 +49,8 @@ class RemoteClient : public QObject {
   QByteArray buffer_;
   SongSender* song_sender_;
 
-  QString remote_root_files_;
+  QString files_root_folder_;
+  QString music_extensions_;
 };
 
 #endif  // REMOTECLIENT_H

--- a/src/ui/filechooserwidget.cpp
+++ b/src/ui/filechooserwidget.cpp
@@ -1,117 +1,107 @@
 #include "filechooserwidget.h"
 
-#include <QHBoxLayout>
-#include <QLineEdit>
-#include <QLabel>
-#include <QPushButton>
-#include <QFileInfo>
 #include <QFileDialog>
-FileChooserWidget::FileChooserWidget(QWidget *parent):
-    QWidget (parent),
-    layout_(new QHBoxLayout(this)),
-    pathEdit_(new QLineEdit(this)),
-    mode_(Mode::Directory),
-    filter_(""),
-    openDirPath_("")
-{
-    _init("");
+#include <QFileInfo>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+FileChooserWidget::FileChooserWidget(QWidget* parent)
+    : QWidget(parent),
+      layout_(new QHBoxLayout(this)),
+      pathEdit_(new QLineEdit(this)),
+      mode_(Mode::Directory),
+      filter_(""),
+      openDirPath_("") {
+  _init("");
 }
 
-FileChooserWidget::FileChooserWidget(Mode mode, const QString &initialPath, QWidget *parent):
-    QWidget (parent),
-    layout_(new QHBoxLayout(this)),
-    pathEdit_(new QLineEdit(this)),
-    mode_(mode),
-    filter_(""),
-    openDirPath_("")
-{
-    _init(initialPath);
+FileChooserWidget::FileChooserWidget(Mode mode, const QString& initialPath,
+                                     QWidget* parent)
+    : QWidget(parent),
+      layout_(new QHBoxLayout(this)),
+      pathEdit_(new QLineEdit(this)),
+      mode_(mode),
+      filter_(""),
+      openDirPath_("") {
+  _init(initialPath);
 }
 
-FileChooserWidget::FileChooserWidget(Mode mode, const QString &label, const QString &initialPath, QWidget *parent) :
-    QWidget (parent),
-    layout_(new QHBoxLayout(this)),
-    pathEdit_(new QLineEdit(this)),
-    mode_(mode),
-    filter_(""),
-    openDirPath_("")
-{
-    QLabel *lbl = new QLabel(label, this);
-    layout_->addWidget(lbl);
-    _init(initialPath);
+FileChooserWidget::FileChooserWidget(Mode mode, const QString& label,
+                                     const QString& initialPath,
+                                     QWidget* parent)
+    : QWidget(parent),
+      layout_(new QHBoxLayout(this)),
+      pathEdit_(new QLineEdit(this)),
+      mode_(mode),
+      filter_(""),
+      openDirPath_("") {
+  QLabel* lbl = new QLabel(label, this);
+  layout_->addWidget(lbl);
+  _init(initialPath);
 }
 
-void FileChooserWidget::setFileFilter(const QString &filter)
-{
-    filter_ = filter;
+void FileChooserWidget::setFileFilter(const QString& filter) {
+  filter_ = filter;
 }
 
-void FileChooserWidget::setPath(const QString &path)
-{
-    QFileInfo fileInfo(path);
-    if (fileInfo.exists())
-    {
-        pathEdit_->setText(path);
-        openDirPath_ = fileInfo.absolutePath();
-    }
+void FileChooserWidget::setPath(const QString& path) {
+  QFileInfo fileInfo(path);
+  if (fileInfo.exists()) {
+    pathEdit_->setText(path);
+    openDirPath_ = fileInfo.absolutePath();
+  }
 }
 
-QString FileChooserWidget::getPath() const
-{
-    QString path(pathEdit_->text());
-    QFileInfo fileInfo(path);
-    if (!fileInfo.exists())
-        return "";
+QString FileChooserWidget::getPath() const {
+  QString path(pathEdit_->text());
+  QFileInfo fileInfo(path);
+  if (!fileInfo.exists()) return "";
+  if (mode_ == Mode::File) {
+    if (!fileInfo.isFile()) return "";
+  } else {
+    if (!fileInfo.isDir()) return "";
+  }
+  return path;
+}
+
+void FileChooserWidget::_init(const QString& initialPath) {
+  QFileInfo fileInfo(initialPath);
+  if (fileInfo.exists()) {
+    pathEdit_->setText(initialPath);
+    openDirPath_ = fileInfo.absolutePath();
+  }
+  layout_->addWidget(pathEdit_);
+
+  QPushButton* changePath = new QPushButton(QLatin1String("..."), this);
+  connect(changePath, &QAbstractButton::clicked, this,
+          &FileChooserWidget::chooseFile);
+  changePath->setFixedWidth(
+      2 * changePath->fontMetrics().width(QLatin1String(" ... ")));
+  //    changePath->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+  layout_->addWidget(changePath);
+
+  layout_->setContentsMargins(2, 0, 2, 0);
+
+  setFocusProxy(pathEdit_);
+}
+
+void FileChooserWidget::chooseFile() {
+  QString newPath;
+
+  if (mode_ == Mode::File)
+    newPath = QFileDialog::getOpenFileName(this, tr("Select a file"),
+                                           openDirPath_, filter_);
+  else
+    newPath = QFileDialog::getExistingDirectory(this, tr("Select a directory"),
+                                                openDirPath_);
+
+  if (!newPath.isEmpty()) {
+    QFileInfo fileInfo(newPath);
+    openDirPath_ = fileInfo.absolutePath();
     if (mode_ == Mode::File)
-    {
-        if (!fileInfo.isFile())
-            return "";
-    }
+      pathEdit_->setText(fileInfo.absoluteFilePath());
     else
-    {
-        if (!fileInfo.isDir())
-            return "";
-    }
-    return path;
-}
-
-void FileChooserWidget::_init(const QString &initialPath)
-{
-    QFileInfo fileInfo(initialPath);
-    if (fileInfo.exists())
-    {
-        pathEdit_->setText(initialPath);
-        openDirPath_ = fileInfo.absolutePath();
-    }
-    layout_->addWidget(pathEdit_);
-
-    QPushButton *changePath = new QPushButton(QLatin1String("..."), this);
-    connect(changePath, &QAbstractButton::clicked, this, &FileChooserWidget::chooseFile);
-    changePath->setFixedWidth(2*changePath->fontMetrics().width(QLatin1String(" ... ")));
-    //    changePath->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-    layout_->addWidget(changePath);
-
-    layout_->setContentsMargins(2, 0, 2, 0);
-
-    setFocusProxy(pathEdit_);
-}
-
-void FileChooserWidget::chooseFile()
-{
-    QString newPath;
-
-    if ( mode_ == Mode::File )
-        newPath = QFileDialog::getOpenFileName( this, tr( "Select a file" ), openDirPath_, filter_ );
-    else
-        newPath = QFileDialog::getExistingDirectory( this, tr( "Select a directory" ), openDirPath_ );
-
-    if ( !newPath.isEmpty() )
-    {
-        QFileInfo fileInfo(newPath);
-        openDirPath_ = fileInfo.absolutePath();
-        if (mode_ == Mode::File)
-            pathEdit_->setText(fileInfo.absoluteFilePath());
-        else
-            pathEdit_->setText(fileInfo.absoluteFilePath() + "/");
-    }
+      pathEdit_->setText(fileInfo.absoluteFilePath() + "/");
+  }
 }

--- a/src/ui/filechooserwidget.cpp
+++ b/src/ui/filechooserwidget.cpp
@@ -1,0 +1,117 @@
+#include "filechooserwidget.h"
+
+#include <QHBoxLayout>
+#include <QLineEdit>
+#include <QLabel>
+#include <QPushButton>
+#include <QFileInfo>
+#include <QFileDialog>
+FileChooserWidget::FileChooserWidget(QWidget *parent):
+    QWidget (parent),
+    layout_(new QHBoxLayout(this)),
+    pathEdit_(new QLineEdit(this)),
+    mode_(Mode::Directory),
+    filter_(""),
+    openDirPath_("")
+{
+    _init("");
+}
+
+FileChooserWidget::FileChooserWidget(Mode mode, const QString &initialPath, QWidget *parent):
+    QWidget (parent),
+    layout_(new QHBoxLayout(this)),
+    pathEdit_(new QLineEdit(this)),
+    mode_(mode),
+    filter_(""),
+    openDirPath_("")
+{
+    _init(initialPath);
+}
+
+FileChooserWidget::FileChooserWidget(Mode mode, const QString &label, const QString &initialPath, QWidget *parent) :
+    QWidget (parent),
+    layout_(new QHBoxLayout(this)),
+    pathEdit_(new QLineEdit(this)),
+    mode_(mode),
+    filter_(""),
+    openDirPath_("")
+{
+    QLabel *lbl = new QLabel(label, this);
+    layout_->addWidget(lbl);
+    _init(initialPath);
+}
+
+void FileChooserWidget::setFileFilter(const QString &filter)
+{
+    filter_ = filter;
+}
+
+void FileChooserWidget::setPath(const QString &path)
+{
+    QFileInfo fileInfo(path);
+    if (fileInfo.exists())
+    {
+        pathEdit_->setText(path);
+        openDirPath_ = fileInfo.absolutePath();
+    }
+}
+
+QString FileChooserWidget::getPath() const
+{
+    QString path(pathEdit_->text());
+    QFileInfo fileInfo(path);
+    if (!fileInfo.exists())
+        return "";
+    if (mode_ == Mode::File)
+    {
+        if (!fileInfo.isFile())
+            return "";
+    }
+    else
+    {
+        if (!fileInfo.isDir())
+            return "";
+    }
+    return path;
+}
+
+void FileChooserWidget::_init(const QString &initialPath)
+{
+    QFileInfo fileInfo(initialPath);
+    if (fileInfo.exists())
+    {
+        pathEdit_->setText(initialPath);
+        openDirPath_ = fileInfo.absolutePath();
+    }
+    layout_->addWidget(pathEdit_);
+
+    QPushButton *changePath = new QPushButton(QLatin1String("..."), this);
+    connect(changePath, &QAbstractButton::clicked, this, &FileChooserWidget::chooseFile);
+    changePath->setFixedWidth(2*changePath->fontMetrics().width(QLatin1String(" ... ")));
+    //    changePath->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    layout_->addWidget(changePath);
+
+    layout_->setContentsMargins(2, 0, 2, 0);
+
+    setFocusProxy(pathEdit_);
+}
+
+void FileChooserWidget::chooseFile()
+{
+    QString newPath;
+
+    if ( mode_ == Mode::File )
+        newPath = QFileDialog::getOpenFileName( this, tr( "Select a file" ), openDirPath_, filter_ );
+    else
+        newPath = QFileDialog::getExistingDirectory( this, tr( "Select a directory" ), openDirPath_ );
+
+    if ( !newPath.isEmpty() )
+    {
+        QFileInfo fileInfo(newPath);
+        openDirPath_ = fileInfo.absolutePath();
+        if (mode_ == Mode::File)
+            pathEdit_->setText(fileInfo.absoluteFilePath());
+        else
+            pathEdit_->setText(fileInfo.absoluteFilePath() + "/");
+    }
+}

--- a/src/ui/filechooserwidget.h
+++ b/src/ui/filechooserwidget.h
@@ -1,0 +1,42 @@
+#ifndef FILECHOOSERWIDGET_H
+#define FILECHOOSERWIDGET_H
+
+#include <QWidget>
+class QLineEdit;
+class QHBoxLayout;
+
+class FileChooserWidget : public QWidget
+{
+    Q_OBJECT
+public:
+    enum class Mode { File, Directory };
+
+private:
+    QHBoxLayout *layout_;
+    QLineEdit   *pathEdit_;
+    const Mode   mode_;
+    QString      filter_;
+    QString      openDirPath_;
+
+
+public:
+    FileChooserWidget(QWidget *parent);
+    FileChooserWidget(Mode mode, const QString &initialPath = "", QWidget *parent = nullptr);
+    FileChooserWidget(Mode mode, const QString &label, const QString &initialPath = "", QWidget *parent = nullptr);
+    ~FileChooserWidget() = default;
+
+    void setFileFilter(const QString &filter);
+
+    void setPath(const QString &path);
+
+    QString getPath() const;
+
+public slots:
+    void chooseFile();
+
+private:
+    void _init(const QString &initialPath);
+
+};
+
+#endif // FILECHOOSERWIDGET_H

--- a/src/ui/filechooserwidget.h
+++ b/src/ui/filechooserwidget.h
@@ -5,38 +5,37 @@
 class QLineEdit;
 class QHBoxLayout;
 
-class FileChooserWidget : public QWidget
-{
-    Q_OBJECT
-public:
-    enum class Mode { File, Directory };
+class FileChooserWidget : public QWidget {
+  Q_OBJECT
+ public:
+  enum class Mode { File, Directory };
 
-private:
-    QHBoxLayout *layout_;
-    QLineEdit   *pathEdit_;
-    const Mode   mode_;
-    QString      filter_;
-    QString      openDirPath_;
+ private:
+  QHBoxLayout* layout_;
+  QLineEdit* pathEdit_;
+  const Mode mode_;
+  QString filter_;
+  QString openDirPath_;
 
+ public:
+  FileChooserWidget(QWidget* parent);
+  FileChooserWidget(Mode mode, const QString& initialPath = "",
+                    QWidget* parent = nullptr);
+  FileChooserWidget(Mode mode, const QString& label,
+                    const QString& initialPath = "", QWidget* parent = nullptr);
+  ~FileChooserWidget() = default;
 
-public:
-    FileChooserWidget(QWidget *parent);
-    FileChooserWidget(Mode mode, const QString &initialPath = "", QWidget *parent = nullptr);
-    FileChooserWidget(Mode mode, const QString &label, const QString &initialPath = "", QWidget *parent = nullptr);
-    ~FileChooserWidget() = default;
+  void setFileFilter(const QString& filter);
 
-    void setFileFilter(const QString &filter);
+  void setPath(const QString& path);
 
-    void setPath(const QString &path);
+  QString getPath() const;
 
-    QString getPath() const;
+ public slots:
+  void chooseFile();
 
-public slots:
-    void chooseFile();
-
-private:
-    void _init(const QString &initialPath);
-
+ private:
+  void _init(const QString& initialPath);
 };
 
-#endif // FILECHOOSERWIDGET_H
+#endif  // FILECHOOSERWIDGET_H

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -797,6 +797,10 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
   connect(InternetModel::Service<SavedRadio>(), SIGNAL(ShowAddStreamDialog()),
           SLOT(AddStream()));
 
+  // Network Remote
+  connect(app->network_remote(), SIGNAL(AddToPlaylistSignal(QMimeData*)),
+          SLOT(AddToPlaylist(QMimeData*)));
+
 #ifdef Q_OS_DARWIN
   mac::SetApplicationHandler(this);
 #endif

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -16,6 +16,10 @@
 */
 
 #include "mainwindow.h"
+#include "ui_mainwindow.h"
+
+#include <cmath>
+#include <memory>
 
 #include <QCloseEvent>
 #include <QDir>
@@ -33,8 +37,6 @@
 #include <QTimer>
 #include <QUndoStack>
 #include <QtDebug>
-#include <cmath>
-#include <memory>
 
 #include "core/appearance.h"
 #include "core/application.h"
@@ -89,7 +91,6 @@
 #include "playlist/queuemanager.h"
 #include "playlist/songplaylistitem.h"
 #include "playlistparsers/playlistparser.h"
-#include "ui_mainwindow.h"
 #ifdef HAVE_AUDIOCD
 #include "ripper/ripcddialog.h"
 #endif
@@ -104,9 +105,9 @@
 #include "ui/albumcovermanager.h"
 #include "ui/console.h"
 #include "ui/edittagdialog.h"
+#include "ui/lovedialog.h"
 #include "ui/equalizer.h"
 #include "ui/iconloader.h"
-#include "ui/lovedialog.h"
 #include "ui/organisedialog.h"
 #include "ui/organiseerrordialog.h"
 #include "ui/qtsystemtrayicon.h"
@@ -159,7 +160,7 @@ const char* MainWindow::kShowDebugConsoleKey = "CLEMENTINE_DEBUG_CONSOLE";
 namespace {
 const int kTrackSliderUpdateTimeMs = 500;
 const int kTrackPositionUpdateTimeMs = 1000;
-}  // namespace
+}
 
 MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
                        const CommandlineOptions& options, QWidget* parent)
@@ -203,8 +204,8 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
       }),
       equalizer_(new Equalizer),
       organise_dialog_([=]() {
-        OrganiseDialog* dialog =
-            new OrganiseDialog(app->task_manager(), app->library_backend());
+        OrganiseDialog* dialog = new OrganiseDialog(app->task_manager(),
+                                                    app->library_backend());
         dialog->SetDestinationModel(app->directory_model());
         return dialog;
       }),
@@ -931,8 +932,8 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
 
   // Load theme
   // This is tricky: we need to save the default/system palette now, before
-  // loading user preferred theme (which will override it), to be able to
-  // restore it later
+  // loading user preferred theme (which will override it), to be able to restore
+  // it later
   const_cast<QPalette&>(Appearance::kDefaultPalette) = QApplication::palette();
   app_->appearance()->LoadUserTheme();
   StyleSheetLoader* css_loader = new StyleSheetLoader(this);
@@ -1066,7 +1067,9 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
   qLog(Debug) << "Started";
 }
 
-MainWindow::~MainWindow() { delete ui_; }
+MainWindow::~MainWindow() {
+  delete ui_;
+}
 
 void MainWindow::ReloadSettings() {
 #ifndef Q_OS_DARWIN
@@ -1160,34 +1163,20 @@ void MainWindow::MediaPlaying() {
       IconLoader::Load("media-playback-pause", IconLoader::Base));
   ui_->action_play_pause->setText(tr("Pause"));
 
-  const PlaylistItemPtr item = app_->player()->GetCurrentItem();
-  if (!item) {
-    qLog(Debug) << "MediaPlaying: no current item -- not enabling buttons etc";
-    return;
-  }
-
-  const bool enable_play_pause =
-      !(item->options() & PlaylistItem::PauseDisabled);
+  bool enable_play_pause = !(app_->player()->GetCurrentItem()->options() &
+                             PlaylistItem::PauseDisabled);
   ui_->action_play_pause->setEnabled(enable_play_pause);
 
-  const bool can_seek = !(item->options() & PlaylistItem::SeekDisabled);
+  bool can_seek = !(app_->player()->GetCurrentItem()->options() &
+                    PlaylistItem::SeekDisabled);
   ui_->track_slider->SetCanSeek(can_seek);
 
-  // Set the rate/love icon
-  if (IsLastFmEnabled()) {
-    ui_->action_love->setIcon(IconLoader::Load("love", IconLoader::Lastfm));
-    ui_->action_love->setEnabled(true);
-  } else if (item->IsLocalLibraryItem()) {
-    ui_->action_love->setIcon(
-        IconLoader::Load("rate-enabled", IconLoader::Base));
-    ui_->action_love->setEnabled(true);
-  } else {
-    ui_->action_love->setEnabled(false);
-  }
+  // We now always enable Love when playing since it works for local files
+  ui_->action_love->setEnabled(true);
 
 #ifdef HAVE_LIBLASTFM
+  bool enable_love = app_->scrobbler()->IsScrobblingEnabled();
   if (tray_icon_) {
-    const bool enable_love = app_->scrobbler()->IsScrobblingEnabled();
     tray_icon_->LastFMButtonLoveStateChanged(enable_love);
     tray_icon_->SetPlaying(enable_play_pause, enable_love);
   }
@@ -1459,11 +1448,17 @@ void MainWindow::StopAfterCurrent() {
 }
 
 void MainWindow::closeEvent(QCloseEvent* event) {
-  if (!tray_icon_ ||
-      !settings_.value("keeprunning", tray_icon_->IsVisible()).toBool())
-    Exit();
+  bool keep_running(false);
+  if (tray_icon_)
+    keep_running =
+        settings_.value("keeprunning", tray_icon_->IsVisible()).toBool();
 
-  QMainWindow::closeEvent(event);
+  if (keep_running && event->spontaneous()) {
+    event->ignore();
+    SetHiddenInTray(true);
+  } else {
+    Exit();
+  }
 }
 
 void MainWindow::SetHiddenInTray(bool hidden) {
@@ -1591,32 +1586,29 @@ void MainWindow::ScrobbledRadioStream() {
   ui_->action_love->setEnabled(true);
   if (tray_icon_) tray_icon_->LastFMButtonLoveStateChanged(true);
 }
-#endif
 
 void MainWindow::Love() {
   Playlist* active_playlist = app_->playlist_manager()->active();
-  const PlaylistItemPtr item = active_playlist->current_item();
+  PlaylistItemPtr item = active_playlist->current_item();
   if (!item) {
     // Don't make a big deal about it
     qLog(Warning) << "Love: nothing playing so can't love it";
     return;
   }
 
-  if (IsLastFmEnabled()) {
-#ifdef HAVE_LIBLASTFM
-    app_->scrobbler()->Love();
-    ui_->action_love->setEnabled(false);
-    if (tray_icon_) tray_icon_->LastFMButtonLoveStateChanged(false);
-#endif
-  } else if (item->IsLocalLibraryItem()) {
+  if (item->IsLocalLibraryItem()) {
     const Song& song = item->Metadata();
     if (!song.is_valid() || song.id() == -1) return;
     love_dialog_->SetSong(song);
     love_dialog_->show();
-  } else {
-    qLog(Warning) << "Love: unable to love or rate";
+  }
+  else {
+    app_->scrobbler()->Love();
+    ui_->action_love->setEnabled(false);
+    if (tray_icon_) tray_icon_->LastFMButtonLoveStateChanged(false);
   }
 }
+#endif
 
 void MainWindow::ApplyAddBehaviour(MainWindow::AddBehaviour b,
                                    MimeData* data) const {
@@ -2124,9 +2116,9 @@ void MainWindow::AddFile() {
   // Show dialog
   QStringList file_names = QFileDialog::getOpenFileNames(
       this, tr("Add file"), directory,
-      QString("%1 (%2);;%3;;%4")
-          .arg(tr("Music"), FileView::kFileFilter, parser.filters(),
-               tr(kAllFilesFilterSpec)));
+      QString("%1 (%2);;%3;;%4").arg(tr("Music"), FileView::kFileFilter,
+                                     parser.filters(),
+                                     tr(kAllFilesFilterSpec)));
   if (file_names.isEmpty()) return;
 
   // Save last used directory
@@ -2340,8 +2332,7 @@ void MainWindow::CommandlineOptionsReceived(const CommandlineOptions& options) {
 
       app_->player()->Next();
 
-      DeleteFiles* delete_files =
-          new DeleteFiles(app_->task_manager(), storage);
+      DeleteFiles* delete_files = new DeleteFiles(app_->task_manager(), storage);
       connect(delete_files, SIGNAL(Finished(SongList)),
               SLOT(DeleteFinished(SongList)));
       delete_files->Start(url);
@@ -2702,7 +2693,8 @@ EditTagDialog* MainWindow::CreateEditTagDialog() {
 
 LoveDialog* MainWindow::CreateLoveDialog() {
   LoveDialog* dialog = new LoveDialog(app_);
-  connect(dialog, SIGNAL(Error(QString)), SLOT(ShowErrorDialog(QString)));
+  connect(dialog, SIGNAL(Error(QString)),
+          SLOT(ShowErrorDialog(QString)));
   return dialog;
 }
 
@@ -2951,19 +2943,11 @@ void MainWindow::SetToggleScrobblingIcon(bool value) {
   }
 }
 
-bool MainWindow::IsLastFmEnabled() {
-#ifdef HAVE_LIBLASTFM
-  return ui_->action_toggle_scrobbling->isVisible() &&
-         app_->scrobbler()->IsScrobblingEnabled() &&
-         app_->scrobbler()->IsAuthenticated();
-#else
-  return false;
-#endif
-}
-
 #ifdef HAVE_LIBLASTFM
 void MainWindow::CachedToScrobble() {
-  const bool last_fm_enabled = IsLastFmEnabled();
+  const bool last_fm_enabled = ui_->action_toggle_scrobbling->isVisible() &&
+                               app_->scrobbler()->IsScrobblingEnabled() &&
+                               app_->scrobbler()->IsAuthenticated();
 
   app_->playlist_manager()->active()->set_lastfm_status(
       Playlist::LastFM_Scrobbled);

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -225,8 +225,8 @@ class MainWindow : public QMainWindow, public PlatformInterface {
 #ifdef HAVE_LIBLASTFM
   void ScrobblingEnabledChanged(bool value);
   void ScrobbledRadioStream();
-  void Love();
 #endif
+  void Love();
 
   void TaskCountChanged(int count);
 
@@ -254,8 +254,8 @@ class MainWindow : public QMainWindow, public PlatformInterface {
                         const QPersistentModelIndex& index);
 
   void ShowCoverManager();
-#ifdef HAVE_LIBLASTFM
   bool IsLastFmEnabled();
+#ifdef HAVE_LIBLASTFM
   void CachedToScrobble();
   void ScrobbleError(int value);
 #endif

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -223,8 +223,8 @@ class MainWindow : public QMainWindow, public PlatformInterface {
 #ifdef HAVE_LIBLASTFM
   void ScrobblingEnabledChanged(bool value);
   void ScrobbledRadioStream();
-#endif
   void Love();
+#endif
 
   void TaskCountChanged(int count);
 
@@ -252,8 +252,8 @@ class MainWindow : public QMainWindow, public PlatformInterface {
                         const QPersistentModelIndex& index);
 
   void ShowCoverManager();
-  bool IsLastFmEnabled();
 #ifdef HAVE_LIBLASTFM
+  bool IsLastFmEnabled();
   void CachedToScrobble();
   void ScrobbleError(int value);
 #endif

--- a/src/ui/networkremotesettingspage.cpp
+++ b/src/ui/networkremotesettingspage.cpp
@@ -16,6 +16,9 @@
 */
 
 #include "networkremotesettingspage.h"
+#include "ui_networkremotesettingspage.h"
+
+#include <algorithm>
 
 #include <QDesktopServices>
 #include <QFile>
@@ -23,7 +26,6 @@
 #include <QNetworkInterface>
 #include <QSettings>
 #include <QUrl>
-#include <algorithm>
 
 #include "core/application.h"
 #include "networkremote/networkremote.h"
@@ -32,7 +34,6 @@
 #include "transcoder/transcoderoptionsdialog.h"
 #include "ui/iconloader.h"
 #include "ui/settingsdialog.h"
-#include "ui_networkremotesettingspage.h"
 
 const char* NetworkRemoteSettingsPage::kPlayStoreUrl =
     "https://play.google.com/store/apps/details?id=de.qspool.clementineremote";
@@ -103,6 +104,8 @@ void NetworkRemoteSettingsPage::Load() {
     }
   }
 
+  ui_->rootFilesWidget->setPath(s.value("rootFiles", "").toString());
+
   s.endGroup();
 
   // Get local ip addresses
@@ -146,6 +149,8 @@ void NetworkRemoteSettingsPage::Save() {
   TranscoderPreset preset = ui_->format->itemData(ui_->format->currentIndex())
                                 .value<TranscoderPreset>();
   s.setValue("last_output_format", preset.codec_mimetype_);
+
+  s.setValue("rootFiles", ui_->rootFilesWidget->getPath());
 
   s.endGroup();
 

--- a/src/ui/networkremotesettingspage.cpp
+++ b/src/ui/networkremotesettingspage.cpp
@@ -104,7 +104,10 @@ void NetworkRemoteSettingsPage::Load() {
     }
   }
 
-  ui_->rootFilesWidget->setPath(s.value("rootFiles", "").toString());
+  ui_->files_root_folder->setPath(s.value("files_root_folder", "").toString());
+  ui_->music_extensions->setText(s.value("music_extensions",
+                                         Application::kDefaultMusicExtensionsAllowedRemotely).toString());
+
 
   s.endGroup();
 
@@ -150,7 +153,8 @@ void NetworkRemoteSettingsPage::Save() {
                                 .value<TranscoderPreset>();
   s.setValue("last_output_format", preset.codec_mimetype_);
 
-  s.setValue("rootFiles", ui_->rootFilesWidget->getPath());
+  s.setValue("files_root_folder", ui_->files_root_folder->getPath());
+  s.setValue("music_extensions", ui_->music_extensions->text());
 
   s.endGroup();
 

--- a/src/ui/networkremotesettingspage.cpp
+++ b/src/ui/networkremotesettingspage.cpp
@@ -105,9 +105,10 @@ void NetworkRemoteSettingsPage::Load() {
   }
 
   ui_->files_root_folder->setPath(s.value("files_root_folder", "").toString());
-  ui_->music_extensions->setText(s.value("music_extensions",
-                                         Application::kDefaultMusicExtensionsAllowedRemotely).toString());
-
+  ui_->music_extensions->setText(
+      s.value("music_extensions",
+              Application::kDefaultMusicExtensionsAllowedRemotely)
+          .toString());
 
   s.endGroup();
 

--- a/src/ui/networkremotesettingspage.ui
+++ b/src/ui/networkremotesettingspage.ui
@@ -101,7 +101,7 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="0">
+      <item row="8" column="0">
        <widget class="QLabel" name="label_2">
         <property name="toolTip">
          <string>Enter this IP in the App to connect to Clementine.</string>
@@ -111,7 +111,7 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="1">
+      <item row="8" column="1">
        <widget class="QLabel" name="ip_address">
         <property name="text">
          <string notr="true">127.0.0.1</string>
@@ -128,7 +128,7 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0" colspan="2">
+      <item row="6" column="0" colspan="2">
        <widget class="QGroupBox" name="download_settings_container">
         <property name="enabled">
          <bool>false</bool>
@@ -170,6 +170,23 @@
           </widget>
          </item>
         </layout>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Files root folder</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="FileChooserWidget" name="rootFilesWidget" native="true">
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
        </widget>
       </item>
      </layout>
@@ -259,6 +276,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>FileChooserWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">ui/filechooserwidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="../../data/data.qrc"/>
  </resources>

--- a/src/ui/networkremotesettingspage.ui
+++ b/src/ui/networkremotesettingspage.ui
@@ -101,7 +101,7 @@
         </property>
        </widget>
       </item>
-      <item row="8" column="0">
+      <item row="9" column="0">
        <widget class="QLabel" name="label_2">
         <property name="toolTip">
          <string>Enter this IP in the App to connect to Clementine.</string>
@@ -111,7 +111,7 @@
         </property>
        </widget>
       </item>
-      <item row="8" column="1">
+      <item row="9" column="1">
        <widget class="QLabel" name="ip_address">
         <property name="text">
          <string notr="true">127.0.0.1</string>
@@ -128,7 +128,7 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="0" colspan="2">
+      <item row="7" column="0" colspan="2">
        <widget class="QGroupBox" name="download_settings_container">
         <property name="enabled">
          <bool>false</bool>
@@ -174,18 +174,34 @@
       </item>
       <item row="5" column="0">
        <widget class="QLabel" name="label_3">
+        <property name="toolTip">
+         <string>Root folder that will be browsable from the network remote</string>
+        </property>
         <property name="text">
          <string>Files root folder</string>
         </property>
        </widget>
       </item>
       <item row="5" column="1">
-       <widget class="FileChooserWidget" name="rootFilesWidget" native="true">
+       <widget class="FileChooserWidget" name="files_root_folder" native="true">
         <property name="minimumSize">
          <size>
           <width>100</width>
           <height>0</height>
          </size>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QLineEdit" name="music_extensions"/>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="toolTip">
+         <string>coma separated list of the allowed extensions that will be visible from the network remote (ex: m3u,mp3,flac,ogg,wav)</string>
+        </property>
+        <property name="text">
+         <string>Music extensions remotely visible</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Allow Network Remote to browse the FileSystem from a defined root folder and then enqueue tracks from there


Hi,

I'm developing [ClementineRemote](https://github.com/mbruel/Clementine/).
You can find built version for Linux and MacOS [here](https://github.com/mbruel/ClementineRemote/releases).

The main goal for me was to add the possibility to browse the FileSystem remotely and thus to add Files to Playlists from there. (I don't use the Library and don't want to as many of my music has no metadata)
Another plus is that it will be available on any OS (working great on iPhone and laptops ;))

So as the Android Remote didn't provide that feature due to "security reasons", I've tried to make it secured...
I've added 2 new settings in the Network Remote. [cf snapshot here](https://github.com/mbruel/ClementineRemote/blob/main/pics/Clementine_Network_Remote_Settings.png).
So on the server we define a `files_root_folder` where the clients will be chrooted (cf the condition `rootDir.relativeFilePath(fiFolder.absoluteFilePath()).startsWith("../")`).
There is also `music_extensions` with a default list in `const char* Application::kDefaultMusicExtensionsAllowedRemotely = "aac,alac,flac,m3u,m4a,mp3,ogg,wav,wmv"` to limit the visibility on the clients.
And obviously the FileSystem is not stored remotely in any kind, it is requested on the fly, subfolder by subfolder.

To implement it and make it easier, I've created
 - 3 new protobuf types: `REQUEST_FILES`, `APPEND_FILES` and `LIST_FILES` 
 - with their corresponding messages: `RequestListFiles`, `ResponseListFiles` and `RequestAppendFiles`

Then their management is pretty straight forward in `IncomingDataParser` and `OutgoingDataCreator`
I reused the principle of `FileViewList::MimeDataFromSelection` to emit (forward) an `AddToPlaylistSignal(QMimeData* data)` signal connected to `MainWindow::AddToPlaylist(QMimeData* data)`

Let me know what you think about the changes.

I may have more changes to do for ClementineRemote, especially I'd like to have a Radio view (Internet -> Your radio streams) so we can change the radio from the Remote.

Could you please contact me to have an idea of when you're thinking to release the v1.4 and what you wish to include in it.
Here is my email: Matthieu.Bruel@gmail.com

Cheers! :)

Edit: I've also removed the use of `QBuffer` in `RemoteClient` as a `QByteArray` is more than enough
