### PR TITLE
Fix output sample depth

### DIFF
--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -850,20 +850,59 @@ void GstEnginePipeline::BufferingMessageReceived(GstMessage* msg) {
   }
 }
 
+QString GstEnginePipeline::GetAudioFormat(GstCaps* caps) {
+  const guint sz = gst_caps_get_size(caps);
+  for (int i = 0; i < sz; i++) {
+    GstStructure* s = gst_caps_get_structure(caps, i);
+    if (strcmp(gst_structure_get_name(s), "audio/x-raw") == 0) {
+      const gchar* fmt = gst_structure_get_string(s, "format");
+      if (fmt != nullptr) {
+        return QString::fromUtf8(fmt);
+      }
+    }
+  }
+  return "";
+}
+
 void GstEnginePipeline::NewPadCallback(GstElement*, GstPad* pad,
                                        gpointer self) {
   GstEnginePipeline* instance = reinterpret_cast<GstEnginePipeline*>(self);
   GstPad* const audiopad =
       gst_element_get_static_pad(instance->audiobin_, "sink");
 
-  // Link decodebin's sink pad to audiobin's src pad.
+  qLog(Debug) << "Decoder bin pad added:" << GST_PAD_NAME(pad);
+
+  // Make sure the audio bin isn't already linked to something.
   if (GST_PAD_IS_LINKED(audiopad)) {
     qLog(Warning) << instance->id()
                   << "audiopad is already linked, unlinking old pad";
     gst_pad_unlink(audiopad, GST_PAD_PEER(audiopad));
   }
 
-  gst_pad_link(pad, audiopad);
+  // See what the decoder bin wants to output.
+  GstCaps* caps = gst_pad_get_current_caps(pad);
+  if (caps) {
+    gchar* caps_str = gst_caps_to_string(caps);
+    qLog(Debug) << "Current caps:" << caps_str;
+    g_free(caps_str);
+
+    QString fmt = GetAudioFormat(caps);
+
+    // The output branch only handles F32LE and S16LE. If the source is S16LE,
+    // then use that throughout the pipeline. Otherwise, use F32LE.
+    if (fmt != "S16LE") {
+      GstCaps* new_caps = gst_caps_new_simple("audio/x-raw", "format",
+                                              G_TYPE_STRING, "F32LE", nullptr);
+      g_object_set(instance->capsfilter_, "caps", new_caps, nullptr);
+      gst_caps_unref(new_caps);
+    }
+    gst_caps_unref(caps);
+  }
+
+  // Link decodebin's sink pad to audiobin's src pad.
+  if (gst_pad_link(pad, audiopad) != GST_PAD_LINK_OK) {
+    qLog(Error) << "Failed to link decoder to audio bin.";
+  }
   gst_object_unref(audiopad);
 
   // Offset the timestamps on all the buffers coming out of the decodebin so
@@ -1099,6 +1138,11 @@ void GstEnginePipeline::TransitionToNext() {
   GstElement* old_decode_bin = uridecodebin_;
 
   ignore_tags_ = true;
+
+  // Reset the caps filter
+  GstCaps* new_caps = gst_caps_new_any();
+  g_object_set(capsfilter_, "caps", new_caps, nullptr);
+  gst_caps_unref(new_caps);
 
   if (!ReplaceDecodeBin(next_.url_)) {
     qLog(Error) << "ReplaceDecodeBin failed with " << next_.url_;

--- a/src/engines/gstenginepipeline.h
+++ b/src/engines/gstenginepipeline.h
@@ -297,6 +297,7 @@ class GstEnginePipeline : public QObject {
   GstElement* volume_;
   GstElement* audioscale_;
   GstElement* audiosink_;
+  GstElement* capsfilter_;
 
   // tee and request pads.
   GstElement* tee_;

--- a/src/engines/gstenginepipeline.h
+++ b/src/engines/gstenginepipeline.h
@@ -168,6 +168,9 @@ class GstEnginePipeline : public QObject {
   // a src pad immediately and we can link it after everything's created.
   void MaybeLinkDecodeToAudio();
 
+  // Helper method to retrieve the audio format from a GstCaps object.
+  static QString GetAudioFormat(GstCaps* caps);
+
  private slots:
   void FaderTimelineFinished();
 


### PR DESCRIPTION
These changes add a capsfilter in the pipeline before the tee. We check the decoder source pad when it's added and, if is going to push S16LE, we set the caps of the new filter to F32LE.

Future considerations:
- This does not address cases where there is already a source pad when the decoder bin is created.
- Maybe use F32LE only if the source format is > 16 bit depth.
- Might want to probe the output device to make sure it can also support F32LE.

Fix for #6861