### PR TITLE
Fix debug console instance leak

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -172,6 +172,7 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
       edit_tag_dialog_(std::bind(&MainWindow::CreateEditTagDialog, this)),
       love_dialog_(std::bind(&MainWindow::CreateLoveDialog, this)),
       stream_discoverer_(std::bind(&MainWindow::CreateStreamDiscoverer, this)),
+      debug_console_(std::bind(&MainWindow::CreateDebugConsole, this)),
       global_shortcuts_(new GlobalShortcuts(this)),
       global_search_view_(new GlobalSearchView(app_, this)),
       library_view_(new LibraryViewContainer(this)),
@@ -2740,6 +2741,8 @@ StreamDiscoverer* MainWindow::CreateStreamDiscoverer() {
   return discoverer;
 }
 
+Console* MainWindow::CreateDebugConsole() { return new Console(app_, this); }
+
 void MainWindow::ShowAboutDialog() { about_dialog_->show(); }
 
 void MainWindow::ShowTranscodeDialog() { transcode_dialog_->show(); }
@@ -3075,10 +3078,7 @@ void MainWindow::DoGlobalSearch(const QString& query) {
   global_search_view_->StartSearch(query);
 }
 
-void MainWindow::ShowConsole() {
-  Console* console = new Console(app_, this);
-  console->show();
-}
+void MainWindow::ShowConsole() { debug_console_->show(); }
 
 void MainWindow::keyPressEvent(QKeyEvent* event) {
   if (event->key() == Qt::Key_Space) {

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -43,6 +43,7 @@ class Application;
 class ArtistInfoView;
 class BackgroundStreams;
 class CommandlineOptions;
+class Console;
 class CoverProviders;
 class Database;
 class DeviceManager;
@@ -268,6 +269,7 @@ class MainWindow : public QMainWindow, public PlatformInterface {
   EditTagDialog* CreateEditTagDialog();
   LoveDialog* CreateLoveDialog();
   StreamDiscoverer* CreateStreamDiscoverer();
+  Console* CreateDebugConsole();
   void OpenSettingsDialog();
   void OpenSettingsDialogAtPage(SettingsDialog::Page page);
   void ShowSongInfoConfig();
@@ -318,6 +320,7 @@ class MainWindow : public QMainWindow, public PlatformInterface {
   Lazy<LoveDialog> love_dialog_;
   Lazy<About> about_dialog_;
   Lazy<StreamDiscoverer> stream_discoverer_;
+  Lazy<Console> debug_console_;
 
   GlobalShortcuts* global_shortcuts_;
 


### PR DESCRIPTION
Each time the debug console is launched, a new instance is created, but never
deleted. To fix, create one instance, if the option is enabled, and show that
one each time the menu option is selected.