### PR TITLE
gstengine: Fix InitFromString return value

### DIFF
--- a/src/engines/gstengine.cpp
+++ b/src/engines/gstengine.cpp
@@ -831,16 +831,18 @@ shared_ptr<GstEnginePipeline> GstEngine::CreatePipeline(
   shared_ptr<GstEnginePipeline> ret = CreatePipeline();
 
   if (req.url_.scheme() == "hypnotoad") {
-    ret->InitFromString(kHypnotoadPipeline);
-    return ret;
+    if (!ret->InitFromString(kHypnotoadPipeline)) {
+      qLog(Error) << "Could not initialize pipeline" << kHypnotoadPipeline;
+      ret.reset();
+    }
+  } else if (req.url_.scheme() == "enterprise") {
+    if (!ret->InitFromString(kEnterprisePipeline)) {
+      qLog(Error) << "Could not initialize pipeline" << kEnterprisePipeline;
+      ret.reset();
+    }
+  } else {
+    if (!ret->InitFromReq(req, end_nanosec)) ret.reset();
   }
-
-  if (req.url_.scheme() == "enterprise") {
-    ret->InitFromString(kEnterprisePipeline);
-    return ret;
-  }
-
-  if (!ret->InitFromReq(req, end_nanosec)) ret.reset();
 
   return ret;
 }

--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -244,7 +244,7 @@ GstElement* GstEnginePipeline::CreateDecodeBinFromString(const char* pipeline) {
   }
 }
 
-bool GstEnginePipeline::Init() {
+bool GstEnginePipeline::InitAudioBin() {
   // Here we create all the parts of the gstreamer pipeline - from the source
   // to the sink.  The parts of the pipeline are split up into bins:
   //   uri decode bin -> audio bin
@@ -489,8 +489,6 @@ bool GstEnginePipeline::Init() {
   bus_cb_id_ = gst_bus_add_watch(bus, BusCallback, this);
   gst_object_unref(bus);
 
-  MaybeLinkDecodeToAudio();
-
   return true;
 }
 
@@ -518,7 +516,7 @@ bool GstEnginePipeline::InitFromString(const QString& pipeline) {
     return false;
   }
 
-  if (!Init()) return false;
+  if (!InitAudioBin()) return false;
   return gst_element_link(new_bin, audiobin_);
 }
 
@@ -545,7 +543,12 @@ bool GstEnginePipeline::InitFromReq(const MediaPlaybackRequest& req,
   // Decode bin
   if (!ReplaceDecodeBin(url)) return false;
 
-  return Init();
+  if (!InitAudioBin()) return false;
+
+  // Link decoder and audio bins if decoder bin already has a src pad.
+  MaybeLinkDecodeToAudio();
+
+  return true;
 }
 
 GstEnginePipeline::~GstEnginePipeline() {

--- a/src/engines/gstenginepipeline.h
+++ b/src/engines/gstenginepipeline.h
@@ -151,7 +151,7 @@ class GstEnginePipeline : public QObject {
 
   QString ParseTag(GstTagList* list, const char* tag) const;
 
-  bool Init();
+  bool InitAudioBin();
   GstElement* CreateDecodeBinFromString(const char* pipeline);
   GstElement* CreateDecodeBinFromUrl(const QUrl& url);
 


### PR DESCRIPTION
GstEnginePipeline::InitFromString was attempting to link the decoder and audio
bins twice and returning the result of the failed second attempt as it's own
status. The return value was also being ignored by the caller.