### PR TITLE
giolister: Don't include invalid mountpoint url

### DIFF
--- a/src/devices/giolister.cpp
+++ b/src/devices/giolister.cpp
@@ -220,7 +220,11 @@ QList<QUrl> GioLister::MakeDeviceUrls(const QString& id) {
     }
   }
 
-  ret << MakeUrlFromLocalPath(mount_point);
+  QUrl mount_point_url = MakeUrlFromLocalPath(mount_point);
+  if (mount_point_url.isValid()) {
+    ret << mount_point_url;
+  }
+
   return ret;
 }
 


### PR DESCRIPTION
If the gvfs mountpoint property for a volume is empty, we add an empty URL to
the devices URL list. This causes errors in duplicate entry detection.