### PR TITLE
Remove extra object unref

### DIFF
--- a/src/devices/giolister.cpp
+++ b/src/devices/giolister.cpp
@@ -520,7 +520,6 @@ void GioLister::UnmountDevice(const QString& id) {
       g_volume_eject_with_operation(
           info.volume_, G_MOUNT_UNMOUNT_NONE, nullptr, nullptr,
           (GAsyncReadyCallback)VolumeEjectFinished, nullptr);
-      g_object_unref(info.volume_);
       return;
     }
   }

--- a/src/devices/giolister.h
+++ b/src/devices/giolister.h
@@ -82,19 +82,19 @@ class GioLister : public DeviceLister {
     void ReadMountInfo(GMount* mount);
 
     // Only available if it's a physical drive
-    ScopedGObject<GVolume> volume;
+    ScopedGObject<GVolume> volume_;
     QString volume_name;
     QString volume_unix_device;
     QString volume_root_uri;
     QString volume_uuid;
 
     // Only available if it's a physical drive
-    ScopedGObject<GDrive> drive;
+    ScopedGObject<GDrive> drive_;
     QString drive_name;
     bool drive_removable;
 
     // Only available if it's mounted
-    ScopedGObject<GMount> mount;
+    ScopedGObject<GMount> mount_;
     QString mount_path;
     QString mount_uri;
     QString mount_name;


### PR DESCRIPTION
GioLister::UnmountDevice calls g_object_unref on the GVolume object held by a
DeviceInfo. This appears to be left over from a time before DeviceInfo held
onto the volume.

Also added _ suffix to some DeviceInfo members to avoid confusion with method args.