### PR TITLE
inform remote in ResponseClementineInfo if downloads are allowed

### DIFF
--- a/ext/libclementine-remote/remotecontrolmessages.proto
+++ b/ext/libclementine-remote/remotecontrolmessages.proto
@@ -200,6 +200,7 @@ message Shuffle {
 message ResponseClementineInfo {
   optional string version = 1;
   optional EngineState state = 2;
+  optional bool allow_downloads = 3;
 }
 
 // The current song played

--- a/src/networkremote/networkremote.cpp
+++ b/src/networkremote/networkremote.cpp
@@ -213,6 +213,9 @@ void NetworkRemote::CreateRemoteClient(QTcpSocket* client_socket) {
     RemoteClient* client = new RemoteClient(app_, client_socket);
     clients_.push_back(client);
 
+    // update OutgoingDataCreator with latest allow_downloads setting
+    outgoing_data_creator_->SetAllowDownloads(client->allow_downloads());
+
     // Connect the signal to parse data
     connect(client, SIGNAL(Parse(pb::remote::Message)),
             incoming_data_parser_.get(), SLOT(Parse(pb::remote::Message)));

--- a/src/networkremote/outgoingdatacreator.cpp
+++ b/src/networkremote/outgoingdatacreator.cpp
@@ -184,6 +184,7 @@ void OutgoingDataCreator::SendClementineInfo() {
       QString("%1 %2").arg(QCoreApplication::applicationName(),
                            QCoreApplication::applicationVersion());
   info->set_version(version.toLatin1());
+  info->set_allow_downloads(allow_downloads_);
   SendDataToClients(&msg);
 }
 

--- a/src/networkremote/outgoingdatacreator.h
+++ b/src/networkremote/outgoingdatacreator.h
@@ -47,6 +47,9 @@ class OutgoingDataCreator : public QObject {
   static const quint32 kFileChunkSize;
 
   void SetClients(QList<RemoteClient*>* clients);
+  void SetAllowDownloads(bool allow_downloads) {
+    allow_downloads_ = allow_downloads;
+  }
 
   static void CreateSong(const Song& song, const QImage& art, const int index,
                          pb::remote::SongMetadata* song_metadata);
@@ -95,6 +98,7 @@ class OutgoingDataCreator : public QObject {
   int keep_alive_timeout_;
   int last_track_position_;
   bool aww_;
+  bool allow_downloads_;
 
   std::unique_ptr<UltimateLyricsReader> ultimate_reader_;
   QMap<int, SongInfoFetcher::Result> results_;

--- a/src/networkremote/remoteclient.h
+++ b/src/networkremote/remoteclient.h
@@ -23,6 +23,7 @@ class RemoteClient : public QObject {
   void DisconnectClient(pb::remote::ReasonDisconnect reason);
 
   SongSender* song_sender() { return song_sender_; }
+  bool allow_downloads() const { return allow_downloads_; }
 
  private slots:
   void IncomingData();


### PR DESCRIPTION
We could just inform the Remote when it connects if downloads are allowed or not.
This avoid to be disconnected if they're not allowed.
Instead we can just warn the user with a popup or disable the download buttons...