### PR TITLE
Add a GstEngine page on the debug console

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -134,6 +134,7 @@ set(SOURCES
   engines/devicefinder.cpp
   engines/enginebase.cpp
   engines/gstengine.cpp
+  engines/gstenginedebug.cpp
   engines/gstenginepipeline.cpp
   engines/gstelementdeleter.cpp
 
@@ -455,6 +456,7 @@ set(HEADERS
 
   engines/enginebase.h
   engines/gstengine.h
+  engines/gstenginedebug.h
   engines/gstenginepipeline.h
   engines/gstelementdeleter.h
 
@@ -686,6 +688,8 @@ set(UI
 
   devices/deviceproperties.ui
   devices/deviceviewcontainer.ui
+
+  engines/gstenginedebug.ui
 
   globalsearch/globalsearchsettingspage.ui
   globalsearch/globalsearchview.ui

--- a/src/core/application.h
+++ b/src/core/application.h
@@ -32,6 +32,7 @@ class QSettings;
 class AlbumCoverLoader;
 class Appearance;
 class ApplicationImpl;
+class Console;
 class CoverProviders;
 class CurrentArtLoader;
 class Database;
@@ -120,6 +121,8 @@ class Application : public QObject {
   void SettingsChanged();
   void SaveSettings(QSettings* settings);
   void SettingsDialogRequested(SettingsDialog::Page page);
+
+  void NewDebugConsole(Console* console);
 
  private slots:
   void SaveSettings_();

--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -56,7 +56,7 @@ Player::Player(Application* app, QObject* parent)
     : PlayerInterface(parent),
       app_(app),
       lastfm_(nullptr),
-      engine_(new GstEngine(app_->task_manager())),
+      engine_(new GstEngine(app_)),
       stream_change_type_(Engine::First),
       last_state_(Engine::Empty),
       nb_errors_received_(0),

--- a/src/engines/gstengine.cpp
+++ b/src/engines/gstengine.cpp
@@ -143,6 +143,14 @@ GstEngine::~GstEngine() {
 }
 
 bool GstEngine::Init() {
+  // This environment variable is required for GST_DEBUG_BIN_TO_DOT_FILE macros.
+  // Gstreamer only reads it on init, so make sure it's set now.
+  QByteArray path = qgetenv("GST_DEBUG_DUMP_DOT_DIR");
+  if (path.isEmpty()) {
+    path = QDir::currentPath().toUtf8();
+    qputenv("GST_DEBUG_DUMP_DOT_DIR", path);
+  }
+
   initialising_ = QtConcurrent::run(this, &GstEngine::InitialiseGstreamer);
   return true;
 }

--- a/src/engines/gstengine.cpp
+++ b/src/engines/gstengine.cpp
@@ -40,13 +40,16 @@
 #include <vector>
 
 #include "config.h"
+#include "core/application.h"
 #include "core/closure.h"
 #include "core/logging.h"
 #include "core/taskmanager.h"
 #include "core/timeconstants.h"
 #include "core/utilities.h"
 #include "devicefinder.h"
+#include "gstenginedebug.h"
 #include "gstenginepipeline.h"
+#include "ui/console.h"
 
 #ifdef HAVE_MOODBAR
 #include "gst/moodbar/plugin.h"
@@ -94,9 +97,9 @@ const char* GstEngine::kEnterprisePipeline =
     "audiotestsrc wave=5 ! "
     "audiocheblimit mode=0 cutoff=120";
 
-GstEngine::GstEngine(TaskManager* task_manager)
+GstEngine::GstEngine(Application* app)
     : Engine::Base(),
-      task_manager_(task_manager),
+      task_manager_(app->task_manager()),
       buffering_task_id_(-1),
       latest_buffer_(nullptr),
       equalizer_enabled_(false),
@@ -119,6 +122,8 @@ GstEngine::GstEngine(TaskManager* task_manager)
   seek_timer_->setSingleShot(true);
   seek_timer_->setInterval(kSeekDelayNanosec / kNsecPerMsec);
   connect(seek_timer_, SIGNAL(timeout()), SLOT(SeekNow()));
+  connect(app, SIGNAL(NewDebugConsole(Console*)), this,
+          SLOT(NewDebugConsole(Console*)));
 
   ReloadSettings();
 
@@ -978,4 +983,8 @@ GstEngine::OutputDetailsList GstEngine::GetOutputsList() const {
   }
 
   return ret;
+}
+
+void GstEngine::NewDebugConsole(Console* console) {
+  console->AddPage(new GstEngineDebug(this), "GstEngine");
 }

--- a/src/engines/gstengine.h
+++ b/src/engines/gstengine.h
@@ -39,7 +39,10 @@
 class QTimer;
 class QTimerEvent;
 
+class Application;
+class Console;
 class DeviceFinder;
+class GstEngineDebug;
 class GstEnginePipeline;
 class TaskManager;
 
@@ -57,7 +60,7 @@ class GstEngine : public Engine::Base, public BufferConsumer {
   Q_OBJECT
 
  public:
-  GstEngine(TaskManager* task_manager);
+  GstEngine(Application* app);
   ~GstEngine();
 
   struct OutputDetails {
@@ -123,9 +126,18 @@ class GstEngine : public Engine::Base, public BufferConsumer {
   GTlsDatabase* tls_database() const { return tls_database_; }
 #endif
 
+  void NewDebugConsole(Console* console);
+
  protected:
   void SetVolumeSW(uint percent);
   void timerEvent(QTimerEvent*);
+
+ private:
+  // Used for debug purposes only.
+  friend class GstEngineDebug;
+  std::shared_ptr<GstEnginePipeline> GetCurrentPipeline() {
+    return current_pipeline_;
+  }
 
  private slots:
   void EndOfStreamReached(int pipeline_id, bool has_next_track);

--- a/src/engines/gstenginedebug.cpp
+++ b/src/engines/gstenginedebug.cpp
@@ -1,0 +1,35 @@
+/* This file is part of Clementine.
+   Copyright 2020, Jim Broadus <jbroadus@gmail.com>
+
+   Clementine is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Clementine is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "gstenginedebug.h"
+
+#include "core/logging.h"
+#include "gstengine.h"
+#include "gstenginepipeline.h"
+
+GstEngineDebug::GstEngineDebug(GstEngine* engine, QWidget* parent)
+    : QWidget(parent), engine_(engine) {
+  ui_.setupUi(this);
+  connect(ui_.dump_graph_button, SIGNAL(clicked()), SLOT(DumpGraph()));
+}
+
+void GstEngineDebug::DumpGraph() {
+  std::shared_ptr<GstEnginePipeline> pipeline = engine_->GetCurrentPipeline();
+  if (pipeline) {
+    pipeline->DumpGraph();
+  }
+}

--- a/src/engines/gstenginedebug.h
+++ b/src/engines/gstenginedebug.h
@@ -1,0 +1,40 @@
+/* This file is part of Clementine.
+   Copyright 2020, Jim Broadus <jbroadus@gmail.com>
+
+   Clementine is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Clementine is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef GSTENGINEDEBUG_H
+#define GSTENGINEDEBUG_H
+
+#include <QWidget>
+
+#include "ui_gstenginedebug.h"
+
+class GstEngine;
+
+class GstEngineDebug : public QWidget {
+  Q_OBJECT
+ public:
+  GstEngineDebug(GstEngine* engine, QWidget* parent = nullptr);
+
+ private slots:
+  void DumpGraph();
+
+ private:
+  Ui::GstEngineDebug ui_;
+  GstEngine* engine_;
+};
+
+#endif  // GSTENGINEDEBUG_H

--- a/src/engines/gstenginedebug.ui
+++ b/src/engines/gstenginedebug.ui
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>GstEngineDebug</class>
+ <widget class="QWidget" name="GstEngineDebug">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="graph_group">
+     <property name="title">
+      <string>Pipeline</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <item>
+       <widget class="QPushButton" name="dump_graph_button">
+        <property name="text">
+         <string>Dump Pipeline Graph</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -1332,3 +1332,12 @@ void GstEnginePipeline::SetNextReq(const MediaPlaybackRequest& req,
   next_beginning_offset_nanosec_ = beginning_nanosec;
   next_end_offset_nanosec_ = end_nanosec;
 }
+
+void GstEnginePipeline::DumpGraph() {
+#ifdef GST_DISABLE_GST_DEBUG
+  qLog(Debug) << "Cannot dump graph. gstreamer debug is not enabled.";
+#else
+  qLog(Debug) << "Dumping pipeline graph";
+  GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN(pipeline_), GST_DEBUG_GRAPH_SHOW_ALL, "pipeline");
+#endif
+}

--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -1337,7 +1337,10 @@ void GstEnginePipeline::DumpGraph() {
 #ifdef GST_DISABLE_GST_DEBUG
   qLog(Debug) << "Cannot dump graph. gstreamer debug is not enabled.";
 #else
-  qLog(Debug) << "Dumping pipeline graph";
-  GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN(pipeline_), GST_DEBUG_GRAPH_SHOW_ALL, "pipeline");
+  if (pipeline_) {
+    qLog(Debug) << "Dumping pipeline graph";
+    GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN(pipeline_),
+                                      GST_DEBUG_GRAPH_SHOW_ALL, "pipeline");
+  }
 #endif
 }

--- a/src/engines/gstenginepipeline.h
+++ b/src/engines/gstenginepipeline.h
@@ -106,6 +106,7 @@ class GstEnginePipeline : public QObject {
 
   QString source_device() const { return source_device_; }
 
+  void DumpGraph();
  public slots:
   void SetVolumeModifier(qreal mod);
 

--- a/src/ui/console.cpp
+++ b/src/ui/console.cpp
@@ -77,3 +77,7 @@ QObject* Console::FindTopLevelObject(QString& name) {
     if (obj->objectName() == name) return obj;
   return nullptr;
 }
+
+void Console::AddPage(QWidget* page, const QString& label) {
+  ui_.tabWidget->addTab(page, label);
+}

--- a/src/ui/console.h
+++ b/src/ui/console.h
@@ -12,6 +12,8 @@ class Console : public QDialog {
  public:
   Console(Application* app, QWidget* parent = nullptr);
 
+  void AddPage(QWidget* page, const QString& label);
+
  private slots:
   // Database
   void RunQuery();

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -487,6 +487,10 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
   connect(ui_->action_view_stream_details, SIGNAL(triggered()),
           SLOT(DiscoverStreamDetails()));
 
+  // Relay this signal to the Application
+  connect(this, SIGNAL(NewDebugConsole(Console*)), app_,
+          SIGNAL(NewDebugConsole(Console*)));
+
   background_streams_->AddAction("Rain", ui_->action_rain);
   background_streams_->AddAction("Hypnotoad", ui_->action_hypnotoad);
   background_streams_->AddAction("Make it so!", ui_->action_enterprise);
@@ -2741,7 +2745,11 @@ StreamDiscoverer* MainWindow::CreateStreamDiscoverer() {
   return discoverer;
 }
 
-Console* MainWindow::CreateDebugConsole() { return new Console(app_, this); }
+Console* MainWindow::CreateDebugConsole() {
+  Console* console = new Console(app_, this);
+  emit NewDebugConsole(console);
+  return console;
+}
 
 void MainWindow::ShowAboutDialog() { about_dialog_->show(); }
 

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -152,6 +152,8 @@ class MainWindow : public QMainWindow, public PlatformInterface {
   void StopAfterToggled(bool stop);
 
   void IntroPointReached();
+
+  void NewDebugConsole(Console* console);
  private slots:
   void FilePathChanged(const QString& path);
 


### PR DESCRIPTION
Added a mechanism to add new pages to the debug console.
Added a method in GstEnginePipeline to dump a graph of the pipeline.
Added a GstEngine page in the console with a button to dump dump the graph.

This should help debug issues like #6861 