### PR TITLE
gstengine: Use existing stream id to track background streams

### DIFF
--- a/src/engines/enginebase.cpp
+++ b/src/engines/enginebase.cpp
@@ -38,7 +38,6 @@ Engine::Base::Base()
       crossfade_enabled_(true),
       autocrossfade_enabled_(false),
       crossfade_same_album_(false),
-      next_background_stream_id_(0),
       about_to_end_emitted_(false) {}
 
 Engine::Base::~Base() {}

--- a/src/engines/enginebase.h
+++ b/src/engines/enginebase.h
@@ -149,7 +149,6 @@ class Base : public QObject {
   bool crossfade_enabled_;
   bool autocrossfade_enabled_;
   bool crossfade_same_album_;
-  int next_background_stream_id_;
   bool fadeout_pause_enabled_;
   qint64 fadeout_pause_duration_nanosec_;
 

--- a/src/engines/gstengine.cpp
+++ b/src/engines/gstengine.cpp
@@ -878,7 +878,7 @@ int GstEngine::AddBackgroundStream(shared_ptr<GstEnginePipeline> pipeline) {
   connect(pipeline.get(), SIGNAL(EndOfStreamReached(int, bool)),
           SLOT(BackgroundStreamFinished()));
 
-  const int stream_id = next_background_stream_id_++;
+  const int stream_id = pipeline->id();
   background_streams_[stream_id] = pipeline;
 
   QFuture<GstStateChangeReturn> future = pipeline->SetState(GST_STATE_PLAYING);


### PR DESCRIPTION
New ids were being created for background stream mapping, but streams already
have unique IDs that can be used for this.