### PR TITLE
Fix hang during internet model reset

### DIFF
--- a/src/core/mergedproxymodel.cpp
+++ b/src/core/mergedproxymodel.cpp
@@ -88,6 +88,8 @@ void MergedProxyModel::DeleteAllMappings() {
 
 void MergedProxyModel::AddSubModel(const QModelIndex& source_parent,
                                    QAbstractItemModel* submodel) {
+  connect(submodel, SIGNAL(modelAboutToBeReset()), this,
+          SLOT(SubModelAboutToBeReset()));
   connect(submodel, SIGNAL(modelReset()), this, SLOT(SubModelReset()));
   connect(submodel, SIGNAL(rowsAboutToBeInserted(QModelIndex, int, int)), this,
           SLOT(RowsAboutToBeInserted(QModelIndex, int, int)));
@@ -194,20 +196,16 @@ void MergedProxyModel::SourceModelReset() {
   endResetModel();
 }
 
-void MergedProxyModel::SubModelReset() {
+void MergedProxyModel::SubModelAboutToBeReset() {
   QAbstractItemModel* submodel = static_cast<QAbstractItemModel*>(sender());
 
-  // TODO(David Sansome): When we require Qt 4.6, use beginResetModel() and
-  // endResetModel() in LibraryModel and catch those here - that will let
-  // us do away with this std::numeric_limits<int>::max() hack.
-
-  // Remove all the children of the item that got deleted
   QModelIndex source_parent = merge_points_.value(submodel);
   QModelIndex proxy_parent = mapFromSource(source_parent);
 
-  // We can't know how many children it had, since it's already disappeared...
+  qLog(Debug) << "Submodel" << submodel << "is resetting.";
+
   resetting_model_ = submodel;
-  beginRemoveRows(proxy_parent, 0, std::numeric_limits<int>::max() - 1);
+  beginRemoveRows(proxy_parent, 0, submodel->rowCount());
   endRemoveRows();
   resetting_model_ = nullptr;
 
@@ -222,6 +220,13 @@ void MergedProxyModel::SubModelReset() {
       ++it;
     }
   }
+}
+
+void MergedProxyModel::SubModelReset() {
+  QAbstractItemModel* submodel = static_cast<QAbstractItemModel*>(sender());
+
+  QModelIndex source_parent = merge_points_.value(submodel);
+  QModelIndex proxy_parent = mapFromSource(source_parent);
 
   // "Insert" items from the newly reset submodel
   int count = submodel->rowCount();

--- a/src/core/mergedproxymodel.h
+++ b/src/core/mergedproxymodel.h
@@ -79,6 +79,7 @@ class MergedProxyModel : public QAbstractProxyModel {
 
  private slots:
   void SourceModelReset();
+  void SubModelAboutToBeReset();
   void SubModelReset();
 
   void RowsAboutToBeInserted(const QModelIndex& source_parent, int start,


### PR DESCRIPTION
An old hack was notifying MergedProxyModel users that max int rows had been
removed when a submodel was reset. This caused the code that invalidates
selected items to spin for a very long time. A modelAboutToBeReset signal,
introduced in Qt 4.6, allows notification before the submodel information is
lost.

Note: there is one other case, in RemoveSubModel, where this hack is used.
This is only called when a device is removed and doesn't trigger this
condition, but it should probably be addressed in the future.