### PR TITLE
Add a base pipeline class to share debug methods with the transcoder pipeline

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -137,6 +137,7 @@ set(SOURCES
   engines/gstenginedebug.cpp
   engines/gstenginepipeline.cpp
   engines/gstelementdeleter.cpp
+  engines/gstpipelinebase.cpp
 
   globalsearch/digitallyimportedsearchprovider.cpp
   globalsearch/globalsearch.cpp
@@ -459,6 +460,7 @@ set(HEADERS
   engines/gstenginedebug.h
   engines/gstenginepipeline.h
   engines/gstelementdeleter.h
+  engines/gstpipelinebase.h
 
   globalsearch/globalsearch.h
   globalsearch/globalsearchmodel.h

--- a/src/engines/gstenginepipeline.h
+++ b/src/engines/gstenginepipeline.h
@@ -18,18 +18,16 @@
 #ifndef GSTENGINEPIPELINE_H
 #define GSTENGINEPIPELINE_H
 
-#include <gst/gst.h>
-
 #include <QBasicTimer>
 #include <QFuture>
 #include <QMutex>
-#include <QObject>
 #include <QThreadPool>
 #include <QTimeLine>
 #include <QUrl>
 #include <memory>
 
 #include "engine_fwd.h"
+#include "gstpipelinebase.h"
 #include "playbackrequest.h"
 
 class GstElementDeleter;
@@ -39,7 +37,7 @@ class BufferConsumer;
 struct GstQueue;
 struct GstURIDecodeBin;
 
-class GstEnginePipeline : public QObject {
+class GstEnginePipeline : public GstPipelineBase {
   Q_OBJECT
 
  public:
@@ -106,7 +104,6 @@ class GstEnginePipeline : public QObject {
 
   QString source_device() const { return source_device_; }
 
-  void DumpGraph();
  public slots:
   void SetVolumeModifier(qreal mod);
 
@@ -280,8 +277,6 @@ class GstEnginePipeline : public QObject {
   std::unique_ptr<QTimeLine> fader_;
   QBasicTimer fader_fudge_timer_;
   bool use_fudge_timer_;
-
-  GstElement* pipeline_;
 
   // Bins
   // uridecodebin ! audiobin

--- a/src/engines/gstpipelinebase.cpp
+++ b/src/engines/gstpipelinebase.cpp
@@ -1,0 +1,46 @@
+/* This file is part of Clementine.
+   Copyright 2021, Jim Broadus <jbroadus@gmail.com>
+
+   Clementine is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Clementine is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "gstpipelinebase.h"
+
+#include "core/logging.h"
+
+GstPipelineBase::GstPipelineBase() : QObject(nullptr), pipeline_(nullptr) {}
+
+GstPipelineBase::~GstPipelineBase() {
+  if (pipeline_) {
+    gst_element_set_state(pipeline_, GST_STATE_NULL);
+    gst_object_unref(GST_OBJECT(pipeline_));
+  }
+}
+
+bool GstPipelineBase::Init(const QString& name) {
+  pipeline_ = gst_pipeline_new(name.toUtf8().constData());
+  return pipeline_ != nullptr;
+}
+
+void GstPipelineBase::DumpGraph() {
+#ifdef GST_DISABLE_GST_DEBUG
+  qLog(Debug) << "Cannot dump graph. gstreamer debug is not enabled.";
+#else
+  if (pipeline_) {
+    qLog(Debug) << "Dumping pipeline graph";
+    GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN(pipeline_),
+                                      GST_DEBUG_GRAPH_SHOW_ALL, "pipeline");
+  }
+#endif
+}

--- a/src/engines/gstpipelinebase.h
+++ b/src/engines/gstpipelinebase.h
@@ -1,0 +1,38 @@
+/* This file is part of Clementine.
+   Copyright 2021, Jim Broadus <jbroadus@gmail.com>
+
+   Clementine is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Clementine is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef GSTPIPELINEBASE_H
+#define GSTPIPELINEBASE_H
+
+#include <gst/gst.h>
+
+#include <QObject>
+
+class GstPipelineBase : public QObject {
+ public:
+  GstPipelineBase();
+  virtual ~GstPipelineBase();
+
+  virtual bool Init(const QString& name);
+
+  void DumpGraph();
+
+ protected:
+  GstElement* pipeline_;
+};
+
+#endif  // GSTPIPELINEBASE_H

--- a/src/transcoder/transcoder.h
+++ b/src/transcoder/transcoder.h
@@ -27,6 +27,7 @@
 #include <memory>
 
 #include "core/song.h"
+#include "engines/gstpipelinebase.h"
 
 struct TranscoderPreset {
   TranscoderPreset() : type_(Song::Type_Unknown) {}
@@ -84,20 +85,18 @@ class Transcoder : public QObject {
 
   // State held by a job and shared across gstreamer callbacks - lives in the
   // job's thread.
-  struct JobState {
+  class JobState : public GstPipelineBase {
+   public:
     JobState(const Job& job, Transcoder* parent)
-        : job_(job),
-          parent_(parent),
-          pipeline_(nullptr),
-          convert_element_(nullptr) {}
-    ~JobState();
+        : job_(job), parent_(parent), convert_element_(nullptr) {}
 
     void PostFinished(bool success);
     void ReportError(GstMessage* msg);
 
+    GstElement* Pipeline() { return pipeline_; }
+
     Job job_;
     Transcoder* parent_;
-    GstElement* pipeline_;
     GstElement* convert_element_;
   };
 


### PR DESCRIPTION
This allows the use of the DumpGraph method in transcoding pipelines. Note that this does not currently provide a UI to do dump. The call can be added to Transcoder::StartJob for debugging.

If we extend the use of the base class to all other pipelines, we could enumerate the list in the debug console and provide a common set of debug tools.