### PR TITLE
Fix rpmbuild error in librojectm

### DIFF
--- a/3rdparty/libprojectm/MilkdropPresetFactory/InitCond.cpp
+++ b/3rdparty/libprojectm/MilkdropPresetFactory/InitCond.cpp
@@ -138,7 +138,7 @@ void InitCond::init_cond_to_string() {
 		return;
 	
 	/* Copy the string into the initial condition string buffer */	
-	strncpy(init_cond_string_buffer + init_cond_string_buffer_index, string, string_length);
+	memcpy(init_cond_string_buffer + init_cond_string_buffer_index, string, string_length + 1);
 	
 	/* Increment the string buffer, offset by one for the null terminator, which will be
 	   overwritten by the next call to this function */

--- a/3rdparty/libprojectm/MilkdropPresetFactory/Parser.cpp
+++ b/3rdparty/libprojectm/MilkdropPresetFactory/Parser.cpp
@@ -331,7 +331,7 @@ int Parser::parse_per_pixel_eqn(std::istream &  fs, MilkdropPreset * preset, cha
 
   if (init_string != 0)
   {
-    strncpy(string, init_string, strlen(init_string));
+    memcpy(string, init_string, strlen(init_string) + 1);
   }
   else
   {
@@ -2254,7 +2254,7 @@ int Parser::parse_wave_helper(std::istream &  fs, MilkdropPreset  * preset, int 
     /// HACK the parse_line code already parsed the per_pixel variable name. This handles that case
     /// Parser needs reworked. Don't have time for it. So this is the result.
     if (init_string)
-      strncpy(string, init_string, strlen(init_string));
+      memcpy(string, init_string, strlen(init_string)+1);
     else
     {
       if (parseToken(fs, string) != tEq)


### PR DESCRIPTION
When using rpmbuild on Fedora 33, the build fails with:
error: ‘__builtin_strncpy’ specified bound depends on the length of the source argument [-Werror=stringop-overflow=]

This was fixed as part of projectm change d4d74f6d. This change takes the
relevant parts of that commit.

Note that the projectm commit contains several other warning fixes that might
affect Clementine builds in the future.