### PR TITLE
Give pipelines unique names

### DIFF
--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -48,13 +48,11 @@ const int GstEnginePipeline::kEqBandCount = 10;
 const int GstEnginePipeline::kEqBandFrequencies[] = {
     60, 170, 310, 600, 1000, 3000, 6000, 12000, 14000, 16000};
 
-int GstEnginePipeline::sId = 1;
 GstElementDeleter* GstEnginePipeline::sElementDeleter = nullptr;
 
 GstEnginePipeline::GstEnginePipeline(GstEngine* engine)
     : GstPipelineBase(),
       engine_(engine),
-      id_(sId++),
       valid_(false),
       sink_(GstEngine::kAutoSink),
       segment_start_(0),

--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -51,7 +51,7 @@ const int GstEnginePipeline::kEqBandFrequencies[] = {
 GstElementDeleter* GstEnginePipeline::sElementDeleter = nullptr;
 
 GstEnginePipeline::GstEnginePipeline(GstEngine* engine)
-    : GstPipelineBase(),
+    : GstPipelineBase("audio"),
       engine_(engine),
       valid_(false),
       sink_(GstEngine::kAutoSink),
@@ -508,7 +508,7 @@ void GstEnginePipeline::MaybeLinkDecodeToAudio() {
 }
 
 bool GstEnginePipeline::InitFromString(const QString& pipeline) {
-  if (!Init("pipeline")) return false;
+  if (!Init()) return false;
 
   GstElement* new_bin =
       CreateDecodeBinFromString(pipeline.toLatin1().constData());
@@ -527,7 +527,7 @@ bool GstEnginePipeline::InitFromString(const QString& pipeline) {
 
 bool GstEnginePipeline::InitFromReq(const MediaPlaybackRequest& req,
                                     qint64 end_nanosec) {
-  if (!Init("pipeline")) return false;
+  if (!Init()) return false;
 
   current_ = req;
   QUrl url = current_.url_;

--- a/src/engines/gstenginepipeline.h
+++ b/src/engines/gstenginepipeline.h
@@ -44,9 +44,6 @@ class GstEnginePipeline : public GstPipelineBase {
   GstEnginePipeline(GstEngine* engine);
   ~GstEnginePipeline();
 
-  // Globally unique across all pipelines.
-  int id() const { return id_; }
-
   // Call these setters before Init
   void set_output_device(const QString& sink, const QVariant& device);
   void set_replaygain(bool enabled, int mode, float preamp, bool compression);
@@ -180,14 +177,6 @@ class GstEnginePipeline : public GstPipelineBase {
   static GstElementDeleter* sElementDeleter;
 
   GstEngine* engine_;
-
-  // Using == to compare two pipelines is a bad idea, because new ones often
-  // get created in the same address as old ones.  This ID will be unique for
-  // each pipeline.
-  // Threading warning: access to the static ID field isn't protected by a
-  // mutex because all pipeline creation is currently done in the main thread.
-  static int sId;
-  int id_;
 
   // General settings for the pipeline
   bool valid_;

--- a/src/engines/gstpipelinebase.cpp
+++ b/src/engines/gstpipelinebase.cpp
@@ -19,7 +19,10 @@
 
 #include "core/logging.h"
 
-GstPipelineBase::GstPipelineBase() : QObject(nullptr), pipeline_(nullptr) {}
+std::atomic<int> GstPipelineBase::sId(1);
+
+GstPipelineBase::GstPipelineBase()
+    : QObject(nullptr), pipeline_(nullptr), id_(sId++) {}
 
 GstPipelineBase::~GstPipelineBase() {
   if (pipeline_) {

--- a/src/engines/gstpipelinebase.cpp
+++ b/src/engines/gstpipelinebase.cpp
@@ -21,8 +21,8 @@
 
 std::atomic<int> GstPipelineBase::sId(1);
 
-GstPipelineBase::GstPipelineBase()
-    : QObject(nullptr), pipeline_(nullptr), id_(sId++) {}
+GstPipelineBase::GstPipelineBase(const QString& type)
+    : QObject(nullptr), pipeline_(nullptr), type_(type), id_(sId++) {}
 
 GstPipelineBase::~GstPipelineBase() {
   if (pipeline_) {
@@ -31,7 +31,8 @@ GstPipelineBase::~GstPipelineBase() {
   }
 }
 
-bool GstPipelineBase::Init(const QString& name) {
+bool GstPipelineBase::Init() {
+  QString name = QString("%1-pipeline-%2").arg(type_).arg(id_);
   pipeline_ = gst_pipeline_new(name.toUtf8().constData());
   return pipeline_ != nullptr;
 }

--- a/src/engines/gstpipelinebase.h
+++ b/src/engines/gstpipelinebase.h
@@ -24,10 +24,10 @@
 
 class GstPipelineBase : public QObject {
  public:
-  GstPipelineBase();
+  GstPipelineBase(const QString& type);
   virtual ~GstPipelineBase();
 
-  virtual bool Init(const QString& name);
+  virtual bool Init();
 
   // Globally unique across all pipelines.
   int id() const { return id_; }
@@ -38,6 +38,8 @@ class GstPipelineBase : public QObject {
   GstElement* pipeline_;
 
  private:
+  const QString type_;
+
   // Using == to compare two pipelines is a bad idea, because new ones often
   // get created in the same address as old ones.  This ID will be unique for
   // each pipeline.

--- a/src/engines/gstpipelinebase.h
+++ b/src/engines/gstpipelinebase.h
@@ -29,10 +29,20 @@ class GstPipelineBase : public QObject {
 
   virtual bool Init(const QString& name);
 
+  // Globally unique across all pipelines.
+  int id() const { return id_; }
+
   void DumpGraph();
 
  protected:
   GstElement* pipeline_;
+
+ private:
+  // Using == to compare two pipelines is a bad idea, because new ones often
+  // get created in the same address as old ones.  This ID will be unique for
+  // each pipeline.
+  static std::atomic<int> sId;
+  const int id_;
 };
 
 #endif  // GSTPIPELINEBASE_H

--- a/src/transcoder/transcoder.cpp
+++ b/src/transcoder/transcoder.cpp
@@ -402,7 +402,7 @@ bool Transcoder::StartJob(const Job& job) {
   // Create the pipeline.
   // This should be a scoped_ptr, but scoped_ptr doesn't support custom
   // destructors.
-  if (!state->Init("pipeline")) return false;
+  if (!state->Init()) return false;
 
   // Create all the elements
   GstElement* src = CreateElement("filesrc", state->Pipeline());

--- a/src/transcoder/transcoder.h
+++ b/src/transcoder/transcoder.h
@@ -88,7 +88,10 @@ class Transcoder : public QObject {
   class JobState : public GstPipelineBase {
    public:
     JobState(const Job& job, Transcoder* parent)
-        : job_(job), parent_(parent), convert_element_(nullptr) {}
+        : GstPipelineBase("transcode"),
+          job_(job),
+          parent_(parent),
+          convert_element_(nullptr) {}
 
     void PostFinished(bool success);
     void ReportError(GstMessage* msg);


### PR DESCRIPTION
Currently, all pipelines are named "pipeline". Use a type string in combination
with the unique stream id to give each pipeline a unique name.