### PR TITLE
Clear cached indexes in InternetModel when rows are removed

### DIFF
--- a/src/internet/core/internetmodel.h
+++ b/src/internet/core/internetmodel.h
@@ -186,8 +186,14 @@ class InternetModel : public QStandardItemModel {
 
  private slots:
   void ServiceDeleted();
+  void RowsAboutToBeRemoved(const QModelIndex& parent, int first, int last);
 
  private:
+  // Index is about to be removed from the merged model
+  void IndexAboutToBeRemoved(const QModelIndex& index);
+  // Determine if d or one of its ancestors is equal to a.
+  bool IsInLineage(QModelIndex d, const QModelIndex& a);
+
   QMap<InternetService*, ServiceItem> shown_services_;
 
   static QMap<QString, InternetService*>* sServices;


### PR DESCRIPTION
When opening a context menu on an internet item, the selected items are stored
in the InternetModel instance. In cases when the items are removed, certain menu
options can cause a crash. A specific case is downloading a podcast when the
user has chosen to limit the number of visible episodes. The subtree for the
podcast is rebuilt after the download completes, so if a context menu was opened
during the download time, selecting the append to playlist option will attempt
to operate on bad indexes.

This fix uses the rowsAboutToBeRemoved signal to remove these stored indexes.

There are likely another rare cases where the indexes can become invalid. For
example, sibling items within a subtree may be removed, causing the stored
indexes to become incorrect or out of range.

This is a fix for #6855 