### PR TITLE
PlayPlaylist: set current and not active playlist to selection

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -244,7 +244,7 @@ void Player::PlayPlaylistInternal(Engine::TrackChangeFlags change,
   }
 
   app_->playlist_manager()->SetActivePlaylist(playlist->id());
-  app_->playlist_manager()->SetActiveToCurrent();
+  app_->playlist_manager()->SetCurrentPlaylist(playlist->id());
   if (playlist->rowCount() == 0) return;
 
   int i = app_->playlist_manager()->active()->current_row();


### PR DESCRIPTION
This PR is to fix a bug introduced with PR https://github.com/clementine-player/Clementine/pull/6809

I used ` SetActiveToCurrent` instead of `SetCurrentPlaylist` to select the new playlist as current .