### PR TITLE
transcoder: Fix flacenc "insane" level encoding

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -615,6 +615,7 @@ set(HEADERS
   transcoder/transcoder.h
   transcoder/transcoderoptionsdialog.h
   transcoder/transcoderoptionsmp3.h
+  transcoder/transcoderoptionsflac.h
   transcoder/transcodersettingspage.h
 
   ui/about.h

--- a/src/transcoder/transcoderoptionsflac.h
+++ b/src/transcoder/transcoderoptionsflac.h
@@ -23,6 +23,8 @@
 class Ui_TranscoderOptionsFlac;
 
 class TranscoderOptionsFlac : public TranscoderOptionsInterface {
+  Q_OBJECT
+
  public:
   TranscoderOptionsFlac(QWidget* parent = nullptr);
   ~TranscoderOptionsFlac();
@@ -30,7 +32,12 @@ class TranscoderOptionsFlac : public TranscoderOptionsInterface {
   void Load();
   void Save();
 
+ private slots:
+  void ValueChanged(int value);
+
  private:
+  static bool IsInStreamingSubset(int level);
+
   static const char* kSettingsGroup;
 
   Ui_TranscoderOptionsFlac* ui_;

--- a/src/transcoder/transcoderoptionsflac.ui
+++ b/src/transcoder/transcoderoptionsflac.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QFormLayout" name="formLayout">
    <item row="0" column="0">
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="quality_label">
      <property name="text">
       <string comment="Sound quality">Quality</string>
      </property>
@@ -24,7 +24,7 @@
    <item row="0" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QLabel" name="label_2">
+      <widget class="QLabel" name="fast_label">
        <property name="text">
         <string>Fast</string>
        </property>
@@ -47,13 +47,29 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label_3">
+      <widget class="QLabel" name="best_label">
        <property name="text">
         <string>Best</string>
        </property>
       </widget>
      </item>
     </layout>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QLabel" name="info">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
The gstreamer flacenc element defines a set of quality levels that is different
from the standard flac library. Its highest level, labeled "insane", uses
settings that are outside of the streamable subset. Set the streamable-subset
property to false for this level.

Reference: https://xiph.org/flac/format.html#subset

Fixes #6876