### PR TITLE
internet/soma.fm: use high quality AAC stream

### DIFF
--- a/src/internet/somafm/somafmservice.cpp
+++ b/src/internet/somafm/somafmservice.cpp
@@ -171,8 +171,8 @@ void SomaFMServiceBase::ReadChannel(QXmlStreamReader& reader, StreamList* ret) {
           stream.title_ = reader.readElementText();
         } else if (reader.name() == "dj") {
           stream.dj_ = reader.readElementText();
-        } else if (reader.name() == "fastpls" &&
-                   reader.attributes().value("format") == "mp3") {
+        } else if (reader.name() == "highestpls" &&
+                   reader.attributes().value("format") == "aac") {
           QUrl url(reader.readElementText());
           url.setScheme(url_handler_->scheme());
 


### PR DESCRIPTION
Prefer the high quality 128 kbit/s AAC stream over the 'fast' 128 kbit/s mp3 stream.