### PR TITLE
Adding a "play next album" function, in addition to "play next track". Closes #2505.

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -170,9 +170,12 @@ void Player::HandleLoadResult(const UrlHandler::LoadResult& result) {
 
 void Player::Next() { NextInternal(Engine::Manual); }
 
-void Player::NextAlbum() { NextInternal(Engine::Manual, true); }
+void Player::NextAlbum() {
+  NextInternal(Engine::Manual, NextTrackOrAlbumSelected::SelectNextAlbum);
+}
 
-void Player::NextInternal(Engine::TrackChangeFlags change, bool next_album) {
+void Player::NextInternal(Engine::TrackChangeFlags change,
+                          NextTrackOrAlbumSelected NextTrackOrAlbum) {
   if (HandleStopAfter()) return;
 
   if (app_->playlist_manager()->active()->current_item()) {
@@ -188,10 +191,11 @@ void Player::NextInternal(Engine::TrackChangeFlags change, bool next_album) {
     }
   }
 
-  NextItem(change, next_album);
+  NextItem(change, NextTrackOrAlbum);
 }
 
-void Player::NextItem(Engine::TrackChangeFlags change, bool next_album) {
+void Player::NextItem(Engine::TrackChangeFlags change,
+                      NextTrackOrAlbumSelected NextTrackOrAlbum) {
   Playlist* active_playlist = app_->playlist_manager()->active();
 
   // If we received too many errors in auto change, with repeat enabled, we stop
@@ -216,7 +220,7 @@ void Player::NextItem(Engine::TrackChangeFlags change, bool next_album) {
   const bool ignore_repeat_track = change & Engine::Manual;
 
   int i = active_playlist->current_row();
-  if (next_album && i != -1) {
+  if (NextTrackOrAlbum == SelectNextAlbum && i != -1) {
     if (active_playlist->sequence()->repeat_mode() !=
         PlaylistSequence::Repeat_Track) {
       int original_index = i;

--- a/src/core/player.h
+++ b/src/core/player.h
@@ -128,6 +128,8 @@ class Player : public PlayerInterface {
     PreviousBehaviour_Restart = 2
   };
 
+  enum NextTrackOrAlbumSelected { SelectNextTrack, SelectNextAlbum };
+
   void Init();
 
   EngineBase* engine() const { return engine_.get(); }
@@ -179,10 +181,13 @@ class Player : public PlayerInterface {
   void TrackEnded();
   // Play the next item on the playlist - disregarding radio stations like
   // last.fm that might have more tracks.
-  void NextItem(Engine::TrackChangeFlags change, bool next_album = false);
+  void NextItem(Engine::TrackChangeFlags change,
+                NextTrackOrAlbumSelected NextTrackOrAlbum = SelectNextTrack);
   void PreviousItem(Engine::TrackChangeFlags change);
 
-  void NextInternal(Engine::TrackChangeFlags, bool next_album = false);
+  void NextInternal(
+      Engine::TrackChangeFlags,
+      NextTrackOrAlbumSelected NextTrackOrAlbum = SelectNextTrack);
   void PlayPlaylistInternal(Engine::TrackChangeFlags,
                             const QString& playlistName);
 

--- a/src/core/player.h
+++ b/src/core/player.h
@@ -72,6 +72,7 @@ class PlayerInterface : public QObject {
 
   // Skips this track.  Might load more of the current radio station.
   virtual void Next() = 0;
+  virtual void NextAlbum() = 0;
 
   virtual void Previous() = 0;
   virtual void SetVolume(int value) = 0;
@@ -150,6 +151,7 @@ class Player : public PlayerInterface {
   void PlayPause();
   void RestartOrPrevious();
   void Next();
+  void NextAlbum();
   void Previous();
   void PlayPlaylist(const QString& playlistName);
   void SetVolume(int value);
@@ -177,10 +179,10 @@ class Player : public PlayerInterface {
   void TrackEnded();
   // Play the next item on the playlist - disregarding radio stations like
   // last.fm that might have more tracks.
-  void NextItem(Engine::TrackChangeFlags change);
+  void NextItem(Engine::TrackChangeFlags change, bool next_album = false);
   void PreviousItem(Engine::TrackChangeFlags change);
 
-  void NextInternal(Engine::TrackChangeFlags);
+  void NextInternal(Engine::TrackChangeFlags, bool next_album = false);
   void PlayPlaylistInternal(Engine::TrackChangeFlags,
                             const QString& playlistName);
 

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -155,6 +155,7 @@ class MainWindow : public QMainWindow, public PlatformInterface {
 
   void NewDebugConsole(Console* console);
  private slots:
+  void SetNextAlbumEnabled(PlaylistSequence::RepeatMode mode);
   void FilePathChanged(const QString& path);
 
   void SaveSettings(QSettings* settings);

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -199,11 +199,20 @@
                 </item>
                 <item>
                  <widget class="QToolButton" name="forward_button">
+                  <property name="minimumSize">
+                   <size>
+                    <width>42</width>
+                    <height>29</height>
+                   </size>
+                  </property>
                   <property name="iconSize">
                    <size>
                     <width>22</width>
                     <height>22</height>
                    </size>
+                  </property>
+                  <property name="popupMode">
+                   <enum>QToolButton::MenuButtonPopup</enum>
                   </property>
                   <property name="autoRaise">
                    <bool>true</bool>
@@ -477,7 +486,7 @@
      <x>0</x>
      <y>0</y>
      <width>1131</width>
-     <height>23</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_music">
@@ -943,6 +952,17 @@
    </property>
    <property name="toolTip">
     <string>Show or hide the sidebar</string>
+   </property>
+  </action>
+  <action name="action_next_album">
+   <property name="text">
+    <string>Next album</string>
+   </property>
+   <property name="toolTip">
+    <string>Skip to the next album</string>
+   </property>
+   <property name="shortcut">
+    <string>F9</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
I've written a small change to clementine to allow the user to skip to the next album in a playlist. Similar functionality to that used to play the next track, but it will continue to skip forward until the album title changes.