### PR TITLE
build: Remove eoan usage

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -124,7 +124,7 @@ jobs:
     name: Build source tarball
     runs-on: ubuntu-18.04
     container:
-      image: ubuntu:eoan
+      image: ubuntu:focal
     steps:
       - name: Install dependencies
         env:


### PR DESCRIPTION
Ubuntu Eoan (19.10) is EOL and the repositories are no longer accessible. Bump
the image used for the source tarball build to LTS ubuntu:focal.