### PR TITLE
gstengine: Remove extra unref on element creation failure

### DIFF
--- a/src/engines/gstengine.cpp
+++ b/src/engines/gstengine.cpp
@@ -763,7 +763,6 @@ GstElement* GstEngine::CreateElement(const QString& factoryName,
                        "Please make sure that you have installed all necessary "
                        "GStreamer plugins (e.g. OGG and MP3)")
                    .arg(factoryName));
-    if (bin) gst_object_unref(GST_OBJECT(bin));
     return nullptr;
   }
 

--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -267,6 +267,7 @@ bool GstEnginePipeline::Init() {
 
   // Audio bin
   audiobin_ = gst_bin_new("audiobin");
+  // Floating reference is transferred to pipeline
   gst_bin_add(GST_BIN(pipeline_), audiobin_);
 
   // Create the sink


### PR DESCRIPTION
GstEngine::CreateElement unrefs the supplied bin if an error
occurs. In all current cases, that bin is referenced by a
pipeline.