### PR TITLE
Regarding Issue #6468  (tagreader problems)

### DIFF
--- a/ext/clementine-tagreader/tagreaderworker.cpp
+++ b/ext/clementine-tagreader/tagreaderworker.cpp
@@ -46,6 +46,13 @@ void TagReaderWorker::MessageArrived(const pb::tagreader::Message& message) {
     reply.mutable_save_file_response()->set_success(tag_reader_.SaveFile(
         QStringFromStdString(message.save_file_request().filename()),
         message.save_file_request().metadata()));
+  } else if (message.has_save_song_tag_to_file_request()) {
+    reply.mutable_save_song_tag_to_file_response()->set_success(
+    tag_reader_.UpdateSongTag(
+    QStringFromStdString(message.save_song_tag_to_file_request().filename()),
+    QStringFromStdString(message.save_song_tag_to_file_request().tagname()),
+    QStringFromStdString(message.save_song_tag_to_file_request().tagvalue())
+    ));
   } else if (message.has_save_song_statistics_to_file_request()) {
     reply.mutable_save_song_statistics_to_file_response()->set_success(
         tag_reader_.SaveSongStatisticsToFile(

--- a/ext/libclementine-tagreader/tagreader.cpp
+++ b/ext/libclementine-tagreader/tagreader.cpp
@@ -306,8 +306,7 @@ void TagReader::ReadFile(const QString& filename,
     }
 
     if (items.contains("BPM")) {
-      Decode(items["BPM"].toStringList().toString(", "), nullptr,
-             song->mutable_performer());
+      song->set_bpm(TStringToQString(items["BPM"].toString()).trimmed().toFloat());
     }
 
     if (items.contains("PERFORMER")) {
@@ -502,7 +501,12 @@ void TagReader::ReadFile(const QString& filename,
           song->set_score(score);
         }
       }
-
+      if (items.contains("tmpo")) {
+	float bpm = (float)items["tmpo"].toInt();
+	if (song->bpm() <= 0 && bpm > 0) {
+	  song->set_bpm(bpm);
+	}
+      }
       if (items.contains("\251wrt")) {
         Decode(items["\251wrt"].toStringList().toString(", "), nullptr,
                song->mutable_composer());

--- a/ext/libclementine-tagreader/tagreader.cpp
+++ b/ext/libclementine-tagreader/tagreader.cpp
@@ -51,6 +51,10 @@
 #include <textidentificationframe.h>
 #include <trueaudiofile.h>
 #include <tstring.h>
+
+#include <tpropertymap.h>
+#include <tfile.h>
+
 #include <unsynchronizedlyricsframe.h>
 #include <vorbisfile.h>
 #include <wavfile.h>
@@ -776,42 +780,6 @@ void TagReader::ParseOggTag(const TagLib::Ogg::FieldListMap& map,
     Decode(map["UNSYNCEDLYRICS"].front(), codec, song->mutable_lyrics());
 }
 
-void TagReader::SetVorbisComments(
-    TagLib::Ogg::XiphComment* vorbis_comments,
-    const pb::tagreader::SongMetadata& song) const {
-  vorbis_comments->addField("COMPOSER",
-                            StdStringToTaglibString(song.composer()), true);
-  vorbis_comments->addField("PERFORMER",
-                            StdStringToTaglibString(song.performer()), true);
-  vorbis_comments->addField("CONTENT GROUP",
-                            StdStringToTaglibString(song.grouping()), true);
-  vorbis_comments->addField(
-      "BPM",
-      QStringToTaglibString(song.bpm() <= 0 - 1 ? QString()
-                                                : QString::number(song.bpm())),
-      true);
-  vorbis_comments->addField(
-      "DISCNUMBER",
-      QStringToTaglibString(song.disc() <= 0 ? QString()
-                                             : QString::number(song.disc())),
-      true);
-  vorbis_comments->addField(
-      "COMPILATION",
-      QStringToTaglibString(song.compilation() ? QString::number(1)
-                                               : QString()),
-      true);
-
-  // Try to be coherent, the two forms are used but the first one is preferred
-
-  vorbis_comments->addField("ALBUMARTIST",
-                            StdStringToTaglibString(song.albumartist()), true);
-  vorbis_comments->removeField("ALBUM ARTIST");
-
-  vorbis_comments->addField("LYRICS", StdStringToTaglibString(song.lyrics()),
-                            true);
-  vorbis_comments->removeField("UNSYNCEDLYRICS");
-}
-
 void TagReader::SetFMPSStatisticsVorbisComments(
     TagLib::Ogg::XiphComment* vorbis_comments,
     const pb::tagreader::SongMetadata& song) const {
@@ -873,111 +841,26 @@ pb::tagreader::SongMetadata_Type TagReader::GuessFileType(
 }
 
 bool TagReader::SaveFile(const QString& filename,
-                         const pb::tagreader::SongMetadata& song) const {
+	      const pb::tagreader::SongMetadata& song) const {
   if (filename.isNull()) return false;
 
-  qLog(Debug) << "Saving tags to" << filename;
-
   std::unique_ptr<TagLib::FileRef> fileref(factory_->GetFileRef(filename));
-
   if (!fileref || fileref->isNull())  // The file probably doesn't exist
     return false;
 
-  fileref->tag()->setTitle(StdStringToTaglibString(song.title()));
-  fileref->tag()->setArtist(StdStringToTaglibString(song.artist()));  // TPE1
-  fileref->tag()->setAlbum(StdStringToTaglibString(song.album()));
-  fileref->tag()->setGenre(StdStringToTaglibString(song.genre()));
-  fileref->tag()->setComment(StdStringToTaglibString(song.comment()));
-  fileref->tag()->setYear(song.year() <= 0 - 1 ? 0 : song.year());
-  fileref->tag()->setTrack(song.track() <= 0 - 1 ? 0 : song.track());
-
-  auto saveApeTag = [&](TagLib::APE::Tag* tag) {
-    tag->addValue(
-        "disc",
-        QStringToTaglibString(song.disc() <= 0 ? QString()
-                                               : QString::number(song.disc())),
-        true);
-    tag->addValue("bpm",
-                  QStringToTaglibString(song.bpm() <= 0 - 1
-                                            ? QString()
-                                            : QString::number(song.bpm())),
-                  true);
-    tag->setItem("composer",
-                 TagLib::APE::Item(
-                     "composer", TagLib::StringList(song.composer().c_str())));
-    tag->setItem("grouping",
-                 TagLib::APE::Item(
-                     "grouping", TagLib::StringList(song.grouping().c_str())));
-    tag->setItem("performer",
-                 TagLib::APE::Item("performer", TagLib::StringList(
-                                                    song.performer().c_str())));
-    tag->setItem(
-        "album artist",
-        TagLib::APE::Item("album artist",
-                          TagLib::StringList(song.albumartist().c_str())));
-    tag->setItem("lyrics",
-                 TagLib::APE::Item("lyrics", TagLib::String(song.lyrics())));
-    tag->addValue("compilation",
-                  QStringToTaglibString(song.compilation() ? QString::number(1)
-                                                           : QString()),
-                  true);
-  };
-
-  if (TagLib::MPEG::File* file =
-          dynamic_cast<TagLib::MPEG::File*>(fileref->file())) {
-    TagLib::ID3v2::Tag* tag = file->ID3v2Tag(true);
-    SetTextFrame("TPOS",
-                 song.disc() <= 0 ? QString() : QString::number(song.disc()),
-                 tag);
-    SetTextFrame("TBPM",
-                 song.bpm() <= 0 - 1 ? QString() : QString::number(song.bpm()),
-                 tag);
-    SetTextFrame("TCOM", song.composer(), tag);
-    SetTextFrame("TIT1", song.grouping(), tag);
-    SetTextFrame("TOPE", song.performer(), tag);
-    SetUnsyncLyricsFrame(song.lyrics(), tag);
-    // Skip TPE1 (which is the artist) here because we already set it
-    SetTextFrame("TPE2", song.albumartist(), tag);
-    SetTextFrame("TCMP", song.compilation() ? QString::number(1) : QString(),
-                 tag);
-  } else if (TagLib::FLAC::File* file =
-                 dynamic_cast<TagLib::FLAC::File*>(fileref->file())) {
-    TagLib::Ogg::XiphComment* tag = file->xiphComment();
-    SetVorbisComments(tag, song);
-  } else if (TagLib::MP4::File* file =
-                 dynamic_cast<TagLib::MP4::File*>(fileref->file())) {
-    TagLib::MP4::Tag* tag = file->tag();
-    tag->itemListMap()["disk"] =
-        TagLib::MP4::Item(song.disc() <= 0 - 1 ? 0 : song.disc(), 0);
-    tag->itemListMap()["tmpo"] = TagLib::StringList(
-        song.bpm() <= 0 - 1 ? "0" : TagLib::String::number(song.bpm()));
-    tag->itemListMap()["\251wrt"] = TagLib::StringList(song.composer().c_str());
-    tag->itemListMap()["\251grp"] = TagLib::StringList(song.grouping().c_str());
-    tag->itemListMap()["\251lyr"] = TagLib::StringList(song.lyrics().c_str());
-    tag->itemListMap()["aART"] = TagLib::StringList(song.albumartist().c_str());
-    tag->itemListMap()["cpil"] =
-        TagLib::StringList(song.compilation() ? "1" : "0");
-  } else if (TagLib::APE::File* file =
-                 dynamic_cast<TagLib::APE::File*>(fileref->file())) {
-    saveApeTag(file->APETag(true));
-  } else if (TagLib::MPC::File* file =
-                 dynamic_cast<TagLib::MPC::File*>(fileref->file())) {
-    saveApeTag(file->APETag(true));
-  } else if (TagLib::WavPack::File* file =
-                 dynamic_cast<TagLib::WavPack::File*>(fileref->file())) {
-    saveApeTag(file->APETag(true));
-  }
-
-  // Handle all the files which have VorbisComments (Ogg, OPUS, ...) in the same
-  // way;
-  // apart, so we keep specific behavior for some formats by adding another
-  // "else if" block above.
-  if (TagLib::Ogg::XiphComment* tag =
-          dynamic_cast<TagLib::Ogg::XiphComment*>(fileref->file()->tag())) {
-    SetVorbisComments(tag, song);
-  }
+  // only basic tags as provided by ripper
+  TagLib::Tag *t = fileref->tag();
+  t->setTitle(StdStringToTaglibString(song.title()));
+  t->setArtist(StdStringToTaglibString(song.artist()));
+  t->setAlbum(StdStringToTaglibString(song.album()));
+  t->setGenre(StdStringToTaglibString(song.genre()));
+  t->setComment(StdStringToTaglibString(song.comment()));
+  t->setYear(song.year() <= 0 - 1 ? 0 : song.year());
+  t->setTrack(song.track() <= 0 - 1 ? 0 : song.track());
+  // if more tags are required propertymap() shall be used
 
   bool ret = fileref->save();
+
 #ifdef Q_OS_LINUX
   if (ret) {
     // Linux: inotify doesn't seem to notice the change to the file unless we
@@ -985,7 +868,56 @@ bool TagReader::SaveFile(const QString& filename,
     utimensat(0, QFile::encodeName(filename).constData(), nullptr, 0);
   }
 #endif  // Q_OS_LINUX
+  
+  return ret;
+}
 
+// Replacing SaveFile for single tag editting (e.g. in playlist)
+// as full store operation (especially when file was mp4) failed
+// This code performs single tag insert/update/delete and
+// relies on taglib's PropertyMap to handle file variants.
+bool TagReader::UpdateSongTag(const QString& filename,
+			      const QString& tagname,
+			      const QString& tagvalue) const {
+
+  qLog(Debug) << "UpdateSongTag of " << filename << " tag " << tagname << " value " << tagvalue;
+
+  if (filename.isNull()) return false;
+
+  std::unique_ptr<TagLib::FileRef> fileref(factory_->GetFileRef(filename));
+  if (!fileref || fileref->isNull())  // The file probably doesn't exist
+    return false;
+
+  qLog(Debug) << "UpdateSongTag begin";
+
+  // according taglib tagwriter example
+  // basic attributes see SaveFile
+  
+  // no check for available ones
+  TagLib::PropertyMap map = fileref->file()->properties();
+
+  TagLib::String key = QStringToTaglibString(tagname);
+
+  if (tagvalue.isEmpty())
+    map.erase(key);
+  else
+    // inserts too if not yet
+    map.replace(key, QStringToTaglibString(tagvalue));
+
+  qLog(Debug) << TStringToQString(map.toString());
+
+  fileref->file()->setProperties(map);
+  bool ret = fileref->save();
+
+#ifdef Q_OS_LINUX
+  if (ret) {
+    // Linux: inotify doesn't seem to notice the change to the file unless we
+    // change the timestamps as well. (this is what touch does)
+    utimensat(0, QFile::encodeName(filename).constData(), nullptr, 0);
+  }
+#endif  // Q_OS_LINUX
+  
+  qLog(Debug) << "UpdateSongTag end";
   return ret;
 }
 

--- a/ext/libclementine-tagreader/tagreader.h
+++ b/ext/libclementine-tagreader/tagreader.h
@@ -62,6 +62,10 @@ class TagReader {
                 const pb::tagreader::SongMetadata& song) const;
   // Returns false if something went wrong; returns true otherwise (might
   // returns true if the file exists but nothing has been written inside because
+  bool UpdateSongTag(const QString& filename,
+		     const QString& tagname,
+		     const QString& tagvalue) const;
+
   // statistics tag format is not supported for this kind of file)
   bool SaveSongStatisticsToFile(const QString& filename,
                                 const pb::tagreader::SongMetadata& song) const;

--- a/ext/libclementine-tagreader/tagreadermessages.proto
+++ b/ext/libclementine-tagreader/tagreadermessages.proto
@@ -106,6 +106,16 @@ message ReadCloudFileResponse {
   optional SongMetadata metadata = 1;
 }
 
+message SaveSongTagToFileRequest {
+  optional string filename = 1;
+  optional string tagname = 2;
+  optional string tagvalue = 3;
+}
+
+message SaveSongTagToFileResponse {
+  optional bool success = 1;
+}
+
 message SaveSongStatisticsToFileRequest {
   optional string filename = 1;
   optional SongMetadata metadata = 2;
@@ -147,4 +157,8 @@ message Message {
   
   optional SaveSongRatingToFileRequest save_song_rating_to_file_request = 14;
   optional SaveSongRatingToFileResponse save_song_rating_to_file_response = 15;
+  optional SaveSongTagToFileRequest save_song_tag_to_file_request = 16;
+
+  optional SaveSongTagToFileResponse save_song_tag_to_file_response = 17;
+
 }

--- a/src/core/application.cpp
+++ b/src/core/application.cpp
@@ -69,8 +69,16 @@ bool Application::kIsPortable = false;
 const char* Application::kLegacyPortableDataDir = "data";
 const char* Application::kDefaultPortableDataDir = "clementine-data";
 const char* Application::kPortableDataDir = nullptr;
+const char* Application::kDebugFeaturesKey = "CLEMENTINE_DEBUG";
 const QStringList Application::kDefaultMusicExtensionsAllowedRemotely = {
     "aac", "alac", "flac", "m3u", "m4a", "mp3", "ogg", "wav", "wmv"};
+
+// Use CLEMENTINE_DEBUG=1 to enable debug features.
+bool Application::DebugFeaturesEnabled() {
+  QString showConsole =
+      QProcessEnvironment::systemEnvironment().value(kDebugFeaturesKey, "0");
+  return (showConsole == "1");
+}
 
 class ApplicationImpl {
  public:

--- a/src/core/application.h
+++ b/src/core/application.h
@@ -67,7 +67,9 @@ class Application : public QObject {
   static const char* kLegacyPortableDataDir;
   static const char* kDefaultPortableDataDir;
   static const QStringList kDefaultMusicExtensionsAllowedRemotely;
+  static const char* kDebugFeaturesKey;
   static bool IsPortable() { return kIsPortable; }
+  static bool DebugFeaturesEnabled();
 
   explicit Application(QObject* parent = nullptr);
   ~Application();

--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -170,9 +170,12 @@ void Player::HandleLoadResult(const UrlHandler::LoadResult& result) {
 
 void Player::Next() { NextInternal(Engine::Manual); }
 
-void Player::NextAlbum() { NextInternal(Engine::Manual, true); }
+void Player::NextAlbum() {
+  NextInternal(Engine::Manual, NextTrackOrAlbumSelected::SelectNextAlbum);
+}
 
-void Player::NextInternal(Engine::TrackChangeFlags change, bool next_album) {
+void Player::NextInternal(Engine::TrackChangeFlags change,
+                          NextTrackOrAlbumSelected NextTrackOrAlbum) {
   if (HandleStopAfter()) return;
 
   if (app_->playlist_manager()->active()->current_item()) {
@@ -188,10 +191,11 @@ void Player::NextInternal(Engine::TrackChangeFlags change, bool next_album) {
     }
   }
 
-  NextItem(change, next_album);
+  NextItem(change, NextTrackOrAlbum);
 }
 
-void Player::NextItem(Engine::TrackChangeFlags change, bool next_album) {
+void Player::NextItem(Engine::TrackChangeFlags change,
+                      NextTrackOrAlbumSelected NextTrackOrAlbum) {
   Playlist* active_playlist = app_->playlist_manager()->active();
 
   // If we received too many errors in auto change, with repeat enabled, we stop
@@ -216,7 +220,7 @@ void Player::NextItem(Engine::TrackChangeFlags change, bool next_album) {
   const bool ignore_repeat_track = change & Engine::Manual;
 
   int i = active_playlist->current_row();
-  if (next_album && i != -1) {
+  if (NextTrackOrAlbum == SelectNextAlbum && i != -1) {
     if (active_playlist->sequence()->repeat_mode() !=
         PlaylistSequence::Repeat_Track) {
       int original_index = i;

--- a/src/core/player.h
+++ b/src/core/player.h
@@ -128,6 +128,8 @@ class Player : public PlayerInterface {
     PreviousBehaviour_Restart = 2
   };
 
+  enum NextTrackOrAlbumSelected { SelectNextTrack, SelectNextAlbum };
+
   void Init();
 
   EngineBase* engine() const { return engine_.get(); }
@@ -179,10 +181,13 @@ class Player : public PlayerInterface {
   void TrackEnded();
   // Play the next item on the playlist - disregarding radio stations like
   // last.fm that might have more tracks.
-  void NextItem(Engine::TrackChangeFlags change, bool next_album = false);
+  void NextItem(Engine::TrackChangeFlags change,
+                NextTrackOrAlbumSelected NextTrackOrAlbum = SelectNextTrack);
   void PreviousItem(Engine::TrackChangeFlags change);
 
-  void NextInternal(Engine::TrackChangeFlags, bool next_album = false);
+  void NextInternal(
+      Engine::TrackChangeFlags,
+      NextTrackOrAlbumSelected NextTrackOrAlbum = SelectNextTrack);
   void PlayPlaylistInternal(Engine::TrackChangeFlags,
                             const QString& playlistName);
 

--- a/src/core/player.h
+++ b/src/core/player.h
@@ -72,6 +72,7 @@ class PlayerInterface : public QObject {
 
   // Skips this track.  Might load more of the current radio station.
   virtual void Next() = 0;
+  virtual void NextAlbum() = 0;
 
   virtual void Previous() = 0;
   virtual void SetVolume(int value) = 0;
@@ -150,6 +151,7 @@ class Player : public PlayerInterface {
   void PlayPause();
   void RestartOrPrevious();
   void Next();
+  void NextAlbum();
   void Previous();
   void PlayPlaylist(const QString& playlistName);
   void SetVolume(int value);
@@ -177,10 +179,10 @@ class Player : public PlayerInterface {
   void TrackEnded();
   // Play the next item on the playlist - disregarding radio stations like
   // last.fm that might have more tracks.
-  void NextItem(Engine::TrackChangeFlags change);
+  void NextItem(Engine::TrackChangeFlags change, bool next_album = false);
   void PreviousItem(Engine::TrackChangeFlags change);
 
-  void NextInternal(Engine::TrackChangeFlags);
+  void NextInternal(Engine::TrackChangeFlags, bool next_album = false);
   void PlayPlaylistInternal(Engine::TrackChangeFlags,
                             const QString& playlistName);
 

--- a/src/core/tagreaderclient.cpp
+++ b/src/core/tagreaderclient.cpp
@@ -83,10 +83,6 @@ TagReaderReply* TagReaderClient::SaveFile(const QString& filename,
   return worker_pool_->SendMessageWithReply(&message);
 }
 
-
-// Single field update, called by  ./src/playlist/playlist.cpp
-// Mayor change necessary, aka any "save..file" members be replaced by
-// save (file, tagname, tagvalue) without sending whole song/metadata
 TagReaderReply* TagReaderClient::UpdateSongTag(const QString& filename,
 						const QString& tagname,
 						const QVariant& tagvalue) {
@@ -94,9 +90,6 @@ TagReaderReply* TagReaderClient::UpdateSongTag(const QString& filename,
   pb::tagreader::SaveSongTagToFileRequest* req =
       message.mutable_save_song_tag_to_file_request();
 
-  qLog(Debug) << "TagReaderClient::SaveSongTag: " << filename
-	      << " tag: " << tagname << " value: " << tagvalue;
-  
   req->set_filename(DataCommaSizeFromQString(filename));
   req->set_tagname(DataCommaSizeFromQString(tagname));
   req->set_tagvalue(DataCommaSizeFromQString(tagvalue.toString()));

--- a/src/core/tagreaderclient.cpp
+++ b/src/core/tagreaderclient.cpp
@@ -66,17 +66,11 @@ TagReaderReply* TagReaderClient::ReadFile(const QString& filename) {
   return worker_pool_->SendMessageWithReply(&message);
 }
 
-//TODO: remove form based metadataeditting (./src/ui/edittagdialog.cpp)
-// shall be used only for new created (e.g. ripper, podcast, ...) files
-// any other editting shall be replaced by field level changes, see below 
 TagReaderReply* TagReaderClient::SaveFile(const QString& filename,
                                           const Song& metadata) {
   pb::tagreader::Message message;
   pb::tagreader::SaveFileRequest* req = message.mutable_save_file_request();
 
-
-  qLog(Debug) << "TagReaderClient::SaveFile: " << filename;
-  
   req->set_filename(DataCommaSizeFromQString(filename));
   metadata.ToProtobuf(req->mutable_metadata());
 
@@ -94,9 +88,6 @@ TagReaderReply* TagReaderClient::UpdateSongTag(const QString& filename,
   pb::tagreader::SaveSongTagToFileRequest* req =
       message.mutable_save_song_tag_to_file_request();
 
-  qLog(Debug) << "TagReaderClient::SaveSongTag: " << filename
-	      << " tag: " << tagname << " value: " << tagvalue;
-  
   req->set_filename(DataCommaSizeFromQString(filename));
   req->set_tagname(DataCommaSizeFromQString(tagname));
   req->set_tagvalue(DataCommaSizeFromQString(tagvalue.toString()));

--- a/src/core/tagreaderclient.h
+++ b/src/core/tagreaderclient.h
@@ -46,8 +46,7 @@ class TagReaderClient : public QObject {
 
   ReplyType* ReadFile(const QString& filename);
   ReplyType* SaveFile(const QString& filename, const Song& metadata);
-  ReplyType* UpdateSongTag(const QString& filename,
-			   const QString& tagname,
+  ReplyType* UpdateSongTag(const QString& filename, const QString& tagname,
 			   const QVariant& tagvalue);
   ReplyType* UpdateSongStatistics(const Song& metadata);
   ReplyType* UpdateSongRating(const Song& metadata);

--- a/src/core/tagreaderclient.h
+++ b/src/core/tagreaderclient.h
@@ -46,6 +46,9 @@ class TagReaderClient : public QObject {
 
   ReplyType* ReadFile(const QString& filename);
   ReplyType* SaveFile(const QString& filename, const Song& metadata);
+  ReplyType* UpdateSongTag(const QString& filename,
+			   const QString& tagname,
+			   const QVariant& tagvalue);
   ReplyType* UpdateSongStatistics(const Song& metadata);
   ReplyType* UpdateSongRating(const Song& metadata);
   ReplyType* IsMediaFile(const QString& filename);

--- a/src/core/tagreaderclient.h
+++ b/src/core/tagreaderclient.h
@@ -45,7 +45,7 @@ class TagReaderClient : public QObject {
   void Start();
 
   ReplyType* ReadFile(const QString& filename);
-  ReplyType* SaveFile(const QString& filename, const Song& 
+  ReplyType* SaveFile(const QString& filename, const Song&);
   ReplyType* UpdateSongTag(const QString& filename, const QString& tagname,
 			   const QVariant& tagvalue);
   ReplyType* UpdateSongStatistics(const Song& metadata);

--- a/src/core/utilities.cpp
+++ b/src/core/utilities.cpp
@@ -443,7 +443,7 @@ void OpenInFileBrowser(const QList<QUrl>& urls) {
 #elif defined(Q_OS_WIN32)
     ShowFileInExplorer(path);
 #else
-    QDesktopServices::openUrl(QUrl::fromLocalFile(directory));
+    QDesktopServices::openUrl(QUrl::fromLocalFile(path));
 #endif
   }
 }

--- a/src/engines/gstpipelinebase.cpp
+++ b/src/engines/gstpipelinebase.cpp
@@ -69,7 +69,7 @@ void GstPipelineModel::RemovePipeline(int id) {
   removeRow(row);
 }
 
-int GstPipelineModel::FindRowById(int id) {
+int GstPipelineModel::FindRowById(int id) const {
   for (int i = 0; i < rowCount(); i++) {
     if (item(i)->data(Role::Role_Id).toInt() == id) return i;
   }

--- a/src/engines/gstpipelinebase.cpp
+++ b/src/engines/gstpipelinebase.cpp
@@ -48,3 +48,31 @@ void GstPipelineBase::DumpGraph() {
   }
 #endif
 }
+
+GstPipelineModel::GstPipelineModel(QObject* parent)
+    : QStandardItemModel(parent) {}
+
+void GstPipelineModel::AddPipeline(int id, const QString& name) {
+  QStandardItem* item = new QStandardItem();
+  item->setData(name, Qt::DisplayRole);
+  item->setData(id, Role::Role_Id);
+  item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
+  appendRow(item);
+}
+
+void GstPipelineModel::RemovePipeline(int id) {
+  int row = FindRowById(id);
+  if (row < 0) {
+    qLog(Warning) << "Did not find pipeline" << id;
+    return;
+  }
+  removeRow(row);
+}
+
+int GstPipelineModel::FindRowById(int id) {
+  for (int i = 0; i < rowCount(); i++) {
+    if (item(i)->data(Role::Role_Id).toInt() == id) return i;
+  }
+
+  return -1;
+}

--- a/src/engines/gstpipelinebase.h
+++ b/src/engines/gstpipelinebase.h
@@ -21,6 +21,7 @@
 #include <gst/gst.h>
 
 #include <QObject>
+#include <QStandardItemModel>
 
 class GstPipelineBase : public QObject {
  public:
@@ -45,6 +46,20 @@ class GstPipelineBase : public QObject {
   // each pipeline.
   static std::atomic<int> sId;
   const int id_;
+};
+
+class GstPipelineModel : public QStandardItemModel {
+  Q_OBJECT
+
+ public:
+  explicit GstPipelineModel(QObject* parent = nullptr);
+  void AddPipeline(int id, const QString& name);
+  void RemovePipeline(int id);
+
+ private:
+  int FindRowById(int id) const;
+
+  enum Role { Role_Id = Qt::UserRole + 1 };
 };
 
 #endif  // GSTPIPELINEBASE_H

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -107,37 +107,36 @@ const qint64 Playlist::kMaxScrobblePointNsecs = 240ll * kNsecPerSec;
 // used for internal informations.
 // When adding lines to column enumeration: Try to add mappable taglib
 // properties.
-const QStringList Playlist::kColumns = QStringList()
-  << "TITLE"
-  << "ARTIST"
-  << "ALBUM"
-  << "ALBUMARTIST"
-  << "COMPOSER"
-  << "LENGTH"
-  << "TRACKNUMBER"
-  << "DISCNUMBER"
-  << "DATE"
-  << "GENRE"	
-  << "BPM"
-  << "bitrate"
-  << "samplerate"
-  << "filename"
-  << "basefilename"
-  << "filesize"
-  << "filetype"
-  << "ctime"
-  << "mtime"
-  << "rating"
-  << "playcount"
-  << "skipcount"
-  << "lastplayed"
-  << "score"
-  << "COMMENT"
-  << "source"
-  << "MOOD"
-  << "performer"
-  << "GROUPING"
-  << "ORIGINALDATE";
+const QStringList Playlist::kColumns = QStringList() << "TITLE"
+						     << "ARTIST"
+						     << "ALBUM"
+						     << "ALBUMARTIST"
+						     << "COMPOSER"
+						     << "LENGTH"
+						     << "TRACKNUMBER"
+						     << "DISCNUMBER"
+						     << "DATE"
+						     << "GENRE"
+						     << "BPM"
+						     << "bitrate"
+						     << "samplerate"
+						     << "filename"
+						     << "basefilename"
+						     << "filesize"
+						     << "filetype"
+						     << "ctime"
+						     << "mtime"
+						     << "rating"
+						     << "playcount"
+						     << "skipcount"
+						     << "lastplayed"
+						     << "score"
+						     << "COMMENT"
+						     << "source"
+						     << "MOOD"
+						     << "performer"
+						     << "GROUPING"
+						     << "ORIGINALDATE";
 
 namespace {
 QString removePrefix(const QString& a, const QStringList& prefixes) {
@@ -478,15 +477,11 @@ bool Playlist::setData(const QModelIndex& index, const QVariant& value,
     library_->AddOrUpdateSongs(SongList() << song);
     emit EditingFinished(index);
   } else {
-    qLog(Debug) << "Playlist::setData file: " << song.url().toLocalFile();
-    const QString name = Playlist::kColumns.at(index.column());    
-    qLog(Debug) << "Playlist::setData name: " << name;
-    qLog(Debug) << "Playlist::setData value: " << value;
+    const QString name = Playlist::kColumns.at(index.column());
     
     // Update just that tag
-    TagReaderReply* reply =
-      TagReaderClient::Instance()->UpdateSongTag(song.url().toLocalFile(),
-						 name, value);
+    TagReaderReply* reply = TagReaderClient::Instance()->UpdateSongTag(
+	song.url().toLocalFile(), name, value);
 
     NewClosure(reply, SIGNAL(Finished(bool)), this,
                SLOT(SongSaveComplete(TagReaderReply*, QPersistentModelIndex)),
@@ -505,8 +500,9 @@ void Playlist::SongSaveComplete(TagReaderReply* reply,
     } else {
       emit Error(
           tr("An error occurred writing metadata to '%1'")
-              .arg(QString::fromStdString(
-                  reply->request_message().save_song_tag_to_file_request().filename())));
+              .arg(QString::fromStdString(reply->request_message()
+					  .save_song_tag_to_file_request()
+					  .filename())));
     }
   }
   reply->deleteLater();

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -477,23 +477,11 @@ bool Playlist::setData(const QModelIndex& index, const QVariant& value,
     library_->AddOrUpdateSongs(SongList() << song);
     emit EditingFinished(index);
   } else {
-<<<<<<< HEAD
     const QString name = Playlist::kColumns.at(index.column());
     
     // Update just that tag
     TagReaderReply* reply = TagReaderClient::Instance()->UpdateSongTag(
 	song.url().toLocalFile(), name, value);
-=======
-    qLog(Debug) << "Playlist::setData file: " << song.url().toLocalFile();
-    const QString name = Playlist::kColumns.at(index.column());    
-    qLog(Debug) << "Playlist::setData name: " << name;
-    qLog(Debug) << "Playlist::setData value: " << value;
-    
-    // Update just that tag
-    TagReaderReply* reply =
-      TagReaderClient::Instance()->UpdateSongTag(song.url().toLocalFile(),
-						 name, value);
->>>>>>> 61799b5a312e6f1910d72f6462442ec031930cc2
 
     NewClosure(reply, SIGNAL(Finished(bool)), this,
                SLOT(SongSaveComplete(TagReaderReply*, QPersistentModelIndex)),
@@ -512,14 +500,9 @@ void Playlist::SongSaveComplete(TagReaderReply* reply,
     } else {
       emit Error(
           tr("An error occurred writing metadata to '%1'")
-<<<<<<< HEAD
               .arg(QString::fromStdString(reply->request_message()
 					  .save_song_tag_to_file_request()
 					  .filename())));
-=======
-              .arg(QString::fromStdString(
-                  reply->request_message().save_song_tag_to_file_request().filename())));
->>>>>>> 61799b5a312e6f1910d72f6462442ec031930cc2
     }
   }
   reply->deleteLater();

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -98,20 +98,27 @@ const int Playlist::kUndoItemLimit = 500;
 const qint64 Playlist::kMinScrobblePointNsecs = 31ll * kNsecPerSec;
 const qint64 Playlist::kMaxScrobblePointNsecs = 240ll * kNsecPerSec;
 
-// see enum Columns, when playlist column is editable the names are
-// used as names for taglib writing
+// kColumns provides names to enum Columns.
+// When the playlist column is editable those names are used as names
+// for taglib writing to file. Names are caseinsensitive and often
+// 3rdparty/taglib/.../id3v2frame translations is base for naming used.
+// When playlist enum columns is changed the list below has to be adapted
+// accordingly. Lowercase written names miss a taglib equivalent and are
+// used for internal informations.
+// When adding lines to column enumeration: Try to add mappable taglib
+// properties.
 const QStringList Playlist::kColumns = QStringList()
-  << "title"
-  << "artist"
-  << "album"
-  << "albumartist"
-  << "composer"
-  << "length"
-  << "track"
-  << "disc"
-  << "year"
-  << "genre"	
-  << "bpm"
+  << "TITLE"
+  << "ARTIST"
+  << "ALBUM"
+  << "ALBUMARTIST"
+  << "COMPOSER"
+  << "LENGTH"
+  << "TRACKNUMBER"
+  << "DISCNUMBER"
+  << "DATE"
+  << "GENRE"	
+  << "BPM"
   << "bitrate"
   << "samplerate"
   << "filename"
@@ -125,12 +132,12 @@ const QStringList Playlist::kColumns = QStringList()
   << "skipcount"
   << "lastplayed"
   << "score"
-  << "comment"
+  << "COMMENT"
   << "source"
-  << "mood"
+  << "MOOD"
   << "performer"
-  << "grouping"
-  << "originalyear";
+  << "GROUPING"
+  << "ORIGINALDATE";
 
 namespace {
 QString removePrefix(const QString& a, const QStringList& prefixes) {

--- a/src/playlist/playlist.h
+++ b/src/playlist/playlist.h
@@ -167,6 +167,8 @@ class Playlist : public QAbstractListModel {
   static const qint64 kMinScrobblePointNsecs;
   static const qint64 kMaxScrobblePointNsecs;
 
+  static const QStringList kColumns;
+
   static bool CompareItems(int column, Qt::SortOrder order, PlaylistItemPtr a,
                            PlaylistItemPtr b, const QStringList& prefixes = {});
 

--- a/src/transcoder/transcodedialog.cpp
+++ b/src/transcoder/transcodedialog.cpp
@@ -49,8 +49,8 @@ static bool ComparePresetsByName(const TranscoderPreset& left,
 TranscodeDialog::TranscodeDialog(QWidget* parent)
     : QDialog(parent),
       ui_(new Ui_TranscodeDialog),
-      log_ui_(new Ui_TranscodeLogDialog),
-      log_dialog_(new QDialog(this)),
+      details_ui_(new Ui_TranscodeLogDialog),
+      details_dialog_(new QDialog(this)),
       transcoder_(new Transcoder(this)),
       queued_(0),
       finished_success_(0),
@@ -58,10 +58,11 @@ TranscodeDialog::TranscodeDialog(QWidget* parent)
   ui_->setupUi(this);
   ui_->files->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
 
-  log_ui_->setupUi(log_dialog_);
-  QPushButton* clear_button =
-      log_ui_->buttonBox->addButton(tr("Clear"), QDialogButtonBox::ResetRole);
-  connect(clear_button, SIGNAL(clicked()), log_ui_->log, SLOT(clear()));
+  details_ui_->setupUi(details_dialog_);
+  details_ui_->pipelines->setModel(transcoder_->model());
+  QPushButton* clear_button = details_ui_->buttonBox->addButton(
+      tr("Clear"), QDialogButtonBox::ResetRole);
+  connect(clear_button, SIGNAL(clicked()), details_ui_->log, SLOT(clear()));
 
   // Get presets
   QList<TranscoderPreset> presets = Transcoder::GetAllPresets();
@@ -107,7 +108,7 @@ TranscodeDialog::TranscodeDialog(QWidget* parent)
   connect(start_button_, SIGNAL(clicked()), SLOT(Start()));
   connect(cancel_button_, SIGNAL(clicked()), SLOT(Cancel()));
   connect(close_button_, SIGNAL(clicked()), SLOT(hide()));
-  connect(ui_->details, SIGNAL(clicked()), log_dialog_, SLOT(show()));
+  connect(ui_->details, SIGNAL(clicked()), details_dialog_, SLOT(show()));
   connect(ui_->options, SIGNAL(clicked()), SLOT(Options()));
   connect(ui_->select, SIGNAL(clicked()), SLOT(AddDestination()));
 
@@ -117,10 +118,7 @@ TranscodeDialog::TranscodeDialog(QWidget* parent)
   connect(transcoder_, SIGNAL(AllJobsComplete()), SLOT(AllJobsComplete()));
 }
 
-TranscodeDialog::~TranscodeDialog() {
-  delete log_ui_;
-  delete ui_;
-}
+TranscodeDialog::~TranscodeDialog() {}
 
 void TranscodeDialog::SetWorking(bool working) {
   start_button_->setVisible(!working);
@@ -278,7 +276,7 @@ void TranscodeDialog::Remove() { qDeleteAll(ui_->files->selectedItems()); }
 
 void TranscodeDialog::LogLine(const QString& message) {
   QString date(QDateTime::currentDateTime().toString(Qt::TextDate));
-  log_ui_->log->appendPlainText(QString("%1: %2").arg(date, message));
+  details_ui_->log->appendPlainText(QString("%1: %2").arg(date, message));
 }
 
 void TranscodeDialog::timerEvent(QTimerEvent* e) {

--- a/src/transcoder/transcodedialog.h
+++ b/src/transcoder/transcodedialog.h
@@ -21,6 +21,7 @@
 #include <QBasicTimer>
 #include <QDialog>
 #include <QFileInfo>
+#include <memory>
 
 class Transcoder;
 class Ui_TranscodeDialog;
@@ -64,9 +65,9 @@ class TranscodeDialog : public QDialog {
                             const TranscoderPreset& preset) const;
 
  private:
-  Ui_TranscodeDialog* ui_;
-  Ui_TranscodeLogDialog* log_ui_;
-  QDialog* log_dialog_;
+  std::unique_ptr<Ui_TranscodeDialog> ui_;
+  std::unique_ptr<Ui_TranscodeLogDialog> details_ui_;
+  QDialog* details_dialog_;
 
   QBasicTimer progress_timer_;
 

--- a/src/transcoder/transcodelogdialog.ui
+++ b/src/transcoder/transcodelogdialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Transcoder Log</string>
+   <string>Transcoder Details</string>
   </property>
   <property name="windowIcon">
    <iconset resource="../../data/data.qrc">
@@ -19,10 +19,56 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QPlainTextEdit" name="log">
-     <property name="readOnly">
-      <bool>true</bool>
+    <widget class="QGroupBox" name="pipelineBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
+     <property name="title">
+      <string>Pipelines</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <widget class="QListView" name="pipelines">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="logBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Logs</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QPlainTextEdit" name="log">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>

--- a/src/transcoder/transcoder.h
+++ b/src/transcoder/transcoder.h
@@ -63,6 +63,8 @@ class Transcoder : public QObject {
   QMap<QString, float> GetProgress() const;
   int QueuedJobsCount() const { return queued_jobs_.count(); }
 
+  GstPipelineModel* model() { return model_; }
+
  public slots:
   void Start();
   void Cancel();
@@ -97,6 +99,7 @@ class Transcoder : public QObject {
     void ReportError(GstMessage* msg);
 
     GstElement* Pipeline() { return pipeline_; }
+    QString GetDisplayName();
 
     Job job_;
     Transcoder* parent_;
@@ -143,6 +146,7 @@ class Transcoder : public QObject {
   QList<Job> queued_jobs_;
   JobStateList current_jobs_;
   QString settings_postfix_;
+  GstPipelineModel* model_;
 };
 
 #endif  // TRANSCODER_H

--- a/src/translations/af.po
+++ b/src/translations/af.po
@@ -514,7 +514,7 @@ msgstr "Voeg nog 'n stroom by..."
 msgid "Add directory..."
 msgstr "Voeg gids by..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Voeg lêer by"
 
@@ -534,7 +534,7 @@ msgstr "Voeg lêer by..."
 msgid "Add files to transcode"
 msgstr "Voeg lêers by om te transkodeer"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Voeg gids by"
@@ -639,7 +639,7 @@ msgstr "Voeg tot Spotify speellyste by"
 msgid "Add to Spotify starred"
 msgstr "Voeg by Spotify gester"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Voeg tot 'n ander speellys by"
 
@@ -861,7 +861,7 @@ msgstr "Is jy seker dat jy die liedjie se statestiek in die liedjie se lêer wil
 msgid "Artist"
 msgstr "Kunstenaar"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Kunstenaar informasie"
 
@@ -1124,7 +1124,7 @@ msgstr "Soek vir nuwe episodes"
 msgid "Check for updates"
 msgstr "Kyk vir nuwer weergawes"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Kyk vir nuwer weergawes..."
 
@@ -1364,7 +1364,7 @@ msgstr "Stel Subsonic op..."
 msgid "Configure global search..."
 msgstr "Globale soek instellings..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Stel my versameling op..."
 
@@ -1436,11 +1436,11 @@ msgid "Copy to clipboard"
 msgstr "Kopiëer na knipbord"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopiëer na die toestel..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kopiëer na my versameling"
@@ -1658,7 +1658,7 @@ msgid "Delete downloaded data"
 msgstr "Vee afgelaaide data uit"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Skrap lêers"
 
@@ -1666,7 +1666,7 @@ msgstr "Skrap lêers"
 msgid "Delete from device..."
 msgstr "Skrap van toestel..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Skrap van skyf..."
@@ -1699,11 +1699,11 @@ msgstr "Lêers word geskrap"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Verwyder gekose snitte uit die tou"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Verwyder snit uit die tou"
 
@@ -1732,7 +1732,7 @@ msgstr "Toestelsnaam"
 msgid "Device properties..."
 msgstr "Toestelseienskappe..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Toestelle"
 
@@ -1983,7 +1983,7 @@ msgstr "Dinamiese skommeling"
 msgid "Edit smart playlist..."
 msgstr "Verander slimspeellys"
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Verander etiket \"%1\"..."
@@ -2122,8 +2122,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Ekwivalent aan --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Fout"
 
@@ -2269,7 +2269,7 @@ msgstr "Uitdowing"
 msgid "Fading duration"
 msgstr "Duur van uitdowing"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Kan nie van die CD-dryf lees nie"
 
@@ -2392,7 +2392,7 @@ msgstr "Lêertipe"
 msgid "Filename"
 msgstr "Lêernaam"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Lêers"
 
@@ -2807,7 +2807,7 @@ msgstr "Geïnstalleer"
 msgid "Integrity check"
 msgstr "Integriteitstoets"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -2995,7 +2995,7 @@ msgstr "Links"
 msgid "Length"
 msgstr "Lengte"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Versameling"
@@ -3004,7 +3004,7 @@ msgstr "Versameling"
 msgid "Library advanced grouping"
 msgstr "Gevorderde groeppering van versameling"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Versameling hernagaan kennisgewing"
 
@@ -3332,7 +3332,7 @@ msgstr "Monteringsadresse"
 msgid "Move down"
 msgstr "Skuid af"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Skuif na my versameling..."
 
@@ -3341,7 +3341,7 @@ msgstr "Skuif na my versameling..."
 msgid "Move up"
 msgstr "Skuid op"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Musiek"
 
@@ -3403,7 +3403,7 @@ msgstr "Moet nooit begin speel nie"
 msgid "New folder"
 msgstr "Nuwe gids"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nuwe speellys"
 
@@ -3474,7 +3474,7 @@ msgstr "Geen kort blokke"
 msgid "None"
 msgstr "Geen"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Geen van die gekose liedjies is geskik om na die toestel te kopiëer nie."
 
@@ -3689,7 +3689,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Sorteer Lêers"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Sorteer Lêers..."
 
@@ -3773,7 +3773,7 @@ msgstr "Partytjie"
 msgid "Password"
 msgstr "Wagwoord"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Vries"
@@ -3809,8 +3809,8 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Gewone sykieslys"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3833,11 +3833,11 @@ msgstr "Speel indien gestop, vries indien aan die speel"
 msgid "Play if there is nothing already playing"
 msgstr "Speel as daar niks anders tans speel nie"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3876,7 +3876,7 @@ msgstr "Speellys keuses"
 msgid "Playlist type"
 msgstr "Speellys tipe"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Speellys"
 
@@ -4058,12 +4058,12 @@ msgstr "Toestel word ondervra..."
 msgid "Queue Manager"
 msgstr "Tou bestuurder"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Plaas geselekteerde snitte in die tou"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Plaas snit in die tou"
 
@@ -4454,7 +4454,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Soek"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Soek"
@@ -4479,7 +4479,7 @@ msgstr "Soek deur Subsonic"
 msgid "Search automatically"
 msgstr "Soek outomaties"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4492,7 +4492,7 @@ msgstr "Soek vir album omslae..."
 msgid "Search for anything"
 msgstr "Soek vir enigiets"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4617,7 +4617,7 @@ msgstr "Bedienerbesonderhede"
 msgid "Service offline"
 msgstr "Diens aflyn"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Stel %1 na \"%2\"..."
@@ -4697,7 +4697,7 @@ msgstr "Wys 'n mooi skermbeeld"
 msgid "Show above status bar"
 msgstr "Wys bo toestandsbalk"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Wys alle liedjies"
 
@@ -4717,12 +4717,12 @@ msgstr "Wys verdelers"
 msgid "Show fullsize..."
 msgstr "Wys volgrootte..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Wys in lêerblaaier..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Wys in die biblioteek..."
 
@@ -4734,11 +4734,11 @@ msgstr "Wys tussen verkeie kunstenaars"
 msgid "Show moodbar"
 msgstr "Wys stemmingsbalk"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Wys slegs duplikate"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Wys slegs sonder etikette"
 
@@ -4830,7 +4830,7 @@ msgstr "Aantal keer oorgeslaan"
 msgid "Skip forwards in playlist"
 msgstr "Spring voorentoe in speellys"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Spring geselekteerde snitte"
 
@@ -4838,7 +4838,7 @@ msgstr "Spring geselekteerde snitte"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Spring snit"
 
@@ -4870,7 +4870,7 @@ msgstr "Sagte Rock"
 msgid "Song Information"
 msgstr "Liedjie Inligting"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Liedjie"
 
@@ -4991,7 +4991,7 @@ msgstr "Stop na elke snit"
 msgid "Stop after every track"
 msgstr "Stop na elke snit"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Stop na hierdie snit"
 
@@ -5159,7 +5159,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Die toetsperiode vir toegang tot die Subsonic bediener is verstreke. Gee asseblief 'n donasie om 'n lisensie sleutel te ontvang. Besoek subsonic.org vir meer inligting."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5201,7 +5201,7 @@ msgid ""
 "continue?"
 msgstr "Hierdie lêers sal vanaf die toestel verwyder word. Is jy seker?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5303,7 +5303,7 @@ msgstr "Skakel mooi skermbeeld aan/af"
 msgid "Toggle fullscreen"
 msgstr "Skakel volskerm aan/af"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Skakel tou-status aan/af"
 
@@ -5441,11 +5441,11 @@ msgstr "Onbekende fout"
 msgid "Unset cover"
 msgstr "Verwyder omslag"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Moet nie geselekteerde snitte spring nie"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Moet nie snit spring nie"
 
@@ -5782,7 +5782,7 @@ msgid ""
 "well?"
 msgstr "Wil jy die ander liedjies in hierdie album ook na Verskeie Kunstenaars skuif?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Wil jy alles van voor af deursoek?"
 

--- a/src/translations/af.po
+++ b/src/translations/af.po
@@ -12,7 +12,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Afrikaans (http://www.transifex.com/davidsansome/clementine/language/af/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -166,19 +166,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n onsuksesvol"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n voltooi"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -196,7 +196,7 @@ msgstr "&Sentreer"
 msgid "&Custom"
 msgstr "&Eie keuse"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Ekstras"
 
@@ -204,7 +204,7 @@ msgstr "&Ekstras"
 msgid "&Grouping"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Hulp"
 
@@ -229,7 +229,7 @@ msgstr ""
 msgid "&Lyrics"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Musiek"
 
@@ -237,15 +237,15 @@ msgstr "&Musiek"
 msgid "&None"
 msgstr "&Geen"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&Speellys"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Maak toe"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "&Herhaal modus"
 
@@ -253,7 +253,7 @@ msgstr "&Herhaal modus"
 msgid "&Right"
 msgstr "&Regs"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "&Skommel modus"
 
@@ -261,7 +261,7 @@ msgstr "&Skommel modus"
 msgid "&Stretch columns to fit window"
 msgstr "&Rek kolomme om in venster te pas"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Gereedskap"
 
@@ -450,11 +450,11 @@ msgstr "Staak"
 msgid "About %1"
 msgstr "Meer oor %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Meer oor Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Meer oor Qt..."
 
@@ -514,32 +514,32 @@ msgstr "Voeg nog 'n stroom by..."
 msgid "Add directory..."
 msgstr "Voeg gids by..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Voeg lêer by"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Voeg die lêer by die transkodeerder by"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Voeg lêer(s) by die transkodeerder by"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Voeg lêer by..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Voeg lêers by om te transkodeer"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Voeg gids by"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Voeg gids by..."
 
@@ -551,7 +551,7 @@ msgstr "Voeg nuwe gids by..."
 msgid "Add podcast"
 msgstr "Voeg potgooi by"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Voeg potgooi by..."
 
@@ -627,7 +627,7 @@ msgstr "Voeg liedjie se snitnommer as 'n etiket by"
 msgid "Add song year tag"
 msgstr "Voeg liedjie se jaar by as 'n etiket"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Voeg stroom by..."
 
@@ -639,7 +639,7 @@ msgstr "Voeg tot Spotify speellyste by"
 msgid "Add to Spotify starred"
 msgstr "Voeg by Spotify gester"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Voeg tot 'n ander speellys by"
 
@@ -733,7 +733,7 @@ msgstr "Alle"
 msgid "All Files (*)"
 msgstr "Alle lêers (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Alle heil aan die Hypnotoad!"
@@ -1124,7 +1124,7 @@ msgstr "Soek vir nuwe episodes"
 msgid "Check for updates"
 msgstr "Kyk vir nuwer weergawes"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Kyk vir nuwer weergawes..."
 
@@ -1173,18 +1173,18 @@ msgstr "Klassiek"
 msgid "Cleaning up"
 msgstr "Daar word skoongemaak"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Wis"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Wis speellys"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1329,7 +1329,7 @@ msgstr "Kommentaar"
 msgid "Complete tags automatically"
 msgstr "Voltooi etikette outomaties"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Voltooi etikette outomaties..."
 
@@ -1364,7 +1364,7 @@ msgstr "Stel Subsonic op..."
 msgid "Configure global search..."
 msgstr "Globale soek instellings..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Stel my versameling op..."
 
@@ -1407,7 +1407,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Die konneksie se tydlimiet is bereik. Beaam die bediener se URL.  Byvoorbeeld: http://localhost:4040"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Konsole"
 
@@ -1436,11 +1436,11 @@ msgid "Copy to clipboard"
 msgstr "Kopiëer na knipbord"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopiëer na die toestel..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kopiëer na my versameling"
@@ -1483,14 +1483,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr "Kon nie speellys skep nie"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Kan nie 'n multiplekser vir %1 vind nie. Maak seker jy het die korrekte GStreamer uitbreidings installeer."
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1505,7 +1505,7 @@ msgstr "Kan nie die uittreelêer %1 oopmaak nie"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Omslagbestuurder"
 
@@ -1658,7 +1658,7 @@ msgid "Delete downloaded data"
 msgstr "Vee afgelaaide data uit"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Skrap lêers"
 
@@ -1666,7 +1666,7 @@ msgstr "Skrap lêers"
 msgid "Delete from device..."
 msgstr "Skrap van toestel..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Skrap van skyf..."
@@ -1699,11 +1699,11 @@ msgstr "Lêers word geskrap"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Verwyder gekose snitte uit die tou"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Verwyder snit uit die tou"
 
@@ -1804,7 +1804,7 @@ msgstr "Vertoon keuses"
 msgid "Display the on-screen-display"
 msgstr "Toon skermbeeld"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Gaan in geheel my versameling weer na"
 
@@ -1983,12 +1983,12 @@ msgstr "Dinamiese skommeling"
 msgid "Edit smart playlist..."
 msgstr "Verander slimspeellys"
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Verander etiket \"%1\"..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Verander etiket"
 
@@ -2001,7 +2001,7 @@ msgid "Edit track information"
 msgstr "Verander snit se inligting"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Verander snit se inligting..."
 
@@ -2109,7 +2109,7 @@ msgstr "Hele versameling"
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Grafiese effenaar"
 
@@ -2122,8 +2122,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Ekwivalent aan --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Fout"
 
@@ -2158,7 +2158,7 @@ msgstr "Fout tydens laai van %1"
 msgid "Error loading di.fm playlist"
 msgstr "Fout tydens laai van di.fm speellys"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Fout tydens verwerking van %1:%2"
@@ -2241,7 +2241,11 @@ msgstr "Uitvoer voltooid"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "%1 omslae uit %2 uitgevoer (%3 gespring)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2265,7 +2269,7 @@ msgstr "Uitdowing"
 msgid "Fading duration"
 msgstr "Duur van uitdowing"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Kan nie van die CD-dryf lees nie"
 
@@ -2547,11 +2551,11 @@ msgstr "Gee dit 'n naam:"
 msgid "Go"
 msgstr "Gaan"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Gaan na volgende speellys oortjie"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Gaan na vorige speellys oortjie"
 
@@ -2884,7 +2888,7 @@ msgstr "Jamendo databasis"
 msgid "Jump to previous song right away"
 msgstr "Spring dadelik na vorige lied"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Spring na die snit wat tans speel"
 
@@ -2908,7 +2912,7 @@ msgstr "Hou aan uitvoer in die agtergrond al word die venster gesluit"
 msgid "Keep the original files"
 msgstr "Hou die oorspronklike lêers"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Katjies"
@@ -3000,7 +3004,7 @@ msgstr "Versameling"
 msgid "Library advanced grouping"
 msgstr "Gevorderde groeppering van versameling"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Versameling hernagaan kennisgewing"
 
@@ -3040,7 +3044,7 @@ msgstr "Verkry omslag van skyf..."
 msgid "Load playlist"
 msgstr "Laai speellys"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Laai speellys..."
 
@@ -3101,11 +3105,15 @@ msgstr "Teken aan"
 msgid "Login failed"
 msgstr "Aanteken onsuksesvol"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Langtermyn voorspellingsmodel (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Bemin"
 
@@ -3140,11 +3148,11 @@ msgstr "Lirieke vanaf %1"
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3186,7 +3194,7 @@ msgstr "Hoofprofiel (MAIN)"
 msgid "Make it so!"
 msgstr "Maak dit so!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Maak dit so!"
@@ -3324,7 +3332,7 @@ msgstr "Monteringsadresse"
 msgid "Move down"
 msgstr "Skuid af"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Skuif na my versameling..."
 
@@ -3333,7 +3341,7 @@ msgstr "Skuif na my versameling..."
 msgid "Move up"
 msgstr "Skuid op"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Musiek"
 
@@ -3346,7 +3354,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Maak stil"
 
@@ -3395,7 +3403,7 @@ msgstr "Moet nooit begin speel nie"
 msgid "New folder"
 msgstr "Nuwe gids"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nuwe speellys"
 
@@ -3423,8 +3431,12 @@ msgstr "Nuutste snitte"
 msgid "Next"
 msgstr "Volgende"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Volgende snit"
 
@@ -3462,7 +3474,7 @@ msgstr "Geen kort blokke"
 msgid "None"
 msgstr "Geen"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Geen van die gekose liedjies is geskik om na die toestel te kopiëer nie."
 
@@ -3547,19 +3559,19 @@ msgstr "Af"
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3603,7 +3615,7 @@ msgstr "Ondeursigtigheid"
 msgid "Open %1 in browser"
 msgstr "Maak %1 in webblaaier oop"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Maak &oudio CD oop..."
 
@@ -3615,7 +3627,7 @@ msgstr "Maak OPML lêer oop"
 msgid "Open OPML file..."
 msgstr "Maak OPML lêer oop..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Maak 'n gids oop om musiek van in te trek"
 
@@ -3623,7 +3635,7 @@ msgstr "Maak 'n gids oop om musiek van in te trek"
 msgid "Open device"
 msgstr "Open device"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Lêer..."
 
@@ -3677,7 +3689,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Sorteer Lêers"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Sorteer Lêers..."
 
@@ -3761,7 +3773,7 @@ msgstr "Partytjie"
 msgid "Password"
 msgstr "Wagwoord"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Vries"
@@ -3785,6 +3797,10 @@ msgstr "Kunstenaar"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Pixel"
@@ -3793,10 +3809,10 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Gewone sykieslys"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Speel"
 
@@ -3817,11 +3833,11 @@ msgstr "Speel indien gestop, vries indien aan die speel"
 msgid "Play if there is nothing already playing"
 msgstr "Speel as daar niks anders tans speel nie"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3920,7 +3936,7 @@ msgstr "Instellings"
 msgid "Preferences"
 msgstr "Instellings"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Instellings..."
 
@@ -3980,7 +3996,7 @@ msgid "Previous"
 msgstr "Vorige"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Vorige snit"
 
@@ -4038,16 +4054,16 @@ msgstr "Kwaliteit"
 msgid "Querying device..."
 msgstr "Toestel word ondervra..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Tou bestuurder"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Plaas geselekteerde snitte in die tou"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Plaas snit in die tou"
 
@@ -4063,7 +4079,7 @@ msgstr "Radio (selfde hardheid vir alle snitte)"
 msgid "Rain"
 msgstr "Reën"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Reën"
@@ -4175,7 +4191,7 @@ msgstr "Verwyder aksie"
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Verwyder duplikate vanuit die speellys"
 
@@ -4183,7 +4199,7 @@ msgstr "Verwyder duplikate vanuit die speellys"
 msgid "Remove folder"
 msgstr "Verwyder vouer"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Verwyder vanuit speellys"
 
@@ -4195,7 +4211,7 @@ msgstr "Verwyder speellys"
 msgid "Remove playlists"
 msgstr "Verwyder speellyste"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Verwyder onbeskikbare snitte van die speellys"
 
@@ -4207,7 +4223,7 @@ msgstr "Herbenoem speellys"
 msgid "Rename playlist..."
 msgstr "Herbenoem speellys..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Hernommer snitte in hierdie volgorde..."
 
@@ -4298,7 +4314,7 @@ msgstr "\"Rip\""
 msgid "Rip CD"
 msgstr "\"Rip\" CD"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "\"Rip\" oudio CD"
 
@@ -4376,7 +4392,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Stoor speellys"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Stoor speellys..."
 
@@ -4463,7 +4479,7 @@ msgstr "Soek deur Subsonic"
 msgid "Search automatically"
 msgstr "Soek outomaties"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4476,7 +4492,7 @@ msgstr "Soek vir album omslae..."
 msgid "Search for anything"
 msgstr "Soek vir enigiets"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4601,7 +4617,7 @@ msgstr "Bedienerbesonderhede"
 msgid "Service offline"
 msgstr "Diens aflyn"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Stel %1 na \"%2\"..."
@@ -4610,7 +4626,7 @@ msgstr "Stel %1 na \"%2\"..."
 msgid "Set the volume to <value> percent"
 msgstr "Stel die volume na <value> persent"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Stel waarde vir alle geselekteerde snitte"
 
@@ -4681,7 +4697,7 @@ msgstr "Wys 'n mooi skermbeeld"
 msgid "Show above status bar"
 msgstr "Wys bo toestandsbalk"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Wys alle liedjies"
 
@@ -4701,12 +4717,12 @@ msgstr "Wys verdelers"
 msgid "Show fullsize..."
 msgstr "Wys volgrootte..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Wys in lêerblaaier..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Wys in die biblioteek..."
 
@@ -4718,15 +4734,15 @@ msgstr "Wys tussen verkeie kunstenaars"
 msgid "Show moodbar"
 msgstr "Wys stemmingsbalk"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Wys slegs duplikate"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Wys slegs sonder etikette"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4734,7 +4750,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr "Wys aanbevole soektogte"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4770,7 +4786,7 @@ msgstr "Skommel albums"
 msgid "Shuffle all"
 msgstr "Skommel alles"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Skommel speellys"
 
@@ -4814,11 +4830,15 @@ msgstr "Aantal keer oorgeslaan"
 msgid "Skip forwards in playlist"
 msgstr "Spring voorentoe in speellys"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Spring geselekteerde snitte"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Spring snit"
 
@@ -4935,7 +4955,7 @@ msgstr "Bigin om te \"rip\""
 msgid "Start the playlist currently playing"
 msgstr "Begin die huidige speellys speel"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Begin transkodering"
 
@@ -4945,7 +4965,7 @@ msgid ""
 "list"
 msgstr "Begin iets bo in die soekblokkie te tik om resultate hier te sien"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "%1 word begin"
@@ -4955,7 +4975,7 @@ msgid "Starting..."
 msgstr "In aanvang..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Stop"
 
@@ -4971,7 +4991,7 @@ msgstr "Stop na elke snit"
 msgid "Stop after every track"
 msgstr "Stop na elke snit"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Stop na hierdie snit"
 
@@ -5139,7 +5159,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Die toetsperiode vir toegang tot die Subsonic bediener is verstreke. Gee asseblief 'n donasie om 'n lisensie sleutel te ontvang. Besoek subsonic.org vir meer inligting."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5181,7 +5201,7 @@ msgid ""
 "continue?"
 msgstr "Hierdie lêers sal vanaf die toestel verwyder word. Is jy seker?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5283,11 +5303,11 @@ msgstr "Skakel mooi skermbeeld aan/af"
 msgid "Toggle fullscreen"
 msgstr "Skakel volskerm aan/af"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Skakel tou-status aan/af"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Skakel log van geluisterde musiek aanlyn aan/af"
 
@@ -5332,19 +5352,19 @@ msgstr ""
 msgid "Track"
 msgstr "Snit"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Transkodeer musiek"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Transkodeerder log"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Besig met transkodering"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Lêer %1 word met %2 prosesse getranskodeer"
@@ -5421,11 +5441,11 @@ msgstr "Onbekende fout"
 msgid "Unset cover"
 msgstr "Verwyder omslag"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Moet nie geselekteerde snitte spring nie"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Moet nie snit spring nie"
 
@@ -5442,7 +5462,7 @@ msgstr "Komende opvoerings"
 msgid "Update all podcasts"
 msgstr "Dateer alle potgooie op"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Gaan versameling na vir veranderinge"
 
@@ -5603,7 +5623,7 @@ msgstr "Weergawe %1"
 msgid "View"
 msgstr "Bekyk"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5611,7 +5631,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr "Visualisasie modus"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Visualisasies"
 
@@ -5652,7 +5672,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5748,7 +5768,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media oudio"
 
@@ -5762,7 +5782,7 @@ msgid ""
 "well?"
 msgstr "Wil jy die ander liedjies in hierdie album ook na Verskeie Kunstenaars skuif?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Wil jy alles van voor af deursoek?"
 

--- a/src/translations/ar.po
+++ b/src/translations/ar.po
@@ -16,7 +16,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Arabic (http://www.transifex.com/davidsansome/clementine/language/ar/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -170,19 +170,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%اسم الملف%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n فشل"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n إنتهى"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -200,7 +200,7 @@ msgstr "&وسط"
 msgid "&Custom"
 msgstr "&تخصيص"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&إضافات"
 
@@ -208,7 +208,7 @@ msgstr "&إضافات"
 msgid "&Grouping"
 msgstr "&تجميع"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&مساعدة"
 
@@ -233,7 +233,7 @@ msgstr "&مستوى القفل"
 msgid "&Lyrics"
 msgstr "&الكلمات"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&موسيقى"
 
@@ -241,15 +241,15 @@ msgstr "&موسيقى"
 msgid "&None"
 msgstr "&لا شيئ"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&قائمة التشغيل"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&خروج"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "&نمط التكرار"
 
@@ -257,7 +257,7 @@ msgstr "&نمط التكرار"
 msgid "&Right"
 msgstr "&يمين"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "&نمط الخلط"
 
@@ -265,7 +265,7 @@ msgstr "&نمط الخلط"
 msgid "&Stretch columns to fit window"
 msgstr "&تمديد الأعمدة لتتناسب مع الناقدة"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&أدوات"
 
@@ -454,11 +454,11 @@ msgstr "ألغ"
 msgid "About %1"
 msgstr "عن %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "عن كليمنتاين..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "عن QT..."
 
@@ -518,32 +518,32 @@ msgstr "إضافة Stream أخر"
 msgid "Add directory..."
 msgstr "أضف مجلد..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "أضف ملفا"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "أضف ملفا للتحويل"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "أضف ملف(s) للتحويل"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "أضافة ملف..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "أضف ملفات للتحويل"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "إضافة مجلد"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "إضافة مجلد..."
 
@@ -555,7 +555,7 @@ msgstr "أضف مجلد جديد..."
 msgid "Add podcast"
 msgstr "إضافة بودكاست"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "إضافة بودكاست..."
 
@@ -631,7 +631,7 @@ msgstr "أضف وسم للمقطع"
 msgid "Add song year tag"
 msgstr "أضف وسم سنة المقطع"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "أضف رابط انترنت..."
 
@@ -643,7 +643,7 @@ msgstr "إضافة لقائمات تشغيل Spotify"
 msgid "Add to Spotify starred"
 msgstr "إضافة للمميزة على Spotify"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "أضف إلى قائمة تشغيل أخرى"
 
@@ -737,7 +737,7 @@ msgstr "الكل"
 msgid "All Files (*)"
 msgstr "جميع الملفات (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "العظمة لهيبنوتود!"
@@ -1128,7 +1128,7 @@ msgstr "التمس حلقات جديدة"
 msgid "Check for updates"
 msgstr "التمس التحديثات"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "التمس التحديثات"
 
@@ -1177,18 +1177,18 @@ msgstr "كلاسيكي"
 msgid "Cleaning up"
 msgstr "تنضيف"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "امسح"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "امسح قائمة التشغيل"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "كلمنتاين"
 
@@ -1333,7 +1333,7 @@ msgstr "تعليق"
 msgid "Complete tags automatically"
 msgstr "أكمل الوسوم تلقائيا"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "أكمل الوسوم تلقائيا..."
 
@@ -1368,7 +1368,7 @@ msgstr "إعدادات Subsonic..."
 msgid "Configure global search..."
 msgstr "إعدادات البحث العامة..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "إعدادات المكتبة"
 
@@ -1411,7 +1411,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "تم تجاوز مدة الانتظار، تأكد من رابط الخادم. مثال: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "طرفية"
 
@@ -1440,11 +1440,11 @@ msgid "Copy to clipboard"
 msgstr "نسخ إلى المكتبة..."
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "نسخ إلى جهاز..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "نسخ إلى المكتبة..."
@@ -1487,14 +1487,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr "لا تنشئ قائمة تشغيل"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "تعذر العثور على معدد من أجل %1، تأكد أن ملحقات GStreamer الضرورية مثبتة"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1509,7 +1509,7 @@ msgstr "تعذر فتح الملف %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "مدير الغلاف"
 
@@ -1662,7 +1662,7 @@ msgid "Delete downloaded data"
 msgstr "حذف البيانات المحملة"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "احذف الملفات"
 
@@ -1670,7 +1670,7 @@ msgstr "احذف الملفات"
 msgid "Delete from device..."
 msgstr "احذف من الجهاز"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "احذف من القرص..."
@@ -1703,11 +1703,11 @@ msgstr "حذف الملفات"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "أزل المختارة من لائحة الانتظار"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "أزل المقطع من لائحة الانتظار"
 
@@ -1808,7 +1808,7 @@ msgstr "خيارات العرض"
 msgid "Display the on-screen-display"
 msgstr "أظهر قائمة الشاشة"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "افحص المكتبة كاملة"
 
@@ -1987,12 +1987,12 @@ msgstr "مزج عشوائي تلقائيا"
 msgid "Edit smart playlist..."
 msgstr "حرر قائمة التشغيل الذكية"
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "حرر الوسم \"%1\""
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "حرر الوسم..."
 
@@ -2005,7 +2005,7 @@ msgid "Edit track information"
 msgstr "تعديل معلومات المقطع"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "تعديل معلومات المقطع..."
 
@@ -2113,7 +2113,7 @@ msgstr "كامل المجموعة"
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "معدل الصوت"
 
@@ -2126,8 +2126,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "يكافئ --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "خطأ"
 
@@ -2162,7 +2162,7 @@ msgstr "خطأ في تحميل %1"
 msgid "Error loading di.fm playlist"
 msgstr "خطأ في تحميل قائمة تشغيل di.fm"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "حدث خطأ بتطبيق %1:%2"
@@ -2245,7 +2245,11 @@ msgstr "تم الانتهاء من التصدير"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "تم تصدير %1 أغلفة من إجمالي %2 (تم تخطي %3)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2269,7 +2273,7 @@ msgstr "تلاشي"
 msgid "Fading duration"
 msgstr "مدة التلاشي"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "فشل في قراءة القرص CD"
 
@@ -2551,11 +2555,11 @@ msgstr "أعط اسما:"
 msgid "Go"
 msgstr "اذهب"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "انتقل للسان قائمة التشغيل التالي"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "انتقل للسان قائمة التشغيل السابق"
 
@@ -2888,7 +2892,7 @@ msgstr "قاعدة بيانات Jamendo"
 msgid "Jump to previous song right away"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "اقفز إلى المقطع الجاري تشغيله"
 
@@ -2912,7 +2916,7 @@ msgstr "تابع التشغيل في الخلفية عند إغلاق الناف
 msgid "Keep the original files"
 msgstr "أبقي على الملفات الأصلية"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "هرر"
@@ -3004,7 +3008,7 @@ msgstr "المكتبة"
 msgid "Library advanced grouping"
 msgstr "إعدادات متقدمة لتجميع المكتبة"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "إشعار إعادة فحص المكتبة"
 
@@ -3044,7 +3048,7 @@ msgstr "تحميل الغلاف من القرص..."
 msgid "Load playlist"
 msgstr "تحميل قائمة تشغيل"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "تحميل قائمة تشغيل..."
 
@@ -3105,11 +3109,15 @@ msgstr "تسجيل الدخول"
 msgid "Login failed"
 msgstr "فشل الولوج"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "ملف تعريف لتوقعات بعيدة المدى (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "إعجاب"
 
@@ -3144,11 +3152,11 @@ msgstr "كلمات المقطع من %1"
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3190,7 +3198,7 @@ msgstr "ملف التعريف القياسي (MAIN)"
 msgid "Make it so!"
 msgstr "فلتكن  هكذا!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "اجعلها كذلك!"
@@ -3328,7 +3336,7 @@ msgstr "نقط الوصل"
 msgid "Move down"
 msgstr "أسفل"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "انقل إلى المكتبة"
 
@@ -3337,7 +3345,7 @@ msgstr "انقل إلى المكتبة"
 msgid "Move up"
 msgstr "أعلى"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "موسيقى"
 
@@ -3350,7 +3358,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "كتم الصوت"
 
@@ -3399,7 +3407,7 @@ msgstr "لم يبدأ تشغيلها أبدا"
 msgid "New folder"
 msgstr "مجلد جديد"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "قائمة تشغيل جديدة"
 
@@ -3427,8 +3435,12 @@ msgstr "أحدث المقاطع"
 msgid "Next"
 msgstr "التالي"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "المقطع التالي"
 
@@ -3466,7 +3478,7 @@ msgstr "بدون أجزاء قصيرة"
 msgid "None"
 msgstr "لا شيء"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "لا مقطع من المقاطع المختارة مناسب لنسخه لجهاز."
 
@@ -3551,19 +3563,19 @@ msgstr "معطل"
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3607,7 +3619,7 @@ msgstr "الشفافية"
 msgid "Open %1 in browser"
 msgstr "فتح %1 في المتصفح"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "فتح &قرص CD..."
 
@@ -3619,7 +3631,7 @@ msgstr "فتح ملف OPML"
 msgid "Open OPML file..."
 msgstr "فتح ملف OPML..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr ""
 
@@ -3627,7 +3639,7 @@ msgstr ""
 msgid "Open device"
 msgstr "فتح جهاز"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "فتح ملف..."
 
@@ -3681,7 +3693,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "ترتيب الملفات"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "ترتيب الملفات..."
 
@@ -3765,7 +3777,7 @@ msgstr "حفلة"
 msgid "Password"
 msgstr "كلمة السر"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "إيقاف مؤقت"
@@ -3789,6 +3801,10 @@ msgstr "المؤدي"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "بكسل"
@@ -3797,10 +3813,10 @@ msgstr "بكسل"
 msgid "Plain sidebar"
 msgstr "شريط جانبي عريض"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "تشغيل"
 
@@ -3821,11 +3837,11 @@ msgstr "شغل إذا انتهى، أوقف إذا كان قيد التشغيل"
 msgid "Play if there is nothing already playing"
 msgstr "شغل إذا لم يكن هناك مقطع قيد التشغيل "
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3924,7 +3940,7 @@ msgstr "التفضيلات"
 msgid "Preferences"
 msgstr "التفضيلات"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "التفضيلات..."
 
@@ -3984,7 +4000,7 @@ msgid "Previous"
 msgstr "السابق"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "المقطع السابق"
 
@@ -4042,16 +4058,16 @@ msgstr "الجودة"
 msgid "Querying device..."
 msgstr "الاستعلام عن الجهاز..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "مدير لائحة الانتظار"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "أضف المختارة للائحة الانتظار"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "أضف للائحة الانتظار"
 
@@ -4067,7 +4083,7 @@ msgstr "راديو (شدة صوت متساوية لجمع المقاطع)"
 msgid "Rain"
 msgstr "مطر"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "مطر"
@@ -4179,7 +4195,7 @@ msgstr "احذف العملية"
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "احذف المقاطع المكررة من قائمة التشغيل"
 
@@ -4187,7 +4203,7 @@ msgstr "احذف المقاطع المكررة من قائمة التشغيل"
 msgid "Remove folder"
 msgstr "أزل الملف"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "احذف من قائمة التشغيل"
 
@@ -4199,7 +4215,7 @@ msgstr "احذف قائمة التشغيل"
 msgid "Remove playlists"
 msgstr "احذف قوائم التشغيل"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr ""
 
@@ -4211,7 +4227,7 @@ msgstr "أعد تسمية قائمة التشغيل"
 msgid "Rename playlist..."
 msgstr "أعد تسمية قائمة التشغيل"
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "أعد ترقيم المقاطع في هذا الترتيب..."
 
@@ -4302,7 +4318,7 @@ msgstr "نسخ"
 msgid "Rip CD"
 msgstr "قرص RIP"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr ""
 
@@ -4380,7 +4396,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "حفظ قائمة التشغيل"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "حفظ قائمة التشغيل..."
 
@@ -4467,7 +4483,7 @@ msgstr "بحث Subsonic"
 msgid "Search automatically"
 msgstr "ابحث تلقائيا"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4480,7 +4496,7 @@ msgstr "ابحث عن أغلفة الألبومات..."
 msgid "Search for anything"
 msgstr "ابحث عن أي شيء"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4605,7 +4621,7 @@ msgstr "معلومات الخادم"
 msgid "Service offline"
 msgstr "خدمة غير متصلة"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "غير %1 إلى %2"
@@ -4614,7 +4630,7 @@ msgstr "غير %1 إلى %2"
 msgid "Set the volume to <value> percent"
 msgstr "اجعل درجة الصوت بنسبة <value>"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "اجعل هذه القيمة لجميع المقاطع المختارة"
 
@@ -4685,7 +4701,7 @@ msgstr "أظهر تنبيهات كلمنتاين"
 msgid "Show above status bar"
 msgstr "أظهر فوق شريط الحالة"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "أظهر جميع المقاطع"
 
@@ -4705,12 +4721,12 @@ msgstr "أظهر الفواصل"
 msgid "Show fullsize..."
 msgstr "أظهر الحجم الأصلي..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "أظهر في متصفح الملفات..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "أظهر في المكتبة..."
 
@@ -4722,15 +4738,15 @@ msgstr "أظهر في فنانين متنوعين"
 msgid "Show moodbar"
 msgstr "أظهر عارضة المزاج"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "أظهر المقاطع المكررة فقط"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "أظهر المقطاع غير الموسومة فقط"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4738,7 +4754,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr "أظهر اقتراحات البحث"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4774,7 +4790,7 @@ msgstr "اخلط الألبومات"
 msgid "Shuffle all"
 msgstr "اخلط الكل"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "اخلط قائمة التشغيل"
 
@@ -4818,11 +4834,15 @@ msgstr "تخطى العد"
 msgid "Skip forwards in playlist"
 msgstr "تجاهل اللاحق في قائمة التشغيل"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "تجاوز المسارات المختارة"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "تجاوز المسار"
 
@@ -4939,7 +4959,7 @@ msgstr "ابدء النسخ"
 msgid "Start the playlist currently playing"
 msgstr "ابدأ قئمة التشغيل اللتي تعمل حالياً"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "ابدأ التحويل"
 
@@ -4949,7 +4969,7 @@ msgid ""
 "list"
 msgstr "ابدأ بكتابة شيء ما في خانة البحث أعلاه لملء هذه اللائحة من النتائج"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "بدأ %1"
@@ -4959,7 +4979,7 @@ msgid "Starting..."
 msgstr "بدأ..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "إيقاف"
 
@@ -4975,7 +4995,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "أوقف بعد هذا المقطع"
 
@@ -5143,7 +5163,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "لقد انتهت المدة التجريبية لخادم Subsonic. الرجاء التبرع للحصول على مفتاح رخصة. لمزيد من التفاصيل زر subsonic.org."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5185,7 +5205,7 @@ msgid ""
 "continue?"
 msgstr "سيتم حذف هذه الملفات من الجهاز. هل أنت متأكد من رغبتك بالاستمرار؟"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5287,11 +5307,11 @@ msgstr "بدّل تنبيهات كلمنتاين"
 msgid "Toggle fullscreen"
 msgstr "بدّل نمط ملء الشاشة"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "بدّل حالة لائحة الانتظار"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "بدّل حالة نقل المعلومات المستمع إليها"
 
@@ -5336,19 +5356,19 @@ msgstr ""
 msgid "Track"
 msgstr "المقطوعة"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "تحويل الصوتيات"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "سجل محول الصوتيات"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "تحويل الصوتيات"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "جاري تحويل %1 ملفات على %2 أشغال"
@@ -5425,11 +5445,11 @@ msgstr "خطأ مجهول"
 msgid "Unset cover"
 msgstr "ألغ الغلاف"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "إلغاء تجاوز المسارات المختارة"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "إلغاء تجاوز المسار"
 
@@ -5446,7 +5466,7 @@ msgstr "الحفلات القادمة"
 msgid "Update all podcasts"
 msgstr "حدّث جميع البودكاست"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "حدّث المجلدات التي تغيرت في المكتبة"
 
@@ -5607,7 +5627,7 @@ msgstr "النسخة %1"
 msgid "View"
 msgstr "عرض"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5615,7 +5635,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr "نمط التأثيرات المرئية"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "التأثيرات المرئية"
 
@@ -5656,7 +5676,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5752,7 +5772,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media audio"
 
@@ -5766,7 +5786,7 @@ msgid ""
 "well?"
 msgstr "هل ترغب بنقل المقاطع الأخرى في هذا الألبوم لفئة فنانون متنوعون؟"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "هل ترغب بالقيام بفحص شامل الآن؟"
 

--- a/src/translations/ar.po
+++ b/src/translations/ar.po
@@ -518,7 +518,7 @@ msgstr "إضافة Stream أخر"
 msgid "Add directory..."
 msgstr "أضف مجلد..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "أضف ملفا"
 
@@ -538,7 +538,7 @@ msgstr "أضافة ملف..."
 msgid "Add files to transcode"
 msgstr "أضف ملفات للتحويل"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "إضافة مجلد"
@@ -643,7 +643,7 @@ msgstr "إضافة لقائمات تشغيل Spotify"
 msgid "Add to Spotify starred"
 msgstr "إضافة للمميزة على Spotify"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "أضف إلى قائمة تشغيل أخرى"
 
@@ -865,7 +865,7 @@ msgstr "هل أنت متأكد من رغبتك بكتابة احصائيات ا�
 msgid "Artist"
 msgstr "الفنان"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "معلومات الفنان"
 
@@ -1128,7 +1128,7 @@ msgstr "التمس حلقات جديدة"
 msgid "Check for updates"
 msgstr "التمس التحديثات"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "التمس التحديثات"
 
@@ -1368,7 +1368,7 @@ msgstr "إعدادات Subsonic..."
 msgid "Configure global search..."
 msgstr "إعدادات البحث العامة..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "إعدادات المكتبة"
 
@@ -1440,11 +1440,11 @@ msgid "Copy to clipboard"
 msgstr "نسخ إلى المكتبة..."
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "نسخ إلى جهاز..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "نسخ إلى المكتبة..."
@@ -1662,7 +1662,7 @@ msgid "Delete downloaded data"
 msgstr "حذف البيانات المحملة"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "احذف الملفات"
 
@@ -1670,7 +1670,7 @@ msgstr "احذف الملفات"
 msgid "Delete from device..."
 msgstr "احذف من الجهاز"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "احذف من القرص..."
@@ -1703,11 +1703,11 @@ msgstr "حذف الملفات"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "أزل المختارة من لائحة الانتظار"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "أزل المقطع من لائحة الانتظار"
 
@@ -1736,7 +1736,7 @@ msgstr "اسم الجهاز"
 msgid "Device properties..."
 msgstr "خصائص الجهاز..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "أجهزة"
 
@@ -1987,7 +1987,7 @@ msgstr "مزج عشوائي تلقائيا"
 msgid "Edit smart playlist..."
 msgstr "حرر قائمة التشغيل الذكية"
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "حرر الوسم \"%1\""
@@ -2126,8 +2126,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "يكافئ --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "خطأ"
 
@@ -2273,7 +2273,7 @@ msgstr "تلاشي"
 msgid "Fading duration"
 msgstr "مدة التلاشي"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "فشل في قراءة القرص CD"
 
@@ -2396,7 +2396,7 @@ msgstr "نوع الملف"
 msgid "Filename"
 msgstr "اسم الملف"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "الملفات"
 
@@ -2811,7 +2811,7 @@ msgstr "مثبت"
 msgid "Integrity check"
 msgstr "فحص شامل"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "انترنت"
 
@@ -2999,7 +2999,7 @@ msgstr "يسار"
 msgid "Length"
 msgstr "المدة"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "المكتبة"
@@ -3008,7 +3008,7 @@ msgstr "المكتبة"
 msgid "Library advanced grouping"
 msgstr "إعدادات متقدمة لتجميع المكتبة"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "إشعار إعادة فحص المكتبة"
 
@@ -3336,7 +3336,7 @@ msgstr "نقط الوصل"
 msgid "Move down"
 msgstr "أسفل"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "انقل إلى المكتبة"
 
@@ -3345,7 +3345,7 @@ msgstr "انقل إلى المكتبة"
 msgid "Move up"
 msgstr "أعلى"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "موسيقى"
 
@@ -3407,7 +3407,7 @@ msgstr "لم يبدأ تشغيلها أبدا"
 msgid "New folder"
 msgstr "مجلد جديد"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "قائمة تشغيل جديدة"
 
@@ -3478,7 +3478,7 @@ msgstr "بدون أجزاء قصيرة"
 msgid "None"
 msgstr "لا شيء"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "لا مقطع من المقاطع المختارة مناسب لنسخه لجهاز."
 
@@ -3693,7 +3693,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "ترتيب الملفات"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "ترتيب الملفات..."
 
@@ -3777,7 +3777,7 @@ msgstr "حفلة"
 msgid "Password"
 msgstr "كلمة السر"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "إيقاف مؤقت"
@@ -3813,8 +3813,8 @@ msgstr "بكسل"
 msgid "Plain sidebar"
 msgstr "شريط جانبي عريض"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3837,11 +3837,11 @@ msgstr "شغل إذا انتهى، أوقف إذا كان قيد التشغيل"
 msgid "Play if there is nothing already playing"
 msgstr "شغل إذا لم يكن هناك مقطع قيد التشغيل "
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3880,7 +3880,7 @@ msgstr "خيارات قائمة التشغيل"
 msgid "Playlist type"
 msgstr "نوع قائمة التشغيل"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "قوائم التشغيل"
 
@@ -4062,12 +4062,12 @@ msgstr "الاستعلام عن الجهاز..."
 msgid "Queue Manager"
 msgstr "مدير لائحة الانتظار"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "أضف المختارة للائحة الانتظار"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "أضف للائحة الانتظار"
 
@@ -4458,7 +4458,7 @@ msgstr ""
 msgid "Search"
 msgstr "البحث"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "بحث"
@@ -4483,7 +4483,7 @@ msgstr "بحث Subsonic"
 msgid "Search automatically"
 msgstr "ابحث تلقائيا"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4496,7 +4496,7 @@ msgstr "ابحث عن أغلفة الألبومات..."
 msgid "Search for anything"
 msgstr "ابحث عن أي شيء"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4621,7 +4621,7 @@ msgstr "معلومات الخادم"
 msgid "Service offline"
 msgstr "خدمة غير متصلة"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "غير %1 إلى %2"
@@ -4701,7 +4701,7 @@ msgstr "أظهر تنبيهات كلمنتاين"
 msgid "Show above status bar"
 msgstr "أظهر فوق شريط الحالة"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "أظهر جميع المقاطع"
 
@@ -4721,12 +4721,12 @@ msgstr "أظهر الفواصل"
 msgid "Show fullsize..."
 msgstr "أظهر الحجم الأصلي..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "أظهر في متصفح الملفات..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "أظهر في المكتبة..."
 
@@ -4738,11 +4738,11 @@ msgstr "أظهر في فنانين متنوعين"
 msgid "Show moodbar"
 msgstr "أظهر عارضة المزاج"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "أظهر المقاطع المكررة فقط"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "أظهر المقطاع غير الموسومة فقط"
 
@@ -4834,7 +4834,7 @@ msgstr "تخطى العد"
 msgid "Skip forwards in playlist"
 msgstr "تجاهل اللاحق في قائمة التشغيل"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "تجاوز المسارات المختارة"
 
@@ -4842,7 +4842,7 @@ msgstr "تجاوز المسارات المختارة"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "تجاوز المسار"
 
@@ -4874,7 +4874,7 @@ msgstr "Soft Rock"
 msgid "Song Information"
 msgstr "معلومات المقطع"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "معلومات المقطع"
 
@@ -4995,7 +4995,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "أوقف بعد هذا المقطع"
 
@@ -5163,7 +5163,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "لقد انتهت المدة التجريبية لخادم Subsonic. الرجاء التبرع للحصول على مفتاح رخصة. لمزيد من التفاصيل زر subsonic.org."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5205,7 +5205,7 @@ msgid ""
 "continue?"
 msgstr "سيتم حذف هذه الملفات من الجهاز. هل أنت متأكد من رغبتك بالاستمرار؟"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5307,7 +5307,7 @@ msgstr "بدّل تنبيهات كلمنتاين"
 msgid "Toggle fullscreen"
 msgstr "بدّل نمط ملء الشاشة"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "بدّل حالة لائحة الانتظار"
 
@@ -5445,11 +5445,11 @@ msgstr "خطأ مجهول"
 msgid "Unset cover"
 msgstr "ألغ الغلاف"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "إلغاء تجاوز المسارات المختارة"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "إلغاء تجاوز المسار"
 
@@ -5786,7 +5786,7 @@ msgid ""
 "well?"
 msgstr "هل ترغب بنقل المقاطع الأخرى في هذا الألبوم لفئة فنانون متنوعون؟"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "هل ترغب بالقيام بفحص شامل الآن؟"
 

--- a/src/translations/be.po
+++ b/src/translations/be.po
@@ -11,7 +11,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Belarusian (http://www.transifex.com/davidsansome/clementine/language/be/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -165,19 +165,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n з памылкай"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n завершана"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -195,7 +195,7 @@ msgstr "Па &цэнтры"
 msgid "&Custom"
 msgstr "&Іншы"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "Пашырэньні"
 
@@ -203,7 +203,7 @@ msgstr "Пашырэньні"
 msgid "&Grouping"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Даведка"
 
@@ -228,7 +228,7 @@ msgstr ""
 msgid "&Lyrics"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "Музыка"
 
@@ -236,15 +236,15 @@ msgstr "Музыка"
 msgid "&None"
 msgstr "&Няма"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "Плэйліст"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Выйсьці"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "Рэжым паўтору"
 
@@ -252,7 +252,7 @@ msgstr "Рэжым паўтору"
 msgid "&Right"
 msgstr "&Справа"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Рэжым мяшаньня"
 
@@ -260,7 +260,7 @@ msgstr "Рэжым мяшаньня"
 msgid "&Stretch columns to fit window"
 msgstr "&Выраўнаць слупкі па памеры вакна"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Iнструмэнты"
 
@@ -449,11 +449,11 @@ msgstr "Адмена"
 msgid "About %1"
 msgstr "Пра %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Пра праграму Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Пра Qt..."
 
@@ -513,32 +513,32 @@ msgstr "Дадаць іншае струменевае  вяшчанне"
 msgid "Add directory..."
 msgstr "Дадаць каталёг"
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Дадаць файл"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Дадаць файл..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Дадаць файлы для перакадаваньня"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Дадаць каталёг"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Дадаць каталёг..."
 
@@ -550,7 +550,7 @@ msgstr "Дадаць новы каталёг..."
 msgid "Add podcast"
 msgstr "Дадаць подкаст"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Дадаць подкаст..."
 
@@ -626,7 +626,7 @@ msgstr "Дадаць тэг \"Нумар трэку\""
 msgid "Add song year tag"
 msgstr "Дадаць тэг \"Год\""
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Дадаць струмень..."
 
@@ -638,7 +638,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Дадаць у іншы плэйліст"
 
@@ -732,7 +732,7 @@ msgstr ""
 msgid "All Files (*)"
 msgstr "Усе файлы (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr ""
@@ -1123,7 +1123,7 @@ msgstr "Праверыць новыя выпускі"
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Праверыць абнаўленьні..."
 
@@ -1172,18 +1172,18 @@ msgstr "Клясычная"
 msgid "Cleaning up"
 msgstr "Ачыстка"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Ачысьціць"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Ачысьціць плэйліст"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1328,7 +1328,7 @@ msgstr "Камэнтар"
 msgid "Complete tags automatically"
 msgstr "Аўтаматычна запоўніць тэгі"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Аўтаматычна запоўніць тэгі..."
 
@@ -1363,7 +1363,7 @@ msgstr "Наладзіць Subsonic..."
 msgid "Configure global search..."
 msgstr "Наладзіць глябальны пошук..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Наладзіць калекцыю..."
 
@@ -1406,7 +1406,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr ""
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Кансоль"
 
@@ -1435,11 +1435,11 @@ msgid "Copy to clipboard"
 msgstr "Скапіяваць у буфэр"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Капіяваць на прыладу..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Капіяваць у калекцыю..."
@@ -1482,14 +1482,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Немагчыма знайсці мультыплексар для %1. Пераканайцеся, што ў вас усталяваныя неабходныя плагіны GStreamer."
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1504,7 +1504,7 @@ msgstr "Немагчыма адкрыць выходны файл %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Мэнэджэр вокладак"
 
@@ -1657,7 +1657,7 @@ msgid "Delete downloaded data"
 msgstr "Выдаліць спампаваныя дадзеныя"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Выдаліць файлы"
 
@@ -1665,7 +1665,7 @@ msgstr "Выдаліць файлы"
 msgid "Delete from device..."
 msgstr "Выдаліць з прылады"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Выдаліць з дыску..."
@@ -1698,11 +1698,11 @@ msgstr "Выдаленьне файлаў"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Прыбраць з чаргі абраныя трэкі"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Прыбраць трэк з чаргі "
 
@@ -1803,7 +1803,7 @@ msgstr "Налады адлюстраваньня"
 msgid "Display the on-screen-display"
 msgstr "Паказваць экраннае апавяшчэньне"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Перасканаваць бібліятэку"
 
@@ -1982,12 +1982,12 @@ msgstr "Выпадковы дынамічны мікс"
 msgid "Edit smart playlist..."
 msgstr "Рэдагаваць смарт-плэйліст"
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Рэдагаваць тэг..."
 
@@ -2000,7 +2000,7 @@ msgid "Edit track information"
 msgstr "Рэдагаваньне інфарамацыі аб кампазыцыі"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Рэдагаваць інфармацыю аб кампазыцыі..."
 
@@ -2108,7 +2108,7 @@ msgstr "Уся калекцыя"
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Эквалайзэр"
 
@@ -2121,8 +2121,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Аналягічна --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Памылка"
 
@@ -2157,7 +2157,7 @@ msgstr "Памылка загрузкі %1"
 msgid "Error loading di.fm playlist"
 msgstr "Памылка пры загрузке плэйлісту di.fm"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Памылка пры апрацоўке %1: %2"
@@ -2240,7 +2240,11 @@ msgstr "Экспартаваньне скончана"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "Экспартавана %1 вокладак(кі) з %2 (%3 прапушчана)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2264,7 +2268,7 @@ msgstr "Згасаньне"
 msgid "Fading duration"
 msgstr "Працягласьць згасаньня"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2546,11 +2550,11 @@ msgstr "Даць імя:"
 msgid "Go"
 msgstr "Перайсьці"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Перайсьці да наступнага сьпісу прайграваньня"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Перайсьці да папярэдняга сьпісу прайграваньня"
 
@@ -2883,7 +2887,7 @@ msgstr "База Jamendo"
 msgid "Jump to previous song right away"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Перайсьці да бягучага трэку"
 
@@ -2907,7 +2911,7 @@ msgstr "Працягваць працу ў фонавым рэжыме, калі
 msgid "Keep the original files"
 msgstr "Захаваць арыгінальныя файлы"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr ""
@@ -2999,7 +3003,7 @@ msgstr "Бібліятэка"
 msgid "Library advanced grouping"
 msgstr "Пашыраная сартоўка калекцыі"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Апавяшчэньне сканіраваньня бібліятэкі"
 
@@ -3039,7 +3043,7 @@ msgstr "Загрузіць вокладку з дыску..."
 msgid "Load playlist"
 msgstr "Загрузіць плэйліст"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Загрузіць плэйліст..."
 
@@ -3100,11 +3104,15 @@ msgstr "Уваход"
 msgid "Login failed"
 msgstr "Памылка ўваходу"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Профіль Long term prediction (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Упадабаць"
 
@@ -3139,11 +3147,11 @@ msgstr "Тэкст песьні з %1"
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr ""
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3185,7 +3193,7 @@ msgstr "Асноўны профіль (MAIN)"
 msgid "Make it so!"
 msgstr "Да будзе так!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr ""
@@ -3323,7 +3331,7 @@ msgstr "Пункты мантаваньня"
 msgid "Move down"
 msgstr "Перамясьціць долу"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Перамясьціць у бібліятэку"
 
@@ -3332,7 +3340,7 @@ msgstr "Перамясьціць у бібліятэку"
 msgid "Move up"
 msgstr "Перамясьціць вышэй"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Музыка"
 
@@ -3345,7 +3353,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Бязгучна"
 
@@ -3394,7 +3402,7 @@ msgstr "Ніколі не пачынаць прайграваць"
 msgid "New folder"
 msgstr "Новая тэчка"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Новы плэйліст"
 
@@ -3422,8 +3430,12 @@ msgstr "Новыя трэкі"
 msgid "Next"
 msgstr "Далей"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Наступны трэк"
 
@@ -3461,7 +3473,7 @@ msgstr "Без кароткіх блёкаў"
 msgid "None"
 msgstr "Нічога"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Ніводная з абраных песень ня будзе скапіяваная на прыладу"
 
@@ -3546,19 +3558,19 @@ msgstr ""
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3602,7 +3614,7 @@ msgstr "Непразрыстасьць"
 msgid "Open %1 in browser"
 msgstr "Адчыніць %1 у браўзэры"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Адкрыць аўдыё CD..."
 
@@ -3614,7 +3626,7 @@ msgstr "Адкрыць файл OPML"
 msgid "Open OPML file..."
 msgstr "Адкрыць файл OPML..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr ""
 
@@ -3622,7 +3634,7 @@ msgstr ""
 msgid "Open device"
 msgstr "Адкрыць прыладу"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Адкрыць файл..."
 
@@ -3676,7 +3688,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Упарадкаваць файлы"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Упарадкаваць файлы..."
 
@@ -3760,7 +3772,7 @@ msgstr "Party"
 msgid "Password"
 msgstr "Пароль"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Прыпыніць"
@@ -3784,6 +3796,10 @@ msgstr ""
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr ""
@@ -3792,10 +3808,10 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr "Нармальная бакавая панэль"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Прайграць"
 
@@ -3816,11 +3832,11 @@ msgstr "Прайграць калі спынена, прыпыніць калі 
 msgid "Play if there is nothing already playing"
 msgstr "Прайграць, калі яшчэ нічога не прайграваецца"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3919,7 +3935,7 @@ msgstr ""
 msgid "Preferences"
 msgstr "Налады"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Налады..."
 
@@ -3979,7 +3995,7 @@ msgid "Previous"
 msgstr "Папярэдні"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Папярэдні трэк"
 
@@ -4037,16 +4053,16 @@ msgstr ""
 msgid "Querying device..."
 msgstr "Апытваньне прылады..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Мэнэджэр Чаргі"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Дадаць абраныя трэкі ў чаргу"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Дадаць у чаргу"
 
@@ -4062,7 +4078,7 @@ msgstr "Радыё (аднолькавая гучнасьць для ўсіх т
 msgid "Rain"
 msgstr "Дождж"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr ""
@@ -4174,7 +4190,7 @@ msgstr "Выдаліць дзеяньне"
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Прыбраць паўторы з плэйлісту"
 
@@ -4182,7 +4198,7 @@ msgstr "Прыбраць паўторы з плэйлісту"
 msgid "Remove folder"
 msgstr "Прыбраць каталёг"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Прыбраць з плэйлісту"
 
@@ -4194,7 +4210,7 @@ msgstr ""
 msgid "Remove playlists"
 msgstr "Выдаліць плэйлісты"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr ""
 
@@ -4206,7 +4222,7 @@ msgstr "Пераназваць плэйліст"
 msgid "Rename playlist..."
 msgstr "Пераназваць плэйліст..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Перанумараваць трэкі ў такім парадку..."
 
@@ -4297,7 +4313,7 @@ msgstr ""
 msgid "Rip CD"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr ""
 
@@ -4375,7 +4391,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr ""
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Захаваць плэйліст..."
 
@@ -4462,7 +4478,7 @@ msgstr "Пошук "
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4475,7 +4491,7 @@ msgstr "Шукаць вокладкі альбомаў..."
 msgid "Search for anything"
 msgstr "Пошук усяго"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4600,7 +4616,7 @@ msgstr "Дэталі сэрвэру"
 msgid "Service offline"
 msgstr "Служба не працуе"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Усталяваць %1 у \"%2\"..."
@@ -4609,7 +4625,7 @@ msgstr "Усталяваць %1 у \"%2\"..."
 msgid "Set the volume to <value> percent"
 msgstr "Усталяваць гучнасьць у <value> адсоткаў"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Усталяваць значэньне для вызначаных трэкаў..."
 
@@ -4680,7 +4696,7 @@ msgstr "Паказваць OSD"
 msgid "Show above status bar"
 msgstr "Паказаць над радком стану"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Паказаць усе кампазыцыі"
 
@@ -4700,12 +4716,12 @@ msgstr "Паказваць падзяляльнікі"
 msgid "Show fullsize..."
 msgstr "Паказаць поўны памер..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Паказаць ў аглядчыку файлаў"
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr ""
 
@@ -4717,15 +4733,15 @@ msgstr "Паказаць ў \"Розных выканаўцах\""
 msgid "Show moodbar"
 msgstr "Паказаць панэль настрою"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Паказваць толькі дубляваныя"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Паказваць толькі бяз тэгаў"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4733,7 +4749,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr "Паказаць пошукавыя падказкі"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4769,7 +4785,7 @@ msgstr "Перамяшаць альбомы"
 msgid "Shuffle all"
 msgstr "Перамяшаць усё"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Перамяшаць плэйліст"
 
@@ -4813,11 +4829,15 @@ msgstr "Прапусьціць падлік"
 msgid "Skip forwards in playlist"
 msgstr "Перамясьціць наперад ў плэйлісьце"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr ""
 
@@ -4934,7 +4954,7 @@ msgstr ""
 msgid "Start the playlist currently playing"
 msgstr "Запусьціць бягучы плэйліст"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Пачаць перакадаваньне"
 
@@ -4944,7 +4964,7 @@ msgid ""
 "list"
 msgstr "Пачніце друкаваць штосьці ў пошукавым радку"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Запуск %1"
@@ -4954,7 +4974,7 @@ msgid "Starting..."
 msgstr "Запуск..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Спыніць"
 
@@ -4970,7 +4990,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Спыніць пасьля гэтага трэку"
 
@@ -5138,7 +5158,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Скончыўся пробны пэрыяд сэрвэру Subsonic. Калі ласка заплаціце каб атрымаць ліцэнзыйны ключ. Наведайце subsonic.org для падрабязнасьцяў."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5180,7 +5200,7 @@ msgid ""
 "continue?"
 msgstr "Гэтыя файлы будуць выдаленыя з прылады, вы дакладна жадаеце працягнуць?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5282,11 +5302,11 @@ msgstr "Уключыць"
 msgid "Toggle fullscreen"
 msgstr "Укл/Выкл поўнаэкранны рэжым"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Пераключыць стан чаргі"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Укл/Выкл скроблінг"
 
@@ -5331,19 +5351,19 @@ msgstr ""
 msgid "Track"
 msgstr "Трэк"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Перакадаваньне Музыкі"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Лог Перакадоўшчыку"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Перакадоўка"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Перакадавана %1 файлаў, выкарыстоўваючы %2 тэм"
@@ -5420,11 +5440,11 @@ msgstr "Невядомая памылка"
 msgid "Unset cover"
 msgstr "Выдаліць вокладку"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr ""
 
@@ -5441,7 +5461,7 @@ msgstr "Канцэрты, якія маюць адбыцца"
 msgid "Update all podcasts"
 msgstr "Абнавіць усе подкасты"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Абнавіць зьмененыя тэчкі бібліятэкі"
 
@@ -5602,7 +5622,7 @@ msgstr "Вэрсія %1"
 msgid "View"
 msgstr "Прагляд"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5610,7 +5630,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr "Рэжым візуалізацыі"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Візуалізацыі"
 
@@ -5651,7 +5671,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5747,7 +5767,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media audio"
 
@@ -5761,7 +5781,7 @@ msgid ""
 "well?"
 msgstr "Перасунуць іншыя песьні з гэтага альбому ў Розныя Выканаўцы?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Ці жадаеце запусьціць паўторнае сканіраваньне?"
 

--- a/src/translations/be.po
+++ b/src/translations/be.po
@@ -513,7 +513,7 @@ msgstr "Дадаць іншае струменевае  вяшчанне"
 msgid "Add directory..."
 msgstr "Дадаць каталёг"
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Дадаць файл"
 
@@ -533,7 +533,7 @@ msgstr "Дадаць файл..."
 msgid "Add files to transcode"
 msgstr "Дадаць файлы для перакадаваньня"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Дадаць каталёг"
@@ -638,7 +638,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Дадаць у іншы плэйліст"
 
@@ -860,7 +860,7 @@ msgstr ""
 msgid "Artist"
 msgstr "Выканаўца"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Пра Артыста"
 
@@ -1123,7 +1123,7 @@ msgstr "Праверыць новыя выпускі"
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Праверыць абнаўленьні..."
 
@@ -1363,7 +1363,7 @@ msgstr "Наладзіць Subsonic..."
 msgid "Configure global search..."
 msgstr "Наладзіць глябальны пошук..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Наладзіць калекцыю..."
 
@@ -1435,11 +1435,11 @@ msgid "Copy to clipboard"
 msgstr "Скапіяваць у буфэр"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Капіяваць на прыладу..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Капіяваць у калекцыю..."
@@ -1657,7 +1657,7 @@ msgid "Delete downloaded data"
 msgstr "Выдаліць спампаваныя дадзеныя"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Выдаліць файлы"
 
@@ -1665,7 +1665,7 @@ msgstr "Выдаліць файлы"
 msgid "Delete from device..."
 msgstr "Выдаліць з прылады"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Выдаліць з дыску..."
@@ -1698,11 +1698,11 @@ msgstr "Выдаленьне файлаў"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Прыбраць з чаргі абраныя трэкі"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Прыбраць трэк з чаргі "
 
@@ -1731,7 +1731,7 @@ msgstr "Імя прылады"
 msgid "Device properties..."
 msgstr "Уласьцівасьці прылады..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Прылады"
 
@@ -1982,7 +1982,7 @@ msgstr "Выпадковы дынамічны мікс"
 msgid "Edit smart playlist..."
 msgstr "Рэдагаваць смарт-плэйліст"
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
@@ -2121,8 +2121,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Аналягічна --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Памылка"
 
@@ -2268,7 +2268,7 @@ msgstr "Згасаньне"
 msgid "Fading duration"
 msgstr "Працягласьць згасаньня"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2391,7 +2391,7 @@ msgstr "Тып файлу"
 msgid "Filename"
 msgstr "Имя файлу"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Файлы"
 
@@ -2806,7 +2806,7 @@ msgstr "Усталявана"
 msgid "Integrity check"
 msgstr "Праверка цельнасьці"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Інтэрнэт"
 
@@ -2994,7 +2994,7 @@ msgstr "Левы"
 msgid "Length"
 msgstr "Працягласьць"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Бібліятэка"
@@ -3003,7 +3003,7 @@ msgstr "Бібліятэка"
 msgid "Library advanced grouping"
 msgstr "Пашыраная сартоўка калекцыі"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Апавяшчэньне сканіраваньня бібліятэкі"
 
@@ -3331,7 +3331,7 @@ msgstr "Пункты мантаваньня"
 msgid "Move down"
 msgstr "Перамясьціць долу"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Перамясьціць у бібліятэку"
 
@@ -3340,7 +3340,7 @@ msgstr "Перамясьціць у бібліятэку"
 msgid "Move up"
 msgstr "Перамясьціць вышэй"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Музыка"
 
@@ -3402,7 +3402,7 @@ msgstr "Ніколі не пачынаць прайграваць"
 msgid "New folder"
 msgstr "Новая тэчка"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Новы плэйліст"
 
@@ -3473,7 +3473,7 @@ msgstr "Без кароткіх блёкаў"
 msgid "None"
 msgstr "Нічога"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Ніводная з абраных песень ня будзе скапіяваная на прыладу"
 
@@ -3688,7 +3688,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Упарадкаваць файлы"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Упарадкаваць файлы..."
 
@@ -3772,7 +3772,7 @@ msgstr "Party"
 msgid "Password"
 msgstr "Пароль"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Прыпыніць"
@@ -3808,8 +3808,8 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr "Нармальная бакавая панэль"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3832,11 +3832,11 @@ msgstr "Прайграць калі спынена, прыпыніць калі 
 msgid "Play if there is nothing already playing"
 msgstr "Прайграць, калі яшчэ нічога не прайграваецца"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3875,7 +3875,7 @@ msgstr "Налады плэйлісту"
 msgid "Playlist type"
 msgstr "Тып плэйлісту"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Плэйлісты"
 
@@ -4057,12 +4057,12 @@ msgstr "Апытваньне прылады..."
 msgid "Queue Manager"
 msgstr "Мэнэджэр Чаргі"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Дадаць абраныя трэкі ў чаргу"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Дадаць у чаргу"
 
@@ -4453,7 +4453,7 @@ msgstr ""
 msgid "Search"
 msgstr "Пошук"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr ""
@@ -4478,7 +4478,7 @@ msgstr "Пошук "
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4491,7 +4491,7 @@ msgstr "Шукаць вокладкі альбомаў..."
 msgid "Search for anything"
 msgstr "Пошук усяго"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4616,7 +4616,7 @@ msgstr "Дэталі сэрвэру"
 msgid "Service offline"
 msgstr "Служба не працуе"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Усталяваць %1 у \"%2\"..."
@@ -4696,7 +4696,7 @@ msgstr "Паказваць OSD"
 msgid "Show above status bar"
 msgstr "Паказаць над радком стану"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Паказаць усе кампазыцыі"
 
@@ -4716,12 +4716,12 @@ msgstr "Паказваць падзяляльнікі"
 msgid "Show fullsize..."
 msgstr "Паказаць поўны памер..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Паказаць ў аглядчыку файлаў"
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr ""
 
@@ -4733,11 +4733,11 @@ msgstr "Паказаць ў \"Розных выканаўцах\""
 msgid "Show moodbar"
 msgstr "Паказаць панэль настрою"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Паказваць толькі дубляваныя"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Паказваць толькі бяз тэгаў"
 
@@ -4829,7 +4829,7 @@ msgstr "Прапусьціць падлік"
 msgid "Skip forwards in playlist"
 msgstr "Перамясьціць наперад ў плэйлісьце"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr ""
 
@@ -4837,7 +4837,7 @@ msgstr ""
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr ""
 
@@ -4869,7 +4869,7 @@ msgstr "Soft Rock"
 msgid "Song Information"
 msgstr "Інфармацыя аб кампазыцыі"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Пра Песьню"
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Спыніць пасьля гэтага трэку"
 
@@ -5158,7 +5158,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Скончыўся пробны пэрыяд сэрвэру Subsonic. Калі ласка заплаціце каб атрымаць ліцэнзыйны ключ. Наведайце subsonic.org для падрабязнасьцяў."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5200,7 +5200,7 @@ msgid ""
 "continue?"
 msgstr "Гэтыя файлы будуць выдаленыя з прылады, вы дакладна жадаеце працягнуць?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5302,7 +5302,7 @@ msgstr "Уключыць"
 msgid "Toggle fullscreen"
 msgstr "Укл/Выкл поўнаэкранны рэжым"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Пераключыць стан чаргі"
 
@@ -5440,11 +5440,11 @@ msgstr "Невядомая памылка"
 msgid "Unset cover"
 msgstr "Выдаліць вокладку"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr ""
 
@@ -5781,7 +5781,7 @@ msgid ""
 "well?"
 msgstr "Перасунуць іншыя песьні з гэтага альбому ў Розныя Выканаўцы?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Ці жадаеце запусьціць паўторнае сканіраваньне?"
 

--- a/src/translations/bg.po
+++ b/src/translations/bg.po
@@ -15,7 +15,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Bulgarian (http://www.transifex.com/davidsansome/clementine/language/bg/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -169,19 +169,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n неуспешно"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n завършено"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -199,7 +199,7 @@ msgstr "&Център"
 msgid "&Custom"
 msgstr "&Потребителски"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "Допълнения"
 
@@ -207,7 +207,7 @@ msgstr "Допълнения"
 msgid "&Grouping"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "Помо&щ"
 
@@ -232,7 +232,7 @@ msgstr ""
 msgid "&Lyrics"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "Музика"
 
@@ -240,15 +240,15 @@ msgstr "Музика"
 msgid "&None"
 msgstr "&Никакъв"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "Списък с песни"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Изход"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "Режим „Повторение“"
 
@@ -256,7 +256,7 @@ msgstr "Режим „Повторение“"
 msgid "&Right"
 msgstr "&Дясно"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Режим „Случаен ред“"
 
@@ -264,7 +264,7 @@ msgstr "Режим „Случаен ред“"
 msgid "&Stretch columns to fit window"
 msgstr "&Разтегли колоните да се вместят в прозореца"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Инструменти"
 
@@ -453,11 +453,11 @@ msgstr "Отхвърляне"
 msgid "About %1"
 msgstr "Относно %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Относно Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Относно QT..."
 
@@ -517,32 +517,32 @@ msgstr "Добавяне на друг поток..."
 msgid "Add directory..."
 msgstr "Добави папка..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Добавяне на файл"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Добавяне на файл към прекодера"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Добавяне на файл(ове) към прекодера"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Добавяне на файл..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Добавяне на файлове за прекодиране"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Добави папка"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Добави папка..."
 
@@ -554,7 +554,7 @@ msgstr "Добави нова папка..."
 msgid "Add podcast"
 msgstr "Добавя движещ се текст"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Добавяне на подкаст..."
 
@@ -630,7 +630,7 @@ msgstr "Добавяне на етикет за номер на песен"
 msgid "Add song year tag"
 msgstr "Добавяне на етикет за година на песен"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Добавяне на поток..."
 
@@ -642,7 +642,7 @@ msgstr "Добавяне към списъците с песни от Spotify"
 msgid "Add to Spotify starred"
 msgstr "Добавяне към оценените песни от Spotify"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Добави в друг списък с песни"
 
@@ -736,7 +736,7 @@ msgstr "Всички"
 msgid "All Files (*)"
 msgstr "Всички файлове (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Славният хипножабок!"
@@ -1127,7 +1127,7 @@ msgstr "Провери за нови епизоди"
 msgid "Check for updates"
 msgstr "Проверка за обновления"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Проверка за обновления..."
 
@@ -1176,18 +1176,18 @@ msgstr "Класически"
 msgid "Cleaning up"
 msgstr "Почистване"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Изчистване"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Изчистване на списъка с песни"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1332,7 +1332,7 @@ msgstr "Коментар"
 msgid "Complete tags automatically"
 msgstr "Автоматично довършване на етикетите"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Автоматично довършване на етикетите..."
 
@@ -1367,7 +1367,7 @@ msgstr "Конфигурация на Subsonic..."
 msgid "Configure global search..."
 msgstr "Конфигурирай глобално търсене"
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Настройване на библиотека..."
 
@@ -1410,7 +1410,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Връзката се забави прекалено, проверете URL адреса на съвъра. Например: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Конзола"
 
@@ -1439,11 +1439,11 @@ msgid "Copy to clipboard"
 msgstr "Копиране в буфера"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Копирай в устройство..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Копиране в библиотека..."
@@ -1486,14 +1486,14 @@ msgstr "Не можах да се свържа с Last.fm. Моля опитай
 msgid "Couldn't create playlist"
 msgstr "Не можах да създам списък с песни."
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Не мога да намеря миксер за %1, проверете дали имате инсталирани правилните GStreamer плъгини."
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1508,7 +1508,7 @@ msgstr "Не мога да отворя изходен файл %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Мениджър за обложки"
 
@@ -1661,7 +1661,7 @@ msgid "Delete downloaded data"
 msgstr "Изтрий свалените данни"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Изтриване на файлове"
 
@@ -1669,7 +1669,7 @@ msgstr "Изтриване на файлове"
 msgid "Delete from device..."
 msgstr "Изтриване от устройство"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Изтриване от диска..."
@@ -1702,11 +1702,11 @@ msgstr "Изтриване на файлове"
 msgid "Depth"
 msgstr "Дълбочина"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Махни от опашката избраните парчета"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Махни от опашката парчето"
 
@@ -1807,7 +1807,7 @@ msgstr "Настройки на показването"
 msgid "Display the on-screen-display"
 msgstr "Показване на екранно уведомление"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Пусни пълно повторно сканиране на библиотеката"
 
@@ -1986,12 +1986,12 @@ msgstr "Динамичен случаен микс"
 msgid "Edit smart playlist..."
 msgstr "Редактиране умен списък с песни..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Редактиране на етикет \"%1\"..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Редактиране на етикет..."
 
@@ -2004,7 +2004,7 @@ msgid "Edit track information"
 msgstr "Редактиране на информацията за песента"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Редактиране на информацията за песента..."
 
@@ -2112,7 +2112,7 @@ msgstr "Цялата колекция"
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Еквалайзер"
 
@@ -2125,8 +2125,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Еквивалентно на --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Грешка"
 
@@ -2161,7 +2161,7 @@ msgstr "Грешка при зареждане на %1"
 msgid "Error loading di.fm playlist"
 msgstr "Грешка при зареждане на di.fm списък с песни"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Грешка при обработване на %1: %2"
@@ -2244,7 +2244,11 @@ msgstr "Експортирането приключи"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "Експортирах %1 обложки от %2 (прескочих %3)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2268,7 +2272,7 @@ msgstr "Заглушаване"
 msgid "Fading duration"
 msgstr "Времетраене на заглушаването"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Не успях да прочета CD устройството"
 
@@ -2550,11 +2554,11 @@ msgstr "Въведете име:"
 msgid "Go"
 msgstr "Давай"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Отиване към подпрозореца със следващия списък с песни"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Отиване към подпрозореца с предишния списък с песни"
 
@@ -2887,7 +2891,7 @@ msgstr "Jamendo база от данни"
 msgid "Jump to previous song right away"
 msgstr "Премини към предната песен веднага"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Отиване до песента, изпълнявана в момента"
 
@@ -2911,7 +2915,7 @@ msgstr "Продължи ипзълнението и във фонов режи�
 msgid "Keep the original files"
 msgstr "Запази оригиналните файлове"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Котенца"
@@ -3003,7 +3007,7 @@ msgstr "Библиотека"
 msgid "Library advanced grouping"
 msgstr "Разширено групиране на Библиотеката"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Известие за повторно сканиране на библиотеката"
 
@@ -3043,7 +3047,7 @@ msgstr "Зареждане на обложката от диска..."
 msgid "Load playlist"
 msgstr "Зареждане на списък с песни"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Зареждане на списък с песни..."
 
@@ -3104,11 +3108,15 @@ msgstr "Влизане"
 msgid "Login failed"
 msgstr "Влизането не успя"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Long term prediction profile (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Любима"
 
@@ -3143,11 +3151,11 @@ msgstr "Текстове на песни от %1"
 msgid "Lyrics from the tag"
 msgstr "Текстове на песни от етикета"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3189,7 +3197,7 @@ msgstr "Main profile (MAIN)"
 msgid "Make it so!"
 msgstr "Направи го така!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Нека бъде!"
@@ -3327,7 +3335,7 @@ msgstr "Точки за монтиране"
 msgid "Move down"
 msgstr "Преместване надолу"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Преместване в библиотека..."
 
@@ -3336,7 +3344,7 @@ msgstr "Преместване в библиотека..."
 msgid "Move up"
 msgstr "Преместване нагоре"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Музика"
 
@@ -3349,7 +3357,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Без звук"
 
@@ -3398,7 +3406,7 @@ msgstr "Никога да не се пуска възпроизвежданет�
 msgid "New folder"
 msgstr "Нова папка"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Нов списък с песни"
 
@@ -3426,8 +3434,12 @@ msgstr "Най-нови парчета"
 msgid "Next"
 msgstr "Следваща"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Следваща песен"
 
@@ -3465,7 +3477,7 @@ msgstr "No short blocks"
 msgid "None"
 msgstr "Никаква"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Никоя от избраните песни бяха сподобни да бъдат копирани на устройството"
 
@@ -3550,19 +3562,19 @@ msgstr "Изключено"
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3606,7 +3618,7 @@ msgstr "Непрозрачност"
 msgid "Open %1 in browser"
 msgstr "Отвори %1 в браузъра"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Отваряне на &аудио CD..."
 
@@ -3618,7 +3630,7 @@ msgstr "Отваряне на OPML файл"
 msgid "Open OPML file..."
 msgstr "Отваряне на OPML файл..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Отваряне на папка за импортиране на музика"
 
@@ -3626,7 +3638,7 @@ msgstr "Отваряне на папка за импортиране на муз
 msgid "Open device"
 msgstr "Отворено устройство"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Отваряне на файл..."
 
@@ -3680,7 +3692,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Организиране на Файлове"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Организиране на файлове..."
 
@@ -3764,7 +3776,7 @@ msgstr "Парти"
 msgid "Password"
 msgstr "Парола"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Пауза"
@@ -3788,6 +3800,10 @@ msgstr "Изпълнител"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Пиксел"
@@ -3796,10 +3812,10 @@ msgstr "Пиксел"
 msgid "Plain sidebar"
 msgstr "Стандартна странична лента"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Възпроизвеждане"
 
@@ -3820,11 +3836,11 @@ msgstr "Продължаване ако е спряно и обратно"
 msgid "Play if there is nothing already playing"
 msgstr "Възпроизвеждане, ако има песен, която вече се изпълнява"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Пусни след това"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Пусни избраните песни след това"
 
@@ -3923,7 +3939,7 @@ msgstr "Настройка"
 msgid "Preferences"
 msgstr "Настройки"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Настройки..."
 
@@ -3983,7 +3999,7 @@ msgid "Previous"
 msgstr "Предишна"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Предишна песен"
 
@@ -4041,16 +4057,16 @@ msgstr "Качество"
 msgid "Querying device..."
 msgstr "Заявящо устойство..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Мениджър на опашката"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Пратете избраните песни на опашката"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Прати избрана песен на опашката"
 
@@ -4066,7 +4082,7 @@ msgstr "Радио (еднаква сила на звука за всички п
 msgid "Rain"
 msgstr "Дъжд"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Дъжд"
@@ -4178,7 +4194,7 @@ msgstr "Премахване на действието"
 msgid "Remove current song from playlist"
 msgstr "Премахни текущата песен от списъка"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Премахни дублиранията от плейлиста"
 
@@ -4186,7 +4202,7 @@ msgstr "Премахни дублиранията от плейлиста"
 msgid "Remove folder"
 msgstr "Премахни папката"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Премахване от списъка с песни"
 
@@ -4198,7 +4214,7 @@ msgstr "Премахване на списъка с песни"
 msgid "Remove playlists"
 msgstr "Премахване на списъци с песни"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Премахни недостъпни песни от плейлиста"
 
@@ -4210,7 +4226,7 @@ msgstr "Преименуване на списъка с песни"
 msgid "Rename playlist..."
 msgstr "Преименуване на списъка с песни..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Преномерирай песните в този ред..."
 
@@ -4301,7 +4317,7 @@ msgstr "Печене"
 msgid "Rip CD"
 msgstr "Печене на CD"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Печене на аудио CD"
 
@@ -4379,7 +4395,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Запазване на списъка с песни"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Запазване на списъка с песни..."
 
@@ -4466,7 +4482,7 @@ msgstr "Търсене в Subsonic"
 msgid "Search automatically"
 msgstr "Автоматично търсене"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Търси албум"
 
@@ -4479,7 +4495,7 @@ msgstr "Търси за обложки"
 msgid "Search for anything"
 msgstr "Търсене из всички"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Търси изпълнител"
 
@@ -4604,7 +4620,7 @@ msgstr "Подробности за сървъра"
 msgid "Service offline"
 msgstr "Услугата е недостъпна"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Задай %1 да е %2\"..."
@@ -4613,7 +4629,7 @@ msgstr "Задай %1 да е %2\"..."
 msgid "Set the volume to <value> percent"
 msgstr "Ниво на звука - <value> процента"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Избери стойност за всички песни"
 
@@ -4684,7 +4700,7 @@ msgstr "Показване на красиво OSD"
 msgid "Show above status bar"
 msgstr "Покажи над status bar-а"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Показвай всички песни"
 
@@ -4704,12 +4720,12 @@ msgstr "Показвай разделители"
 msgid "Show fullsize..."
 msgstr "Покажи в пълен размер..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Покажи във файловия мениджър..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Показване в библиотеката..."
 
@@ -4721,15 +4737,15 @@ msgstr "Показване в смесени изпълнители"
 msgid "Show moodbar"
 msgstr "Показване на лента по настроение"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Показвай само дубликати"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Показване само на неотбелязани"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Покажи или скрий страничната лента"
 
@@ -4737,7 +4753,7 @@ msgstr "Покажи или скрий страничната лента"
 msgid "Show search suggestions"
 msgstr "Покажи подсказвания при търсене"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Покажи страничната лента"
 
@@ -4773,7 +4789,7 @@ msgstr "Случаен ред на албуми"
 msgid "Shuffle all"
 msgstr "Случаен ред на изпълнение на всички"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Разбъркване на списъка с песни"
 
@@ -4817,11 +4833,15 @@ msgstr "Презключи броя"
 msgid "Skip forwards in playlist"
 msgstr "Прескачане напред в списъка с песни"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Прескачане на избраните песни"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Прескачане на песента"
 
@@ -4938,7 +4958,7 @@ msgstr "Започни печене"
 msgid "Start the playlist currently playing"
 msgstr "Стартиране на текущо възпроизвеждания списък с песни"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Начало на прекодирането"
 
@@ -4948,7 +4968,7 @@ msgid ""
 "list"
 msgstr "Започнете да пишете нещо в кутията за търсене отгоре, за да запълните списъка с резултати от търсенето"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Стартиране на %1"
@@ -4958,7 +4978,7 @@ msgid "Starting..."
 msgstr "Стартиране..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Спиране"
 
@@ -4974,7 +4994,7 @@ msgstr "Спирай след всяка песен"
 msgid "Stop after every track"
 msgstr "Спирай след всяка песен"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Спри след тази песен"
 
@@ -5142,7 +5162,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Пробния период на Subsonic сървъра изтече. Моля дайте дарение за да получите ключ за лиценз. Посетете subsonic.org за подробности."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5184,7 +5204,7 @@ msgid ""
 "continue?"
 msgstr "Тези файлове ще бъдат изтрити от устройството,сигурни ли сте че искате да продължите?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5286,11 +5306,11 @@ msgstr "Вкл./Изкл. на красиво екранно меню"
 msgid "Toggle fullscreen"
 msgstr "Превключване на пълен екран"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Покажи статус на опашката"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Включаване на скроблинга"
 
@@ -5335,19 +5355,19 @@ msgstr ""
 msgid "Track"
 msgstr "Песен"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Прекодирай музиката"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Журнал на прекодирането"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Прекодиране"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Прекодиране на %1 файлове чрез %2 начина"
@@ -5424,11 +5444,11 @@ msgstr "Неизвестна грешка"
 msgid "Unset cover"
 msgstr "Махни обложката"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Не прескачай избраните песни"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Не прескачай песента"
 
@@ -5445,7 +5465,7 @@ msgstr "Наближаващи концерти"
 msgid "Update all podcasts"
 msgstr "Обнови всички подкасти"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Обнови папките с промени в библиотеката"
 
@@ -5606,7 +5626,7 @@ msgstr "Версия %1"
 msgid "View"
 msgstr "Изглед"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Виж подробности за потока"
 
@@ -5614,7 +5634,7 @@ msgstr "Виж подробности за потока"
 msgid "Visualization mode"
 msgstr "Режим \"Визуализация\""
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Визуализации"
 
@@ -5655,7 +5675,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5751,7 +5771,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Аудио — Windows Media"
 
@@ -5765,7 +5785,7 @@ msgid ""
 "well?"
 msgstr "Искате ли да преместим другите песни от този албум в Различни изпълнители?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Искате ли да изпълните пълно повторно сканиране сега?"
 

--- a/src/translations/bg.po
+++ b/src/translations/bg.po
@@ -517,7 +517,7 @@ msgstr "Добавяне на друг поток..."
 msgid "Add directory..."
 msgstr "Добави папка..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Добавяне на файл"
 
@@ -537,7 +537,7 @@ msgstr "Добавяне на файл..."
 msgid "Add files to transcode"
 msgstr "Добавяне на файлове за прекодиране"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Добави папка"
@@ -642,7 +642,7 @@ msgstr "Добавяне към списъците с песни от Spotify"
 msgid "Add to Spotify starred"
 msgstr "Добавяне към оценените песни от Spotify"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Добави в друг списък с песни"
 
@@ -864,7 +864,7 @@ msgstr "Сигурни ли сте, че искате да запишете ст
 msgid "Artist"
 msgstr "Изпълнител"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Изпълнител"
 
@@ -1127,7 +1127,7 @@ msgstr "Провери за нови епизоди"
 msgid "Check for updates"
 msgstr "Проверка за обновления"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Проверка за обновления..."
 
@@ -1367,7 +1367,7 @@ msgstr "Конфигурация на Subsonic..."
 msgid "Configure global search..."
 msgstr "Конфигурирай глобално търсене"
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Настройване на библиотека..."
 
@@ -1439,11 +1439,11 @@ msgid "Copy to clipboard"
 msgstr "Копиране в буфера"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Копирай в устройство..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Копиране в библиотека..."
@@ -1661,7 +1661,7 @@ msgid "Delete downloaded data"
 msgstr "Изтрий свалените данни"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Изтриване на файлове"
 
@@ -1669,7 +1669,7 @@ msgstr "Изтриване на файлове"
 msgid "Delete from device..."
 msgstr "Изтриване от устройство"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Изтриване от диска..."
@@ -1702,11 +1702,11 @@ msgstr "Изтриване на файлове"
 msgid "Depth"
 msgstr "Дълбочина"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Махни от опашката избраните парчета"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Махни от опашката парчето"
 
@@ -1735,7 +1735,7 @@ msgstr "Име на устройство"
 msgid "Device properties..."
 msgstr "Свойства на устройство..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Устройства"
 
@@ -1986,7 +1986,7 @@ msgstr "Динамичен случаен микс"
 msgid "Edit smart playlist..."
 msgstr "Редактиране умен списък с песни..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Редактиране на етикет \"%1\"..."
@@ -2125,8 +2125,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Еквивалентно на --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Грешка"
 
@@ -2272,7 +2272,7 @@ msgstr "Заглушаване"
 msgid "Fading duration"
 msgstr "Времетраене на заглушаването"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Не успях да прочета CD устройството"
 
@@ -2395,7 +2395,7 @@ msgstr "Тип на файла"
 msgid "Filename"
 msgstr "Име на файл"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Файлове"
 
@@ -2810,7 +2810,7 @@ msgstr "Инсталирани"
 msgid "Integrity check"
 msgstr "Проверка на интегритета"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Интернет"
 
@@ -2998,7 +2998,7 @@ msgstr "Ляво"
 msgid "Length"
 msgstr "Дължина"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Библиотека"
@@ -3007,7 +3007,7 @@ msgstr "Библиотека"
 msgid "Library advanced grouping"
 msgstr "Разширено групиране на Библиотеката"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Известие за повторно сканиране на библиотеката"
 
@@ -3335,7 +3335,7 @@ msgstr "Точки за монтиране"
 msgid "Move down"
 msgstr "Преместване надолу"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Преместване в библиотека..."
 
@@ -3344,7 +3344,7 @@ msgstr "Преместване в библиотека..."
 msgid "Move up"
 msgstr "Преместване нагоре"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Музика"
 
@@ -3406,7 +3406,7 @@ msgstr "Никога да не се пуска възпроизвежданет�
 msgid "New folder"
 msgstr "Нова папка"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Нов списък с песни"
 
@@ -3477,7 +3477,7 @@ msgstr "No short blocks"
 msgid "None"
 msgstr "Никаква"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Никоя от избраните песни бяха сподобни да бъдат копирани на устройството"
 
@@ -3692,7 +3692,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Организиране на Файлове"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Организиране на файлове..."
 
@@ -3776,7 +3776,7 @@ msgstr "Парти"
 msgid "Password"
 msgstr "Парола"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Пауза"
@@ -3812,8 +3812,8 @@ msgstr "Пиксел"
 msgid "Plain sidebar"
 msgstr "Стандартна странична лента"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3836,11 +3836,11 @@ msgstr "Продължаване ако е спряно и обратно"
 msgid "Play if there is nothing already playing"
 msgstr "Възпроизвеждане, ако има песен, която вече се изпълнява"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Пусни след това"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Пусни избраните песни след това"
 
@@ -3879,7 +3879,7 @@ msgstr "Настройки на списъка с песни"
 msgid "Playlist type"
 msgstr "Тип на списъка с песни"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Списъци с песни"
 
@@ -4061,12 +4061,12 @@ msgstr "Заявящо устойство..."
 msgid "Queue Manager"
 msgstr "Мениджър на опашката"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Пратете избраните песни на опашката"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Прати избрана песен на опашката"
 
@@ -4457,7 +4457,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Търсене"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Търсене"
@@ -4482,7 +4482,7 @@ msgstr "Търсене в Subsonic"
 msgid "Search automatically"
 msgstr "Автоматично търсене"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Търси албум"
 
@@ -4495,7 +4495,7 @@ msgstr "Търси за обложки"
 msgid "Search for anything"
 msgstr "Търсене из всички"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Търси изпълнител"
 
@@ -4620,7 +4620,7 @@ msgstr "Подробности за сървъра"
 msgid "Service offline"
 msgstr "Услугата е недостъпна"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Задай %1 да е %2\"..."
@@ -4700,7 +4700,7 @@ msgstr "Показване на красиво OSD"
 msgid "Show above status bar"
 msgstr "Покажи над status bar-а"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Показвай всички песни"
 
@@ -4720,12 +4720,12 @@ msgstr "Показвай разделители"
 msgid "Show fullsize..."
 msgstr "Покажи в пълен размер..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Покажи във файловия мениджър..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Показване в библиотеката..."
 
@@ -4737,11 +4737,11 @@ msgstr "Показване в смесени изпълнители"
 msgid "Show moodbar"
 msgstr "Показване на лента по настроение"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Показвай само дубликати"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Показване само на неотбелязани"
 
@@ -4833,7 +4833,7 @@ msgstr "Презключи броя"
 msgid "Skip forwards in playlist"
 msgstr "Прескачане напред в списъка с песни"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Прескачане на избраните песни"
 
@@ -4841,7 +4841,7 @@ msgstr "Прескачане на избраните песни"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Прескачане на песента"
 
@@ -4873,7 +4873,7 @@ msgstr "Лек рок"
 msgid "Song Information"
 msgstr "Информация за песен"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Песен"
 
@@ -4994,7 +4994,7 @@ msgstr "Спирай след всяка песен"
 msgid "Stop after every track"
 msgstr "Спирай след всяка песен"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Спри след тази песен"
 
@@ -5162,7 +5162,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Пробния период на Subsonic сървъра изтече. Моля дайте дарение за да получите ключ за лиценз. Посетете subsonic.org за подробности."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5204,7 +5204,7 @@ msgid ""
 "continue?"
 msgstr "Тези файлове ще бъдат изтрити от устройството,сигурни ли сте че искате да продължите?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5306,7 +5306,7 @@ msgstr "Вкл./Изкл. на красиво екранно меню"
 msgid "Toggle fullscreen"
 msgstr "Превключване на пълен екран"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Покажи статус на опашката"
 
@@ -5444,11 +5444,11 @@ msgstr "Неизвестна грешка"
 msgid "Unset cover"
 msgstr "Махни обложката"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Не прескачай избраните песни"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Не прескачай песента"
 
@@ -5785,7 +5785,7 @@ msgid ""
 "well?"
 msgstr "Искате ли да преместим другите песни от този албум в Различни изпълнители?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Искате ли да изпълните пълно повторно сканиране сега?"
 

--- a/src/translations/bn.po
+++ b/src/translations/bn.po
@@ -9,7 +9,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Bengali (http://www.transifex.com/davidsansome/clementine/language/bn/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -163,19 +163,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n অসফল"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n সমাপ্ত"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -193,7 +193,7 @@ msgstr "&সেন্টার"
 msgid "&Custom"
 msgstr "&কাস্টম"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&অতিরিক্ত"
 
@@ -201,7 +201,7 @@ msgstr "&অতিরিক্ত"
 msgid "&Grouping"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&সহায়িকা"
 
@@ -226,7 +226,7 @@ msgstr ""
 msgid "&Lyrics"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr ""
 
@@ -234,15 +234,15 @@ msgstr ""
 msgid "&None"
 msgstr "কিছু &নয়"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "প্রস্থান করো"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "&Right"
 msgstr "ডানদিকে (&ড)"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr ""
 
@@ -258,7 +258,7 @@ msgstr ""
 msgid "&Stretch columns to fit window"
 msgstr "& সামঞ্জস্য পূর্ণ প্রসারণ - উইন্ডো অনুপাতে"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&সরঞ্জামসমূহ"
 
@@ -447,11 +447,11 @@ msgstr ""
 msgid "About %1"
 msgstr "%1-এর সম্বন্ধে"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "ক্লেমেন্টাইন সন্মন্ধে"
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "কিউ টি সন্মন্ধে"
 
@@ -511,32 +511,32 @@ msgstr "অন্য এক্ টি সঙ্গীত যোগ করুন"
 msgid "Add directory..."
 msgstr "ডাইরেকট রি যোগ করুন"
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "ফাইল যোগ করুন"
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "অনুবাদ এর জন্য ফাইল যোগ করুন"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "ফোল্ডার যোগ করুন"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "ফোল্ডার যুক্ত করুন..."
 
@@ -548,7 +548,7 @@ msgstr "এক টি নতুন ফোল্ডার যোগ করুন"
 msgid "Add podcast"
 msgstr ""
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr "সঙ্গীত এর ট্র্যাক ট্যাগ যু�
 msgid "Add song year tag"
 msgstr "সঙ্গীত এর প্রকাশ কাল ট্যাগ যুক্ত করুন"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "সঙ্গীত এর ধারা যুক্ত করুন"
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "অন্য প্লে লিস্ট যুক্ত করুন"
 
@@ -730,7 +730,7 @@ msgstr ""
 msgid "All Files (*)"
 msgstr "সব ফাইল (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr ""
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr ""
 
@@ -1170,18 +1170,18 @@ msgstr ""
 msgid "Cleaning up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr ""
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr ""
 
@@ -1326,7 +1326,7 @@ msgstr ""
 msgid "Complete tags automatically"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr ""
 
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr ""
 
@@ -1404,7 +1404,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr ""
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr ""
 
@@ -1433,11 +1433,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1480,14 +1480,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr ""
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1502,7 +1502,7 @@ msgstr "আউটপুট ফাইল %1 খোলা যায়নি"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "প্রচ্ছদ সংগঠক"
 
@@ -1655,7 +1655,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr ""
 
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1696,11 +1696,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr ""
 
@@ -1801,7 +1801,7 @@ msgstr ""
 msgid "Display the on-screen-display"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr ""
 
@@ -1980,12 +1980,12 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr ""
 
@@ -1998,7 +1998,7 @@ msgid "Edit track information"
 msgstr "গানের তথ্য পরিবর্তন"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "গানের তথ্য পরিবর্তন..."
 
@@ -2106,7 +2106,7 @@ msgstr ""
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr ""
 
@@ -2119,8 +2119,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr ""
 
@@ -2155,7 +2155,7 @@ msgstr ""
 msgid "Error loading di.fm playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr ""
@@ -2238,7 +2238,11 @@ msgstr ""
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr ""
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2262,7 +2266,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2544,11 +2548,11 @@ msgstr ""
 msgid "Go"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr ""
 
@@ -2881,7 +2885,7 @@ msgstr ""
 msgid "Jump to previous song right away"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr ""
 
@@ -2905,7 +2909,7 @@ msgstr "উইন্ডো বন্ধ করা হলেও পেছনে �
 msgid "Keep the original files"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr ""
@@ -2997,7 +3001,7 @@ msgstr ""
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3037,7 +3041,7 @@ msgstr ""
 msgid "Load playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr ""
 
@@ -3098,11 +3102,15 @@ msgstr ""
 msgid "Login failed"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr ""
 
@@ -3137,11 +3145,11 @@ msgstr ""
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr ""
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr ""
@@ -3183,7 +3191,7 @@ msgstr ""
 msgid "Make it so!"
 msgstr "তাই হোক!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr ""
@@ -3321,7 +3329,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3330,7 +3338,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "সঙ্গীত"
 
@@ -3343,7 +3351,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr ""
 
@@ -3392,7 +3400,7 @@ msgstr ""
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3420,8 +3428,12 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr ""
 
@@ -3459,7 +3471,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3544,19 +3556,19 @@ msgstr ""
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr ""
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr ""
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr ""
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3600,7 +3612,7 @@ msgstr ""
 msgid "Open %1 in browser"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr ""
 
@@ -3612,7 +3624,7 @@ msgstr ""
 msgid "Open OPML file..."
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr ""
 
@@ -3620,7 +3632,7 @@ msgstr ""
 msgid "Open device"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr ""
 
@@ -3674,7 +3686,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr ""
 
@@ -3758,7 +3770,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr ""
@@ -3782,6 +3794,10 @@ msgstr ""
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr ""
@@ -3790,10 +3806,10 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr ""
 
@@ -3814,11 +3830,11 @@ msgstr "যদি বন্ধ থাকে তবে চালাও, যদি
 msgid "Play if there is nothing already playing"
 msgstr "চালু কর যদি অন্য কিছু চালু না থাকে"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3917,7 +3933,7 @@ msgstr ""
 msgid "Preferences"
 msgstr "পছন্দসমূহ"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "পছন্দসমূহ..."
 
@@ -3977,7 +3993,7 @@ msgid "Previous"
 msgstr ""
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr ""
 
@@ -4035,16 +4051,16 @@ msgstr ""
 msgid "Querying device..."
 msgstr ""
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "ক্রম সংগঠক"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr ""
 
@@ -4060,7 +4076,7 @@ msgstr ""
 msgid "Rain"
 msgstr "বৃষ্টি"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr ""
@@ -4172,7 +4188,7 @@ msgstr ""
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr ""
 
@@ -4180,7 +4196,7 @@ msgstr ""
 msgid "Remove folder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr ""
 
@@ -4192,7 +4208,7 @@ msgstr ""
 msgid "Remove playlists"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr ""
 
@@ -4204,7 +4220,7 @@ msgstr ""
 msgid "Rename playlist..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr ""
 
@@ -4295,7 +4311,7 @@ msgstr ""
 msgid "Rip CD"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr ""
 
@@ -4373,7 +4389,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr ""
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr ""
 
@@ -4460,7 +4476,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4473,7 +4489,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4598,7 +4614,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4607,7 +4623,7 @@ msgstr ""
 msgid "Set the volume to <value> percent"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr ""
 
@@ -4678,7 +4694,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr ""
 
@@ -4698,12 +4714,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr ""
 
@@ -4715,15 +4731,15 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4731,7 +4747,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4767,7 +4783,7 @@ msgstr ""
 msgid "Shuffle all"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr ""
 
@@ -4811,11 +4827,15 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr ""
 
@@ -4932,7 +4952,7 @@ msgstr ""
 msgid "Start the playlist currently playing"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr ""
 
@@ -4942,7 +4962,7 @@ msgid ""
 "list"
 msgstr ""
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr ""
@@ -4952,7 +4972,7 @@ msgid "Starting..."
 msgstr ""
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr ""
 
@@ -4968,7 +4988,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5136,7 +5156,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5178,7 +5198,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5280,11 +5300,11 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr ""
 
@@ -5329,19 +5349,19 @@ msgstr ""
 msgid "Track"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr ""
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
 msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr ""
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr ""
@@ -5418,11 +5438,11 @@ msgstr ""
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr ""
 
@@ -5439,7 +5459,7 @@ msgstr ""
 msgid "Update all podcasts"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr ""
 
@@ -5600,7 +5620,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5608,7 +5628,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr ""
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr ""
 
@@ -5649,7 +5669,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr ""
 
@@ -5745,7 +5765,7 @@ msgstr ""
 msgid "Windows Media 64k"
 msgstr ""
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr ""
 
@@ -5759,7 +5779,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/bn.po
+++ b/src/translations/bn.po
@@ -511,7 +511,7 @@ msgstr "অন্য এক্ টি সঙ্গীত যোগ করুন"
 msgid "Add directory..."
 msgstr "ডাইরেকট রি যোগ করুন"
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr ""
 
@@ -531,7 +531,7 @@ msgstr "ফাইল যোগ করুন"
 msgid "Add files to transcode"
 msgstr "অনুবাদ এর জন্য ফাইল যোগ করুন"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "ফোল্ডার যোগ করুন"
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "অন্য প্লে লিস্ট যুক্ত করুন"
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Artist"
 msgstr "শিল্পী"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "শিল্পী সম্পকিত তথ্য"
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr ""
 
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr ""
 
@@ -1433,11 +1433,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1655,7 +1655,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr ""
 
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1696,11 +1696,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr ""
 
@@ -1729,7 +1729,7 @@ msgstr ""
 msgid "Device properties..."
 msgstr ""
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr ""
 
@@ -1980,7 +1980,7 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
@@ -2119,8 +2119,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr ""
 
@@ -2266,7 +2266,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2389,7 +2389,7 @@ msgstr ""
 msgid "Filename"
 msgstr ""
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr ""
 
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "Integrity check"
 msgstr ""
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr ""
 
@@ -2992,7 +2992,7 @@ msgstr ""
 msgid "Length"
 msgstr "দৈর্ঘ্য"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr ""
@@ -3001,7 +3001,7 @@ msgstr ""
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3329,7 +3329,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3338,7 +3338,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "সঙ্গীত"
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3471,7 +3471,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3686,7 +3686,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr ""
 
@@ -3770,7 +3770,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr ""
@@ -3806,8 +3806,8 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3830,11 +3830,11 @@ msgstr "যদি বন্ধ থাকে তবে চালাও, যদি
 msgid "Play if there is nothing already playing"
 msgstr "চালু কর যদি অন্য কিছু চালু না থাকে"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3873,7 +3873,7 @@ msgstr ""
 msgid "Playlist type"
 msgstr ""
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr ""
 
@@ -4055,12 +4055,12 @@ msgstr ""
 msgid "Queue Manager"
 msgstr "ক্রম সংগঠক"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr ""
 
@@ -4451,7 +4451,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr ""
@@ -4476,7 +4476,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4489,7 +4489,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4614,7 +4614,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4694,7 +4694,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr ""
 
@@ -4714,12 +4714,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr ""
 
@@ -4731,11 +4731,11 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr ""
 
@@ -4835,7 +4835,7 @@ msgstr ""
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr ""
 
@@ -4867,7 +4867,7 @@ msgstr ""
 msgid "Song Information"
 msgstr "গানের তথ্য"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "গানের তথ্য"
 
@@ -4988,7 +4988,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5156,7 +5156,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5198,7 +5198,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5300,7 +5300,7 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr ""
 
@@ -5438,11 +5438,11 @@ msgstr ""
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr ""
 
@@ -5779,7 +5779,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/br.po
+++ b/src/translations/br.po
@@ -516,7 +516,7 @@ msgstr "Ouzhpennañ ul lanv all..."
 msgid "Add directory..."
 msgstr "Ouzhpennañ un teuliad..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Ouzhpennañ ur restr"
 
@@ -536,7 +536,7 @@ msgstr "Ouzhpennañ ur restr..."
 msgid "Add files to transcode"
 msgstr "Ouzhpennañ restroù da"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Ouzhpennañ un teuliad"
@@ -641,7 +641,7 @@ msgstr "Ouzhpennañ d'am rolloù-seniñ Spotify"
 msgid "Add to Spotify starred"
 msgstr "Ouzhpennañ da tonioù karetañ Spotify"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Ouzhpennañ d'ur roll seniñ all"
 
@@ -863,7 +863,7 @@ msgstr "Ha sur oc'h da gaout c'hoant enrollañ an stadegoù an ton e-barzh restr
 msgid "Artist"
 msgstr "Arzour"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Arzour"
 
@@ -1126,7 +1126,7 @@ msgstr "Klask pennadoù nevez"
 msgid "Check for updates"
 msgstr "Gwiriekaat an hizivadennoù"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Klask hizivadurioù..."
 
@@ -1366,7 +1366,7 @@ msgstr "Kefluniañ Subsonic..."
 msgid "Configure global search..."
 msgstr "Kefluniañ an enklsak hollek..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Kefluniañ ar sonaoueg..."
 
@@ -1438,11 +1438,11 @@ msgid "Copy to clipboard"
 msgstr "Kopiañ d'ar golver"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopiañ war an drobarzhell"
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Eilañ er sonaoueg..."
@@ -1660,7 +1660,7 @@ msgid "Delete downloaded data"
 msgstr "Diverkañ ar roadennoù pellgarget"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Diverkañ restroù"
 
@@ -1668,7 +1668,7 @@ msgstr "Diverkañ restroù"
 msgid "Delete from device..."
 msgstr "Diverkañ eus an drobarzhell"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Diverkañ eus ar bladenn"
@@ -1701,11 +1701,11 @@ msgstr "O tiverkañ restroù"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Dilemel ar roudoù diuzet diwar al listenn c'hortoz"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Dilemel ar roud-mañ diwar al listenn c'hortoz"
 
@@ -1734,7 +1734,7 @@ msgstr "Anv an drobarzhell"
 msgid "Device properties..."
 msgstr "Oerzhioù an drobarzhell..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Trevnadoù"
 
@@ -1985,7 +1985,7 @@ msgstr "Meskaj dargouezhek dialuskel"
 msgid "Edit smart playlist..."
 msgstr "Kemmañ ar roll seniñ speredek..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Cheñch an tag \"%1\"..."
@@ -2124,8 +2124,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Kenkoulz a --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Fazi"
 
@@ -2271,7 +2271,7 @@ msgstr "Arveuz"
 msgid "Fading duration"
 msgstr "Padelezh an arveuz"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Kudenn en ul lenn ar CD"
 
@@ -2394,7 +2394,7 @@ msgstr "Stumm ar restr"
 msgid "Filename"
 msgstr "Anv ar restr"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Restroù"
 
@@ -2809,7 +2809,7 @@ msgstr "Staliaet"
 msgid "Integrity check"
 msgstr "O gwiriañ an anterinder"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -2997,7 +2997,7 @@ msgstr "Kleiz"
 msgid "Length"
 msgstr "Padelezh"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Sonaoueg"
@@ -3006,7 +3006,7 @@ msgstr "Sonaoueg"
 msgid "Library advanced grouping"
 msgstr "Strolladur ar sonaoueg kempleshoc'h"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Kemenn hizivadur ar sonaoueg"
 
@@ -3334,7 +3334,7 @@ msgstr "Poentoù staliañ"
 msgid "Move down"
 msgstr "Dindan"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Dilec'hiañ davet ar sonaoueg..."
 
@@ -3343,7 +3343,7 @@ msgstr "Dilec'hiañ davet ar sonaoueg..."
 msgid "Move up"
 msgstr "A-us"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Sonerezh"
 
@@ -3405,7 +3405,7 @@ msgstr "Morse kregiñ da lenn"
 msgid "New folder"
 msgstr "Teuliad nevez"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Roll seniñ nevez"
 
@@ -3476,7 +3476,7 @@ msgstr "Bloc'h berr ebet"
 msgid "None"
 msgstr "Hini ebet"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Ton ebet eus ar reoù diuzet a oa mat evit bezañ kopiet war an drobarzhell"
 
@@ -3691,7 +3691,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Aozañ ar restroù"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Aozañ ar restroù..."
 
@@ -3775,7 +3775,7 @@ msgstr "Fest"
 msgid "Password"
 msgstr "Ger-tremen"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Ehan"
@@ -3811,8 +3811,8 @@ msgstr "Piksel"
 msgid "Plain sidebar"
 msgstr "Bareen gostez simpl"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3835,11 +3835,11 @@ msgstr "Lenn pe ehan, hervez ar stad"
 msgid "Play if there is nothing already playing"
 msgstr "Lenn ma vez netra all o vezañ lennet"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3878,7 +3878,7 @@ msgstr "Dibarzhioù ar roll seniñ"
 msgid "Playlist type"
 msgstr "Doare ar roll seniñ"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Rolloù seniñ"
 
@@ -4060,12 +4060,12 @@ msgstr "Goulennadeg trobarzhell"
 msgid "Queue Manager"
 msgstr "Merour listenn c'hortoz"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Lakaat ar roudoù da heul"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Lakaat ar roud da heul"
 
@@ -4456,7 +4456,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Klask"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Klask"
@@ -4481,7 +4481,7 @@ msgstr "Klask Subsonic"
 msgid "Search automatically"
 msgstr "Klask ent emgefreek"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4494,7 +4494,7 @@ msgstr "Klask goloioù albom..."
 msgid "Search for anything"
 msgstr "Klask pep tra"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4619,7 +4619,7 @@ msgstr "Munudoù an dafariad"
 msgid "Service offline"
 msgstr "Servij ezlinenn"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Termeniñ %1 d'an talvoud %2..."
@@ -4699,7 +4699,7 @@ msgstr "Diskouez un OSD brav"
 msgid "Show above status bar"
 msgstr "Diskouez a-us d'ar varenn stad"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Diskouez an holl tonioù"
 
@@ -4719,12 +4719,12 @@ msgstr "Diskouez an dispartierien"
 msgid "Show fullsize..."
 msgstr "Diskouez er ment gwirion..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Diskouez er merdeer retroù"
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Diskouez er sonaoueg"
 
@@ -4736,11 +4736,11 @@ msgstr "Diskouez e \"Arzourien Liesseurt\""
 msgid "Show moodbar"
 msgstr "Diskouez ar varenn imor"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Diskouez an doublennoù nemetken"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Diskouez an tonioù hep klav nemetken"
 
@@ -4832,7 +4832,7 @@ msgstr "Konter tonioù lammet"
 msgid "Skip forwards in playlist"
 msgstr "Mont dirak er roll seniñ"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Tremen ar roudoù diuzet"
 
@@ -4840,7 +4840,7 @@ msgstr "Tremen ar roudoù diuzet"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Tremen ar roud"
 
@@ -4872,7 +4872,7 @@ msgstr "Soft Rock"
 msgid "Song Information"
 msgstr "Titouroù an ton"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Ton"
 
@@ -4993,7 +4993,7 @@ msgstr "Paouez goude pep roudenn"
 msgid "Stop after every track"
 msgstr "Paouez goude pep roudenn"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Paouez goude ar roud-mañ"
 
@@ -5161,7 +5161,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Ar mare amprouiñ evit an dafariad Subsonic a zo echuet. Roit arc'hant evit kaout un alc'hwez lañvaz mar plij. Kit war subsonic.org evit ar munudoù."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5203,7 +5203,7 @@ msgid ""
 "continue?"
 msgstr "Ar restroù-mañ a vo diverket eus an drobarzhell, sur oc'h da gaout c'hoant kenderc'hel ?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5305,7 +5305,7 @@ msgstr "Gweredekaat/Diweredekaat an OSD brav"
 msgid "Toggle fullscreen"
 msgstr "Tremen e skramm leun"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Cheñch stad al listenn c'hortoz"
 
@@ -5443,11 +5443,11 @@ msgstr "Kudenn dianav"
 msgid "Unset cover"
 msgstr "Ar golo n'eo ket bet lakaet"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Nullañ tremen ar roudoù diuzet"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Nullañ tremen ar roud"
 
@@ -5784,7 +5784,7 @@ msgid ""
 "well?"
 msgstr "Ha c'hoant ho peus lakaat tonioù all an albom-mañ e Arzourien Liesseurt ?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "C'hoant ho peus d'ober ur c'hwilervadenn eus al levraoueg bremañ ?"
 

--- a/src/translations/br.po
+++ b/src/translations/br.po
@@ -14,7 +14,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Breton (http://www.transifex.com/davidsansome/clementine/language/br/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -168,19 +168,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n c'hwitet"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n echuet"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -198,7 +198,7 @@ msgstr "E K&reiz"
 msgid "&Custom"
 msgstr "&Personelaat"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Ouzhpenn"
 
@@ -206,7 +206,7 @@ msgstr "&Ouzhpenn"
 msgid "&Grouping"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Skoazell"
 
@@ -231,7 +231,7 @@ msgstr "Notenn &prennañ"
 msgid "&Lyrics"
 msgstr "&Komzoù"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Sonerezh"
 
@@ -239,15 +239,15 @@ msgstr "&Sonerezh"
 msgid "&None"
 msgstr "&Hini ebet"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&Roll Seniñ"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Kuitaat"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "Doare &adlenn"
 
@@ -255,7 +255,7 @@ msgstr "Doare &adlenn"
 msgid "&Right"
 msgstr "&Dehou"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Doare &meskañ"
 
@@ -263,7 +263,7 @@ msgstr "Doare &meskañ"
 msgid "&Stretch columns to fit window"
 msgstr "&Astenn ar bannoù evit klotañ gant ar prenestr"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Ostilhoù"
 
@@ -452,11 +452,11 @@ msgstr "Dilezel"
 msgid "About %1"
 msgstr "A-zivout %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "A-zivout Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "A-zivout Qt..."
 
@@ -516,32 +516,32 @@ msgstr "Ouzhpennañ ul lanv all..."
 msgid "Add directory..."
 msgstr "Ouzhpennañ un teuliad..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Ouzhpennañ ur restr"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Ouzhpennañ ur restr d'an treuzkemmer"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Ouzhpennañ ur restr pe muioc'h d'an treuzkemmer"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Ouzhpennañ ur restr..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Ouzhpennañ restroù da"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Ouzhpennañ un teuliad"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Ouzhpennañ un teuliad..."
 
@@ -553,7 +553,7 @@ msgstr "Ouzhpennañ un teuliad nevez..."
 msgid "Add podcast"
 msgstr "Ouzhpennañ ar podkast"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Ouzhpennañ ur podkast..."
 
@@ -629,7 +629,7 @@ msgstr "Ouzhpennañ klav niverenn an ton"
 msgid "Add song year tag"
 msgstr "Ouzhpennañ klav bloavezh an ton"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Ouzhpennan ul lanv..."
 
@@ -641,7 +641,7 @@ msgstr "Ouzhpennañ d'am rolloù-seniñ Spotify"
 msgid "Add to Spotify starred"
 msgstr "Ouzhpennañ da tonioù karetañ Spotify"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Ouzhpennañ d'ur roll seniñ all"
 
@@ -735,7 +735,7 @@ msgstr "Pep tra"
 msgid "All Files (*)"
 msgstr "Holl restroù (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "All Glory to the Hypnotoad!"
@@ -1126,7 +1126,7 @@ msgstr "Klask pennadoù nevez"
 msgid "Check for updates"
 msgstr "Gwiriekaat an hizivadennoù"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Klask hizivadurioù..."
 
@@ -1175,18 +1175,18 @@ msgstr "Klasel"
 msgid "Cleaning up"
 msgstr "O naetaat"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Goullonderiñ"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Skarzhañ ar roll seniñ"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1331,7 +1331,7 @@ msgstr "Evezhiadenn"
 msgid "Complete tags automatically"
 msgstr "Leuniañ ar c'hlavioù ent emgefreek"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Leuniañ ar c'hlavioù ent emgefreek..."
 
@@ -1366,7 +1366,7 @@ msgstr "Kefluniañ Subsonic..."
 msgid "Configure global search..."
 msgstr "Kefluniañ an enklsak hollek..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Kefluniañ ar sonaoueg..."
 
@@ -1409,7 +1409,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Ar c'hennask a lak re a amzer, gwiriekait URL an dafariad. Skouer : http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Letrin"
 
@@ -1438,11 +1438,11 @@ msgid "Copy to clipboard"
 msgstr "Kopiañ d'ar golver"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopiañ war an drobarzhell"
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Eilañ er sonaoueg..."
@@ -1485,14 +1485,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr "N'eus ket bet tu krouiñ ar roll-seniñ"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Dibosupl eo kavout ur multiplekser evit %1, gwiriekait ez eo staliet an enlugelladoù a-zere evit GStreamer"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1507,7 +1507,7 @@ msgstr "Dibosubl eo digeriñ ar restr ec'hankañ %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Merour ar godeligoù"
 
@@ -1660,7 +1660,7 @@ msgid "Delete downloaded data"
 msgstr "Diverkañ ar roadennoù pellgarget"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Diverkañ restroù"
 
@@ -1668,7 +1668,7 @@ msgstr "Diverkañ restroù"
 msgid "Delete from device..."
 msgstr "Diverkañ eus an drobarzhell"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Diverkañ eus ar bladenn"
@@ -1701,11 +1701,11 @@ msgstr "O tiverkañ restroù"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Dilemel ar roudoù diuzet diwar al listenn c'hortoz"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Dilemel ar roud-mañ diwar al listenn c'hortoz"
 
@@ -1806,7 +1806,7 @@ msgstr "Dibarzhioù ar skrammañ"
 msgid "Display the on-screen-display"
 msgstr "Diskouez ar roll war ar skramm"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Ober un adc'hwilervadur eus ar sonaoueg a-bezh"
 
@@ -1985,12 +1985,12 @@ msgstr "Meskaj dargouezhek dialuskel"
 msgid "Edit smart playlist..."
 msgstr "Kemmañ ar roll seniñ speredek..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Cheñch an tag \"%1\"..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Cheñch ar c'hlav..."
 
@@ -2003,7 +2003,7 @@ msgid "Edit track information"
 msgstr "Cheñch deskrivadur ar roud"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Cheñch deskrivadur ar roud..."
 
@@ -2111,7 +2111,7 @@ msgstr "Dastumadeg hollek"
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Kevataler"
 
@@ -2124,8 +2124,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Kenkoulz a --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Fazi"
 
@@ -2160,7 +2160,7 @@ msgstr "Ur gudenn a zo savet e-pad kargadur %1"
 msgid "Error loading di.fm playlist"
 msgstr "Kudenn o kargañ roll seniñ di.fm"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Ur gudenn a zo savet e-pad treterezh %1 : %2"
@@ -2243,7 +2243,11 @@ msgstr "Ezporzhiadur echuet"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "Ezporzhiet %1 golo war %2 (%3 tremenet)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2267,7 +2271,7 @@ msgstr "Arveuz"
 msgid "Fading duration"
 msgstr "Padelezh an arveuz"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Kudenn en ul lenn ar CD"
 
@@ -2549,11 +2553,11 @@ msgstr "Reiñ un anv:"
 msgid "Go"
 msgstr "Go"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Mont d'ar roll seniñ o tont"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Mont d'ar roll seniñ a-raok"
 
@@ -2886,7 +2890,7 @@ msgstr "Stlennvon Jamendo"
 msgid "Jump to previous song right away"
 msgstr "Lammat diouzhtu d'an ton a-raok"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Mont d'ar roud lennet bremañ"
 
@@ -2910,7 +2914,7 @@ msgstr "Leuskel da dreiñ pa 'z eo serret ar prenstr"
 msgid "Keep the original files"
 msgstr "Dec'hel ar restroù orin"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Bisig"
@@ -3002,7 +3006,7 @@ msgstr "Sonaoueg"
 msgid "Library advanced grouping"
 msgstr "Strolladur ar sonaoueg kempleshoc'h"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Kemenn hizivadur ar sonaoueg"
 
@@ -3042,7 +3046,7 @@ msgstr "Kargañ ar golo adalek ur bladenn..."
 msgid "Load playlist"
 msgstr "Kargañ ar roll seniñ"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Kargañ ar roll seniñ..."
 
@@ -3103,11 +3107,15 @@ msgstr "Kennaskañ"
 msgid "Login failed"
 msgstr "C'hwitet eo bet ar c'hennaskañ"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Aelad Diougan Padus (ADP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Karout"
 
@@ -3142,11 +3150,11 @@ msgstr "Komzoù eus %1"
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3188,7 +3196,7 @@ msgstr "Aelad pennañ (MAIN)"
 msgid "Make it so!"
 msgstr "Ober evel-se !"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Gra an dra-mañ !"
@@ -3326,7 +3334,7 @@ msgstr "Poentoù staliañ"
 msgid "Move down"
 msgstr "Dindan"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Dilec'hiañ davet ar sonaoueg..."
 
@@ -3335,7 +3343,7 @@ msgstr "Dilec'hiañ davet ar sonaoueg..."
 msgid "Move up"
 msgstr "A-us"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Sonerezh"
 
@@ -3348,7 +3356,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Mut"
 
@@ -3397,7 +3405,7 @@ msgstr "Morse kregiñ da lenn"
 msgid "New folder"
 msgstr "Teuliad nevez"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Roll seniñ nevez"
 
@@ -3425,8 +3433,12 @@ msgstr "Roudoù nevesañ"
 msgid "Next"
 msgstr "Da-heul"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Roud o tont"
 
@@ -3464,7 +3476,7 @@ msgstr "Bloc'h berr ebet"
 msgid "None"
 msgstr "Hini ebet"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Ton ebet eus ar reoù diuzet a oa mat evit bezañ kopiet war an drobarzhell"
 
@@ -3549,19 +3561,19 @@ msgstr "Off"
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3605,7 +3617,7 @@ msgstr "Demerez"
 msgid "Open %1 in browser"
 msgstr "Digeriñ %1 er merdeer"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Lenn ur CD &audio"
 
@@ -3617,7 +3629,7 @@ msgstr "Digeriñ ur restr OPML"
 msgid "Open OPML file..."
 msgstr "Digeriñ ur restr OPML..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Digeriñ ur c'havlec'h evit enporzhiañ ar sonerezh dioutañ"
 
@@ -3625,7 +3637,7 @@ msgstr "Digeriñ ur c'havlec'h evit enporzhiañ ar sonerezh dioutañ"
 msgid "Open device"
 msgstr "Digeriñ an drobarzhell"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Digeriñ ur restr..."
 
@@ -3679,7 +3691,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Aozañ ar restroù"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Aozañ ar restroù..."
 
@@ -3763,7 +3775,7 @@ msgstr "Fest"
 msgid "Password"
 msgstr "Ger-tremen"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Ehan"
@@ -3787,6 +3799,10 @@ msgstr "Soner"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Piksel"
@@ -3795,10 +3811,10 @@ msgstr "Piksel"
 msgid "Plain sidebar"
 msgstr "Bareen gostez simpl"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Lenn"
 
@@ -3819,11 +3835,11 @@ msgstr "Lenn pe ehan, hervez ar stad"
 msgid "Play if there is nothing already playing"
 msgstr "Lenn ma vez netra all o vezañ lennet"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3922,7 +3938,7 @@ msgstr "Gwellvezioù"
 msgid "Preferences"
 msgstr "Gwellvezioù"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Gwellvezioù..."
 
@@ -3982,7 +3998,7 @@ msgid "Previous"
 msgstr "A-raok"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Roud a-raok"
 
@@ -4040,16 +4056,16 @@ msgstr "Perzhded"
 msgid "Querying device..."
 msgstr "Goulennadeg trobarzhell"
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Merour listenn c'hortoz"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Lakaat ar roudoù da heul"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Lakaat ar roud da heul"
 
@@ -4065,7 +4081,7 @@ msgstr "Skingomz (Ampled kevatal evit an holl roudoù)"
 msgid "Rain"
 msgstr "Glav"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Glav"
@@ -4177,7 +4193,7 @@ msgstr "Tennañ an oberiadenn"
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Tennañ an tonioù doubl eus ar roll seniñ"
 
@@ -4185,7 +4201,7 @@ msgstr "Tennañ an tonioù doubl eus ar roll seniñ"
 msgid "Remove folder"
 msgstr "Tennañ an teuliad"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Tennañ kuit eus ar roll seniñ"
 
@@ -4197,7 +4213,7 @@ msgstr "Tennañ ar roll seniñ"
 msgid "Remove playlists"
 msgstr "Tennañ ar rolloù seniñ"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Tennañ an tonioù dihegerz eus ar roll-seniñ"
 
@@ -4209,7 +4225,7 @@ msgstr "Adenvel ar roll seniñ"
 msgid "Rename playlist..."
 msgstr "Adenvel ar roll seniñ..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Adniverenniñ ar roudoù en urzh-mañ..."
 
@@ -4300,7 +4316,7 @@ msgstr "Eztennañ"
 msgid "Rip CD"
 msgstr "Eztennañ ar bladenn"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Eztennañ ar bladenn aodio"
 
@@ -4378,7 +4394,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Enrollañ ar roll seniñ"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Enrollañ ar roll seniñ..."
 
@@ -4465,7 +4481,7 @@ msgstr "Klask Subsonic"
 msgid "Search automatically"
 msgstr "Klask ent emgefreek"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4478,7 +4494,7 @@ msgstr "Klask goloioù albom..."
 msgid "Search for anything"
 msgstr "Klask pep tra"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4603,7 +4619,7 @@ msgstr "Munudoù an dafariad"
 msgid "Service offline"
 msgstr "Servij ezlinenn"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Termeniñ %1 d'an talvoud %2..."
@@ -4612,7 +4628,7 @@ msgstr "Termeniñ %1 d'an talvoud %2..."
 msgid "Set the volume to <value> percent"
 msgstr "Termeniñ an ampled da <value> dre gant"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Lakaat un talvoud evit an holll roudoù diuzet"
 
@@ -4683,7 +4699,7 @@ msgstr "Diskouez un OSD brav"
 msgid "Show above status bar"
 msgstr "Diskouez a-us d'ar varenn stad"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Diskouez an holl tonioù"
 
@@ -4703,12 +4719,12 @@ msgstr "Diskouez an dispartierien"
 msgid "Show fullsize..."
 msgstr "Diskouez er ment gwirion..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Diskouez er merdeer retroù"
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Diskouez er sonaoueg"
 
@@ -4720,15 +4736,15 @@ msgstr "Diskouez e \"Arzourien Liesseurt\""
 msgid "Show moodbar"
 msgstr "Diskouez ar varenn imor"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Diskouez an doublennoù nemetken"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Diskouez an tonioù hep klav nemetken"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4736,7 +4752,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr "Diskouez alioù enklask."
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4772,7 +4788,7 @@ msgstr "Meskañ an albomoù"
 msgid "Shuffle all"
 msgstr "Meskañ an holl"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Meskañ ar roll seniñ"
 
@@ -4816,11 +4832,15 @@ msgstr "Konter tonioù lammet"
 msgid "Skip forwards in playlist"
 msgstr "Mont dirak er roll seniñ"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Tremen ar roudoù diuzet"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Tremen ar roud"
 
@@ -4937,7 +4957,7 @@ msgstr "Kregiñ gant an eztennadenn"
 msgid "Start the playlist currently playing"
 msgstr "Kregiñ ar roll seniñ"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Kregin an transkodiñ"
 
@@ -4947,7 +4967,7 @@ msgid ""
 "list"
 msgstr "Krogit da skrivañ un dra bennak er boest enklask a-us evit leuniañ listenn an disoc'hoù."
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "O kregiñ %1"
@@ -4957,7 +4977,7 @@ msgid "Starting..."
 msgstr "O kregiñ..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Paouez"
 
@@ -4973,7 +4993,7 @@ msgstr "Paouez goude pep roudenn"
 msgid "Stop after every track"
 msgstr "Paouez goude pep roudenn"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Paouez goude ar roud-mañ"
 
@@ -5141,7 +5161,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Ar mare amprouiñ evit an dafariad Subsonic a zo echuet. Roit arc'hant evit kaout un alc'hwez lañvaz mar plij. Kit war subsonic.org evit ar munudoù."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5183,7 +5203,7 @@ msgid ""
 "continue?"
 msgstr "Ar restroù-mañ a vo diverket eus an drobarzhell, sur oc'h da gaout c'hoant kenderc'hel ?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5285,11 +5305,11 @@ msgstr "Gweredekaat/Diweredekaat an OSD brav"
 msgid "Toggle fullscreen"
 msgstr "Tremen e skramm leun"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Cheñch stad al listenn c'hortoz"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Cheñch ar scrobbling"
 
@@ -5334,19 +5354,19 @@ msgstr ""
 msgid "Track"
 msgstr "Roud"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Treuzkodañ Sonerezh"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Renabl an transkoder"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Transkodiñ"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "O transkodiñ %1 restr oc'h implij %2 threads"
@@ -5423,11 +5443,11 @@ msgstr "Kudenn dianav"
 msgid "Unset cover"
 msgstr "Ar golo n'eo ket bet lakaet"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Nullañ tremen ar roudoù diuzet"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Nullañ tremen ar roud"
 
@@ -5444,7 +5464,7 @@ msgstr "Sonadegoù o-tont"
 msgid "Update all podcasts"
 msgstr "Hizivaat ar podkastoù"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Hizivaat teuliadoù kemmet ar sonaoueg"
 
@@ -5605,7 +5625,7 @@ msgstr "Handelv %1"
 msgid "View"
 msgstr "Gwelout"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5613,7 +5633,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr "Doare heweladur"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Heweladurioù"
 
@@ -5654,7 +5674,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5750,7 +5770,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "ausio Windows Media"
 
@@ -5764,7 +5784,7 @@ msgid ""
 "well?"
 msgstr "Ha c'hoant ho peus lakaat tonioù all an albom-mañ e Arzourien Liesseurt ?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "C'hoant ho peus d'ober ur c'hwilervadenn eus al levraoueg bremañ ?"
 

--- a/src/translations/bs.po
+++ b/src/translations/bs.po
@@ -510,7 +510,7 @@ msgstr "Dodaj još jedan tok..."
 msgid "Add directory..."
 msgstr "Dodaj fasciklu..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr ""
 
@@ -530,7 +530,7 @@ msgstr "Dodaj datoteku..."
 msgid "Add files to transcode"
 msgstr "Dodaj datoteke za pretvorbu"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Dodaj fasciklu"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Dodaj drugoj listi pjesama"
 
@@ -857,7 +857,7 @@ msgstr ""
 msgid "Artist"
 msgstr "Izvođač"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Informacije o izvođaču"
 
@@ -1120,7 +1120,7 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Provjeri za nadogradnje..."
 
@@ -1360,7 +1360,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Podesi biblioteku..."
 
@@ -1432,11 +1432,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopiraj na uređaj..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kopiraj u biblioteku..."
@@ -1654,7 +1654,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Obriši datoteke"
 
@@ -1662,7 +1662,7 @@ msgstr "Obriši datoteke"
 msgid "Delete from device..."
 msgstr "Obriši sa uređaja"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Obriši sa diska..."
@@ -1695,11 +1695,11 @@ msgstr "Brišem datoteke"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Makni sa liste čekanja označene pjesme"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Makni sa liste čekanja označenu pjesmu"
 
@@ -1728,7 +1728,7 @@ msgstr "Ime uređaja"
 msgid "Device properties..."
 msgstr "Osobine uređaja..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Uređaji"
 
@@ -1979,7 +1979,7 @@ msgstr "Dinamični nasumični miks"
 msgid "Edit smart playlist..."
 msgstr "Uredi pametnu listu..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
@@ -2118,8 +2118,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Ekvivalentno --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Greška"
 
@@ -2265,7 +2265,7 @@ msgstr "Izbljeđivanje"
 msgid "Fading duration"
 msgstr "Tok izbljeđivanja"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2388,7 +2388,7 @@ msgstr "Vrsta datoteke"
 msgid "Filename"
 msgstr "Naziv datoteke"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Datoteke"
 
@@ -2803,7 +2803,7 @@ msgstr "Instalirano"
 msgid "Integrity check"
 msgstr ""
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -2991,7 +2991,7 @@ msgstr ""
 msgid "Length"
 msgstr "Dužina"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Biblioteka"
@@ -3000,7 +3000,7 @@ msgstr "Biblioteka"
 msgid "Library advanced grouping"
 msgstr "Napredno grupiranje u biblioteci"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Obavijest o ponovnom skeniranju biblioteke"
 
@@ -3328,7 +3328,7 @@ msgstr "Montiraj točke"
 msgid "Move down"
 msgstr "Prebaci dole"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Prebaci u biblioteku..."
 
@@ -3337,7 +3337,7 @@ msgstr "Prebaci u biblioteku..."
 msgid "Move up"
 msgstr "Prebaci gore"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr ""
 
@@ -3399,7 +3399,7 @@ msgstr "Nikad ne započni pokretati"
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nova playlista"
 
@@ -3470,7 +3470,7 @@ msgstr "Bez kratkih blokova"
 msgid "None"
 msgstr "Ništa"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Nijedna od odabranih pjesama nije bila prikladna za kopiranje na uređaj"
 
@@ -3685,7 +3685,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr "Organizuj Datoteke"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Organizuj datoteke..."
 
@@ -3769,7 +3769,7 @@ msgstr "Zabava"
 msgid "Password"
 msgstr "Šifra"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pauza"
@@ -3805,8 +3805,8 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr "Obična bočna traka"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3829,11 +3829,11 @@ msgstr "Pokreni ako je zaustavljeno, pauziraj ako je pokrenuto"
 msgid "Play if there is nothing already playing"
 msgstr "Pokreni ako ništa već nije pokrenuto"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3872,7 +3872,7 @@ msgstr "Opcije za Playlistu"
 msgid "Playlist type"
 msgstr "Vrsta Playliste"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr ""
 
@@ -4054,12 +4054,12 @@ msgstr "Ispituje se uređaj..."
 msgid "Queue Manager"
 msgstr "Menadžer za red čekanja"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Stavi odabrane pjesme u red čekanja"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Stavi pjesmu u red čekanja"
 
@@ -4450,7 +4450,7 @@ msgstr ""
 msgid "Search"
 msgstr "Traži"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr ""
@@ -4475,7 +4475,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4488,7 +4488,7 @@ msgstr "Traži za okvire za albume..."
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4613,7 +4613,7 @@ msgstr ""
 msgid "Service offline"
 msgstr "Usluga trenutno nije dostupna"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Namjesti %1 na \"%2\"..."
@@ -4693,7 +4693,7 @@ msgstr "Pokaži lijepi OSD"
 msgid "Show above status bar"
 msgstr "Pokaži iznad status bara"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Pokaži sve pjesme"
 
@@ -4713,12 +4713,12 @@ msgstr "Pokaži razdjelnike"
 msgid "Show fullsize..."
 msgstr "Pokaži punu veličinu..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Pokaži u pretražniku za datoteke"
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr ""
 
@@ -4730,11 +4730,11 @@ msgstr "Pokaži u raznim izvođačima"
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Pokaži samo duplikate"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Pokaži samo necitirane"
 
@@ -4826,7 +4826,7 @@ msgstr "Broj preskakanja"
 msgid "Skip forwards in playlist"
 msgstr "Preskoči unaprijed u playlisti"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr ""
 
@@ -4834,7 +4834,7 @@ msgstr ""
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr ""
 
@@ -4866,7 +4866,7 @@ msgstr "Mekani Rock"
 msgid "Song Information"
 msgstr "Informacija o Pjesmi"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Informacija pjesme"
 
@@ -4987,7 +4987,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Zaustavi nakon ovog snimka"
 
@@ -5155,7 +5155,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5197,7 +5197,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5299,7 +5299,7 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr ""
 
@@ -5437,11 +5437,11 @@ msgstr ""
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr ""
 
@@ -5778,7 +5778,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/bs.po
+++ b/src/translations/bs.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Bosnian (http://www.transifex.com/davidsansome/clementine/language/bs/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -162,19 +162,19 @@ msgstr ""
 msgid "%filename%"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n neuspjelo"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n završeno"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -192,7 +192,7 @@ msgstr "&Sredina"
 msgid "&Custom"
 msgstr "&Vlastito"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr ""
 
@@ -200,7 +200,7 @@ msgstr ""
 msgid "&Grouping"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Pomoć"
 
@@ -225,7 +225,7 @@ msgstr ""
 msgid "&Lyrics"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr ""
 
@@ -233,15 +233,15 @@ msgstr ""
 msgid "&None"
 msgstr "&Nijedan"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Izlaz"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr ""
 
@@ -249,7 +249,7 @@ msgstr ""
 msgid "&Right"
 msgstr "&Desno"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr ""
 
@@ -257,7 +257,7 @@ msgstr ""
 msgid "&Stretch columns to fit window"
 msgstr "&Razvuci red da odgovara veličini prozora"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Alati"
 
@@ -446,11 +446,11 @@ msgstr ""
 msgid "About %1"
 msgstr "O %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "O Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "O Qt-u..."
 
@@ -510,32 +510,32 @@ msgstr "Dodaj još jedan tok..."
 msgid "Add directory..."
 msgstr "Dodaj fasciklu..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Dodaj datoteku..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Dodaj datoteke za pretvorbu"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Dodaj fasciklu"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Dodaj fasciklu..."
 
@@ -547,7 +547,7 @@ msgstr "Dodaj novu fasciklu..."
 msgid "Add podcast"
 msgstr ""
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr ""
 
@@ -623,7 +623,7 @@ msgstr "Dodajte oznaku same pjesme"
 msgid "Add song year tag"
 msgstr "Dodajte oznaku godine pjesme"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Dodaj tok..."
 
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Dodaj drugoj listi pjesama"
 
@@ -729,7 +729,7 @@ msgstr ""
 msgid "All Files (*)"
 msgstr "Sve datoteke (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr ""
@@ -1120,7 +1120,7 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Provjeri za nadogradnje..."
 
@@ -1169,18 +1169,18 @@ msgstr "Klasična"
 msgid "Cleaning up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Čisto"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Isprazni listu pjesama"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1325,7 +1325,7 @@ msgstr "Komentar"
 msgid "Complete tags automatically"
 msgstr "Automatski završi oznake"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Automatski završi oznake..."
 
@@ -1360,7 +1360,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Podesi biblioteku..."
 
@@ -1403,7 +1403,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr ""
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr ""
 
@@ -1432,11 +1432,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopiraj na uređaj..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kopiraj u biblioteku..."
@@ -1479,14 +1479,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Nemoguće pronaći muxer za %1, provjerite da li imate sve potrebne GStreamer dodatke instalirane."
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1501,7 +1501,7 @@ msgstr "Nemoguće otvoriti izlaznu datoteku %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Menadžer omota"
 
@@ -1654,7 +1654,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Obriši datoteke"
 
@@ -1662,7 +1662,7 @@ msgstr "Obriši datoteke"
 msgid "Delete from device..."
 msgstr "Obriši sa uređaja"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Obriši sa diska..."
@@ -1695,11 +1695,11 @@ msgstr "Brišem datoteke"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Makni sa liste čekanja označene pjesme"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Makni sa liste čekanja označenu pjesmu"
 
@@ -1800,7 +1800,7 @@ msgstr "Opcije prikazivanje"
 msgid "Display the on-screen-display"
 msgstr "Prikaži prikaz na ekranu"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Uradi ponovni pregled biblioteke"
 
@@ -1979,12 +1979,12 @@ msgstr "Dinamični nasumični miks"
 msgid "Edit smart playlist..."
 msgstr "Uredi pametnu listu..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Uredi oznaku..."
 
@@ -1997,7 +1997,7 @@ msgid "Edit track information"
 msgstr "Uredi informaciju pjesme"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Uredi informaciju pjesme..."
 
@@ -2105,7 +2105,7 @@ msgstr "Cijela kolekcija"
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Ekvilajzer/Ujednačajnik"
 
@@ -2118,8 +2118,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Ekvivalentno --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Greška"
 
@@ -2154,7 +2154,7 @@ msgstr "Pogreška prilikom učitavanja %1"
 msgid "Error loading di.fm playlist"
 msgstr "Pogreška prilikom učitavanja di.fm playliste"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Pogreška prilikom prerade %1: %2"
@@ -2237,7 +2237,11 @@ msgstr ""
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr ""
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2261,7 +2265,7 @@ msgstr "Izbljeđivanje"
 msgid "Fading duration"
 msgstr "Tok izbljeđivanja"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2543,11 +2547,11 @@ msgstr "Dadni mu ime:"
 msgid "Go"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Idite na sljedeću karticu playlistih"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Idite na prošlu karticu playlistih"
 
@@ -2880,7 +2884,7 @@ msgstr "Jamendo baza podataka"
 msgid "Jump to previous song right away"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Skočite na trenutno pokrenutu pjesmu"
 
@@ -2904,7 +2908,7 @@ msgstr "Nek se dalje pokreće u pozadini kad je prozor zatvoren"
 msgid "Keep the original files"
 msgstr "Čuvajte originalne datoteke"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr ""
@@ -2996,7 +3000,7 @@ msgstr "Biblioteka"
 msgid "Library advanced grouping"
 msgstr "Napredno grupiranje u biblioteci"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Obavijest o ponovnom skeniranju biblioteke"
 
@@ -3036,7 +3040,7 @@ msgstr "Učitaj okvir sa računara..."
 msgid "Load playlist"
 msgstr "Učitaj playlistu"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Učitaj playlistu..."
 
@@ -3097,11 +3101,15 @@ msgstr "Upis"
 msgid "Login failed"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Profil za dugotrajno predviđanje (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Ljubav"
 
@@ -3136,11 +3144,11 @@ msgstr "Lirike od %1"
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr ""
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3182,7 +3190,7 @@ msgstr "Glavni profil (GLAVNI)"
 msgid "Make it so!"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr ""
@@ -3320,7 +3328,7 @@ msgstr "Montiraj točke"
 msgid "Move down"
 msgstr "Prebaci dole"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Prebaci u biblioteku..."
 
@@ -3329,7 +3337,7 @@ msgstr "Prebaci u biblioteku..."
 msgid "Move up"
 msgstr "Prebaci gore"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr ""
 
@@ -3342,7 +3350,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Bez zvuka"
 
@@ -3391,7 +3399,7 @@ msgstr "Nikad ne započni pokretati"
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nova playlista"
 
@@ -3419,8 +3427,12 @@ msgstr "Najnoviji snimci"
 msgid "Next"
 msgstr "Sljedeće"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Sljedeći snimak"
 
@@ -3458,7 +3470,7 @@ msgstr "Bez kratkih blokova"
 msgid "None"
 msgstr "Ništa"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Nijedna od odabranih pjesama nije bila prikladna za kopiranje na uređaj"
 
@@ -3543,19 +3555,19 @@ msgstr ""
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr ""
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3599,7 +3611,7 @@ msgstr ""
 msgid "Open %1 in browser"
 msgstr "Otvori %1 u pretraživaču"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Otvori &audio CD..."
 
@@ -3611,7 +3623,7 @@ msgstr ""
 msgid "Open OPML file..."
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr ""
 
@@ -3619,7 +3631,7 @@ msgstr ""
 msgid "Open device"
 msgstr "Otvori uređaj"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr ""
 
@@ -3673,7 +3685,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr "Organizuj Datoteke"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Organizuj datoteke..."
 
@@ -3757,7 +3769,7 @@ msgstr "Zabava"
 msgid "Password"
 msgstr "Šifra"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pauza"
@@ -3781,6 +3793,10 @@ msgstr ""
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr ""
@@ -3789,10 +3805,10 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr "Obična bočna traka"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Pokreni"
 
@@ -3813,11 +3829,11 @@ msgstr "Pokreni ako je zaustavljeno, pauziraj ako je pokrenuto"
 msgid "Play if there is nothing already playing"
 msgstr "Pokreni ako ništa već nije pokrenuto"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3916,7 +3932,7 @@ msgstr ""
 msgid "Preferences"
 msgstr "Povlašćanja"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Povlašćanja..."
 
@@ -3976,7 +3992,7 @@ msgid "Previous"
 msgstr "Prošla"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Prošli snimak"
 
@@ -4034,16 +4050,16 @@ msgstr ""
 msgid "Querying device..."
 msgstr "Ispituje se uređaj..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Menadžer za red čekanja"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Stavi odabrane pjesme u red čekanja"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Stavi pjesmu u red čekanja"
 
@@ -4059,7 +4075,7 @@ msgstr "Radio (jednaka glasnoča za sve snimke)"
 msgid "Rain"
 msgstr "Kiša"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr ""
@@ -4171,7 +4187,7 @@ msgstr "Skloni radnju"
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr ""
 
@@ -4179,7 +4195,7 @@ msgstr ""
 msgid "Remove folder"
 msgstr "Skloni fasciklu"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Skloni iz playliste"
 
@@ -4191,7 +4207,7 @@ msgstr ""
 msgid "Remove playlists"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr ""
 
@@ -4203,7 +4219,7 @@ msgstr "Daj playlisti novo ime"
 msgid "Rename playlist..."
 msgstr "Daj playlisti novo ime..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Prebroji snimke u ovom redu..."
 
@@ -4294,7 +4310,7 @@ msgstr ""
 msgid "Rip CD"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr ""
 
@@ -4372,7 +4388,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr ""
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Spasi playlistu..."
 
@@ -4459,7 +4475,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4472,7 +4488,7 @@ msgstr "Traži za okvire za albume..."
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4597,7 +4613,7 @@ msgstr ""
 msgid "Service offline"
 msgstr "Usluga trenutno nije dostupna"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Namjesti %1 na \"%2\"..."
@@ -4606,7 +4622,7 @@ msgstr "Namjesti %1 na \"%2\"..."
 msgid "Set the volume to <value> percent"
 msgstr "Naštinaj glasnoću na <value> posto"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Naštimaj valutu za sve odabrane snimke..."
 
@@ -4677,7 +4693,7 @@ msgstr "Pokaži lijepi OSD"
 msgid "Show above status bar"
 msgstr "Pokaži iznad status bara"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Pokaži sve pjesme"
 
@@ -4697,12 +4713,12 @@ msgstr "Pokaži razdjelnike"
 msgid "Show fullsize..."
 msgstr "Pokaži punu veličinu..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Pokaži u pretražniku za datoteke"
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr ""
 
@@ -4714,15 +4730,15 @@ msgstr "Pokaži u raznim izvođačima"
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Pokaži samo duplikate"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Pokaži samo necitirane"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4730,7 +4746,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4766,7 +4782,7 @@ msgstr ""
 msgid "Shuffle all"
 msgstr "Pomješaj sve"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Pomješaj playlistu"
 
@@ -4810,11 +4826,15 @@ msgstr "Broj preskakanja"
 msgid "Skip forwards in playlist"
 msgstr "Preskoči unaprijed u playlisti"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr ""
 
@@ -4931,7 +4951,7 @@ msgstr ""
 msgid "Start the playlist currently playing"
 msgstr "Započni trenutno pokrenutu playlistu"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Započni transkodiranje"
 
@@ -4941,7 +4961,7 @@ msgid ""
 "list"
 msgstr ""
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Započinje %1"
@@ -4951,7 +4971,7 @@ msgid "Starting..."
 msgstr "Započinje..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Zaustavi"
 
@@ -4967,7 +4987,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Zaustavi nakon ovog snimka"
 
@@ -5135,7 +5155,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5177,7 +5197,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5279,11 +5299,11 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr ""
 
@@ -5328,19 +5348,19 @@ msgstr ""
 msgid "Track"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr ""
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
 msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr ""
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr ""
@@ -5417,11 +5437,11 @@ msgstr ""
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr ""
 
@@ -5438,7 +5458,7 @@ msgstr ""
 msgid "Update all podcasts"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr ""
 
@@ -5599,7 +5619,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5607,7 +5627,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr ""
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr ""
 
@@ -5648,7 +5668,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr ""
 
@@ -5744,7 +5764,7 @@ msgstr ""
 msgid "Windows Media 64k"
 msgstr ""
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr ""
 
@@ -5758,7 +5778,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/ca.po
+++ b/src/translations/ca.po
@@ -518,7 +518,7 @@ msgstr "Afegeix un altre flux…"
 msgid "Add directory..."
 msgstr "Afegeix un directori…"
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Afegeix un fitxer"
 
@@ -538,7 +538,7 @@ msgstr "Afegeix un fitxer…"
 msgid "Add files to transcode"
 msgstr "Afegeix fitxers per convertir-los"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Afegeix una carpeta"
@@ -643,7 +643,7 @@ msgstr "Afegeix a les llistes de l’Spotify"
 msgid "Add to Spotify starred"
 msgstr "Afegeix a les destacades de l’Spotify"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Afegeix a una altra llista de reproducció"
 
@@ -865,7 +865,7 @@ msgstr "Esteu segur que voleu escriure les estadístiques de les cançons en tot
 msgid "Artist"
 msgstr "Artista"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Inf.artista"
 
@@ -1128,7 +1128,7 @@ msgstr "Comprova si hi ha episodis nous"
 msgid "Check for updates"
 msgstr "Comprova si hi ha actualitzacions"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Comprova si hi ha actualitzacions…"
 
@@ -1368,7 +1368,7 @@ msgstr "Configura el Subsonic…"
 msgid "Configure global search..."
 msgstr "Configura la cerca global…"
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Configura la col·lecció…"
 
@@ -1440,11 +1440,11 @@ msgid "Copy to clipboard"
 msgstr "Copia al porta-retalls"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Copia al dispositiu…"
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Copia a la col·lecció…"
@@ -1662,7 +1662,7 @@ msgid "Delete downloaded data"
 msgstr "Suprimeix les dades baixades"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Suprimeix els fitxers"
 
@@ -1670,7 +1670,7 @@ msgstr "Suprimeix els fitxers"
 msgid "Delete from device..."
 msgstr "Suprimeix del dispositiu…"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Suprimeix del disc…"
@@ -1703,11 +1703,11 @@ msgstr "S’estan suprimint els fitxers"
 msgid "Depth"
 msgstr "Profunditat"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Treu de la cua les peces seleccionades"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Treu de la cua la peça"
 
@@ -1736,7 +1736,7 @@ msgstr "Nom de dispositiu"
 msgid "Device properties..."
 msgstr "Propietats del dispositiu…"
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Dispositius"
 
@@ -1987,7 +1987,7 @@ msgstr "Mescla dinàmica aleatòria"
 msgid "Edit smart playlist..."
 msgstr "Edita la llista de reproducció intel·ligent"
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Edita l’etiqueta «%1»…"
@@ -2126,8 +2126,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Equivalent a --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Error"
 
@@ -2273,7 +2273,7 @@ msgstr "Esvaïment"
 msgid "Fading duration"
 msgstr "Durada de l’esvaïment"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Ha fallat la lectura de la unitat de CD"
 
@@ -2396,7 +2396,7 @@ msgstr "Tipus de fitxer"
 msgid "Filename"
 msgstr "Nom de fitxer"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Fitxers"
 
@@ -2811,7 +2811,7 @@ msgstr "Instal·lat"
 msgid "Integrity check"
 msgstr "Comprovació d’integritat"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -2999,7 +2999,7 @@ msgstr "Esquerra"
 msgid "Length"
 msgstr "Durada"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Col·lecció"
@@ -3008,7 +3008,7 @@ msgstr "Col·lecció"
 msgid "Library advanced grouping"
 msgstr "Agrupació avançada de la col·lecció"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Avís de reescaneig de la col·lecció"
 
@@ -3336,7 +3336,7 @@ msgstr "Punts de muntatge"
 msgid "Move down"
 msgstr "Mou cap avall"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Mou a la col·lecció…"
 
@@ -3345,7 +3345,7 @@ msgstr "Mou a la col·lecció…"
 msgid "Move up"
 msgstr "Mou cap amunt"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Música"
 
@@ -3407,7 +3407,7 @@ msgstr "Mai no comencis a reproduir"
 msgid "New folder"
 msgstr "Carpeta nova"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Llista de reproducció nova"
 
@@ -3478,7 +3478,7 @@ msgstr "No utilitzis blocs curs"
 msgid "None"
 msgstr "Cap"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Cap de les cançons seleccionades són adequades per copiar-les a un dispositiu"
 
@@ -3693,7 +3693,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organitza fitxers"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Organitza fitxers..."
 
@@ -3777,7 +3777,7 @@ msgstr "Festa"
 msgid "Password"
 msgstr "Contrasenya"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pausa"
@@ -3813,8 +3813,8 @@ msgstr "Píxel"
 msgid "Plain sidebar"
 msgstr "Barra lateral senzilla"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3837,11 +3837,11 @@ msgstr "Reprodueix si està parat, posa en pausa si està reproduint"
 msgid "Play if there is nothing already playing"
 msgstr "Reprodueix si encara no hi ha res reproduint-se"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Reprodueix a continuació"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Reprodueix les peces següents a continuació"
 
@@ -3880,7 +3880,7 @@ msgstr "Opcions de la llista de reproducció"
 msgid "Playlist type"
 msgstr "Tipus de llista de reproducció"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Llistes"
 
@@ -4062,12 +4062,12 @@ msgstr "S’està consultant el dispositiu…"
 msgid "Queue Manager"
 msgstr "Gestor de la cua"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Afegeix les peces seleccionades a la cua"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Afegeix la peça a la cua"
 
@@ -4458,7 +4458,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Cerca"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Cerca"
@@ -4483,7 +4483,7 @@ msgstr "Cerca a Subsonic"
 msgid "Search automatically"
 msgstr "Cerca automàticament"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Cerca per àlbum"
 
@@ -4496,7 +4496,7 @@ msgstr "Cerca la caràtula del àlbum…"
 msgid "Search for anything"
 msgstr "Cerca a tot arreu"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Cerca per artista"
 
@@ -4621,7 +4621,7 @@ msgstr "Detalls del servidor"
 msgid "Service offline"
 msgstr "Servei fora de línia"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Estableix %1 a «%2»…"
@@ -4701,7 +4701,7 @@ msgstr "Mostra un OSD bonic"
 msgid "Show above status bar"
 msgstr "Mostra sota la barra d'estat"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Mostra totes les cançons"
 
@@ -4721,12 +4721,12 @@ msgstr "Mostra els separadors"
 msgid "Show fullsize..."
 msgstr "Mostra a mida completa..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Mostra al gestor de fitxers"
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Mostra a la col·lecció…"
 
@@ -4738,11 +4738,11 @@ msgstr "Mostra en Artistes diversos"
 msgid "Show moodbar"
 msgstr "Mostra les barres d’ànim"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Mostra només els duplicats"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Mostra només les peces sense etiquetar"
 
@@ -4834,7 +4834,7 @@ msgstr "Comptador d’omissions"
 msgid "Skip forwards in playlist"
 msgstr "Salta endavant en la llista de reproducció"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Omet les peces seleccionades"
 
@@ -4842,7 +4842,7 @@ msgstr "Omet les peces seleccionades"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Omet la peça"
 
@@ -4874,7 +4874,7 @@ msgstr "Rock suau"
 msgid "Song Information"
 msgstr "Informació de la cançó"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Inf. cançó"
 
@@ -4995,7 +4995,7 @@ msgstr "Atura després de cada peça"
 msgid "Stop after every track"
 msgstr "Atura després de cada peça"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Atura després d’aquesta peça"
 
@@ -5163,7 +5163,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Ha acabat el període de prova del servidor de Subsonic. Feu una donació per a obtenir una clau de llicència. Visiteu subsonic.org para més detalls."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5205,7 +5205,7 @@ msgid ""
 "continue?"
 msgstr "Se suprimiran aquests fitxers del dispositiu; segur que voleu continuar?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5307,7 +5307,7 @@ msgstr "Activa la visualització per pantalla elegant"
 msgid "Toggle fullscreen"
 msgstr "Commuta a pantalla completa"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Commuta l’estat de la cua"
 
@@ -5445,11 +5445,11 @@ msgstr "Error desconegut"
 msgid "Unset cover"
 msgstr "Esborra’n la caràtula"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "No ometis les peces seleccionades"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "No ometis la peça"
 
@@ -5786,7 +5786,7 @@ msgid ""
 "well?"
 msgstr "Voleu moure també les altres cançons d’aquest àlbum a Artistes diversos?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Voleu fer de nou un escaneig complet ara?"
 

--- a/src/translations/ca.po
+++ b/src/translations/ca.po
@@ -16,8 +16,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-13 12:17+0000\n"
-"Last-Translator: Juanjo\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
+"Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Catalan (http://www.transifex.com/davidsansome/clementine/language/ca/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -170,19 +170,19 @@ msgstr "%L1 peces"
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n han fallat"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n han acabat"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -200,7 +200,7 @@ msgstr "&Centre"
 msgid "&Custom"
 msgstr "&Personalitzades"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "E&xtres"
 
@@ -208,7 +208,7 @@ msgstr "E&xtres"
 msgid "&Grouping"
 msgstr "A&grupament"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Ajuda"
 
@@ -233,7 +233,7 @@ msgstr "&Bloca la valoració"
 msgid "&Lyrics"
 msgstr "&Lletres"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Música"
 
@@ -241,15 +241,15 @@ msgstr "&Música"
 msgid "&None"
 msgstr "&Cap"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&Llista de reproducció"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Surt"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "Mode de &repetició"
 
@@ -257,7 +257,7 @@ msgstr "Mode de &repetició"
 msgid "&Right"
 msgstr "&Dreta"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Mode de me&scla"
 
@@ -265,7 +265,7 @@ msgstr "Mode de me&scla"
 msgid "&Stretch columns to fit window"
 msgstr "&Encabeix les columnes a la finestra"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Eines"
 
@@ -454,11 +454,11 @@ msgstr "Interromp"
 msgid "About %1"
 msgstr "Quant al %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Quant al Clementine…"
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Quant al Qt…"
 
@@ -518,32 +518,32 @@ msgstr "Afegeix un altre flux…"
 msgid "Add directory..."
 msgstr "Afegeix un directori…"
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Afegeix un fitxer"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Afegeix un fitxer al convertidor"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Afegeix fitxer(s) al convertidor"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Afegeix un fitxer…"
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Afegeix fitxers per convertir-los"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Afegeix una carpeta"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Afegeix una carpeta…"
 
@@ -555,7 +555,7 @@ msgstr "Afegeix una carpeta nova…"
 msgid "Add podcast"
 msgstr "Afegeix un podcast"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Afegeix un podcast…"
 
@@ -631,7 +631,7 @@ msgstr "Afegeix l’etiqueta de número de peça a la cançó"
 msgid "Add song year tag"
 msgstr "Afegeix l’etiqueta d’any a la cançó"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Afegeix un flux…"
 
@@ -643,7 +643,7 @@ msgstr "Afegeix a les llistes de l’Spotify"
 msgid "Add to Spotify starred"
 msgstr "Afegeix a les destacades de l’Spotify"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Afegeix a una altra llista de reproducció"
 
@@ -737,7 +737,7 @@ msgstr "Tot"
 msgid "All Files (*)"
 msgstr "Tots els fitxers (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Lloem l’hipnogripau!"
@@ -1128,7 +1128,7 @@ msgstr "Comprova si hi ha episodis nous"
 msgid "Check for updates"
 msgstr "Comprova si hi ha actualitzacions"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Comprova si hi ha actualitzacions…"
 
@@ -1177,18 +1177,18 @@ msgstr "Clàssica"
 msgid "Cleaning up"
 msgstr "S’està netejant"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Neteja"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Neteja la llista de reproducció"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1333,7 +1333,7 @@ msgstr "Comentari"
 msgid "Complete tags automatically"
 msgstr "Completa les etiquetes automàticament"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Completa les etiquetes automàticament…"
 
@@ -1368,7 +1368,7 @@ msgstr "Configura el Subsonic…"
 msgid "Configure global search..."
 msgstr "Configura la cerca global…"
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Configura la col·lecció…"
 
@@ -1411,7 +1411,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "S’ha esgotat el temps d’espera de la connexió, comproveu l’URL del servidor. Exemple: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Terminal"
 
@@ -1440,11 +1440,11 @@ msgid "Copy to clipboard"
 msgstr "Copia al porta-retalls"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Copia al dispositiu…"
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Copia a la col·lecció…"
@@ -1487,14 +1487,14 @@ msgstr "No s'ha pogut iniciar sessió a Last.fm. Si us plau, proveu-ho de nou."
 msgid "Couldn't create playlist"
 msgstr "No s’ha pogut crear la llista de reproducció"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "No s’ha pogut trobar un muxer per %1. Comproveu que teniu els connectors adequats de GStreamer instal·lats"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1509,7 +1509,7 @@ msgstr "No s’ha pogut obrir el fitxer de sortida %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Gestor de caràtules"
 
@@ -1662,7 +1662,7 @@ msgid "Delete downloaded data"
 msgstr "Suprimeix les dades baixades"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Suprimeix els fitxers"
 
@@ -1670,7 +1670,7 @@ msgstr "Suprimeix els fitxers"
 msgid "Delete from device..."
 msgstr "Suprimeix del dispositiu…"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Suprimeix del disc…"
@@ -1703,11 +1703,11 @@ msgstr "S’estan suprimint els fitxers"
 msgid "Depth"
 msgstr "Profunditat"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Treu de la cua les peces seleccionades"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Treu de la cua la peça"
 
@@ -1808,7 +1808,7 @@ msgstr "Opcions de visualització"
 msgid "Display the on-screen-display"
 msgstr "Mostra la indicació a pantalla"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Analitza tota la col·lecció de nou"
 
@@ -1987,12 +1987,12 @@ msgstr "Mescla dinàmica aleatòria"
 msgid "Edit smart playlist..."
 msgstr "Edita la llista de reproducció intel·ligent"
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Edita l’etiqueta «%1»…"
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Edita l’etiqueta…"
 
@@ -2005,7 +2005,7 @@ msgid "Edit track information"
 msgstr "Edita la informació de la peça"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Edita la informació de la peça…"
 
@@ -2113,7 +2113,7 @@ msgstr "Tota la col·lecció"
 msgid "Episode information"
 msgstr "Informació de l'episodi"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Equalitzador"
 
@@ -2126,8 +2126,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Equivalent a --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Error"
 
@@ -2162,7 +2162,7 @@ msgstr "S’ha produït un error en carregar %1"
 msgid "Error loading di.fm playlist"
 msgstr "S’ha produït un error en carregar la llista de reproducció del di.fm"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "S’ha produït un error en processar %1: %2"
@@ -2245,7 +2245,11 @@ msgstr "Ha finalitzat l’exportació"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "S’han exportat %1 caràtules de %2 (s’han omès %3)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2269,7 +2273,7 @@ msgstr "Esvaïment"
 msgid "Fading duration"
 msgstr "Durada de l’esvaïment"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Ha fallat la lectura de la unitat de CD"
 
@@ -2551,11 +2555,11 @@ msgstr "Doneu-li un nom:"
 msgid "Go"
 msgstr "Vés-hi"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Vés a la pestanya de la següent llista de reproducció"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Vés a la pestanya de l'anterior llista de reproducció"
 
@@ -2888,7 +2892,7 @@ msgstr "Base de dades del Jamendo"
 msgid "Jump to previous song right away"
 msgstr "Vés a la peça anterior"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Vés a la peça que s’està reproduint"
 
@@ -2912,7 +2916,7 @@ msgstr "Conserva l’aplicació executant-se en segon pla quan tanqueu la finest
 msgid "Keep the original files"
 msgstr "Conserva els fitxers originals"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Gatets"
@@ -3004,7 +3008,7 @@ msgstr "Col·lecció"
 msgid "Library advanced grouping"
 msgstr "Agrupació avançada de la col·lecció"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Avís de reescaneig de la col·lecció"
 
@@ -3044,7 +3048,7 @@ msgstr "Carrega la caràtula des del disc…"
 msgid "Load playlist"
 msgstr "Carrega la llista de reproducció"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Carrega la llista de reproducció..."
 
@@ -3105,11 +3109,15 @@ msgstr "Entra"
 msgid "Login failed"
 msgstr "Ha fallat l'inici de sessió"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr "Registres"
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Perfil de predicció a llarg termini (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "M’encanta"
 
@@ -3144,11 +3152,11 @@ msgstr "Lletres des de %1"
 msgid "Lyrics from the tag"
 msgstr "Lletra de l'etiqueta"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3190,7 +3198,7 @@ msgstr "Perfil principal (MAIN)"
 msgid "Make it so!"
 msgstr "Fes-ho doncs!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Fes-ho doncs!"
@@ -3328,7 +3336,7 @@ msgstr "Punts de muntatge"
 msgid "Move down"
 msgstr "Mou cap avall"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Mou a la col·lecció…"
 
@@ -3337,7 +3345,7 @@ msgstr "Mou a la col·lecció…"
 msgid "Move up"
 msgstr "Mou cap amunt"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Música"
 
@@ -3350,7 +3358,7 @@ msgid "Music extensions remotely visible"
 msgstr "Extensions visibles a la xarxa remota"
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Silenci"
 
@@ -3399,7 +3407,7 @@ msgstr "Mai no comencis a reproduir"
 msgid "New folder"
 msgstr "Carpeta nova"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Llista de reproducció nova"
 
@@ -3427,8 +3435,12 @@ msgstr "Peces més recents"
 msgid "Next"
 msgstr "Següent"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Peça següent"
 
@@ -3466,7 +3478,7 @@ msgstr "No utilitzis blocs curs"
 msgid "None"
 msgstr "Cap"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Cap de les cançons seleccionades són adequades per copiar-les a un dispositiu"
 
@@ -3551,19 +3563,19 @@ msgstr "Inactiu"
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3607,7 +3619,7 @@ msgstr "Opacitat"
 msgid "Open %1 in browser"
 msgstr "Obre %1 en un navegador"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Obre un &CD d’àudio…"
 
@@ -3619,7 +3631,7 @@ msgstr "Obre un fitxer OPML"
 msgid "Open OPML file..."
 msgstr "Obre un fitxer OPML…"
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Obriu una carpeta des d’on s’importarà la música"
 
@@ -3627,7 +3639,7 @@ msgstr "Obriu una carpeta des d’on s’importarà la música"
 msgid "Open device"
 msgstr "Obrir dispositiu"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Obre un fitxer..."
 
@@ -3681,7 +3693,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organitza fitxers"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Organitza fitxers..."
 
@@ -3765,7 +3777,7 @@ msgstr "Festa"
 msgid "Password"
 msgstr "Contrasenya"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pausa"
@@ -3789,6 +3801,10 @@ msgstr "Intèrpret"
 msgid "Pipeline"
 msgstr "Pipeline"
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr "Pipelines"
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Píxel"
@@ -3797,10 +3813,10 @@ msgstr "Píxel"
 msgid "Plain sidebar"
 msgstr "Barra lateral senzilla"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Reprodueix"
 
@@ -3821,11 +3837,11 @@ msgstr "Reprodueix si està parat, posa en pausa si està reproduint"
 msgid "Play if there is nothing already playing"
 msgstr "Reprodueix si encara no hi ha res reproduint-se"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Reprodueix a continuació"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Reprodueix les peces següents a continuació"
 
@@ -3924,7 +3940,7 @@ msgstr "Preferència"
 msgid "Preferences"
 msgstr "Preferències"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Preferències…"
 
@@ -3984,7 +4000,7 @@ msgid "Previous"
 msgstr "Anterior"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Peça anterior"
 
@@ -4042,16 +4058,16 @@ msgstr "Qualitat"
 msgid "Querying device..."
 msgstr "S’està consultant el dispositiu…"
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Gestor de la cua"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Afegeix les peces seleccionades a la cua"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Afegeix la peça a la cua"
 
@@ -4067,7 +4083,7 @@ msgstr "Ràdio (mateix volum per a totes les peces)"
 msgid "Rain"
 msgstr "Pluja"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Pluja"
@@ -4179,7 +4195,7 @@ msgstr "Elimina l’acció"
 msgid "Remove current song from playlist"
 msgstr "Suprimeix aquesta peça de la llista de reproducció"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Esborra els duplicats de la llista de reproducció"
 
@@ -4187,7 +4203,7 @@ msgstr "Esborra els duplicats de la llista de reproducció"
 msgid "Remove folder"
 msgstr "Suprimeix carpeta"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Suprimeix de la llista de reproducció"
 
@@ -4199,7 +4215,7 @@ msgstr "Esborra la llista de reproducció"
 msgid "Remove playlists"
 msgstr "Suprimeix llistes de reproducció"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Elimina les peces no disponibles de la llista de reproducció"
 
@@ -4211,7 +4227,7 @@ msgstr "Renombra de la llista de reproducció"
 msgid "Rename playlist..."
 msgstr "Renombra de la llista de reproducció..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Posa els números de les peces en aquest ordre..."
 
@@ -4302,7 +4318,7 @@ msgstr "Captura"
 msgid "Rip CD"
 msgstr "Captura un CD"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Captura CD d’àudio"
 
@@ -4380,7 +4396,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Desa la llista de reproducció"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Desa la llista de reproducció..."
 
@@ -4467,7 +4483,7 @@ msgstr "Cerca a Subsonic"
 msgid "Search automatically"
 msgstr "Cerca automàticament"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Cerca per àlbum"
 
@@ -4480,7 +4496,7 @@ msgstr "Cerca la caràtula del àlbum…"
 msgid "Search for anything"
 msgstr "Cerca a tot arreu"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Cerca per artista"
 
@@ -4605,7 +4621,7 @@ msgstr "Detalls del servidor"
 msgid "Service offline"
 msgstr "Servei fora de línia"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Estableix %1 a «%2»…"
@@ -4614,7 +4630,7 @@ msgstr "Estableix %1 a «%2»…"
 msgid "Set the volume to <value> percent"
 msgstr "Estableix el volum al <value> percent"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Estableix valor per a totes les peces seleccionades…"
 
@@ -4685,7 +4701,7 @@ msgstr "Mostra un OSD bonic"
 msgid "Show above status bar"
 msgstr "Mostra sota la barra d'estat"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Mostra totes les cançons"
 
@@ -4705,12 +4721,12 @@ msgstr "Mostra els separadors"
 msgid "Show fullsize..."
 msgstr "Mostra a mida completa..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Mostra al gestor de fitxers"
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Mostra a la col·lecció…"
 
@@ -4722,15 +4738,15 @@ msgstr "Mostra en Artistes diversos"
 msgid "Show moodbar"
 msgstr "Mostra les barres d’ànim"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Mostra només els duplicats"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Mostra només les peces sense etiquetar"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Mostra o amaga la barra lateral"
 
@@ -4738,7 +4754,7 @@ msgstr "Mostra o amaga la barra lateral"
 msgid "Show search suggestions"
 msgstr "Mostra suggeriments de cerca"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Mostra la barra lateral"
 
@@ -4774,7 +4790,7 @@ msgstr "Mescla els àlbums"
 msgid "Shuffle all"
 msgstr "Mescla-ho tot"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Mescla la llista de reproducció"
 
@@ -4818,11 +4834,15 @@ msgstr "Comptador d’omissions"
 msgid "Skip forwards in playlist"
 msgstr "Salta endavant en la llista de reproducció"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Omet les peces seleccionades"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Omet la peça"
 
@@ -4939,7 +4959,7 @@ msgstr "Inicia la captura"
 msgid "Start the playlist currently playing"
 msgstr "Inicia la llista de reproducció que s'està reproduint"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Inicia la conversió"
 
@@ -4949,7 +4969,7 @@ msgid ""
 "list"
 msgstr "Comenceu a escriure quelcom al quadre de cerca de dalt per omplir-ne la llista de resultats"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "S’està començant %1"
@@ -4959,7 +4979,7 @@ msgid "Starting..."
 msgstr "S’està iniciant…"
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Atura"
 
@@ -4975,7 +4995,7 @@ msgstr "Atura després de cada peça"
 msgid "Stop after every track"
 msgstr "Atura després de cada peça"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Atura després d’aquesta peça"
 
@@ -5143,7 +5163,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Ha acabat el període de prova del servidor de Subsonic. Feu una donació per a obtenir una clau de llicència. Visiteu subsonic.org para més detalls."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5185,7 +5205,7 @@ msgid ""
 "continue?"
 msgstr "Se suprimiran aquests fitxers del dispositiu; segur que voleu continuar?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5287,11 +5307,11 @@ msgstr "Activa la visualització per pantalla elegant"
 msgid "Toggle fullscreen"
 msgstr "Commuta a pantalla completa"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Commuta l’estat de la cua"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Commuta l’«scrobbling»"
 
@@ -5336,19 +5356,19 @@ msgstr "&Peça"
 msgid "Track"
 msgstr "Peça"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Converteix música"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Registre del convertidor"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr "Detalls del transcodificador"
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Conversió"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "S’estan convertint %1 fitxers emprant %2 fils"
@@ -5425,11 +5445,11 @@ msgstr "Error desconegut"
 msgid "Unset cover"
 msgstr "Esborra’n la caràtula"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "No ometis les peces seleccionades"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "No ometis la peça"
 
@@ -5446,7 +5466,7 @@ msgstr "Propers concerts"
 msgid "Update all podcasts"
 msgstr "Actualitza tots els podcasts"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Actualitza les carpetes de la col·lecció amb canvis"
 
@@ -5607,7 +5627,7 @@ msgstr "Versió %1"
 msgid "View"
 msgstr "Vista"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Mostra els detalls del flux"
 
@@ -5615,7 +5635,7 @@ msgstr "Mostra els detalls del flux"
 msgid "Visualization mode"
 msgstr "Mode de visualització"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Visualitzacions"
 
@@ -5656,7 +5676,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr "Avís: Aquest nivell de compressió està fora del subconjunt que es pot transmetre. Això vol dir que un decodificador potser no podrà reproduir-ho sense començar pel principi. També pot afectar al rendiment dels decodificadors per maquinari."
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5752,7 +5772,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Audio Windows Media"
 
@@ -5766,7 +5786,7 @@ msgid ""
 "well?"
 msgstr "Voleu moure també les altres cançons d’aquest àlbum a Artistes diversos?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Voleu fer de nou un escaneig complet ara?"
 

--- a/src/translations/cs.po
+++ b/src/translations/cs.po
@@ -21,8 +21,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-26 23:47+0000\n"
-"Last-Translator: John Maguire <john.maguire@gmail.com>\n"
+"PO-Revision-Date: 2021-01-27 08:04+0000\n"
+"Last-Translator: fri\n"
 "Language-Team: Czech (http://www.transifex.com/davidsansome/clementine/language/cs/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -523,7 +523,7 @@ msgstr "Přidat další proud..."
 msgid "Add directory..."
 msgstr "Přidat složku..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Přidat soubor"
 
@@ -543,7 +543,7 @@ msgstr "Přidat soubor..."
 msgid "Add files to transcode"
 msgstr "Přidat soubory pro překódování"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Přidat složku"
@@ -648,7 +648,7 @@ msgstr "Přidat do seznamů skladeb Spotify"
 msgid "Add to Spotify starred"
 msgstr "Přidat do Spotify s hvězdičkou"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Přidat do jiného seznamu skladeb"
 
@@ -870,7 +870,7 @@ msgstr "Opravdu chcete ukládat statistiky písní do souboru písně u všech p
 msgid "Artist"
 msgstr "Umělec"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Umělec"
 
@@ -1133,7 +1133,7 @@ msgstr "Podívat se po nových dílech"
 msgid "Check for updates"
 msgstr "Podívat se po aktualizacích"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Zkontrolovat aktualizace"
 
@@ -1373,7 +1373,7 @@ msgstr "Nastavit Subsonic..."
 msgid "Configure global search..."
 msgstr "Nastavit celkové hledání..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Nastavit sbírku..."
 
@@ -1445,11 +1445,11 @@ msgid "Copy to clipboard"
 msgstr "Kopírovat do schránky"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Zkopírovat do zařízení..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Zkopírovat do sbírky..."
@@ -1667,7 +1667,7 @@ msgid "Delete downloaded data"
 msgstr "Smazat stažená data"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Smazat soubory"
 
@@ -1675,7 +1675,7 @@ msgstr "Smazat soubory"
 msgid "Delete from device..."
 msgstr "Smazat ze zařízení..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Smazat z disku..."
@@ -1708,11 +1708,11 @@ msgstr "Probíhá mazání souborů"
 msgid "Depth"
 msgstr "Hloubka"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Odstranit vybrané skladby z řady"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Odstranit skladbu z řady"
 
@@ -1741,7 +1741,7 @@ msgstr "Název zařízení"
 msgid "Device properties..."
 msgstr "Vlastnosti zařízení..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Zařízení"
 
@@ -1992,7 +1992,7 @@ msgstr "Dynamický náhodný výběr"
 msgid "Edit smart playlist..."
 msgstr "Upravit chytrý seznam skladeb..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Upravit značku \"%1\"..."
@@ -2131,8 +2131,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Rovnocenné s --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Chyba"
 
@@ -2252,7 +2252,7 @@ msgstr "Uloženo %1 obalů z %2 (%3 přeskočeno)"
 
 #: ../bin/src/ui_mainwindow.h:790
 msgid "F9"
-msgstr ""
+msgstr "F9"
 
 #: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
@@ -2278,7 +2278,7 @@ msgstr "Slábnutí"
 msgid "Fading duration"
 msgstr "Doba slábnutí"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Nepodařilo se číst z CD v mechanice"
 
@@ -2401,7 +2401,7 @@ msgstr "Typ souboru"
 msgid "Filename"
 msgstr "Název souboru"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Soubory"
 
@@ -2816,7 +2816,7 @@ msgstr "Nainstalován"
 msgid "Integrity check"
 msgstr "Ověření celistvosti"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -3004,7 +3004,7 @@ msgstr "Vlevo"
 msgid "Length"
 msgstr "Délka"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Sbírka"
@@ -3013,7 +3013,7 @@ msgstr "Sbírka"
 msgid "Library advanced grouping"
 msgstr "Pokročilé seskupování sbírky"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Zpráva o prohledání sbírky"
 
@@ -3116,7 +3116,7 @@ msgstr "Přihlášení se nezdařilo"
 
 #: ../bin/src/ui_transcodelogdialog.h:107
 msgid "Logs"
-msgstr ""
+msgstr "Záznamy"
 
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
@@ -3341,7 +3341,7 @@ msgstr "Přípojné body"
 msgid "Move down"
 msgstr "Posunout dolů"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Přesunout do sbírky..."
 
@@ -3350,7 +3350,7 @@ msgstr "Přesunout do sbírky..."
 msgid "Move up"
 msgstr "Posunout nahoru"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Hudba"
 
@@ -3412,7 +3412,7 @@ msgstr "Nikdy nezačít přehrávání"
 msgid "New folder"
 msgstr "Nová složka"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nový seznam skladeb"
 
@@ -3442,7 +3442,7 @@ msgstr "Další"
 
 #: ../bin/src/ui_mainwindow.h:785
 msgid "Next album"
-msgstr ""
+msgstr "Další album"
 
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
 #: ../bin/src/ui_mainwindow.h:727
@@ -3483,7 +3483,7 @@ msgstr "Žádné krátké bloky"
 msgid "None"
 msgstr "Žádná"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Žádná z vybraných písní nebyla vhodná ke zkopírování do zařízení"
 
@@ -3698,7 +3698,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Uspořádat soubory"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Uspořádat soubory..."
 
@@ -3782,7 +3782,7 @@ msgstr "Oslava"
 msgid "Password"
 msgstr "Heslo"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pozastavit"
@@ -3808,7 +3808,7 @@ msgstr "Roura"
 
 #: ../bin/src/ui_transcodelogdialog.h:106
 msgid "Pipelines"
-msgstr ""
+msgstr "Roury"
 
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
@@ -3818,8 +3818,8 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Prostý postranní panel"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3842,11 +3842,11 @@ msgstr "Přehrát, pokud je zastaveno, pozastavit, pokud je přehráváno"
 msgid "Play if there is nothing already playing"
 msgstr "Hrát, pokud se již něco nepřehrává"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Přehrát další"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Přehrát vybrané skladby jako další"
 
@@ -3885,7 +3885,7 @@ msgstr "Nastavení seznamu skladeb"
 msgid "Playlist type"
 msgstr "Typ seznamu skladeb"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Seznamy"
 
@@ -4067,12 +4067,12 @@ msgstr "Dotazování se zařízení..."
 msgid "Queue Manager"
 msgstr "Správce řady"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Přidat vybrané skladby do řady"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Přidat skladbu do řady"
 
@@ -4463,7 +4463,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Hledat"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Hledat"
@@ -4488,7 +4488,7 @@ msgstr "Vyhledat Subsonic"
 msgid "Search automatically"
 msgstr "Hledat automaticky"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Hledat album"
 
@@ -4501,7 +4501,7 @@ msgstr "Hledat obaly alb..."
 msgid "Search for anything"
 msgstr "Hledat vše"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Hledat umělce"
 
@@ -4626,7 +4626,7 @@ msgstr "Podrobnosti o serveru"
 msgid "Service offline"
 msgstr "Služba není dostupná"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Nastavit %1 na \"%2\"..."
@@ -4706,7 +4706,7 @@ msgstr "Ukazovat OSD"
 msgid "Show above status bar"
 msgstr "Ukazovat nad stavovým řádkem"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Ukázat všechny písně"
 
@@ -4726,12 +4726,12 @@ msgstr "Ukazovat oddělovače"
 msgid "Show fullsize..."
 msgstr "Ukázat v plné velikosti..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Ukázat v prohlížeči souborů..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Ukazovat ve sbírce..."
 
@@ -4743,11 +4743,11 @@ msgstr "Ukázat pod různými umělci"
 msgid "Show moodbar"
 msgstr "Ukázat náladový proužek"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Ukázat pouze zdvojené"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Ukázat pouze neoznačené"
 
@@ -4839,15 +4839,15 @@ msgstr "Počet přeskočení"
 msgid "Skip forwards in playlist"
 msgstr "Další skladba v seznamu skladeb"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Přeskočit vybrané skladby"
 
 #: ../bin/src/ui_mainwindow.h:787
 msgid "Skip to the next album"
-msgstr ""
+msgstr "Skočit na další album"
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Přeskočit skladbu"
 
@@ -4879,7 +4879,7 @@ msgstr "Soft rock"
 msgid "Song Information"
 msgstr "Informace o písni"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Píseň"
 
@@ -5000,7 +5000,7 @@ msgstr "Zastavit po každé skladbě"
 msgid "Stop after every track"
 msgstr "Zastavit po každé skladbě"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Zastavit po této skladbě"
 
@@ -5168,7 +5168,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Lhůta na vyzkoušení serveru Subsonic uplynula. Dejte, prosím, dar, abyste dostali licenční klíč. Navštivte subsonic.org kvůli podrobnostem."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5210,7 +5210,7 @@ msgid ""
 "continue?"
 msgstr "Tyto soubory budou smazány ze zařízení. Opravdu chcete pokračovat?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5312,7 +5312,7 @@ msgstr "Přepnout OSD"
 msgid "Toggle fullscreen"
 msgstr "Zapnout/Vypnout zobrazení na celou obrazovku"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Přepnout stav řady"
 
@@ -5367,7 +5367,7 @@ msgstr "Převést hudbu"
 
 #: ../bin/src/ui_transcodelogdialog.h:105
 msgid "Transcoder Details"
-msgstr ""
+msgstr "Podrobnosti převodu"
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
@@ -5450,11 +5450,11 @@ msgstr "Neznámá chyba"
 msgid "Unset cover"
 msgstr "Odebrat obal"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Zrušit přeskočení vybraných skladeb"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Zrušit přeskočení skladby"
 
@@ -5791,7 +5791,7 @@ msgid ""
 "well?"
 msgstr "Chcete další písně na tomto albu přesunout do Různí umělci?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Chcete spustit toto úplné nové prohledání hned teď?"
 

--- a/src/translations/cs.po
+++ b/src/translations/cs.po
@@ -21,8 +21,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 18:39+0000\n"
-"Last-Translator: fri\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
+"Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Czech (http://www.transifex.com/davidsansome/clementine/language/cs/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -175,19 +175,19 @@ msgstr "%L1 skladeb"
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "nepodařilo se %n"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "dokončeno %n"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -205,7 +205,7 @@ msgstr "&Na střed"
 msgid "&Custom"
 msgstr "Vl&astní"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "Doplňky"
 
@@ -213,7 +213,7 @@ msgstr "Doplňky"
 msgid "&Grouping"
 msgstr "&Seskupení"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "Nápo&věda"
 
@@ -238,7 +238,7 @@ msgstr "&Zamknout hodnocení"
 msgid "&Lyrics"
 msgstr "&Texty písní"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "Hudba"
 
@@ -246,15 +246,15 @@ msgstr "Hudba"
 msgid "&None"
 msgstr "Žád&né"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "Seznam skladeb"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Ukončit"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "Režim opakování"
 
@@ -262,7 +262,7 @@ msgstr "Režim opakování"
 msgid "&Right"
 msgstr "&Vpravo"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Režim míchání"
 
@@ -270,7 +270,7 @@ msgstr "Režim míchání"
 msgid "&Stretch columns to fit window"
 msgstr "Roztáhnout sloupce tak, aby se vešly do okna"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "Nástroje"
 
@@ -459,11 +459,11 @@ msgstr "Přerušit"
 msgid "About %1"
 msgstr "O %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "O Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "O Qt..."
 
@@ -523,32 +523,32 @@ msgstr "Přidat další proud..."
 msgid "Add directory..."
 msgstr "Přidat složku..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Přidat soubor"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Přidat soubor k překódování"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Přidat soubor(y) k překódování"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Přidat soubor..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Přidat soubory pro překódování"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Přidat složku"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Přidat složku..."
 
@@ -560,7 +560,7 @@ msgstr "Přidat novou složku..."
 msgid "Add podcast"
 msgstr "Přidat záznam"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Přidat zvukový záznam..."
 
@@ -636,7 +636,7 @@ msgstr "Přidat značku pořadí písně"
 msgid "Add song year tag"
 msgstr "Přidat značku rok písně"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Přidat proud..."
 
@@ -648,7 +648,7 @@ msgstr "Přidat do seznamů skladeb Spotify"
 msgid "Add to Spotify starred"
 msgstr "Přidat do Spotify s hvězdičkou"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Přidat do jiného seznamu skladeb"
 
@@ -742,7 +742,7 @@ msgstr "Vše"
 msgid "All Files (*)"
 msgstr "Všechny soubory (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Sláva hypnožábě!"
@@ -1133,7 +1133,7 @@ msgstr "Podívat se po nových dílech"
 msgid "Check for updates"
 msgstr "Podívat se po aktualizacích"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Zkontrolovat aktualizace"
 
@@ -1182,18 +1182,18 @@ msgstr "Klasická"
 msgid "Cleaning up"
 msgstr "Úklid"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Smazat"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Vyprázdnit seznam skladeb"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1338,7 +1338,7 @@ msgstr "Poznámka"
 msgid "Complete tags automatically"
 msgstr "Doplnit značky automaticky"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Doplnit značky automaticky..."
 
@@ -1373,7 +1373,7 @@ msgstr "Nastavit Subsonic..."
 msgid "Configure global search..."
 msgstr "Nastavit celkové hledání..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Nastavit sbírku..."
 
@@ -1416,7 +1416,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Spojení vypršelo, prověřte adresu serveru (URL). Příklad: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Konzole"
 
@@ -1445,11 +1445,11 @@ msgid "Copy to clipboard"
 msgstr "Kopírovat do schránky"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Zkopírovat do zařízení..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Zkopírovat do sbírky..."
@@ -1492,14 +1492,14 @@ msgstr "Nepodařilo se přihlásit se k Last.fm. Zkuste to, prosím, znovu.."
 msgid "Couldn't create playlist"
 msgstr "Nepodařilo se vytvořit seznam skladeb"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Nepodařilo se najít multiplexer pro \"%1\" - ujistěte se, že máte nainstalovány správné přídavné moduly GStreamer"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1514,7 +1514,7 @@ msgstr "Nepodařilo se otevřít výstupní soubor %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Správce obalů"
 
@@ -1667,7 +1667,7 @@ msgid "Delete downloaded data"
 msgstr "Smazat stažená data"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Smazat soubory"
 
@@ -1675,7 +1675,7 @@ msgstr "Smazat soubory"
 msgid "Delete from device..."
 msgstr "Smazat ze zařízení..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Smazat z disku..."
@@ -1708,11 +1708,11 @@ msgstr "Probíhá mazání souborů"
 msgid "Depth"
 msgstr "Hloubka"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Odstranit vybrané skladby z řady"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Odstranit skladbu z řady"
 
@@ -1813,7 +1813,7 @@ msgstr "Volby zobrazení"
 msgid "Display the on-screen-display"
 msgstr "Zobrazovat informace na obrazovce (OSD)"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Znovu kompletně prohledat sbírku"
 
@@ -1992,12 +1992,12 @@ msgstr "Dynamický náhodný výběr"
 msgid "Edit smart playlist..."
 msgstr "Upravit chytrý seznam skladeb..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Upravit značku \"%1\"..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Upravit značku..."
 
@@ -2010,7 +2010,7 @@ msgid "Edit track information"
 msgstr "Upravit informace o skladbě"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Upravit informace o skladbě..."
 
@@ -2118,7 +2118,7 @@ msgstr "Celá sbírka"
 msgid "Episode information"
 msgstr "Informace o dílu"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Ekvalizér"
 
@@ -2131,8 +2131,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Rovnocenné s --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Chyba"
 
@@ -2167,7 +2167,7 @@ msgstr "Chyba při nahrávání %1"
 msgid "Error loading di.fm playlist"
 msgstr "Chyba při nahrávání seznamu skladeb di.fm"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Chyba při zpracovávání %1: %2"
@@ -2250,7 +2250,11 @@ msgstr "Uložení dokončeno"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "Uloženo %1 obalů z %2 (%3 přeskočeno)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2274,7 +2278,7 @@ msgstr "Slábnutí"
 msgid "Fading duration"
 msgstr "Doba slábnutí"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Nepodařilo se číst z CD v mechanice"
 
@@ -2556,11 +2560,11 @@ msgstr "Pojmenujte to:"
 msgid "Go"
 msgstr "Jít"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Jít na další kartu seznamu skladeb"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Jít na předchozí kartu seznamu skladeb"
 
@@ -2893,7 +2897,7 @@ msgstr "Databáze Jamendo"
 msgid "Jump to previous song right away"
 msgstr "Skočit ihned na předchozí píseň"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Skočit na nyní přehrávanou skladbu"
 
@@ -2917,7 +2921,7 @@ msgstr "Při zavření okna nechat běžet na pozadí"
 msgid "Keep the original files"
 msgstr "Zachovat původní soubory"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Koťátka"
@@ -3009,7 +3013,7 @@ msgstr "Sbírka"
 msgid "Library advanced grouping"
 msgstr "Pokročilé seskupování sbírky"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Zpráva o prohledání sbírky"
 
@@ -3049,7 +3053,7 @@ msgstr "Nahrát obal na disku..."
 msgid "Load playlist"
 msgstr "Nahrát seznam skladeb"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Nahrát seznam skladeb..."
 
@@ -3110,11 +3114,15 @@ msgstr "Přihlášení"
 msgid "Login failed"
 msgstr "Přihlášení se nezdařilo"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Dlouhodobý předpověďní profil"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Líbí se"
 
@@ -3149,11 +3157,11 @@ msgstr "Texty písní z %1"
 msgid "Lyrics from the tag"
 msgstr "Text písně ze značky"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3195,7 +3203,7 @@ msgstr "Hlavní profil"
 msgid "Make it so!"
 msgstr "Proveďte!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Proveďte!"
@@ -3333,7 +3341,7 @@ msgstr "Přípojné body"
 msgid "Move down"
 msgstr "Posunout dolů"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Přesunout do sbírky..."
 
@@ -3342,7 +3350,7 @@ msgstr "Přesunout do sbírky..."
 msgid "Move up"
 msgstr "Posunout nahoru"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Hudba"
 
@@ -3355,7 +3363,7 @@ msgid "Music extensions remotely visible"
 msgstr "Vzdáleně viditelné hudební přípony"
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Ztlumit"
 
@@ -3404,7 +3412,7 @@ msgstr "Nikdy nezačít přehrávání"
 msgid "New folder"
 msgstr "Nová složka"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nový seznam skladeb"
 
@@ -3432,8 +3440,12 @@ msgstr "Nejnovější skladby"
 msgid "Next"
 msgstr "Další"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Další skladba"
 
@@ -3471,7 +3483,7 @@ msgstr "Žádné krátké bloky"
 msgid "None"
 msgstr "Žádná"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Žádná z vybraných písní nebyla vhodná ke zkopírování do zařízení"
 
@@ -3556,19 +3568,19 @@ msgstr "Vypnuto"
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg FLAC"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3612,7 +3624,7 @@ msgstr "Neprůhlednost"
 msgid "Open %1 in browser"
 msgstr "Otevřít %1 v prohlížeči"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Otevřít &zvukové CD..."
 
@@ -3624,7 +3636,7 @@ msgstr "Otevřít soubor OPML"
 msgid "Open OPML file..."
 msgstr "Otevřít soubor OPML..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Otevřít adresář a zavést hudbu v něm"
 
@@ -3632,7 +3644,7 @@ msgstr "Otevřít adresář a zavést hudbu v něm"
 msgid "Open device"
 msgstr "Otevřít zařízení"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Otevřít soubor"
 
@@ -3686,7 +3698,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Uspořádat soubory"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Uspořádat soubory..."
 
@@ -3770,7 +3782,7 @@ msgstr "Oslava"
 msgid "Password"
 msgstr "Heslo"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pozastavit"
@@ -3794,6 +3806,10 @@ msgstr "Účinkující"
 msgid "Pipeline"
 msgstr "Roura"
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Pixel"
@@ -3802,10 +3818,10 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Prostý postranní panel"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Přehrát"
 
@@ -3826,11 +3842,11 @@ msgstr "Přehrát, pokud je zastaveno, pozastavit, pokud je přehráváno"
 msgid "Play if there is nothing already playing"
 msgstr "Hrát, pokud se již něco nepřehrává"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Přehrát další"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Přehrát vybrané skladby jako další"
 
@@ -3929,7 +3945,7 @@ msgstr "Nastavení"
 msgid "Preferences"
 msgstr "Nastavení"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Nastavení..."
 
@@ -3989,7 +4005,7 @@ msgid "Previous"
 msgstr "Předchozí"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Předchozí skladba"
 
@@ -4047,16 +4063,16 @@ msgstr "Kvalita"
 msgid "Querying device..."
 msgstr "Dotazování se zařízení..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Správce řady"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Přidat vybrané skladby do řady"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Přidat skladbu do řady"
 
@@ -4072,7 +4088,7 @@ msgstr "Rádio (shodná hlasitost pro všechny skladby)"
 msgid "Rain"
 msgstr "Déšť"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Déšť"
@@ -4184,7 +4200,7 @@ msgstr "Odstranit činnost"
 msgid "Remove current song from playlist"
 msgstr "Odstranit nynější píseň ze seznamu skladeb"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Odstranit zdvojené ze seznamu skladeb"
 
@@ -4192,7 +4208,7 @@ msgstr "Odstranit zdvojené ze seznamu skladeb"
 msgid "Remove folder"
 msgstr "Odstranit složku"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Odstranit ze seznamu skladeb"
 
@@ -4204,7 +4220,7 @@ msgstr "Odstranit seznam skladeb"
 msgid "Remove playlists"
 msgstr "Odstranit seznamy skladeb"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Odstranit nedostupné skladby ze seznamu skladeb"
 
@@ -4216,7 +4232,7 @@ msgstr "Přejmenovat seznam skladeb"
 msgid "Rename playlist..."
 msgstr "Přejmenovat seznam skladeb..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Přečíslovat skladby v tomto pořadí..."
 
@@ -4307,7 +4323,7 @@ msgstr "Vytáhnout"
 msgid "Rip CD"
 msgstr "Vytáhnout skladby z CD"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Vytáhnout skladby ze zvukového CD"
 
@@ -4385,7 +4401,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Uložit seznam skladeb"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Uložit seznam skladeb..."
 
@@ -4472,7 +4488,7 @@ msgstr "Vyhledat Subsonic"
 msgid "Search automatically"
 msgstr "Hledat automaticky"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Hledat album"
 
@@ -4485,7 +4501,7 @@ msgstr "Hledat obaly alb..."
 msgid "Search for anything"
 msgstr "Hledat vše"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Hledat umělce"
 
@@ -4610,7 +4626,7 @@ msgstr "Podrobnosti o serveru"
 msgid "Service offline"
 msgstr "Služba není dostupná"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Nastavit %1 na \"%2\"..."
@@ -4619,7 +4635,7 @@ msgstr "Nastavit %1 na \"%2\"..."
 msgid "Set the volume to <value> percent"
 msgstr "Nastavit hlasitost na <value> procent"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Nastavit hodnotu pro vybrané skladby..."
 
@@ -4690,7 +4706,7 @@ msgstr "Ukazovat OSD"
 msgid "Show above status bar"
 msgstr "Ukazovat nad stavovým řádkem"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Ukázat všechny písně"
 
@@ -4710,12 +4726,12 @@ msgstr "Ukazovat oddělovače"
 msgid "Show fullsize..."
 msgstr "Ukázat v plné velikosti..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Ukázat v prohlížeči souborů..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Ukazovat ve sbírce..."
 
@@ -4727,15 +4743,15 @@ msgstr "Ukázat pod různými umělci"
 msgid "Show moodbar"
 msgstr "Ukázat náladový proužek"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Ukázat pouze zdvojené"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Ukázat pouze neoznačené"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Ukázat nebo skrýt postranní panel"
 
@@ -4743,7 +4759,7 @@ msgstr "Ukázat nebo skrýt postranní panel"
 msgid "Show search suggestions"
 msgstr "Ukázat návrhy hledání"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Ukázat postranní panel"
 
@@ -4779,7 +4795,7 @@ msgstr "Zamíchat alba"
 msgid "Shuffle all"
 msgstr "Zamíchat vše"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Zamíchat seznam skladeb"
 
@@ -4823,11 +4839,15 @@ msgstr "Počet přeskočení"
 msgid "Skip forwards in playlist"
 msgstr "Další skladba v seznamu skladeb"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Přeskočit vybrané skladby"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Přeskočit skladbu"
 
@@ -4944,7 +4964,7 @@ msgstr "Začít vytahovat"
 msgid "Start the playlist currently playing"
 msgstr "Přehrát současnou skladbu v seznamu skladeb"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Převést"
 
@@ -4954,7 +4974,7 @@ msgid ""
 "list"
 msgstr "Začněte něco psát do vyhledávacího pole výše, abyste naplnil tento seznam pro hledání výsledků."
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Spouští se %1"
@@ -4964,7 +4984,7 @@ msgid "Starting..."
 msgstr "Spouští se..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Zastavit"
 
@@ -4980,7 +5000,7 @@ msgstr "Zastavit po každé skladbě"
 msgid "Stop after every track"
 msgstr "Zastavit po každé skladbě"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Zastavit po této skladbě"
 
@@ -5148,7 +5168,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Lhůta na vyzkoušení serveru Subsonic uplynula. Dejte, prosím, dar, abyste dostali licenční klíč. Navštivte subsonic.org kvůli podrobnostem."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5190,7 +5210,7 @@ msgid ""
 "continue?"
 msgstr "Tyto soubory budou smazány ze zařízení. Opravdu chcete pokračovat?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5292,11 +5312,11 @@ msgstr "Přepnout OSD"
 msgid "Toggle fullscreen"
 msgstr "Zapnout/Vypnout zobrazení na celou obrazovku"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Přepnout stav řady"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Přepnout odesílání informací o přehrávání"
 
@@ -5341,19 +5361,19 @@ msgstr "Skla&dby"
 msgid "Track"
 msgstr "Skladba"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Převést hudbu"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Záznam o převodu"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Překódování"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Převádí se %1 souborů s %2 procesy"
@@ -5430,11 +5450,11 @@ msgstr "Neznámá chyba"
 msgid "Unset cover"
 msgstr "Odebrat obal"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Zrušit přeskočení vybraných skladeb"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Zrušit přeskočení skladby"
 
@@ -5451,7 +5471,7 @@ msgstr "Připravované koncerty"
 msgid "Update all podcasts"
 msgstr "Obnovit všechny zvukovové záznamy"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Obnovit změněné složky sbírky"
 
@@ -5612,7 +5632,7 @@ msgstr "Verze %1"
 msgid "View"
 msgstr "Pohled"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Zobrazit podrobnosti o proudu"
 
@@ -5620,7 +5640,7 @@ msgstr "Zobrazit podrobnosti o proudu"
 msgid "Visualization mode"
 msgstr "Režim vizualizací"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Vizualizace"
 
@@ -5661,7 +5681,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr "Varování: Tato úroveň komprese je mimo vysílatelnou podmnožinu. To znamená, že dekodér nemusí být schopen začít přehrávat uprostřed proudu. Může to také ovlivnit výkon hardwarových dekodérů."
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "WAV"
 
@@ -5757,7 +5777,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media Audio"
 
@@ -5771,7 +5791,7 @@ msgid ""
 "well?"
 msgstr "Chcete další písně na tomto albu přesunout do Různí umělci?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Chcete spustit toto úplné nové prohledání hned teď?"
 

--- a/src/translations/cy.po
+++ b/src/translations/cy.po
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add directory..."
 msgstr ""
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgstr ""
 msgid "Add files to transcode"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr ""
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr ""
 
@@ -856,7 +856,7 @@ msgstr ""
 msgid "Artist"
 msgstr ""
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr ""
 
@@ -1119,7 +1119,7 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr ""
 
@@ -1359,7 +1359,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr ""
 
@@ -1431,11 +1431,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1653,7 +1653,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr ""
 
@@ -1661,7 +1661,7 @@ msgstr ""
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1694,11 +1694,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr ""
 
@@ -1727,7 +1727,7 @@ msgstr ""
 msgid "Device properties..."
 msgstr ""
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr ""
 
@@ -1978,7 +1978,7 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
@@ -2117,8 +2117,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr ""
 
@@ -2264,7 +2264,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2387,7 +2387,7 @@ msgstr ""
 msgid "Filename"
 msgstr ""
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr ""
 
@@ -2802,7 +2802,7 @@ msgstr ""
 msgid "Integrity check"
 msgstr ""
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr ""
 
@@ -2990,7 +2990,7 @@ msgstr ""
 msgid "Length"
 msgstr ""
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr ""
@@ -2999,7 +2999,7 @@ msgstr ""
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3327,7 +3327,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3336,7 +3336,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr ""
 
@@ -3398,7 +3398,7 @@ msgstr ""
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3469,7 +3469,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3684,7 +3684,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr ""
 
@@ -3768,7 +3768,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr ""
@@ -3804,8 +3804,8 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3828,11 +3828,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Playlist type"
 msgstr ""
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr ""
 
@@ -4053,12 +4053,12 @@ msgstr ""
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr ""
 
@@ -4449,7 +4449,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr ""
@@ -4474,7 +4474,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4487,7 +4487,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4692,7 +4692,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr ""
 
@@ -4712,12 +4712,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr ""
 
@@ -4729,11 +4729,11 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr ""
 
@@ -4825,7 +4825,7 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr ""
 
@@ -4833,7 +4833,7 @@ msgstr ""
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr ""
 
@@ -4865,7 +4865,7 @@ msgstr ""
 msgid "Song Information"
 msgstr ""
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr ""
 
@@ -4986,7 +4986,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5154,7 +5154,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5196,7 +5196,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5298,7 +5298,7 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr ""
 
@@ -5436,11 +5436,11 @@ msgstr ""
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr ""
 
@@ -5777,7 +5777,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/cy.po
+++ b/src/translations/cy.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Welsh (http://www.transifex.com/davidsansome/clementine/language/cy/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -161,19 +161,19 @@ msgstr ""
 msgid "%filename%"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -191,7 +191,7 @@ msgstr ""
 msgid "&Custom"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr ""
 
@@ -199,7 +199,7 @@ msgstr ""
 msgid "&Grouping"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr ""
 
@@ -224,7 +224,7 @@ msgstr ""
 msgid "&Lyrics"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr ""
 
@@ -232,15 +232,15 @@ msgstr ""
 msgid "&None"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr ""
 
@@ -248,7 +248,7 @@ msgstr ""
 msgid "&Right"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr ""
 
@@ -256,7 +256,7 @@ msgstr ""
 msgid "&Stretch columns to fit window"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr ""
 
@@ -445,11 +445,11 @@ msgstr ""
 msgid "About %1"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr ""
 
@@ -509,32 +509,32 @@ msgstr ""
 msgid "Add directory..."
 msgstr ""
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr ""
 
@@ -546,7 +546,7 @@ msgstr ""
 msgid "Add podcast"
 msgstr ""
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr ""
 
@@ -622,7 +622,7 @@ msgstr ""
 msgid "Add song year tag"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr ""
 
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr ""
 
@@ -728,7 +728,7 @@ msgstr ""
 msgid "All Files (*)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr ""
@@ -1119,7 +1119,7 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr ""
 
@@ -1168,18 +1168,18 @@ msgstr ""
 msgid "Cleaning up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr ""
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr ""
 
@@ -1324,7 +1324,7 @@ msgstr ""
 msgid "Complete tags automatically"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr ""
 
@@ -1359,7 +1359,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr ""
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr ""
 
@@ -1431,11 +1431,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1478,14 +1478,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr ""
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1500,7 +1500,7 @@ msgstr ""
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr ""
 
@@ -1653,7 +1653,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr ""
 
@@ -1661,7 +1661,7 @@ msgstr ""
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1694,11 +1694,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr ""
 
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "Display the on-screen-display"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr ""
 
@@ -1978,12 +1978,12 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr ""
 
@@ -1996,7 +1996,7 @@ msgid "Edit track information"
 msgstr ""
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr ""
 
@@ -2104,7 +2104,7 @@ msgstr ""
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr ""
 
@@ -2117,8 +2117,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr ""
 
@@ -2153,7 +2153,7 @@ msgstr ""
 msgid "Error loading di.fm playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr ""
@@ -2236,7 +2236,11 @@ msgstr ""
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr ""
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2260,7 +2264,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2542,11 +2546,11 @@ msgstr ""
 msgid "Go"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr ""
 
@@ -2879,7 +2883,7 @@ msgstr ""
 msgid "Jump to previous song right away"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr ""
 
@@ -2903,7 +2907,7 @@ msgstr ""
 msgid "Keep the original files"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr ""
@@ -2995,7 +2999,7 @@ msgstr ""
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3035,7 +3039,7 @@ msgstr ""
 msgid "Load playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr ""
 
@@ -3096,11 +3100,15 @@ msgstr ""
 msgid "Login failed"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr ""
 
@@ -3135,11 +3143,11 @@ msgstr ""
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr ""
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr ""
@@ -3181,7 +3189,7 @@ msgstr ""
 msgid "Make it so!"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr ""
@@ -3319,7 +3327,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3328,7 +3336,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr ""
 
@@ -3341,7 +3349,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr ""
 
@@ -3390,7 +3398,7 @@ msgstr ""
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3418,8 +3426,12 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr ""
 
@@ -3457,7 +3469,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3542,19 +3554,19 @@ msgstr ""
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr ""
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr ""
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr ""
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3598,7 +3610,7 @@ msgstr ""
 msgid "Open %1 in browser"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr ""
 
@@ -3610,7 +3622,7 @@ msgstr ""
 msgid "Open OPML file..."
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr ""
 
@@ -3618,7 +3630,7 @@ msgstr ""
 msgid "Open device"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr ""
 
@@ -3672,7 +3684,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr ""
 
@@ -3756,7 +3768,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr ""
@@ -3780,6 +3792,10 @@ msgstr ""
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr ""
@@ -3788,10 +3804,10 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr ""
 
@@ -3812,11 +3828,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3915,7 +3931,7 @@ msgstr ""
 msgid "Preferences"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr ""
 
@@ -3975,7 +3991,7 @@ msgid "Previous"
 msgstr ""
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr ""
 
@@ -4033,16 +4049,16 @@ msgstr ""
 msgid "Querying device..."
 msgstr ""
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr ""
 
@@ -4058,7 +4074,7 @@ msgstr ""
 msgid "Rain"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr ""
@@ -4170,7 +4186,7 @@ msgstr ""
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr ""
 
@@ -4178,7 +4194,7 @@ msgstr ""
 msgid "Remove folder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr ""
 
@@ -4190,7 +4206,7 @@ msgstr ""
 msgid "Remove playlists"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr ""
 
@@ -4202,7 +4218,7 @@ msgstr ""
 msgid "Rename playlist..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr ""
 
@@ -4293,7 +4309,7 @@ msgstr ""
 msgid "Rip CD"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr ""
 
@@ -4371,7 +4387,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr ""
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr ""
 
@@ -4458,7 +4474,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4471,7 +4487,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4596,7 +4612,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4605,7 +4621,7 @@ msgstr ""
 msgid "Set the volume to <value> percent"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr ""
 
@@ -4676,7 +4692,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr ""
 
@@ -4696,12 +4712,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr ""
 
@@ -4713,15 +4729,15 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4729,7 +4745,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4765,7 +4781,7 @@ msgstr ""
 msgid "Shuffle all"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr ""
 
@@ -4809,11 +4825,15 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr ""
 
@@ -4930,7 +4950,7 @@ msgstr ""
 msgid "Start the playlist currently playing"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr ""
 
@@ -4940,7 +4960,7 @@ msgid ""
 "list"
 msgstr ""
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr ""
@@ -4950,7 +4970,7 @@ msgid "Starting..."
 msgstr ""
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr ""
 
@@ -4966,7 +4986,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5134,7 +5154,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5176,7 +5196,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5278,11 +5298,11 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr ""
 
@@ -5327,19 +5347,19 @@ msgstr ""
 msgid "Track"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr ""
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
 msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr ""
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr ""
@@ -5416,11 +5436,11 @@ msgstr ""
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr ""
 
@@ -5437,7 +5457,7 @@ msgstr ""
 msgid "Update all podcasts"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr ""
 
@@ -5598,7 +5618,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5606,7 +5626,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr ""
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr ""
 
@@ -5647,7 +5667,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr ""
 
@@ -5743,7 +5763,7 @@ msgstr ""
 msgid "Windows Media 64k"
 msgstr ""
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr ""
 
@@ -5757,7 +5777,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/da.po
+++ b/src/translations/da.po
@@ -25,7 +25,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Danish (http://www.transifex.com/davidsansome/clementine/language/da/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -179,19 +179,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filnavn%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n fejlede"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n færdige"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -209,7 +209,7 @@ msgstr "&Centrer"
 msgid "&Custom"
 msgstr "&Brugervalgt"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Ekstra"
 
@@ -217,7 +217,7 @@ msgstr "&Ekstra"
 msgid "&Grouping"
 msgstr "&Gruppering"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Hjælp"
 
@@ -242,7 +242,7 @@ msgstr "&Lås bedømmelse"
 msgid "&Lyrics"
 msgstr "&Sangtekster"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Musik"
 
@@ -250,15 +250,15 @@ msgstr "&Musik"
 msgid "&None"
 msgstr "&Ingen"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&Afspilningsliste"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Afslut"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "&Gentagelsestilstand"
 
@@ -266,7 +266,7 @@ msgstr "&Gentagelsestilstand"
 msgid "&Right"
 msgstr "&Højre"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Tilfældighed&stilstand"
 
@@ -274,7 +274,7 @@ msgstr "Tilfældighed&stilstand"
 msgid "&Stretch columns to fit window"
 msgstr "&Udvid søjler til at passe til vindue"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Værktøjer"
 
@@ -463,11 +463,11 @@ msgstr "Afbryd"
 msgid "About %1"
 msgstr "Om %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Om Clementine ..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Om Qt ..."
 
@@ -527,32 +527,32 @@ msgstr "Henter udsendelser ..."
 msgid "Add directory..."
 msgstr "Tilføj mappe ..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Tilføj fil"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Tilføj fil til omkoder"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Tilføj fil(er) til omkoder"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Tilføj fil ..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Tilføj filer til omkodning"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Tilføj mappe"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Tilføj mappe ..."
 
@@ -564,7 +564,7 @@ msgstr "Tilføj ny mappe ..."
 msgid "Add podcast"
 msgstr "Tilføj podcast"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Tilføj podcast ..."
 
@@ -640,7 +640,7 @@ msgstr "Tilføj sangspor-mærke"
 msgid "Add song year tag"
 msgstr "Tilføj sangår-mærke"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Genopfrisk udsendelser ..."
 
@@ -652,7 +652,7 @@ msgstr "Tilføj til Spotify-afspilningslister"
 msgid "Add to Spotify starred"
 msgstr "Tilføj til Spotify med stjerne"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Tilføj til en anden afspilningsliste"
 
@@ -746,7 +746,7 @@ msgstr "Alle"
 msgid "All Files (*)"
 msgstr "Alle filer (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Al ære til Hypnotudsen!"
@@ -1137,7 +1137,7 @@ msgstr "Søg efter nye episoder"
 msgid "Check for updates"
 msgstr "Søg efter opdateringer"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Søg efter opdateringer ..."
 
@@ -1186,18 +1186,18 @@ msgstr "Klassisk"
 msgid "Cleaning up"
 msgstr "Rydder op"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Ryd"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Ryd afspilningsliste"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1342,7 +1342,7 @@ msgstr "Kommentar"
 msgid "Complete tags automatically"
 msgstr "Fuldfør mærker automatisk"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Fuldfør mærker automatisk ..."
 
@@ -1377,7 +1377,7 @@ msgstr "Konfigurer Subsonic ..."
 msgid "Configure global search..."
 msgstr "Konfigurer blobal søgning ..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Indstil bibliotek ..."
 
@@ -1420,7 +1420,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Forbindelsen fik tidsudløb, kontroller serveradressen. Eksempel: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Konsol"
 
@@ -1449,11 +1449,11 @@ msgid "Copy to clipboard"
 msgstr "Kopier til udklipsholder"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopier til enhed ..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kopier til bibliotek ..."
@@ -1496,14 +1496,14 @@ msgstr "Kunne ikke logge ind på Last.fm. Prøv igen."
 msgid "Couldn't create playlist"
 msgstr "Kunne ikke oprette afspilningsliste"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Kunne ikke finde muxer for %1, tjek at du har de rigtige GStreamer-plugins installeret"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1518,7 +1518,7 @@ msgstr "Kunne ikke åbne output fil %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Omslagshåndtering"
 
@@ -1671,7 +1671,7 @@ msgid "Delete downloaded data"
 msgstr "Sletter hentet data"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Slet filer"
 
@@ -1679,7 +1679,7 @@ msgstr "Slet filer"
 msgid "Delete from device..."
 msgstr "Slet fra enhed ..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Slet fra disk ..."
@@ -1712,11 +1712,11 @@ msgstr "Sletter filer"
 msgid "Depth"
 msgstr "Dybde"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Fjern valgte spor fra afspilningskøen"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Fjern spor fra afspilningskøen"
 
@@ -1817,7 +1817,7 @@ msgstr "Visningsegenskaber"
 msgid "Display the on-screen-display"
 msgstr "Vis on-screen-display"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Genindlæs hele biblioteket"
 
@@ -1996,12 +1996,12 @@ msgstr "Dynamisk tilfældig mix"
 msgid "Edit smart playlist..."
 msgstr "Rediger smart afspilningsliste ..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Rediger mærke »%1« ..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Rediger mærke ..."
 
@@ -2014,7 +2014,7 @@ msgid "Edit track information"
 msgstr "Rediger sporinformation"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Rediger information om spor ..."
 
@@ -2122,7 +2122,7 @@ msgstr "Hele samlingen"
 msgid "Episode information"
 msgstr "Episodeinformation"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Equalizer"
 
@@ -2135,8 +2135,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Svarende til --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Fejl"
 
@@ -2171,7 +2171,7 @@ msgstr "Kunne ikke indlæse %1"
 msgid "Error loading di.fm playlist"
 msgstr "Kunne ikke indlæse afspilningsliste fra di.fm"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Kunne ikke behandle %1: %2"
@@ -2254,7 +2254,11 @@ msgstr "Eksport færdig"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "Eksporterede %1 omslag ud af %2 (%3 sprunget over)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2278,7 +2282,7 @@ msgstr "Fading"
 msgid "Fading duration"
 msgstr "Varighed af fade"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Fejl ved læsning af CD-drev"
 
@@ -2560,11 +2564,11 @@ msgstr "Giv det et navn:"
 msgid "Go"
 msgstr "Start"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Gå til næste faneblad på afspilningslisten"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Gå til forrige faneblad på afspilningslisten"
 
@@ -2897,7 +2901,7 @@ msgstr "Jamendo-database"
 msgid "Jump to previous song right away"
 msgstr "Gå til forrige sang nu"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Gå til sporet som afspilles nu"
 
@@ -2921,7 +2925,7 @@ msgstr "Fortsæt i baggrunden selv om du lukker vinduet"
 msgid "Keep the original files"
 msgstr "Behold de originale filer"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Killinger"
@@ -3013,7 +3017,7 @@ msgstr "Bibliotek"
 msgid "Library advanced grouping"
 msgstr "Avanceret bibliotektsgruppering"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Meddelelse om genindlæsning af biblioteket"
 
@@ -3053,7 +3057,7 @@ msgstr "Hent omslag fra disk ..."
 msgid "Load playlist"
 msgstr "Åbn afspilningsliste"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Åbn afspilningsliste ..."
 
@@ -3114,11 +3118,15 @@ msgstr "Log ind"
 msgid "Login failed"
 msgstr "Login mislykkedes"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Long term prediction-profil (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Elsker"
 
@@ -3153,11 +3161,11 @@ msgstr "Sangtekster fra %1"
 msgid "Lyrics from the tag"
 msgstr "Sangtekster fra mærket"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3199,7 +3207,7 @@ msgstr "Main profile (MAIN)"
 msgid "Make it so!"
 msgstr "Make it so!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Make it so!"
@@ -3337,7 +3345,7 @@ msgstr "Monteringspunkter"
 msgid "Move down"
 msgstr "Flyt ned"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Flyt til bibliotek ..."
 
@@ -3346,7 +3354,7 @@ msgstr "Flyt til bibliotek ..."
 msgid "Move up"
 msgstr "Flyt op"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Musik"
 
@@ -3359,7 +3367,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Slå lyden fra"
 
@@ -3408,7 +3416,7 @@ msgstr "Begynd aldrig afspilning"
 msgid "New folder"
 msgstr "Ny mappe"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Ny afspilningsliste"
 
@@ -3436,8 +3444,12 @@ msgstr "Nyeste spor"
 msgid "Next"
 msgstr "Næste"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Næste spor"
 
@@ -3475,7 +3487,7 @@ msgstr "Ingen korte blokke"
 msgid "None"
 msgstr "Ingen"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Kunne ikke kopiere nogen af de valgte sange til enheden"
 
@@ -3560,19 +3572,19 @@ msgstr "Fra"
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg FLAC"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3616,7 +3628,7 @@ msgstr "Uigennemsigtighed"
 msgid "Open %1 in browser"
 msgstr "Åbn %1 i browser"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Åbn lyd-&cd ..."
 
@@ -3628,7 +3640,7 @@ msgstr "Åbn OPML-fil"
 msgid "Open OPML file..."
 msgstr "Åbn OPML-fil ..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Åbn en mappe hvor musik skal importeres fra"
 
@@ -3636,7 +3648,7 @@ msgstr "Åbn en mappe hvor musik skal importeres fra"
 msgid "Open device"
 msgstr "Åbn enhed"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Åbn fil ..."
 
@@ -3690,7 +3702,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organiser filer"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Organiser filer ..."
 
@@ -3774,7 +3786,7 @@ msgstr "Party"
 msgid "Password"
 msgstr "Adgangskode"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pause"
@@ -3798,6 +3810,10 @@ msgstr "Kunstner"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Pixel"
@@ -3806,10 +3822,10 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Simpelt sidepanel"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Afspil"
 
@@ -3830,11 +3846,11 @@ msgstr "Spil hvis der er stoppet, hold pause hvis der spilles"
 msgid "Play if there is nothing already playing"
 msgstr "Afspil hvis der ikke er noget andet som afspilles i øjeblikket"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Afspil næste"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Afspil valgte spor næste gang"
 
@@ -3933,7 +3949,7 @@ msgstr "Præference"
 msgid "Preferences"
 msgstr "Indstillinger"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Præferencer ..."
 
@@ -3993,7 +4009,7 @@ msgid "Previous"
 msgstr "Forrige"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Forrige spor"
 
@@ -4051,16 +4067,16 @@ msgstr "Kvalitet"
 msgid "Querying device..."
 msgstr "Forespørger enhed ..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Køhåndtering"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Sæt valgte spor i kø"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Sæt spor i kø"
 
@@ -4076,7 +4092,7 @@ msgstr "Radio (samme lydstyrke for alle spor)"
 msgid "Rain"
 msgstr "Regn"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Regn"
@@ -4188,7 +4204,7 @@ msgstr "Fjern handling"
 msgid "Remove current song from playlist"
 msgstr "Fjern nuværende sang fra afspilningsliste"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Fjern dubletter fra afspilningsliste"
 
@@ -4196,7 +4212,7 @@ msgstr "Fjern dubletter fra afspilningsliste"
 msgid "Remove folder"
 msgstr "Fjern mappe"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Fjern fra afspilningsliste"
 
@@ -4208,7 +4224,7 @@ msgstr "Fjern afspilningsliste"
 msgid "Remove playlists"
 msgstr "Fjern afspilningslister"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Fjern utilgængelige spor fra afspilningsliste"
 
@@ -4220,7 +4236,7 @@ msgstr "Omdøb afspilningsliste"
 msgid "Rename playlist..."
 msgstr "Omdøb afspilningsliste..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Lav ny rækkefølge for spor ..."
 
@@ -4311,7 +4327,7 @@ msgstr "Rip"
 msgid "Rip CD"
 msgstr "Rip CD"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Rip lyd-CD"
 
@@ -4389,7 +4405,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Gem afspilningsliste"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Gem afspilningsliste ..."
 
@@ -4476,7 +4492,7 @@ msgstr "Søg efter Subsonic"
 msgid "Search automatically"
 msgstr "Søg automatisk"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Søg efter album"
 
@@ -4489,7 +4505,7 @@ msgstr "Søg efter omslag ..."
 msgid "Search for anything"
 msgstr "Søg efter noget"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Søg efter kunstner"
 
@@ -4614,7 +4630,7 @@ msgstr "Serverdetaljer"
 msgid "Service offline"
 msgstr "Tjeneste offline"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Sæt %1 til »%2« …"
@@ -4623,7 +4639,7 @@ msgstr "Sæt %1 til »%2« …"
 msgid "Set the volume to <value> percent"
 msgstr "Sæt lydstyrken til <value> procent"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Sæt værdi på alle valgte spor ..."
 
@@ -4694,7 +4710,7 @@ msgstr "Vis et kønt skærmdisplay"
 msgid "Show above status bar"
 msgstr "Vis over statuslinjen"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Vis alle sange"
 
@@ -4714,12 +4730,12 @@ msgstr "Vis adskillere"
 msgid "Show fullsize..."
 msgstr "Vis i fuld størrelse ..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Vis i filbrowser ..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Vis i biblioteket ..."
 
@@ -4731,15 +4747,15 @@ msgstr "Vis under Diverse kunstnere"
 msgid "Show moodbar"
 msgstr "Vis stemningslinje"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Vis kun dubletter"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Vis kun filer uden mærker"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Vis eller skjul sidepanel"
 
@@ -4747,7 +4763,7 @@ msgstr "Vis eller skjul sidepanel"
 msgid "Show search suggestions"
 msgstr "Vis søgeforslag"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Vis sidepanel"
 
@@ -4783,7 +4799,7 @@ msgstr "Bland albummer"
 msgid "Shuffle all"
 msgstr "Bland alle"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Bland afspilningsliste"
 
@@ -4827,11 +4843,15 @@ msgstr "Antal gange sprunget over"
 msgid "Skip forwards in playlist"
 msgstr "Gå fremad i afspilningslisten"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Udelad valgte spor"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Udelad spor"
 
@@ -4948,7 +4968,7 @@ msgstr "Start udtræk"
 msgid "Start the playlist currently playing"
 msgstr "Start den afspilningsliste der afspiller nu"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Start omkodning"
 
@@ -4958,7 +4978,7 @@ msgid ""
 "list"
 msgstr "Begynd med at skrive noget i søgeboksen ovenfor, for at fylde denne listen med søgeresultater"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Starter %1"
@@ -4968,7 +4988,7 @@ msgid "Starting..."
 msgstr "Starter …"
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Stop"
 
@@ -4984,7 +5004,7 @@ msgstr "Stop efter hvert spor"
 msgid "Stop after every track"
 msgstr "Stop efter hvert spor"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Stop efter dette spor"
 
@@ -5152,7 +5172,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Prøveperioden for Subsonic-serveren er ovre. Donér for at få en licens-nøgle. Besøg subsonic.org for flere detaljer."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5194,7 +5214,7 @@ msgid ""
 "continue?"
 msgstr "Disse filer vil blive slettet fra disken, er du sikker på at du vil fortsætte?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5296,11 +5316,11 @@ msgstr "Slå pænt skærmdisplay til/fra"
 msgid "Toggle fullscreen"
 msgstr "Slå fuldskærmstilstand til/fra"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Slå køstatus til/fra"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Slå scrobbling til/fra"
 
@@ -5345,19 +5365,19 @@ msgstr "&Spor"
 msgid "Track"
 msgstr "Spor"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Omkod musik"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Omkoder-log"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Omkodning"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Omkoder %1 filer i %2 tråde"
@@ -5434,11 +5454,11 @@ msgstr "Ukendt fejl"
 msgid "Unset cover"
 msgstr "Fravælg omslag"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Fjern udelad for valgte spor"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Fjern udelad for spor"
 
@@ -5455,7 +5475,7 @@ msgstr "Kommende Koncerter"
 msgid "Update all podcasts"
 msgstr "Ajourfør alle podcasts"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Opdater ændrede biblioteksmapper"
 
@@ -5616,7 +5636,7 @@ msgstr "Version %1"
 msgid "View"
 msgstr "Vis"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Vis strømdetaljer"
 
@@ -5624,7 +5644,7 @@ msgstr "Vis strømdetaljer"
 msgid "Visualization mode"
 msgstr "Visualiseringstilstand"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Visualiseringer"
 
@@ -5665,7 +5685,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5761,7 +5781,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media audio"
 
@@ -5775,7 +5795,7 @@ msgid ""
 "well?"
 msgstr "Vil du også flytte de andre sange i dette album til Diverse kunstnere?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Vil du genindlæse hele biblioteket nu?"
 

--- a/src/translations/da.po
+++ b/src/translations/da.po
@@ -527,7 +527,7 @@ msgstr "Henter udsendelser ..."
 msgid "Add directory..."
 msgstr "Tilføj mappe ..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Tilføj fil"
 
@@ -547,7 +547,7 @@ msgstr "Tilføj fil ..."
 msgid "Add files to transcode"
 msgstr "Tilføj filer til omkodning"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Tilføj mappe"
@@ -652,7 +652,7 @@ msgstr "Tilføj til Spotify-afspilningslister"
 msgid "Add to Spotify starred"
 msgstr "Tilføj til Spotify med stjerne"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Tilføj til en anden afspilningsliste"
 
@@ -874,7 +874,7 @@ msgstr "Er du sikker på, at du ønsker at skrive sangens statistik ind i sangfi
 msgid "Artist"
 msgstr "Kunstner"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Kunstnerinfo"
 
@@ -1137,7 +1137,7 @@ msgstr "Søg efter nye episoder"
 msgid "Check for updates"
 msgstr "Søg efter opdateringer"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Søg efter opdateringer ..."
 
@@ -1377,7 +1377,7 @@ msgstr "Konfigurer Subsonic ..."
 msgid "Configure global search..."
 msgstr "Konfigurer blobal søgning ..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Indstil bibliotek ..."
 
@@ -1449,11 +1449,11 @@ msgid "Copy to clipboard"
 msgstr "Kopier til udklipsholder"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopier til enhed ..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kopier til bibliotek ..."
@@ -1671,7 +1671,7 @@ msgid "Delete downloaded data"
 msgstr "Sletter hentet data"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Slet filer"
 
@@ -1679,7 +1679,7 @@ msgstr "Slet filer"
 msgid "Delete from device..."
 msgstr "Slet fra enhed ..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Slet fra disk ..."
@@ -1712,11 +1712,11 @@ msgstr "Sletter filer"
 msgid "Depth"
 msgstr "Dybde"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Fjern valgte spor fra afspilningskøen"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Fjern spor fra afspilningskøen"
 
@@ -1745,7 +1745,7 @@ msgstr "Enhedsnavn"
 msgid "Device properties..."
 msgstr "Enhedsindstillinger ..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Enhed"
 
@@ -1996,7 +1996,7 @@ msgstr "Dynamisk tilfældig mix"
 msgid "Edit smart playlist..."
 msgstr "Rediger smart afspilningsliste ..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Rediger mærke »%1« ..."
@@ -2135,8 +2135,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Svarende til --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Fejl"
 
@@ -2282,7 +2282,7 @@ msgstr "Fading"
 msgid "Fading duration"
 msgstr "Varighed af fade"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Fejl ved læsning af CD-drev"
 
@@ -2405,7 +2405,7 @@ msgstr "Filtype"
 msgid "Filename"
 msgstr "Filnavn"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Filer"
 
@@ -2820,7 +2820,7 @@ msgstr "Installeret"
 msgid "Integrity check"
 msgstr "Integritetskontrol"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -3008,7 +3008,7 @@ msgstr "Venstre"
 msgid "Length"
 msgstr "Længde"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Bibliotek"
@@ -3017,7 +3017,7 @@ msgstr "Bibliotek"
 msgid "Library advanced grouping"
 msgstr "Avanceret bibliotektsgruppering"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Meddelelse om genindlæsning af biblioteket"
 
@@ -3345,7 +3345,7 @@ msgstr "Monteringspunkter"
 msgid "Move down"
 msgstr "Flyt ned"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Flyt til bibliotek ..."
 
@@ -3354,7 +3354,7 @@ msgstr "Flyt til bibliotek ..."
 msgid "Move up"
 msgstr "Flyt op"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Musik"
 
@@ -3416,7 +3416,7 @@ msgstr "Begynd aldrig afspilning"
 msgid "New folder"
 msgstr "Ny mappe"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Ny afspilningsliste"
 
@@ -3487,7 +3487,7 @@ msgstr "Ingen korte blokke"
 msgid "None"
 msgstr "Ingen"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Kunne ikke kopiere nogen af de valgte sange til enheden"
 
@@ -3702,7 +3702,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organiser filer"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Organiser filer ..."
 
@@ -3786,7 +3786,7 @@ msgstr "Party"
 msgid "Password"
 msgstr "Adgangskode"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pause"
@@ -3822,8 +3822,8 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Simpelt sidepanel"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3846,11 +3846,11 @@ msgstr "Spil hvis der er stoppet, hold pause hvis der spilles"
 msgid "Play if there is nothing already playing"
 msgstr "Afspil hvis der ikke er noget andet som afspilles i øjeblikket"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Afspil næste"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Afspil valgte spor næste gang"
 
@@ -3889,7 +3889,7 @@ msgstr "Indstillinger for afspilningsliste"
 msgid "Playlist type"
 msgstr "Afspilningslistetype"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Afspilningslister"
 
@@ -4071,12 +4071,12 @@ msgstr "Forespørger enhed ..."
 msgid "Queue Manager"
 msgstr "Køhåndtering"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Sæt valgte spor i kø"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Sæt spor i kø"
 
@@ -4467,7 +4467,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Søg"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Søg"
@@ -4492,7 +4492,7 @@ msgstr "Søg efter Subsonic"
 msgid "Search automatically"
 msgstr "Søg automatisk"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Søg efter album"
 
@@ -4505,7 +4505,7 @@ msgstr "Søg efter omslag ..."
 msgid "Search for anything"
 msgstr "Søg efter noget"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Søg efter kunstner"
 
@@ -4630,7 +4630,7 @@ msgstr "Serverdetaljer"
 msgid "Service offline"
 msgstr "Tjeneste offline"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Sæt %1 til »%2« …"
@@ -4710,7 +4710,7 @@ msgstr "Vis et kønt skærmdisplay"
 msgid "Show above status bar"
 msgstr "Vis over statuslinjen"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Vis alle sange"
 
@@ -4730,12 +4730,12 @@ msgstr "Vis adskillere"
 msgid "Show fullsize..."
 msgstr "Vis i fuld størrelse ..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Vis i filbrowser ..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Vis i biblioteket ..."
 
@@ -4747,11 +4747,11 @@ msgstr "Vis under Diverse kunstnere"
 msgid "Show moodbar"
 msgstr "Vis stemningslinje"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Vis kun dubletter"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Vis kun filer uden mærker"
 
@@ -4843,7 +4843,7 @@ msgstr "Antal gange sprunget over"
 msgid "Skip forwards in playlist"
 msgstr "Gå fremad i afspilningslisten"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Udelad valgte spor"
 
@@ -4851,7 +4851,7 @@ msgstr "Udelad valgte spor"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Udelad spor"
 
@@ -4883,7 +4883,7 @@ msgstr "Soft Rock"
 msgid "Song Information"
 msgstr "Sanginformation"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Sanginfo"
 
@@ -5004,7 +5004,7 @@ msgstr "Stop efter hvert spor"
 msgid "Stop after every track"
 msgstr "Stop efter hvert spor"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Stop efter dette spor"
 
@@ -5172,7 +5172,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Prøveperioden for Subsonic-serveren er ovre. Donér for at få en licens-nøgle. Besøg subsonic.org for flere detaljer."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5214,7 +5214,7 @@ msgid ""
 "continue?"
 msgstr "Disse filer vil blive slettet fra disken, er du sikker på at du vil fortsætte?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5316,7 +5316,7 @@ msgstr "Slå pænt skærmdisplay til/fra"
 msgid "Toggle fullscreen"
 msgstr "Slå fuldskærmstilstand til/fra"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Slå køstatus til/fra"
 
@@ -5454,11 +5454,11 @@ msgstr "Ukendt fejl"
 msgid "Unset cover"
 msgstr "Fravælg omslag"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Fjern udelad for valgte spor"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Fjern udelad for spor"
 
@@ -5795,7 +5795,7 @@ msgid ""
 "well?"
 msgstr "Vil du også flytte de andre sange i dette album til Diverse kunstnere?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Vil du genindlæse hele biblioteket nu?"
 

--- a/src/translations/de.po
+++ b/src/translations/de.po
@@ -67,7 +67,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: German (http://www.transifex.com/davidsansome/clementine/language/de/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -221,19 +221,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n fehlgeschlagen"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n abgeschlossen"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -251,7 +251,7 @@ msgstr "&Zentriert"
 msgid "&Custom"
 msgstr "&Benutzerdefiniert"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Extras"
 
@@ -259,7 +259,7 @@ msgstr "&Extras"
 msgid "&Grouping"
 msgstr "&Gruppierung"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Hilfe"
 
@@ -284,7 +284,7 @@ msgstr "Bewertung &sperren"
 msgid "&Lyrics"
 msgstr "&Liedtext"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Musik"
 
@@ -292,15 +292,15 @@ msgstr "&Musik"
 msgid "&None"
 msgstr "&Keine"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&Wiedergabeliste"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Beenden"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "&Wiederholung"
 
@@ -308,7 +308,7 @@ msgstr "&Wiederholung"
 msgid "&Right"
 msgstr "&Rechts"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "&Zufallsmodus"
 
@@ -316,7 +316,7 @@ msgstr "&Zufallsmodus"
 msgid "&Stretch columns to fit window"
 msgstr "&Spalten an Fenstergröße anpassen"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "Werk&zeuge"
 
@@ -505,11 +505,11 @@ msgstr "Abbrechen"
 msgid "About %1"
 msgstr "Über %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Über Clementine …"
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Über Qt …"
 
@@ -569,32 +569,32 @@ msgstr "Einen weiteren Datenstrom hinzufügen …"
 msgid "Add directory..."
 msgstr "Verzeichnis hinzufügen …"
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Datei hinzufügen"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Datei zum Umwandler hinzufügen"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Datei(en) zum Umwandler hinzufügen"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Datei hinzufügen …"
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Dateien zum Umwandeln hinzufügen"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Ordner hinzufügen"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Ordner hinzufügen …"
 
@@ -606,7 +606,7 @@ msgstr "Neuen Ordner hinzufügen …"
 msgid "Add podcast"
 msgstr "Podcast hinzufügen"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "&Podcast hinzufügen …"
 
@@ -682,7 +682,7 @@ msgstr "Titelnummer hinzufügen"
 msgid "Add song year tag"
 msgstr "Titelerscheinungsjahr hinzufügen"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Datenstrom hinzufügen …"
 
@@ -694,7 +694,7 @@ msgstr "Zur Spotify-Wiedergabeliste hinzufügen"
 msgid "Add to Spotify starred"
 msgstr "Markierte Titel von Spotify hinzufügen"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Zu anderer Wiedergabeliste hinzufügen"
 
@@ -788,7 +788,7 @@ msgstr "Alle"
 msgid "All Files (*)"
 msgstr "Alle Dateien (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Aller Ruhm der Hypnosekröte!"
@@ -1179,7 +1179,7 @@ msgstr "Nach neuen Episoden suchen"
 msgid "Check for updates"
 msgstr "Auf Aktualisierungen suchen"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Nach Aktualisierungen suchen …"
 
@@ -1228,18 +1228,18 @@ msgstr "Klassisch"
 msgid "Cleaning up"
 msgstr "Bereinigen"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Leeren"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Wiedergabeliste leeren"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1384,7 +1384,7 @@ msgstr "Kommentar"
 msgid "Complete tags automatically"
 msgstr "Schlagworte automatisch vervollständigen"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Schlagworte automatisch vervollständigen …"
 
@@ -1419,7 +1419,7 @@ msgstr "Subsonic wird konfiguriert …"
 msgid "Configure global search..."
 msgstr "Globale Suche konfigurieren …"
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Bibliothek einrichten …"
 
@@ -1462,7 +1462,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Zeitüberschreitung, bitte überprüfen Sie die Server-Adresse. Beispiel: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Konsole"
 
@@ -1491,11 +1491,11 @@ msgid "Copy to clipboard"
 msgstr "Kopieren"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Auf das Gerät kopieren …"
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Zur Bibliothek kopieren …"
@@ -1538,14 +1538,14 @@ msgstr "Konnte bei Last.fm nicht einloggen. Bitte versuchen Sie es noch einmal."
 msgid "Couldn't create playlist"
 msgstr "Wiedergabeliste konnte nicht erstellt werden"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Es konnte kein Multiplexer für %1 gefunden werden. Prüfen Sie ob die erforderlichen GStreamer-Erweiterungen installiert sind."
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1560,7 +1560,7 @@ msgstr "Ausgabedatei %1 konnte nicht geöffnet werden"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Titelbildverwaltung"
 
@@ -1713,7 +1713,7 @@ msgid "Delete downloaded data"
 msgstr "Heruntergeladene Dateien löschen"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Dateien löschen"
 
@@ -1721,7 +1721,7 @@ msgstr "Dateien löschen"
 msgid "Delete from device..."
 msgstr "Vom Gerät löschen …"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Vom Datenträger löschen …"
@@ -1754,11 +1754,11 @@ msgstr "Dateien werden gelöscht"
 msgid "Depth"
 msgstr "Tiefe"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Titel aus der Warteschlange nehmen"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Titel aus der Warteschlange nehmen"
 
@@ -1859,7 +1859,7 @@ msgstr "Anzeigeoptionen"
 msgid "Display the on-screen-display"
 msgstr "Bildschirmanzeige anzeigen"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Bibliothek erneut einlesen"
 
@@ -2038,12 +2038,12 @@ msgstr "Dynamischer Zufallsmix"
 msgid "Edit smart playlist..."
 msgstr "Intelligente Wiedergabeliste bearbeiten …"
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Schlagwort »%1« bearbeiten …"
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Schlagwort bearbeiten …"
 
@@ -2056,7 +2056,7 @@ msgid "Edit track information"
 msgstr "Metadaten bearbeiten"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Metadaten bearbeiten …"
 
@@ -2164,7 +2164,7 @@ msgstr "Gesamte Sammlung"
 msgid "Episode information"
 msgstr "Episodeninformation"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Equalizer"
 
@@ -2177,8 +2177,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Äquivalent zu --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Fehler"
 
@@ -2213,7 +2213,7 @@ msgstr "Fehler beim Laden von %1"
 msgid "Error loading di.fm playlist"
 msgstr "Fehler beim Laden der di.fm-Wiedergabeliste"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Fehler bei %1: %2"
@@ -2296,7 +2296,11 @@ msgstr "Export beendet"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "%1 von %2 Titelbildern exportiert (%3 übersprungen)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2320,7 +2324,7 @@ msgstr "Überblenden"
 msgid "Fading duration"
 msgstr "Dauer:"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "CD-Laufwerk kann nicht gelesen werden"
 
@@ -2602,11 +2606,11 @@ msgstr "Namen angeben:"
 msgid "Go"
 msgstr "Start"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Zum nächsten Wiedergabelistenreiter wechseln"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Zum vorherigen Wiedergabelistenreiter wechseln"
 
@@ -2939,7 +2943,7 @@ msgstr "Jamendo-Datenbank"
 msgid "Jump to previous song right away"
 msgstr "Gleich zum vorherigen Titel springen"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Zum aktuellen Titel springen"
 
@@ -2963,7 +2967,7 @@ msgstr "Im Hintergrund weiterlaufen, wenn das Fenster geschlossen wurde"
 msgid "Keep the original files"
 msgstr "Ursprüngliche Dateien behalten"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Kätzchen"
@@ -3055,7 +3059,7 @@ msgstr "Bibliothek"
 msgid "Library advanced grouping"
 msgstr "Erweiterte Bibliothekssortierung"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Hinweis beim erneuten durchsuchen der Bibliothek"
 
@@ -3095,7 +3099,7 @@ msgstr "Titelbild von Datenträger wählen …"
 msgid "Load playlist"
 msgstr "Wiedergabeliste laden"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Wiedergabeliste laden …"
 
@@ -3156,11 +3160,15 @@ msgstr "Anmelden"
 msgid "Login failed"
 msgstr "Anmeldung fehlgeschlagen"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Langzeitvorhersageprofil (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Lieben"
 
@@ -3195,11 +3203,11 @@ msgstr "Liedtext von %1"
 msgid "Lyrics from the tag"
 msgstr "Liedtext vom Schlagwort"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3241,7 +3249,7 @@ msgstr "Hauptprofil (MAIN)"
 msgid "Make it so!"
 msgstr "Energie!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Machen Sie es so!"
@@ -3379,7 +3387,7 @@ msgstr "Einhängepunkte"
 msgid "Move down"
 msgstr "Nach unten"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Zur Bibliothek verschieben …"
 
@@ -3388,7 +3396,7 @@ msgstr "Zur Bibliothek verschieben …"
 msgid "Move up"
 msgstr "Nach oben"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Musik"
 
@@ -3401,7 +3409,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Stumm"
 
@@ -3450,7 +3458,7 @@ msgstr "Nie mit der Wiedergabe beginnen"
 msgid "New folder"
 msgstr "Neuer Ordner"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Neue Wiedergabeliste"
 
@@ -3478,8 +3486,12 @@ msgstr "Neueste Titel"
 msgid "Next"
 msgstr "Weiter"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Nächster Titel"
 
@@ -3517,7 +3529,7 @@ msgstr "Keine kurzen Blöcke"
 msgid "None"
 msgstr "Nichts"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Keiner der gewählten Titel war zum Kopieren auf ein Gerät geeignet."
 
@@ -3602,19 +3614,19 @@ msgstr "Aus"
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3658,7 +3670,7 @@ msgstr "Deckkraft"
 msgid "Open %1 in browser"
 msgstr "%1 im Browser öffnen"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "&Audio-CD öffnen …"
 
@@ -3670,7 +3682,7 @@ msgstr "OPML-Datei öffnen"
 msgid "Open OPML file..."
 msgstr "OPML-Datei öffnen …"
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Verzeichnis öffnen, um Musik von dort zu importieren"
 
@@ -3678,7 +3690,7 @@ msgstr "Verzeichnis öffnen, um Musik von dort zu importieren"
 msgid "Open device"
 msgstr "Gerät öffnen"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "&Datei öffnen …"
 
@@ -3732,7 +3744,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Dateien organisieren"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Dateien organisieren …"
 
@@ -3816,7 +3828,7 @@ msgstr "Party"
 msgid "Password"
 msgstr "Passwort:"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pause"
@@ -3840,6 +3852,10 @@ msgstr "Besetzung"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Pixel"
@@ -3848,10 +3864,10 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Einfache Seitenleiste"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Wiedergabe"
 
@@ -3872,11 +3888,11 @@ msgstr "Wiedergeben wenn angehalten, pausieren bei Wiedergabe"
 msgid "Play if there is nothing already playing"
 msgstr "Mit der Wiedergabe beginnen, falls gerade nichts anderes abgespielt wird"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Nächsten Titel wiedergeben"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Ausgewählte Titel als Nächstes wiedergeben"
 
@@ -3975,7 +3991,7 @@ msgstr "Einstellung"
 msgid "Preferences"
 msgstr "Einstellungen"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Einstellungen …"
 
@@ -4035,7 +4051,7 @@ msgid "Previous"
 msgstr "Vorheriger"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Vorherigen Titel"
 
@@ -4093,16 +4109,16 @@ msgstr "Qualität"
 msgid "Querying device..."
 msgstr "Gerät wird abgefragt …"
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Warteschlangenverwaltung"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Titel in die Warteschlange einreihen"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Titel in die Warteschlange einreihen"
 
@@ -4118,7 +4134,7 @@ msgstr "Radio (gleicher Pegel für alle Titel)"
 msgid "Rain"
 msgstr "Regen"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Regen"
@@ -4230,7 +4246,7 @@ msgstr "Aktion entfernen"
 msgid "Remove current song from playlist"
 msgstr "Aktuellen Titel aus der Wiedergabeliste entfernen"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Doppelte aus der Wiedergabeliste entfernen"
 
@@ -4238,7 +4254,7 @@ msgstr "Doppelte aus der Wiedergabeliste entfernen"
 msgid "Remove folder"
 msgstr "Ordner entfernen"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Aus der Wiedergabeliste entfernen"
 
@@ -4250,7 +4266,7 @@ msgstr "Wiedergabeliste entfernen"
 msgid "Remove playlists"
 msgstr "Wiedergabeliste entfernen"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Nicht verfügbare Titel von der Wiedergabeliste entfernen"
 
@@ -4262,7 +4278,7 @@ msgstr "Wiedergabeliste umbenennen"
 msgid "Rename playlist..."
 msgstr "Wiedergabeliste umbenennen …"
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Musiktitel in dieser Reihenfolge neu nummerieren …"
 
@@ -4353,7 +4369,7 @@ msgstr "Auslesen"
 msgid "Rip CD"
 msgstr "CD auslesen"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Audio-CD auslesen"
 
@@ -4431,7 +4447,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Wiedergabeliste speichern"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Wiedergabeliste speichern …"
 
@@ -4518,7 +4534,7 @@ msgstr "Subsonic durchsuchen"
 msgid "Search automatically"
 msgstr "Automatisch suchen"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Nach Album suchen"
 
@@ -4531,7 +4547,7 @@ msgstr "Nach Titelbild suchen …"
 msgid "Search for anything"
 msgstr "Alle Quellen durchsuchen"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Nach Interpret suchen"
 
@@ -4656,7 +4672,7 @@ msgstr "Server-Details"
 msgid "Service offline"
 msgstr "Dienst nicht verfügbar"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "%1 zu »%2« einstellen …"
@@ -4665,7 +4681,7 @@ msgstr "%1 zu »%2« einstellen …"
 msgid "Set the volume to <value> percent"
 msgstr "Setze Lautstärke auf <value>%"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Wert für ausgewählte Titel einstellen …"
 
@@ -4736,7 +4752,7 @@ msgstr "Clementine-Bildschirmanzeige anzeigen"
 msgid "Show above status bar"
 msgstr "Oberhalb der Statusleiste anzeigen"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Alle Titel anzeigen"
 
@@ -4756,12 +4772,12 @@ msgstr "Trenner anzeigen"
 msgid "Show fullsize..."
 msgstr "In Originalgröße anzeigen …"
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "In Dateiverwaltung anzeigen …"
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "In Bibliothek anzeigen …"
 
@@ -4773,15 +4789,15 @@ msgstr "Unter »Verschiedene Interpreten« anzeigen"
 msgid "Show moodbar"
 msgstr "Stimmungsbarometer anzeigen"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Nur Doppelte anzeigen"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Nur ohne Schlagworte anzeigen"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Seitenleiste anzeigen oder ausblenden"
 
@@ -4789,7 +4805,7 @@ msgstr "Seitenleiste anzeigen oder ausblenden"
 msgid "Show search suggestions"
 msgstr "Suchvorschläge anzeigen"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Seitenleiste anzeigen"
 
@@ -4825,7 +4841,7 @@ msgstr "Zufällige Albenreihenfolge"
 msgid "Shuffle all"
 msgstr "Zufällige Titelreihenfolge"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Wiedergabeliste mischen"
 
@@ -4869,11 +4885,15 @@ msgstr "Übersprungzähler"
 msgid "Skip forwards in playlist"
 msgstr "Nächsten Titel in der Wiedergabeliste"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Ausgewählte Titel überspringen"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Titel überspringen"
 
@@ -4990,7 +5010,7 @@ msgstr "Auslesen starten"
 msgid "Start the playlist currently playing"
 msgstr "Die aktuelle Wiedergabeliste abspielen"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Umwandeln starten"
 
@@ -5000,7 +5020,7 @@ msgid ""
 "list"
 msgstr "Geben Sie etwas in die Suchleiste ein um diese Ergebnisliste zu füllen"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Starte %1"
@@ -5010,7 +5030,7 @@ msgid "Starting..."
 msgstr "Starten …"
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Anhalten"
 
@@ -5026,7 +5046,7 @@ msgstr "Wiedergabe nach jedem Titel anhalten"
 msgid "Stop after every track"
 msgstr "Wiedergabe nach jedem Titel anhalten"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Wiedergabe nach diesem Titel anhalten"
 
@@ -5194,7 +5214,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Die Versuchsperiode für den Subsonic-Server ist abgelaufen. Bitte machen Sie eine Spende, um einen Lizenzschlüssel zu erhalten. Details finden sich auf subsonic.org."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5236,7 +5256,7 @@ msgid ""
 "continue?"
 msgstr "Diese Dateien werden vom Gerät gelöscht. Möchten Sie wirklich fortfahren?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5338,11 +5358,11 @@ msgstr "Clementine-Bildschirmanzeige umschalten"
 msgid "Toggle fullscreen"
 msgstr "Vollbild an/aus"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Einreihungsstatus ändern"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Scrobbeln ein- oder ausschalten"
 
@@ -5387,19 +5407,19 @@ msgstr "&Titel"
 msgid "Track"
 msgstr "Titel-Nr."
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Musik umwandeln"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Umwandlungsprotokoll"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Umwandlung"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "%1 Dateien werden mit %2 Prozessen umgewandelt"
@@ -5476,11 +5496,11 @@ msgstr "Unbekannter Fehler"
 msgid "Unset cover"
 msgstr "Titelbild entfernen"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Überspringen der ausgewählten Titel aufheben"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Titel nicht überspringen"
 
@@ -5497,7 +5517,7 @@ msgstr "Nächste Konzerte"
 msgid "Update all podcasts"
 msgstr "Alle Podcasts aktualisieren"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Geänderte Bibliotheksordner aktualisieren"
 
@@ -5658,7 +5678,7 @@ msgstr "Version %1"
 msgid "View"
 msgstr "Ansicht"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Streamdetails"
 
@@ -5666,7 +5686,7 @@ msgstr "Streamdetails"
 msgid "Visualization mode"
 msgstr "Art der Visualisierung"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Visualisierungen"
 
@@ -5707,7 +5727,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "WAV"
 
@@ -5803,7 +5823,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media Audio"
 
@@ -5817,7 +5837,7 @@ msgid ""
 "well?"
 msgstr "Möchten Sie die anderen Titel dieses Albums ebenfalls unter »Verschiedene Interpreten« anzeigen?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Möchten Sie jetzt Ihre Musiksammlung erneut einlesen?"
 

--- a/src/translations/de.po
+++ b/src/translations/de.po
@@ -569,7 +569,7 @@ msgstr "Einen weiteren Datenstrom hinzufügen …"
 msgid "Add directory..."
 msgstr "Verzeichnis hinzufügen …"
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Datei hinzufügen"
 
@@ -589,7 +589,7 @@ msgstr "Datei hinzufügen …"
 msgid "Add files to transcode"
 msgstr "Dateien zum Umwandeln hinzufügen"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Ordner hinzufügen"
@@ -694,7 +694,7 @@ msgstr "Zur Spotify-Wiedergabeliste hinzufügen"
 msgid "Add to Spotify starred"
 msgstr "Markierte Titel von Spotify hinzufügen"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Zu anderer Wiedergabeliste hinzufügen"
 
@@ -916,7 +916,7 @@ msgstr "Sind Sie sicher, dass Sie für alle Titel Ihrer Bibliothek, die Titelsta
 msgid "Artist"
 msgstr "Interpret"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Künstlerinfo"
 
@@ -1179,7 +1179,7 @@ msgstr "Nach neuen Episoden suchen"
 msgid "Check for updates"
 msgstr "Auf Aktualisierungen suchen"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Nach Aktualisierungen suchen …"
 
@@ -1419,7 +1419,7 @@ msgstr "Subsonic wird konfiguriert …"
 msgid "Configure global search..."
 msgstr "Globale Suche konfigurieren …"
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Bibliothek einrichten …"
 
@@ -1491,11 +1491,11 @@ msgid "Copy to clipboard"
 msgstr "Kopieren"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Auf das Gerät kopieren …"
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Zur Bibliothek kopieren …"
@@ -1713,7 +1713,7 @@ msgid "Delete downloaded data"
 msgstr "Heruntergeladene Dateien löschen"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Dateien löschen"
 
@@ -1721,7 +1721,7 @@ msgstr "Dateien löschen"
 msgid "Delete from device..."
 msgstr "Vom Gerät löschen …"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Vom Datenträger löschen …"
@@ -1754,11 +1754,11 @@ msgstr "Dateien werden gelöscht"
 msgid "Depth"
 msgstr "Tiefe"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Titel aus der Warteschlange nehmen"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Titel aus der Warteschlange nehmen"
 
@@ -1787,7 +1787,7 @@ msgstr "Gerätename"
 msgid "Device properties..."
 msgstr "Geräteeinstellungen …"
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Geräte"
 
@@ -2038,7 +2038,7 @@ msgstr "Dynamischer Zufallsmix"
 msgid "Edit smart playlist..."
 msgstr "Intelligente Wiedergabeliste bearbeiten …"
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Schlagwort »%1« bearbeiten …"
@@ -2177,8 +2177,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Äquivalent zu --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Fehler"
 
@@ -2324,7 +2324,7 @@ msgstr "Überblenden"
 msgid "Fading duration"
 msgstr "Dauer:"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "CD-Laufwerk kann nicht gelesen werden"
 
@@ -2447,7 +2447,7 @@ msgstr "Dateityp"
 msgid "Filename"
 msgstr "Dateiname"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Dateien"
 
@@ -2862,7 +2862,7 @@ msgstr "Installiert"
 msgid "Integrity check"
 msgstr "Integritätsprüfung"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -3050,7 +3050,7 @@ msgstr "Links"
 msgid "Length"
 msgstr "Länge"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Bibliothek"
@@ -3059,7 +3059,7 @@ msgstr "Bibliothek"
 msgid "Library advanced grouping"
 msgstr "Erweiterte Bibliothekssortierung"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Hinweis beim erneuten durchsuchen der Bibliothek"
 
@@ -3387,7 +3387,7 @@ msgstr "Einhängepunkte"
 msgid "Move down"
 msgstr "Nach unten"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Zur Bibliothek verschieben …"
 
@@ -3396,7 +3396,7 @@ msgstr "Zur Bibliothek verschieben …"
 msgid "Move up"
 msgstr "Nach oben"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Musik"
 
@@ -3458,7 +3458,7 @@ msgstr "Nie mit der Wiedergabe beginnen"
 msgid "New folder"
 msgstr "Neuer Ordner"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Neue Wiedergabeliste"
 
@@ -3529,7 +3529,7 @@ msgstr "Keine kurzen Blöcke"
 msgid "None"
 msgstr "Nichts"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Keiner der gewählten Titel war zum Kopieren auf ein Gerät geeignet."
 
@@ -3744,7 +3744,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Dateien organisieren"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Dateien organisieren …"
 
@@ -3828,7 +3828,7 @@ msgstr "Party"
 msgid "Password"
 msgstr "Passwort:"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pause"
@@ -3864,8 +3864,8 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Einfache Seitenleiste"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3888,11 +3888,11 @@ msgstr "Wiedergeben wenn angehalten, pausieren bei Wiedergabe"
 msgid "Play if there is nothing already playing"
 msgstr "Mit der Wiedergabe beginnen, falls gerade nichts anderes abgespielt wird"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Nächsten Titel wiedergeben"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Ausgewählte Titel als Nächstes wiedergeben"
 
@@ -3931,7 +3931,7 @@ msgstr "Wiedergabeliste einrichten"
 msgid "Playlist type"
 msgstr "Art der Wiedergabeliste"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Wiedergabelisten"
 
@@ -4113,12 +4113,12 @@ msgstr "Gerät wird abgefragt …"
 msgid "Queue Manager"
 msgstr "Warteschlangenverwaltung"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Titel in die Warteschlange einreihen"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Titel in die Warteschlange einreihen"
 
@@ -4509,7 +4509,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Suche"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Suche"
@@ -4534,7 +4534,7 @@ msgstr "Subsonic durchsuchen"
 msgid "Search automatically"
 msgstr "Automatisch suchen"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Nach Album suchen"
 
@@ -4547,7 +4547,7 @@ msgstr "Nach Titelbild suchen …"
 msgid "Search for anything"
 msgstr "Alle Quellen durchsuchen"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Nach Interpret suchen"
 
@@ -4672,7 +4672,7 @@ msgstr "Server-Details"
 msgid "Service offline"
 msgstr "Dienst nicht verfügbar"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "%1 zu »%2« einstellen …"
@@ -4752,7 +4752,7 @@ msgstr "Clementine-Bildschirmanzeige anzeigen"
 msgid "Show above status bar"
 msgstr "Oberhalb der Statusleiste anzeigen"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Alle Titel anzeigen"
 
@@ -4772,12 +4772,12 @@ msgstr "Trenner anzeigen"
 msgid "Show fullsize..."
 msgstr "In Originalgröße anzeigen …"
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "In Dateiverwaltung anzeigen …"
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "In Bibliothek anzeigen …"
 
@@ -4789,11 +4789,11 @@ msgstr "Unter »Verschiedene Interpreten« anzeigen"
 msgid "Show moodbar"
 msgstr "Stimmungsbarometer anzeigen"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Nur Doppelte anzeigen"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Nur ohne Schlagworte anzeigen"
 
@@ -4885,7 +4885,7 @@ msgstr "Übersprungzähler"
 msgid "Skip forwards in playlist"
 msgstr "Nächsten Titel in der Wiedergabeliste"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Ausgewählte Titel überspringen"
 
@@ -4893,7 +4893,7 @@ msgstr "Ausgewählte Titel überspringen"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Titel überspringen"
 
@@ -4925,7 +4925,7 @@ msgstr "Soft Rock"
 msgid "Song Information"
 msgstr "Titelinformationen"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Titelinfo"
 
@@ -5046,7 +5046,7 @@ msgstr "Wiedergabe nach jedem Titel anhalten"
 msgid "Stop after every track"
 msgstr "Wiedergabe nach jedem Titel anhalten"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Wiedergabe nach diesem Titel anhalten"
 
@@ -5214,7 +5214,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Die Versuchsperiode für den Subsonic-Server ist abgelaufen. Bitte machen Sie eine Spende, um einen Lizenzschlüssel zu erhalten. Details finden sich auf subsonic.org."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5256,7 +5256,7 @@ msgid ""
 "continue?"
 msgstr "Diese Dateien werden vom Gerät gelöscht. Möchten Sie wirklich fortfahren?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5358,7 +5358,7 @@ msgstr "Clementine-Bildschirmanzeige umschalten"
 msgid "Toggle fullscreen"
 msgstr "Vollbild an/aus"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Einreihungsstatus ändern"
 
@@ -5496,11 +5496,11 @@ msgstr "Unbekannter Fehler"
 msgid "Unset cover"
 msgstr "Titelbild entfernen"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Überspringen der ausgewählten Titel aufheben"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Titel nicht überspringen"
 
@@ -5837,7 +5837,7 @@ msgid ""
 "well?"
 msgstr "Möchten Sie die anderen Titel dieses Albums ebenfalls unter »Verschiedene Interpreten« anzeigen?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Möchten Sie jetzt Ihre Musiksammlung erneut einlesen?"
 

--- a/src/translations/el.po
+++ b/src/translations/el.po
@@ -528,7 +528,7 @@ msgstr "Προσθήκη άλλης ροής..."
 msgid "Add directory..."
 msgstr "Προσθήκη καταλόγου..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Προσθήκη αρχείου"
 
@@ -548,7 +548,7 @@ msgstr "Προσθήκη αρχείου..."
 msgid "Add files to transcode"
 msgstr "Προσθήκη αρχείων για επανακωδικοποίηση"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Προσθήκη φακέλου"
@@ -653,7 +653,7 @@ msgstr "Προσθήκη στην λίστα αναπαραγωγής Spotify"
 msgid "Add to Spotify starred"
 msgstr "Προσθήκη για Spotify πρωταγωνίστησε"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Προσθήκη σε άλλη λίστα"
 
@@ -875,7 +875,7 @@ msgstr "Είστε σίγουροι πως θέλετε να γράψετε τα
 msgid "Artist"
 msgstr "Καλλιτέχνης"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Πληρ. καλλιτέχνη"
 
@@ -1138,7 +1138,7 @@ msgstr "Έλεγχος για νέα επεισόδια"
 msgid "Check for updates"
 msgstr "Έλεγχος για ενημερώσεις"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Έλεγχος για ενημερώσεις..."
 
@@ -1378,7 +1378,7 @@ msgstr "Ρύθμιση του Subsonic..."
 msgid "Configure global search..."
 msgstr "Ρύθμιση καθολικής αναζήτησης..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Διαμόρφωση της βιβλιοθήκης..."
 
@@ -1450,11 +1450,11 @@ msgid "Copy to clipboard"
 msgstr "Αντιγραφή στο πρόχειρο"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Αντιγραφή στην συσκευή..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Αντιγραφή στην βιβλιοθήκη..."
@@ -1672,7 +1672,7 @@ msgid "Delete downloaded data"
 msgstr "Διαγραφή ληφθέντων δεδομένων"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Διαγραφή αρχείων"
 
@@ -1680,7 +1680,7 @@ msgstr "Διαγραφή αρχείων"
 msgid "Delete from device..."
 msgstr "Διαγραφή από την συσκευή..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Διαγραφή από τον δίσκο..."
@@ -1713,11 +1713,11 @@ msgstr "Γίνεται διαγραφή αρχείων"
 msgid "Depth"
 msgstr "Βάθος"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Αφαίρεση των επιλεγμένων κομματιών από την λίστα αναμονής"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Αφαίρεση του κομματιού από την λίστα αναμονής"
 
@@ -1746,7 +1746,7 @@ msgstr "Όνομα συσκευής"
 msgid "Device properties..."
 msgstr "Ιδιότητες συσκευής..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Συσκευές"
 
@@ -1997,7 +1997,7 @@ msgstr "Δυναμική τυχαία ανάμιξη"
 msgid "Edit smart playlist..."
 msgstr "Τροποποίηση της έξυπνης λίστας εκτέλεσης..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Τροποποίηση ετικέτας \"%1\"..."
@@ -2136,8 +2136,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Ισοδύναμο με --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Σφάλμα"
 
@@ -2283,7 +2283,7 @@ msgstr "Εξομάλυνση"
 msgid "Fading duration"
 msgstr "Διάρκεια εξομάλυνσης"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Αποτυχία ανάγνωσης της μονάδας CD"
 
@@ -2406,7 +2406,7 @@ msgstr "Τύπος αρχείου"
 msgid "Filename"
 msgstr "Όνομα αρχείου"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Αρχεία"
 
@@ -2821,7 +2821,7 @@ msgstr "Εγκατεστημένο"
 msgid "Integrity check"
 msgstr "έλεγχος ακεραιότητας"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Διαδίκτυο"
 
@@ -3009,7 +3009,7 @@ msgstr "Αριστερά"
 msgid "Length"
 msgstr "Διάρκεια"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Βιβλιοθήκη"
@@ -3018,7 +3018,7 @@ msgstr "Βιβλιοθήκη"
 msgid "Library advanced grouping"
 msgstr "Προχωρημένη ομαδοποίηση βιβλιοθήκης"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Ειδοποίηση σάρωσης βιβλιοθήκης"
 
@@ -3346,7 +3346,7 @@ msgstr "Σημεία προσάρτησης"
 msgid "Move down"
 msgstr "Μετακίνηση κάτω"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Μετακίνηση στην βιβλιοθήκη..."
 
@@ -3355,7 +3355,7 @@ msgstr "Μετακίνηση στην βιβλιοθήκη..."
 msgid "Move up"
 msgstr "Μετακίνηση πάνω"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Μουσική"
 
@@ -3417,7 +3417,7 @@ msgstr "Να μην ξεκινά ποτέ η αναπαραγωγή"
 msgid "New folder"
 msgstr "Νέος φάκελος"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Νέα λίστα"
 
@@ -3488,7 +3488,7 @@ msgstr "Όχι μικρές πλοκάδες"
 msgid "None"
 msgstr "Κανένα"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Κανένα από τα επιλεγμένα τραγούδια δεν ήταν κατάλληλο για αντιγραφή σε μία συσκευή"
 
@@ -3703,7 +3703,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Οργάνωση αρχείων"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Οργάνωση αρχείων..."
 
@@ -3787,7 +3787,7 @@ msgstr "Πάρτι"
 msgid "Password"
 msgstr "Συνθηματικό"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Παύση"
@@ -3823,8 +3823,8 @@ msgstr "Εικονοστοιχεία"
 msgid "Plain sidebar"
 msgstr "Απλή πλευρική μπάρα"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3847,11 +3847,11 @@ msgstr "Αναπαραγωγή αν είναι σταματημένο, αλλι�
 msgid "Play if there is nothing already playing"
 msgstr "Αναπαραγωγή εάν δεν παίζει κάτι άλλο"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Εκτέλεση επομένου"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Εκτέλεση των επόμενων επιλεγμένων κομματιών"
 
@@ -3890,7 +3890,7 @@ msgstr "Επιλογές λίστας αναπαραγωγής"
 msgid "Playlist type"
 msgstr "Τύπος λίστας αναπαραγωγής"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Λίστες"
 
@@ -4072,12 +4072,12 @@ msgstr "Ερώτηση συσκευής..."
 msgid "Queue Manager"
 msgstr "Διαχειριστής λίστας αναμονής"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Τοποθέτηση στη λίστας αναμονής τα επιλεγμένα κομμάτια"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Τοποθέτηση στη λίστας αναμονής του κομματιού"
 
@@ -4468,7 +4468,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Αναζήτηση"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Αναζήτηση"
@@ -4493,7 +4493,7 @@ msgstr "Αναζήτηση στο Subsonic"
 msgid "Search automatically"
 msgstr "Αναζήτηση αυτόματα"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Αναζήτηση για δίσκο"
 
@@ -4506,7 +4506,7 @@ msgstr "Αναζήτηση για εξώφυλλα του δίσκου..."
 msgid "Search for anything"
 msgstr "Αναζήτηση για οτιδήποτε"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Αναζήτηση για καλλιτέχνη"
 
@@ -4631,7 +4631,7 @@ msgstr "Λεπτομέρειες διακομιστή"
 msgid "Service offline"
 msgstr "Υπηρεσία εκτός σύνδεσης"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Δώσε %1 στο \"%2\"..."
@@ -4711,7 +4711,7 @@ msgstr "Εμφάνισε ένα όμορφο OSD"
 msgid "Show above status bar"
 msgstr "Εμφάνιση πάνω από την μπάρα κατάστασης"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Εμφάνιση όλων των τραγουδιών"
 
@@ -4731,12 +4731,12 @@ msgstr "Εμφάνιση διαχωριστών"
 msgid "Show fullsize..."
 msgstr "Εμφάνισε σε πλήρες μέγεθος..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Εμφάνιση στον περιηγητή αρχείων..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Εμφάνιση στην βιβλιοθήκη..."
 
@@ -4748,11 +4748,11 @@ msgstr "Εμφάνιση στους διάφορους καλλιτέχνες"
 msgid "Show moodbar"
 msgstr "Εμφάνιση της γραμμής διάθεσης"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Εμφάνιση μόνο διπλότυπων"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Εμφάνιση μόνο μη επισημασμένων"
 
@@ -4844,7 +4844,7 @@ msgstr "Μετρητής παραλήψεων"
 msgid "Skip forwards in playlist"
 msgstr "Παράλειψη προς τα μπροστά στη λίστα"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Παράκαμψη επιλεγμένων κομματιών"
 
@@ -4852,7 +4852,7 @@ msgstr "Παράκαμψη επιλεγμένων κομματιών"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Παράκαμψη κομματιού"
 
@@ -4884,7 +4884,7 @@ msgstr "Απαλή Rock"
 msgid "Song Information"
 msgstr "Πληρ. τραγουδιού"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Πληρ. τραγουδιού"
 
@@ -5005,7 +5005,7 @@ msgstr "Σταμάτημα μετά από κάθε κομμάτι"
 msgid "Stop after every track"
 msgstr "Σταμάτημα μετά από κάθε κομμάτι"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Σταμάτημα μετά από αυτό το κομμάτι"
 
@@ -5173,7 +5173,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Η δοκιμαστική περίοδος του Subsonic τελείωσε. Παρακαλώ κάντε μια δωρεά για να λάβετε ένα κλειδί άδειας. Δείτε στο subsonic.org για λεπτομέρειες."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5215,7 +5215,7 @@ msgid ""
 "continue?"
 msgstr "Αυτά τα αρχεία θα διαγραφούν από την συσκευή, θέλετε σίγουρα να συνεχίσετε;"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5317,7 +5317,7 @@ msgstr "Εναλλαγή Όμορφου OSD"
 msgid "Toggle fullscreen"
 msgstr "Εναλλαγή πλήρης οθόνης"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Εναλλαγή της κατάστασης της λίστας αναμονής"
 
@@ -5455,11 +5455,11 @@ msgstr "Άγνωστο σφάλμα"
 msgid "Unset cover"
 msgstr "Αφαίρεση εξώφυλλου"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Καταργήση της παράλειψης επιλεγμένων κομματιών"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Καταργήση της παράλειψης τροχιάς"
 
@@ -5796,7 +5796,7 @@ msgid ""
 "well?"
 msgstr "Θα θέλατε να μετακινήσετε και τα άλλα τραγούδια σε αυτόν τον δίσκο στην κατηγορία Διάφοροι Καλλιτέχνες;"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Θέλετε να εκτελέσετε μία πλήρη επανασάρωση αμέσως τώρα;"
 

--- a/src/translations/el.po
+++ b/src/translations/el.po
@@ -26,7 +26,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Greek (http://www.transifex.com/davidsansome/clementine/language/el/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -180,19 +180,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n απέτυχε"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n ολοκληρώθηκε"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -210,7 +210,7 @@ msgstr "&Κέντρο"
 msgid "&Custom"
 msgstr "&Προσαρμοσμένο"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Επιπρόσθετα"
 
@@ -218,7 +218,7 @@ msgstr "&Επιπρόσθετα"
 msgid "&Grouping"
 msgstr "&Ομαδοποίηση"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Βοήθεια"
 
@@ -243,7 +243,7 @@ msgstr "&Κλείδωμα της αξιολόγησης"
 msgid "&Lyrics"
 msgstr "&Στίχοι"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Μουσική"
 
@@ -251,15 +251,15 @@ msgstr "&Μουσική"
 msgid "&None"
 msgstr "&Καμία"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&Λίστα αναπαραγωγής"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Έξοδος"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "Λειτουργία &επανάληψης "
 
@@ -267,7 +267,7 @@ msgstr "Λειτουργία &επανάληψης "
 msgid "&Right"
 msgstr "&Δεξιά"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Λειτουργία &ανακατέματος"
 
@@ -275,7 +275,7 @@ msgstr "Λειτουργία &ανακατέματος"
 msgid "&Stretch columns to fit window"
 msgstr "&Επέκταση των στηλών για πλήρωση του παραθύρου"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Εργαλεία"
 
@@ -464,11 +464,11 @@ msgstr "Ματαίωση"
 msgid "About %1"
 msgstr "Περί %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Περί του Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Περί του Qt..."
 
@@ -528,32 +528,32 @@ msgstr "Προσθήκη άλλης ροής..."
 msgid "Add directory..."
 msgstr "Προσθήκη καταλόγου..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Προσθήκη αρχείου"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Προσθήκη αρχείου για διακωδικοποίηση"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Προσθήκη αρχείου(ων) για διακωδικοποίηση"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Προσθήκη αρχείου..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Προσθήκη αρχείων για επανακωδικοποίηση"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Προσθήκη φακέλου"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Προσθήκη φακέλου..."
 
@@ -565,7 +565,7 @@ msgstr "Προσθήκη νέου φακέλου..."
 msgid "Add podcast"
 msgstr "Προσθήκη διαδικτυακής εκπομπής"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Προσθήκη διαδικτυακής εκπομπής..."
 
@@ -641,7 +641,7 @@ msgstr "Προσθήκη ετικέτας αριθμού τραγουδιού"
 msgid "Add song year tag"
 msgstr "Προσθήκη ετικέτας χρονολογίας τραγουδιού"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Προσθήκη ροής..."
 
@@ -653,7 +653,7 @@ msgstr "Προσθήκη στην λίστα αναπαραγωγής Spotify"
 msgid "Add to Spotify starred"
 msgstr "Προσθήκη για Spotify πρωταγωνίστησε"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Προσθήκη σε άλλη λίστα"
 
@@ -747,7 +747,7 @@ msgstr "όλα"
 msgid "All Files (*)"
 msgstr "Όλα τα αρχεία (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Όλη η δόξα στον Hypnotoad!"
@@ -1138,7 +1138,7 @@ msgstr "Έλεγχος για νέα επεισόδια"
 msgid "Check for updates"
 msgstr "Έλεγχος για ενημερώσεις"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Έλεγχος για ενημερώσεις..."
 
@@ -1187,18 +1187,18 @@ msgstr "Κλασσική"
 msgid "Cleaning up"
 msgstr "Καθάρισμα"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Καθαρισμός"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Καθαρισμός λίστας"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1343,7 +1343,7 @@ msgstr "Σχόλια"
 msgid "Complete tags automatically"
 msgstr "Συμπλήρωση των ετικετών αυτόματα"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Συμπλήρωση των ετικετών αυτόματα..."
 
@@ -1378,7 +1378,7 @@ msgstr "Ρύθμιση του Subsonic..."
 msgid "Configure global search..."
 msgstr "Ρύθμιση καθολικής αναζήτησης..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Διαμόρφωση της βιβλιοθήκης..."
 
@@ -1421,7 +1421,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Η σύνδεση διακόπηκε, ελέγξτε το URL του διακομιστή. Παράδειγμα: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Τερματικό"
 
@@ -1450,11 +1450,11 @@ msgid "Copy to clipboard"
 msgstr "Αντιγραφή στο πρόχειρο"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Αντιγραφή στην συσκευή..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Αντιγραφή στην βιβλιοθήκη..."
@@ -1497,14 +1497,14 @@ msgstr "Αδύνατη η σύνδεση στο Last.fm. Παρακαλώ προ
 msgid "Couldn't create playlist"
 msgstr "Δεν ήταν δυνατή η δημιουργία λίστας αναπαραγωγής"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Δεν βρέθηκε κάποιος πολυπλέκτης για %1, ελέγξτε πως έχετε τα σωστά πρόσθετα του  GStreamer εγκατεστημένα"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1519,7 +1519,7 @@ msgstr "Δεν μπορεί να ανοίξει το αρχείο εξόδου %
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Διαχείριση εξώφυλλων"
 
@@ -1672,7 +1672,7 @@ msgid "Delete downloaded data"
 msgstr "Διαγραφή ληφθέντων δεδομένων"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Διαγραφή αρχείων"
 
@@ -1680,7 +1680,7 @@ msgstr "Διαγραφή αρχείων"
 msgid "Delete from device..."
 msgstr "Διαγραφή από την συσκευή..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Διαγραφή από τον δίσκο..."
@@ -1713,11 +1713,11 @@ msgstr "Γίνεται διαγραφή αρχείων"
 msgid "Depth"
 msgstr "Βάθος"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Αφαίρεση των επιλεγμένων κομματιών από την λίστα αναμονής"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Αφαίρεση του κομματιού από την λίστα αναμονής"
 
@@ -1818,7 +1818,7 @@ msgstr "Επιλογές απεικόνισης"
 msgid "Display the on-screen-display"
 msgstr "Εμφάνιση της «απεικόνισης στην οθόνη»"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Εκτελέστε μία πλήρη επανασάρωση της βιβλιοθήκης"
 
@@ -1997,12 +1997,12 @@ msgstr "Δυναμική τυχαία ανάμιξη"
 msgid "Edit smart playlist..."
 msgstr "Τροποποίηση της έξυπνης λίστας εκτέλεσης..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Τροποποίηση ετικέτας \"%1\"..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Τροποποίηση ετικέτας..."
 
@@ -2015,7 +2015,7 @@ msgid "Edit track information"
 msgstr "Τροποποίηση πληροφοριών κομματιού"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Τροποποίηση πληροφοριών κομματιού..."
 
@@ -2123,7 +2123,7 @@ msgstr "Ολόκληρη η συλλογή"
 msgid "Episode information"
 msgstr "Πληροφορίες επεισοδίου"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Ισοσταθμιστής"
 
@@ -2136,8 +2136,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Ισοδύναμο με --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Σφάλμα"
 
@@ -2172,7 +2172,7 @@ msgstr "Σφάλμα φόρτωσης του %1"
 msgid "Error loading di.fm playlist"
 msgstr "Σφάλμα φόρτωσης λίστας από το di.fm"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Σφάλμα επεξεργασίας %1: %2"
@@ -2255,7 +2255,11 @@ msgstr "Η εξαγωγή ολοκληρώθηκε"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "Εξαγωγή %1 εξώφυλλων από τα %2 (%3 παραλείφθηκαν)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2279,7 +2283,7 @@ msgstr "Εξομάλυνση"
 msgid "Fading duration"
 msgstr "Διάρκεια εξομάλυνσης"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Αποτυχία ανάγνωσης της μονάδας CD"
 
@@ -2561,11 +2565,11 @@ msgstr "Δώστε του ένα όνομα:"
 msgid "Go"
 msgstr "Μετάβαση"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Μετάβαση στην επόμενη καρτέλα της λίστας αναπαραγωγής"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Μετάβαση στην προηγούμενη καρτέλα της λίστας αναπαραγωγής"
 
@@ -2898,7 +2902,7 @@ msgstr "Βάση δεδομένων Jamendo"
 msgid "Jump to previous song right away"
 msgstr "Μετάβαση στο προηγούμενο τραγούδι αμέσως"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Μετάβαση στο τρέχον κομμάτι που παίζει"
 
@@ -2922,7 +2926,7 @@ msgstr "Συνέχιση της εκτέλεσης στο παρασκήνιο �
 msgid "Keep the original files"
 msgstr "Διατήρηση των αρχικών αρχείων"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Γατάκια"
@@ -3014,7 +3018,7 @@ msgstr "Βιβλιοθήκη"
 msgid "Library advanced grouping"
 msgstr "Προχωρημένη ομαδοποίηση βιβλιοθήκης"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Ειδοποίηση σάρωσης βιβλιοθήκης"
 
@@ -3054,7 +3058,7 @@ msgstr "Φόρτωση εξώφυλλου από τον δίσκο..."
 msgid "Load playlist"
 msgstr "Φόρτωση λίστας αναπαραγωγής"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Φόρτωση λίστας αναπαραγωγής..."
 
@@ -3115,11 +3119,15 @@ msgstr "Είσοδος"
 msgid "Login failed"
 msgstr "Αποτυχία εισόδου"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Προφίλ χρόνιας πρόβλεψης (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Αγάπη"
 
@@ -3154,11 +3162,11 @@ msgstr "Στίχοι από %1"
 msgid "Lyrics from the tag"
 msgstr "Στίχοι από την ετικέτα"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3200,7 +3208,7 @@ msgstr "Κύριο προφίλ (MAIN)"
 msgid "Make it so!"
 msgstr "Κάνε το!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Κάνε το!"
@@ -3338,7 +3346,7 @@ msgstr "Σημεία προσάρτησης"
 msgid "Move down"
 msgstr "Μετακίνηση κάτω"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Μετακίνηση στην βιβλιοθήκη..."
 
@@ -3347,7 +3355,7 @@ msgstr "Μετακίνηση στην βιβλιοθήκη..."
 msgid "Move up"
 msgstr "Μετακίνηση πάνω"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Μουσική"
 
@@ -3360,7 +3368,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Σίγαση"
 
@@ -3409,7 +3417,7 @@ msgstr "Να μην ξεκινά ποτέ η αναπαραγωγή"
 msgid "New folder"
 msgstr "Νέος φάκελος"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Νέα λίστα"
 
@@ -3437,8 +3445,12 @@ msgstr "Νεότερα κομμάτια"
 msgid "Next"
 msgstr "Επόμενο"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Επόμενο κομμάτι"
 
@@ -3476,7 +3488,7 @@ msgstr "Όχι μικρές πλοκάδες"
 msgid "None"
 msgstr "Κανένα"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Κανένα από τα επιλεγμένα τραγούδια δεν ήταν κατάλληλο για αντιγραφή σε μία συσκευή"
 
@@ -3561,19 +3573,19 @@ msgstr "Απενεργοποίηση"
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3617,7 +3629,7 @@ msgstr "Αδιαφάνεια"
 msgid "Open %1 in browser"
 msgstr "Άνοιγμα του %1 στον περιηγητή"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Άνοιγμα CD ή&χου..."
 
@@ -3629,7 +3641,7 @@ msgstr "Άνοιγμα αρχείου OPML"
 msgid "Open OPML file..."
 msgstr "Άνοιγμα αρχείου OPML..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Άνοιγμα ένος κατάλογου για εισάγωγη μουσικής από"
 
@@ -3637,7 +3649,7 @@ msgstr "Άνοιγμα ένος κατάλογου για εισάγωγη μο�
 msgid "Open device"
 msgstr "Άνοιγμα συσκευής"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Άνοιγμα αρχείου..."
 
@@ -3691,7 +3703,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Οργάνωση αρχείων"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Οργάνωση αρχείων..."
 
@@ -3775,7 +3787,7 @@ msgstr "Πάρτι"
 msgid "Password"
 msgstr "Συνθηματικό"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Παύση"
@@ -3799,6 +3811,10 @@ msgstr "Εκτελεστής"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Εικονοστοιχεία"
@@ -3807,10 +3823,10 @@ msgstr "Εικονοστοιχεία"
 msgid "Plain sidebar"
 msgstr "Απλή πλευρική μπάρα"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Αναπαραγωγή"
 
@@ -3831,11 +3847,11 @@ msgstr "Αναπαραγωγή αν είναι σταματημένο, αλλι�
 msgid "Play if there is nothing already playing"
 msgstr "Αναπαραγωγή εάν δεν παίζει κάτι άλλο"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Εκτέλεση επομένου"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Εκτέλεση των επόμενων επιλεγμένων κομματιών"
 
@@ -3934,7 +3950,7 @@ msgstr "Προτιμήσεις"
 msgid "Preferences"
 msgstr "Προτιμήσεις"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Προτιμήσεις..."
 
@@ -3994,7 +4010,7 @@ msgid "Previous"
 msgstr "Προηγούμενο"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Προηγούμενο κομμάτι"
 
@@ -4052,16 +4068,16 @@ msgstr "Ποιότητα"
 msgid "Querying device..."
 msgstr "Ερώτηση συσκευής..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Διαχειριστής λίστας αναμονής"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Τοποθέτηση στη λίστας αναμονής τα επιλεγμένα κομμάτια"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Τοποθέτηση στη λίστας αναμονής του κομματιού"
 
@@ -4077,7 +4093,7 @@ msgstr "Ραδιόφωνο (ίση ένταση για όλα τα κομμάτ�
 msgid "Rain"
 msgstr "Βροχή"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Βροχή"
@@ -4189,7 +4205,7 @@ msgstr "Αφαίρεση ενέργειας"
 msgid "Remove current song from playlist"
 msgstr "Αφαίρεση του τρέχοντος τραγουδιού από την λίστα αναπαραγωγής"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Αφαίρεση διπλότυπων από την λίστα"
 
@@ -4197,7 +4213,7 @@ msgstr "Αφαίρεση διπλότυπων από την λίστα"
 msgid "Remove folder"
 msgstr "Αφαίρεση φακέλου"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Αφαίρεση από την λίστα"
 
@@ -4209,7 +4225,7 @@ msgstr "Αφαίρεση λίστας αναπαραγωγής"
 msgid "Remove playlists"
 msgstr "Αφαίρεση λίστας αναπαραγωγής"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Αφαίρεση διαθέσιμων κομμάτιων από την λίστα αναπαραγωγής"
 
@@ -4221,7 +4237,7 @@ msgstr "Μετονομασία λίστας αναπαραγωγής"
 msgid "Rename playlist..."
 msgstr "Μετονομασία λίστας αναπαραγωγής..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Επαναρίθμησε τα κομμάτια κατά αυτή την σειρά..."
 
@@ -4312,7 +4328,7 @@ msgstr "Αντιγραφή"
 msgid "Rip CD"
 msgstr "Αντιγραφή CD"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Αντιγραφή CD ήχου"
 
@@ -4390,7 +4406,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Αποθήκευση λίστας αναπαραγωγής"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Αποθήκευση λίστας αναπαραγωγής..."
 
@@ -4477,7 +4493,7 @@ msgstr "Αναζήτηση στο Subsonic"
 msgid "Search automatically"
 msgstr "Αναζήτηση αυτόματα"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Αναζήτηση για δίσκο"
 
@@ -4490,7 +4506,7 @@ msgstr "Αναζήτηση για εξώφυλλα του δίσκου..."
 msgid "Search for anything"
 msgstr "Αναζήτηση για οτιδήποτε"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Αναζήτηση για καλλιτέχνη"
 
@@ -4615,7 +4631,7 @@ msgstr "Λεπτομέρειες διακομιστή"
 msgid "Service offline"
 msgstr "Υπηρεσία εκτός σύνδεσης"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Δώσε %1 στο \"%2\"..."
@@ -4624,7 +4640,7 @@ msgstr "Δώσε %1 στο \"%2\"..."
 msgid "Set the volume to <value> percent"
 msgstr "Ρύθμιση της έντασης ήχου στο <value> τοις εκατό"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Δώσε τιμή σε όλα τα επιλεγμένα κομμάτια..."
 
@@ -4695,7 +4711,7 @@ msgstr "Εμφάνισε ένα όμορφο OSD"
 msgid "Show above status bar"
 msgstr "Εμφάνιση πάνω από την μπάρα κατάστασης"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Εμφάνιση όλων των τραγουδιών"
 
@@ -4715,12 +4731,12 @@ msgstr "Εμφάνιση διαχωριστών"
 msgid "Show fullsize..."
 msgstr "Εμφάνισε σε πλήρες μέγεθος..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Εμφάνιση στον περιηγητή αρχείων..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Εμφάνιση στην βιβλιοθήκη..."
 
@@ -4732,15 +4748,15 @@ msgstr "Εμφάνιση στους διάφορους καλλιτέχνες"
 msgid "Show moodbar"
 msgstr "Εμφάνιση της γραμμής διάθεσης"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Εμφάνιση μόνο διπλότυπων"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Εμφάνιση μόνο μη επισημασμένων"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Εμφάνιση ή απόκρυψη της πλευρικής στήλης"
 
@@ -4748,7 +4764,7 @@ msgstr "Εμφάνιση ή απόκρυψη της πλευρικής στήλ�
 msgid "Show search suggestions"
 msgstr "Εμφάνιση προτάσεων αναζήτησης"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Εμφάνιση της πλευρικής στήλης"
 
@@ -4784,7 +4800,7 @@ msgstr "Ανακάτεμα των δίσκων"
 msgid "Shuffle all"
 msgstr "Ανακάτεμα όλων"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Ανακάτεμα λίστας"
 
@@ -4828,11 +4844,15 @@ msgstr "Μετρητής παραλήψεων"
 msgid "Skip forwards in playlist"
 msgstr "Παράλειψη προς τα μπροστά στη λίστα"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Παράκαμψη επιλεγμένων κομματιών"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Παράκαμψη κομματιού"
 
@@ -4949,7 +4969,7 @@ msgstr "Έναρξη αντιγραφής"
 msgid "Start the playlist currently playing"
 msgstr "Εκκίνηση της λίστας αναπαραγωγής που παίζει τώρα"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Εκκίνηση διακωδικοποίησης"
 
@@ -4959,7 +4979,7 @@ msgid ""
 "list"
 msgstr "Ξεκίνα να γράφεις κάτι στο κουτί εύρεσης παραπάνω για να γεμίσει αυτή η λίστα εύρεσης αποτελεσμάτων"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Εκκίνηση %1"
@@ -4969,7 +4989,7 @@ msgid "Starting..."
 msgstr "Εκκίνηση..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Σταμάτημα"
 
@@ -4985,7 +5005,7 @@ msgstr "Σταμάτημα μετά από κάθε κομμάτι"
 msgid "Stop after every track"
 msgstr "Σταμάτημα μετά από κάθε κομμάτι"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Σταμάτημα μετά από αυτό το κομμάτι"
 
@@ -5153,7 +5173,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Η δοκιμαστική περίοδος του Subsonic τελείωσε. Παρακαλώ κάντε μια δωρεά για να λάβετε ένα κλειδί άδειας. Δείτε στο subsonic.org για λεπτομέρειες."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5195,7 +5215,7 @@ msgid ""
 "continue?"
 msgstr "Αυτά τα αρχεία θα διαγραφούν από την συσκευή, θέλετε σίγουρα να συνεχίσετε;"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5297,11 +5317,11 @@ msgstr "Εναλλαγή Όμορφου OSD"
 msgid "Toggle fullscreen"
 msgstr "Εναλλαγή πλήρης οθόνης"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Εναλλαγή της κατάστασης της λίστας αναμονής"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Εναλλαγή του μουσικού προφίλ"
 
@@ -5346,19 +5366,19 @@ msgstr "Κο&μμάτι"
 msgid "Track"
 msgstr "Κομμάτι"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Διακωδικοποίηση μουσικής"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Αρχείο καταγραφής διακωδικοποίησης"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Διακωδικοποίηση"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Διακωδικοποίηση %1 αρχείων χρησιμοποιώντας %2 νήματα"
@@ -5435,11 +5455,11 @@ msgstr "Άγνωστο σφάλμα"
 msgid "Unset cover"
 msgstr "Αφαίρεση εξώφυλλου"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Καταργήση της παράλειψης επιλεγμένων κομματιών"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Καταργήση της παράλειψης τροχιάς"
 
@@ -5456,7 +5476,7 @@ msgstr "Προσεχής συναυλίες"
 msgid "Update all podcasts"
 msgstr "Ενημέρωση όλων των διαδικτυακών εκπομπών"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Ενημέρωση φακέλων βιβλιοθήκης που άλλαξαν"
 
@@ -5617,7 +5637,7 @@ msgstr "Έκδοση %1"
 msgid "View"
 msgstr "Προβολή"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Προβολή λεπτομερειών της ροής"
 
@@ -5625,7 +5645,7 @@ msgstr "Προβολή λεπτομερειών της ροής"
 msgid "Visualization mode"
 msgstr "Τρόπος λειτουργίας οπτικών εφέ"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Οπτικά εφέ"
 
@@ -5666,7 +5686,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5762,7 +5782,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media audio"
 
@@ -5776,7 +5796,7 @@ msgid ""
 "well?"
 msgstr "Θα θέλατε να μετακινήσετε και τα άλλα τραγούδια σε αυτόν τον δίσκο στην κατηγορία Διάφοροι Καλλιτέχνες;"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Θέλετε να εκτελέσετε μία πλήρη επανασάρωση αμέσως τώρα;"
 

--- a/src/translations/en_CA.po
+++ b/src/translations/en_CA.po
@@ -511,7 +511,7 @@ msgstr "Add another stream..."
 msgid "Add directory..."
 msgstr "Add directory..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Add file"
 
@@ -531,7 +531,7 @@ msgstr "Add file..."
 msgid "Add files to transcode"
 msgstr "Add files to transcode"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Add folder"
@@ -636,7 +636,7 @@ msgstr "Add to Spotify playlists"
 msgid "Add to Spotify starred"
 msgstr "Add to Spotify starred"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Add to another playlist"
 
@@ -858,7 +858,7 @@ msgstr "Are you sure you want to write song's statistics into song's file for al
 msgid "Artist"
 msgstr "Artist"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Artist info"
 
@@ -1121,7 +1121,7 @@ msgstr "Check for new episodes"
 msgid "Check for updates"
 msgstr "Check for updates"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Check for updates..."
 
@@ -1361,7 +1361,7 @@ msgstr "Configure Subsonic..."
 msgid "Configure global search..."
 msgstr "Configure global search..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Configure library..."
 
@@ -1433,11 +1433,11 @@ msgid "Copy to clipboard"
 msgstr "Copy to clipboard"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Copy to device..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Copy to library..."
@@ -1655,7 +1655,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr ""
 
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1696,11 +1696,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr ""
 
@@ -1729,7 +1729,7 @@ msgstr ""
 msgid "Device properties..."
 msgstr ""
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr ""
 
@@ -1980,7 +1980,7 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
@@ -2119,8 +2119,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr ""
 
@@ -2266,7 +2266,7 @@ msgstr "Fading"
 msgid "Fading duration"
 msgstr "Fading duration"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Failed reading CD drive"
 
@@ -2389,7 +2389,7 @@ msgstr "File type"
 msgid "Filename"
 msgstr "Filename"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Files"
 
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "Integrity check"
 msgstr ""
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -2992,7 +2992,7 @@ msgstr ""
 msgid "Length"
 msgstr "Length"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Library"
@@ -3001,7 +3001,7 @@ msgstr "Library"
 msgid "Library advanced grouping"
 msgstr "Library advanced grouping"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3329,7 +3329,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Move to library..."
 
@@ -3338,7 +3338,7 @@ msgstr "Move to library..."
 msgid "Move up"
 msgstr "Move up"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Music"
 
@@ -3400,7 +3400,7 @@ msgstr "Never start playing"
 msgid "New folder"
 msgstr "New folder"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "New playlist"
 
@@ -3471,7 +3471,7 @@ msgstr "No short blocks"
 msgid "None"
 msgstr "None"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "None of the selected songs were suitable for copying to a device"
 
@@ -3686,7 +3686,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr ""
 
@@ -3770,7 +3770,7 @@ msgstr "Party"
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pause"
@@ -3806,8 +3806,8 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3830,11 +3830,11 @@ msgstr "Play if stopped, pause if playing"
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3873,7 +3873,7 @@ msgstr "Playlist options"
 msgid "Playlist type"
 msgstr ""
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr ""
 
@@ -4055,12 +4055,12 @@ msgstr ""
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr ""
 
@@ -4451,7 +4451,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr ""
@@ -4476,7 +4476,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4489,7 +4489,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4614,7 +4614,7 @@ msgstr ""
 msgid "Service offline"
 msgstr "Service offline"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Set %1 to \"%2\"..."
@@ -4694,7 +4694,7 @@ msgstr "Show a pretty OSD"
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr ""
 
@@ -4714,12 +4714,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr "Show fullsize..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr ""
 
@@ -4731,11 +4731,11 @@ msgstr "Show in various artists"
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgstr "Skip count"
 msgid "Skip forwards in playlist"
 msgstr "Skip forwards in playlist"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Skip selected tracks"
 
@@ -4835,7 +4835,7 @@ msgstr "Skip selected tracks"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Skip track"
 
@@ -4867,7 +4867,7 @@ msgstr "Soft Rock"
 msgid "Song Information"
 msgstr ""
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr ""
 
@@ -4988,7 +4988,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Stop after this track"
 
@@ -5156,7 +5156,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5198,7 +5198,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5300,7 +5300,7 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr ""
 
@@ -5438,11 +5438,11 @@ msgstr "Unknown error"
 msgid "Unset cover"
 msgstr "Unset cover"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr ""
 
@@ -5779,7 +5779,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/en_CA.po
+++ b/src/translations/en_CA.po
@@ -9,7 +9,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: English (Canada) (http://www.transifex.com/davidsansome/clementine/language/en_CA/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -163,19 +163,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n failed"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n finished"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -193,7 +193,7 @@ msgstr "&Centre"
 msgid "&Custom"
 msgstr "&Custom"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Extras"
 
@@ -201,7 +201,7 @@ msgstr "&Extras"
 msgid "&Grouping"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "Help"
 
@@ -226,7 +226,7 @@ msgstr ""
 msgid "&Lyrics"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "Music"
 
@@ -234,15 +234,15 @@ msgstr "Music"
 msgid "&None"
 msgstr "&None"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "Playlist"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Quit"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "Repeat mode"
 
@@ -250,7 +250,7 @@ msgstr "Repeat mode"
 msgid "&Right"
 msgstr "&Right"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Shuffle mode"
 
@@ -258,7 +258,7 @@ msgstr "Shuffle mode"
 msgid "&Stretch columns to fit window"
 msgstr "&Stretch columns to fit window"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Tools"
 
@@ -447,11 +447,11 @@ msgstr "Abort"
 msgid "About %1"
 msgstr "About %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "About Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "About Qt..."
 
@@ -511,32 +511,32 @@ msgstr "Add another stream..."
 msgid "Add directory..."
 msgstr "Add directory..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Add file"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Add file to transcoder"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Add file(s) to transcoder"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Add file..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Add files to transcode"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Add folder"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Add folder..."
 
@@ -548,7 +548,7 @@ msgstr "Add new folder..."
 msgid "Add podcast"
 msgstr "Add podcast"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Add podcast..."
 
@@ -624,7 +624,7 @@ msgstr "Add song track tag"
 msgid "Add song year tag"
 msgstr "Add song year tag"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Add stream..."
 
@@ -636,7 +636,7 @@ msgstr "Add to Spotify playlists"
 msgid "Add to Spotify starred"
 msgstr "Add to Spotify starred"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Add to another playlist"
 
@@ -730,7 +730,7 @@ msgstr "All"
 msgid "All Files (*)"
 msgstr "All Files (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "All Glory to the Hypnotoad!"
@@ -1121,7 +1121,7 @@ msgstr "Check for new episodes"
 msgid "Check for updates"
 msgstr "Check for updates"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Check for updates..."
 
@@ -1170,18 +1170,18 @@ msgstr "Classical"
 msgid "Cleaning up"
 msgstr "Cleaning up"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Clear"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Clear playlist"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1326,7 +1326,7 @@ msgstr "Comment"
 msgid "Complete tags automatically"
 msgstr "Complete tags automatically"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Complete tags automatically..."
 
@@ -1361,7 +1361,7 @@ msgstr "Configure Subsonic..."
 msgid "Configure global search..."
 msgstr "Configure global search..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Configure library..."
 
@@ -1404,7 +1404,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Connection timed out, check server URL. Example: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Console"
 
@@ -1433,11 +1433,11 @@ msgid "Copy to clipboard"
 msgstr "Copy to clipboard"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Copy to device..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Copy to library..."
@@ -1480,14 +1480,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr "Couldn't create playlist"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Couldn't find a muxer for %1, check you have the correct GStreamer plugins installed"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1502,7 +1502,7 @@ msgstr "Couldn't open output file %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Cover Manager"
 
@@ -1655,7 +1655,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr ""
 
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1696,11 +1696,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr ""
 
@@ -1801,7 +1801,7 @@ msgstr "Display options"
 msgid "Display the on-screen-display"
 msgstr "Display the on-screen-display"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr ""
 
@@ -1980,12 +1980,12 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Edit tag..."
 
@@ -1998,7 +1998,7 @@ msgid "Edit track information"
 msgstr "Edit track information"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Edit track information..."
 
@@ -2106,7 +2106,7 @@ msgstr "Entire collection"
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Equalizer"
 
@@ -2119,8 +2119,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr ""
 
@@ -2155,7 +2155,7 @@ msgstr ""
 msgid "Error loading di.fm playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Error processing %1: %2"
@@ -2238,7 +2238,11 @@ msgstr ""
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr ""
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2262,7 +2266,7 @@ msgstr "Fading"
 msgid "Fading duration"
 msgstr "Fading duration"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Failed reading CD drive"
 
@@ -2544,11 +2548,11 @@ msgstr "Give it a name:"
 msgid "Go"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr ""
 
@@ -2881,7 +2885,7 @@ msgstr ""
 msgid "Jump to previous song right away"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Jump to the currently playing track"
 
@@ -2905,7 +2909,7 @@ msgstr ""
 msgid "Keep the original files"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr ""
@@ -2997,7 +3001,7 @@ msgstr "Library"
 msgid "Library advanced grouping"
 msgstr "Library advanced grouping"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3037,7 +3041,7 @@ msgstr ""
 msgid "Load playlist"
 msgstr "Load playlist"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Load playlist..."
 
@@ -3098,11 +3102,15 @@ msgstr ""
 msgid "Login failed"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Love"
 
@@ -3137,11 +3145,11 @@ msgstr ""
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr ""
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3183,7 +3191,7 @@ msgstr ""
 msgid "Make it so!"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr ""
@@ -3321,7 +3329,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Move to library..."
 
@@ -3330,7 +3338,7 @@ msgstr "Move to library..."
 msgid "Move up"
 msgstr "Move up"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Music"
 
@@ -3343,7 +3351,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Mute"
 
@@ -3392,7 +3400,7 @@ msgstr "Never start playing"
 msgid "New folder"
 msgstr "New folder"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "New playlist"
 
@@ -3420,8 +3428,12 @@ msgstr "Newest tracks"
 msgid "Next"
 msgstr "Next"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Next track"
 
@@ -3459,7 +3471,7 @@ msgstr "No short blocks"
 msgid "None"
 msgstr "None"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "None of the selected songs were suitable for copying to a device"
 
@@ -3544,19 +3556,19 @@ msgstr "Off"
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3600,7 +3612,7 @@ msgstr "Opacity"
 msgid "Open %1 in browser"
 msgstr "Open %1 in browser"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Open &audio CD..."
 
@@ -3612,7 +3624,7 @@ msgstr "Open OPML file"
 msgid "Open OPML file..."
 msgstr "Open OPML file..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Open a directory to import music from"
 
@@ -3620,7 +3632,7 @@ msgstr "Open a directory to import music from"
 msgid "Open device"
 msgstr "Open device"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr ""
 
@@ -3674,7 +3686,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr ""
 
@@ -3758,7 +3770,7 @@ msgstr "Party"
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pause"
@@ -3782,6 +3794,10 @@ msgstr ""
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr ""
@@ -3790,10 +3806,10 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Play"
 
@@ -3814,11 +3830,11 @@ msgstr "Play if stopped, pause if playing"
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3917,7 +3933,7 @@ msgstr ""
 msgid "Preferences"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr ""
 
@@ -3977,7 +3993,7 @@ msgid "Previous"
 msgstr ""
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Previous track"
 
@@ -4035,16 +4051,16 @@ msgstr ""
 msgid "Querying device..."
 msgstr ""
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr ""
 
@@ -4060,7 +4076,7 @@ msgstr "Radio (equal loudness for all tracks)"
 msgid "Rain"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr ""
@@ -4172,7 +4188,7 @@ msgstr ""
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr ""
 
@@ -4180,7 +4196,7 @@ msgstr ""
 msgid "Remove folder"
 msgstr "Remove folder"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Remove from playlist"
 
@@ -4192,7 +4208,7 @@ msgstr ""
 msgid "Remove playlists"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr ""
 
@@ -4204,7 +4220,7 @@ msgstr "Rename playlist"
 msgid "Rename playlist..."
 msgstr "Rename playlist..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Renumber tracks in this order..."
 
@@ -4295,7 +4311,7 @@ msgstr ""
 msgid "Rip CD"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr ""
 
@@ -4373,7 +4389,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr ""
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Save playlist..."
 
@@ -4460,7 +4476,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4473,7 +4489,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4598,7 +4614,7 @@ msgstr ""
 msgid "Service offline"
 msgstr "Service offline"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Set %1 to \"%2\"..."
@@ -4607,7 +4623,7 @@ msgstr "Set %1 to \"%2\"..."
 msgid "Set the volume to <value> percent"
 msgstr "Set the volume to <value> percent"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Set value for all selected tracks..."
 
@@ -4678,7 +4694,7 @@ msgstr "Show a pretty OSD"
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr ""
 
@@ -4698,12 +4714,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr "Show fullsize..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr ""
 
@@ -4715,15 +4731,15 @@ msgstr "Show in various artists"
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4731,7 +4747,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4767,7 +4783,7 @@ msgstr "Shuffle albums"
 msgid "Shuffle all"
 msgstr "Shuffle all"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Shuffle playlist"
 
@@ -4811,11 +4827,15 @@ msgstr "Skip count"
 msgid "Skip forwards in playlist"
 msgstr "Skip forwards in playlist"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Skip selected tracks"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Skip track"
 
@@ -4932,7 +4952,7 @@ msgstr ""
 msgid "Start the playlist currently playing"
 msgstr "Start the playlist currently playing"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Start transcoding"
 
@@ -4942,7 +4962,7 @@ msgid ""
 "list"
 msgstr ""
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Starting %1"
@@ -4952,7 +4972,7 @@ msgid "Starting..."
 msgstr ""
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Stop"
 
@@ -4968,7 +4988,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Stop after this track"
 
@@ -5136,7 +5156,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5178,7 +5198,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5280,11 +5300,11 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr ""
 
@@ -5329,19 +5349,19 @@ msgstr ""
 msgid "Track"
 msgstr "Track"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Transcode Music"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Transcoder Log"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr ""
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Transcoding %1 files using %2 threads"
@@ -5418,11 +5438,11 @@ msgstr "Unknown error"
 msgid "Unset cover"
 msgstr "Unset cover"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr ""
 
@@ -5439,7 +5459,7 @@ msgstr ""
 msgid "Update all podcasts"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr ""
 
@@ -5600,7 +5620,7 @@ msgstr "Version %1"
 msgid "View"
 msgstr "View"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5608,7 +5628,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr "Visualisation mode"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Visualisations"
 
@@ -5649,7 +5669,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr ""
 
@@ -5745,7 +5765,7 @@ msgstr ""
 msgid "Windows Media 64k"
 msgstr ""
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr ""
 
@@ -5759,7 +5779,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/en_GB.po
+++ b/src/translations/en_GB.po
@@ -512,7 +512,7 @@ msgstr "Add another stream..."
 msgid "Add directory..."
 msgstr "Add directory..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Add file"
 
@@ -532,7 +532,7 @@ msgstr "Add file..."
 msgid "Add files to transcode"
 msgstr "Add files to transcode"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Add folder"
@@ -637,7 +637,7 @@ msgstr "Add to Spotify playlists"
 msgid "Add to Spotify starred"
 msgstr "Add to Spotify starred"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Add to another playlist"
 
@@ -859,7 +859,7 @@ msgstr "Are you sure you want to write song statistics to file for all the songs
 msgid "Artist"
 msgstr "Artist"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Artist info"
 
@@ -1122,7 +1122,7 @@ msgstr "Check for new episodes"
 msgid "Check for updates"
 msgstr "Check for updates"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Check for updates..."
 
@@ -1362,7 +1362,7 @@ msgstr "Configure Subsonic..."
 msgid "Configure global search..."
 msgstr "Configure global search..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Configure library..."
 
@@ -1434,11 +1434,11 @@ msgid "Copy to clipboard"
 msgstr "Copy to clipboard"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Copy to device..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Copy to library..."
@@ -1656,7 +1656,7 @@ msgid "Delete downloaded data"
 msgstr "Delete downloaded data"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Delete files"
 
@@ -1664,7 +1664,7 @@ msgstr "Delete files"
 msgid "Delete from device..."
 msgstr "Delete from device..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Delete from disk..."
@@ -1697,11 +1697,11 @@ msgstr "Deleting files"
 msgid "Depth"
 msgstr "Depth"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Dequeue selected tracks"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Dequeue track"
 
@@ -1730,7 +1730,7 @@ msgstr "Device name"
 msgid "Device properties..."
 msgstr "Device properties..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Devices"
 
@@ -1981,7 +1981,7 @@ msgstr "Dynamic random mix"
 msgid "Edit smart playlist..."
 msgstr "Edit smart playlist..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Edit tag \"%1\"..."
@@ -2120,8 +2120,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Equivalent to --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Error"
 
@@ -2267,7 +2267,7 @@ msgstr "Fading"
 msgid "Fading duration"
 msgstr "Fading duration"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Failed reading CD drive"
 
@@ -2390,7 +2390,7 @@ msgstr "File type"
 msgid "Filename"
 msgstr "Filename"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Files"
 
@@ -2805,7 +2805,7 @@ msgstr "Installed"
 msgid "Integrity check"
 msgstr "Integrity check"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -2993,7 +2993,7 @@ msgstr "Left"
 msgid "Length"
 msgstr "Length"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Library"
@@ -3002,7 +3002,7 @@ msgstr "Library"
 msgid "Library advanced grouping"
 msgstr "Library advanced grouping"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Library rescan notice"
 
@@ -3330,7 +3330,7 @@ msgstr "Mount points"
 msgid "Move down"
 msgstr "Move down"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Move to library..."
 
@@ -3339,7 +3339,7 @@ msgstr "Move to library..."
 msgid "Move up"
 msgstr "Move up"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Music"
 
@@ -3401,7 +3401,7 @@ msgstr "Never start playing"
 msgid "New folder"
 msgstr "New folder"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "New playlist"
 
@@ -3472,7 +3472,7 @@ msgstr "No short blocks"
 msgid "None"
 msgstr "None"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "None of the selected songs were suitable for copying to a device"
 
@@ -3687,7 +3687,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organise Files"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Organise files..."
 
@@ -3771,7 +3771,7 @@ msgstr "Party"
 msgid "Password"
 msgstr "Password"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pause"
@@ -3807,8 +3807,8 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Plain sidebar"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3831,11 +3831,11 @@ msgstr "Play if stopped, pause if playing"
 msgid "Play if there is nothing already playing"
 msgstr "Play if there is nothing already playing"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Play next"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Play selected tracks next"
 
@@ -3874,7 +3874,7 @@ msgstr "Playlist options"
 msgid "Playlist type"
 msgstr "Playlist type"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Playlists"
 
@@ -4056,12 +4056,12 @@ msgstr "Querying device..."
 msgid "Queue Manager"
 msgstr "Queue Manager"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Queue selected tracks"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Queue track"
 
@@ -4452,7 +4452,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Search"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Search"
@@ -4477,7 +4477,7 @@ msgstr "Search Subsonic"
 msgid "Search automatically"
 msgstr "Search automatically"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Search for album"
 
@@ -4490,7 +4490,7 @@ msgstr "Search for album covers..."
 msgid "Search for anything"
 msgstr "Search for anything"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Search for artist"
 
@@ -4615,7 +4615,7 @@ msgstr "Server details"
 msgid "Service offline"
 msgstr "Service offline"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Set %1 to \"%2\"..."
@@ -4695,7 +4695,7 @@ msgstr "Show a pretty OSD"
 msgid "Show above status bar"
 msgstr "Show above status bar"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Show all songs"
 
@@ -4715,12 +4715,12 @@ msgstr "Show dividers"
 msgid "Show fullsize..."
 msgstr "Show fullsize..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Show in file browser..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Show in library..."
 
@@ -4732,11 +4732,11 @@ msgstr "Show in various artists"
 msgid "Show moodbar"
 msgstr "Show moodbar"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Show only duplicates"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Show only untagged"
 
@@ -4828,7 +4828,7 @@ msgstr "Skip count"
 msgid "Skip forwards in playlist"
 msgstr "Skip forwards in playlist"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Skip selected tracks"
 
@@ -4836,7 +4836,7 @@ msgstr "Skip selected tracks"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Skip track"
 
@@ -4868,7 +4868,7 @@ msgstr "Soft Rock"
 msgid "Song Information"
 msgstr "Song Information"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Song info"
 
@@ -4989,7 +4989,7 @@ msgstr "Stop after each track"
 msgid "Stop after every track"
 msgstr "Stop after every track"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Stop after this track"
 
@@ -5157,7 +5157,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "The trial period for the Subsonic server is over. Please donate to get a license key. Visit subsonic.org for details."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5199,7 +5199,7 @@ msgid ""
 "continue?"
 msgstr "These files will be deleted from the device, are you sure you want to continue?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5301,7 +5301,7 @@ msgstr "Toggle Pretty OSD"
 msgid "Toggle fullscreen"
 msgstr "Toggle fullscreen"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Toggle queue status"
 
@@ -5439,11 +5439,11 @@ msgstr "Unknown error"
 msgid "Unset cover"
 msgstr "Unset cover"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Unskip selected tracks"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Unskip track"
 
@@ -5780,7 +5780,7 @@ msgid ""
 "well?"
 msgstr "Would you like to move the other songs in this album to Various Artists as well?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Would you like to run a full rescan right now?"
 

--- a/src/translations/en_GB.po
+++ b/src/translations/en_GB.po
@@ -3,15 +3,15 @@
 # This file is distributed under the same license as the Clementine package.
 # 
 # Translators:
-# Andi Chandler <andi@gowling.com>, 2015-2017,2019
+# Andi Chandler <andi@gowling.com>, 2015-2017,2019,2021
 # davidsansome <me@davidsansome.com>, 2010
 # Eilidh Martin <maxqueue93+github@gmail.com>, 2017
 # Luke Hollins <luke@farcry.ca>, 2015
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
-"Last-Translator: John Maguire <john.maguire@gmail.com>\n"
+"PO-Revision-Date: 2021-01-21 13:58+0000\n"
+"Last-Translator: Andi Chandler <andi@gowling.com>\n"
 "Language-Team: English (United Kingdom) (http://www.transifex.com/davidsansome/clementine/language/en_GB/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -102,7 +102,7 @@ msgstr "%1 playlists (%2)"
 msgid ""
 "%1 request failed:\n"
 "%2"
-msgstr ""
+msgstr "%1 request failed:\n%2"
 
 #: devices/deviceview.cpp:122
 #, qt-format
@@ -148,7 +148,7 @@ msgstr "%L1 other listeners"
 #: playlist/playlistmanager.cpp:439
 #, qt-format
 msgid "%L1 selected of"
-msgstr ""
+msgstr "%L1 selected of"
 
 #: songinfo/lastfmtrackinfoprovider.cpp:94
 #, qt-format
@@ -158,7 +158,7 @@ msgstr "%L1 total plays"
 #: playlist/playlistmanager.cpp:445
 #, qt-format
 msgid "%L1 tracks"
-msgstr ""
+msgstr "%L1 tracks"
 
 #: ../bin/src/ui_notificationssettingspage.h:432
 msgid "%filename%"
@@ -1058,7 +1058,7 @@ msgstr "Buttons"
 
 #: internet/podcasts/addpodcastdialog.cpp:95
 msgid "CBC Podcasts"
-msgstr ""
+msgstr "CBC Podcasts"
 
 #: core/song.cpp:453
 msgid "CDDA"
@@ -1316,7 +1316,7 @@ msgstr "Comma separated list of prefix words to ignore when sorting"
 
 #: ../bin/src/ui_console.h:129
 msgid "Command"
-msgstr ""
+msgstr "Command"
 
 #: playlist/playlist.cpp:1436 smartplaylists/searchterm.cpp:386
 #: ui/organisedialog.cpp:77 ../bin/src/ui_edittagdialog.h:719
@@ -1467,7 +1467,7 @@ msgstr "Could not detect an audio stream in %1"
 
 #: internet/googledrive/googledriveservice.cpp:208
 msgid "Could not find Google Drive file."
-msgstr ""
+msgstr "Could not find Google Drive file."
 
 #: songinfo/streamdiscoverer.cpp:124
 msgid "Could not get details"
@@ -1588,7 +1588,7 @@ msgstr "Dance"
 
 #: ../bin/src/ui_console.h:131
 msgid "Database"
-msgstr ""
+msgstr "Database"
 
 #: core/database.cpp:629
 msgid ""
@@ -1901,11 +1901,11 @@ msgstr "Download settings"
 
 #: ../bin/src/ui_networkremotesettingspage.h:385
 msgid "Download the original Android app"
-msgstr ""
+msgstr "Download the original Android app"
 
 #: ../bin/src/ui_networkremotesettingspage.h:381
 msgid "Download the remote for Desktops, Android and iOS"
-msgstr ""
+msgstr "Download the remote for Desktops, Android and iOS"
 
 #: internet/magnatune/magnatuneservice.cpp:279
 msgid "Download this album"
@@ -1959,11 +1959,11 @@ msgstr "Dubstep"
 
 #: ../bin/src/ui_gstenginedebug.h:68
 msgid "Dump Pipeline Graph"
-msgstr ""
+msgstr "Dump Pipeline Graph"
 
 #: ../bin/src/ui_console.h:132
 msgid "Dump To Logs"
-msgstr ""
+msgstr "Dump To Logs"
 
 #: ../bin/src/ui_episodeinfowidget.h:134 ../bin/src/ui_ripcddialog.h:308
 msgid "Duration"
@@ -2284,7 +2284,7 @@ msgstr "Failed to fetch podcasts"
 msgid ""
 "Failed to get channel list:\n"
 "%1"
-msgstr ""
+msgstr "Failed to get channel list:\n%1"
 
 #: internet/podcasts/addpodcastbyurl.cpp:71
 #: internet/podcasts/fixedopmlpage.cpp:55
@@ -2296,7 +2296,7 @@ msgstr "Failed to load podcast"
 msgid ""
 "Failed to parse %1 response:\n"
 "%2"
-msgstr ""
+msgstr "Failed to parse %1 response:\n%2"
 
 #: internet/podcasts/podcasturlloader.cpp:177
 msgid "Failed to parse the XML for this RSS feed"
@@ -2307,7 +2307,7 @@ msgstr "Failed to parse the XML for this RSS feed"
 msgid ""
 "Failed to update icecast directory:\n"
 "%1"
-msgstr ""
+msgstr "Failed to update Icecast directory:\n%1"
 
 #: ui/trackselectiondialog.cpp:247
 #, qt-format
@@ -2346,7 +2346,7 @@ msgstr "Fetching cover error"
 #: internet/subsonic/subsonicdynamicplaylist.cpp:98
 #: internet/subsonic/subsonicdynamicplaylist.cpp:164
 msgid "Fetching playlist items"
-msgstr ""
+msgstr "Fetching playlist items"
 
 #: ../bin/src/ui_ripcddialog.h:319
 msgid "File Format"
@@ -2392,7 +2392,7 @@ msgstr "Files"
 
 #: ../bin/src/ui_networkremotesettingspage.h:376
 msgid "Files root folder"
-msgstr ""
+msgstr "Files root folder"
 
 #: ../bin/src/ui_transcodedialog.h:214
 msgid "Files to transcode"
@@ -2482,7 +2482,7 @@ msgstr "Frames per buffer"
 
 #: internet/subsonic/subsonicservice.cpp:107
 msgid "Frequently Played Albums"
-msgstr ""
+msgstr "Frequently Played Albums"
 
 #: moodbar/moodbarrenderer.cpp:173
 msgid "Frozen"
@@ -3236,7 +3236,7 @@ msgstr "Maximum bitrate"
 
 #: ../bin/src/ui_behavioursettingspage.h:449
 msgid "Maximum number of child processes for tag handling (requires restart)"
-msgstr ""
+msgstr "Maximum number of child processes for tag handling (requires restart)"
 
 #: ripper/ripcddialog.cpp:154
 msgid "Media has changed. Reloading"
@@ -3341,7 +3341,7 @@ msgstr "Music Library"
 
 #: ../bin/src/ui_networkremotesettingspage.h:380
 msgid "Music extensions remotely visible"
-msgstr ""
+msgstr "Music extensions remotely visible"
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
 #: ../bin/src/ui_mainwindow.h:763
@@ -3411,7 +3411,7 @@ msgstr "New tracks will be added automatically."
 
 #: internet/subsonic/subsonicservice.cpp:101
 msgid "Newest Albums"
-msgstr ""
+msgstr "Newest Albums"
 
 #: library/library.cpp:96
 msgid "Newest tracks"
@@ -3531,7 +3531,7 @@ msgstr "Number of episodes to show"
 
 #: ../bin/src/ui_behavioursettingspage.h:450
 msgid "Number of processes:"
-msgstr ""
+msgstr "Number of processes:"
 
 #: ui/notificationssettingspage.cpp:40
 msgid "OSD Preview"
@@ -3781,7 +3781,7 @@ msgstr "Performer"
 
 #: ../bin/src/ui_gstenginedebug.h:67
 msgid "Pipeline"
-msgstr ""
+msgstr "Pipeline"
 
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
@@ -3804,7 +3804,7 @@ msgstr "Play count"
 
 #: core/commandlineoptions.cpp:183
 msgid "Play given playlist"
-msgstr ""
+msgstr "Play given playlist"
 
 #: core/commandlineoptions.cpp:162
 msgid "Play if stopped, pause if playing"
@@ -4017,7 +4017,7 @@ msgstr "Put songs in a random order"
 
 #: ../bin/src/ui_console.h:134
 msgid "Qt"
-msgstr ""
+msgstr "Qt"
 
 #: ../bin/src/ui_transcoderoptionsflac.h:92
 #: ../bin/src/ui_transcoderoptionsmp3.h:191
@@ -4051,7 +4051,7 @@ msgstr "Queue track"
 
 #: ../bin/src/ui_lovedialog.h:115
 msgid "Quickly rate the playing track"
-msgstr ""
+msgstr "Quickly rate the playing track"
 
 #: ../bin/src/ui_playbacksettingspage.h:358
 msgid "Radio (equal loudness for all tracks)"
@@ -4068,11 +4068,11 @@ msgstr "Rain"
 
 #: internet/subsonic/subsonicservice.cpp:104
 msgid "Random Albums"
-msgstr ""
+msgstr "Random Albums"
 
 #: internet/subsonic/subsonicservice.cpp:122
 msgid "Random Songs"
-msgstr ""
+msgstr "Random Songs"
 
 #: ../bin/src/ui_visualisationselector.h:111
 msgid "Random visualization"
@@ -4113,7 +4113,7 @@ msgstr "Really cancel?"
 
 #: internet/subsonic/subsonicservice.cpp:115
 msgid "Recently Played Albums"
-msgstr ""
+msgstr "Recently Played Albums"
 
 #: internet/subsonic/subsonicsettingspage.cpp:161
 msgid "Redirect limit exceeded, verify server configuration."
@@ -4306,7 +4306,7 @@ msgstr "Rock"
 
 #: ../bin/src/ui_networkremotesettingspage.h:374
 msgid "Root folder that will be browsable from the network remote"
-msgstr ""
+msgstr "Root folder that will be browsable from the network remote"
 
 #: ../bin/src/ui_console.h:130
 msgid "Run"
@@ -4545,11 +4545,11 @@ msgstr "Select None"
 
 #: ui/filechooserwidget.cpp:95
 msgid "Select a directory"
-msgstr ""
+msgstr "Select a directory"
 
 #: ui/filechooserwidget.cpp:92
 msgid "Select a file"
-msgstr ""
+msgstr "Select a file"
 
 #: ../bin/src/ui_appearancesettingspage.h:303
 msgid "Select background color:"
@@ -4923,7 +4923,7 @@ msgstr "Starred"
 
 #: internet/subsonic/subsonicservice.cpp:119
 msgid "Starred Albums"
-msgstr ""
+msgstr "Starred Albums"
 
 #: ripper/ripcddialog.cpp:73
 msgid "Start ripping"
@@ -5303,7 +5303,7 @@ msgstr "Too many redirects"
 
 #: internet/subsonic/subsonicservice.cpp:111
 msgid "Top Rated Albums"
-msgstr ""
+msgstr "Top Rated Albums"
 
 #: internet/spotify/spotifyservice.cpp:423
 msgid "Top tracks"
@@ -5373,7 +5373,7 @@ msgstr "URL"
 
 #: ../bin/src/ui_addstreamdialog.h:128
 msgid "URL of its Logo:"
-msgstr ""
+msgstr "URL of its Logo:"
 
 #: core/commandlineoptions.cpp:159
 msgid "URL(s)"
@@ -5648,7 +5648,7 @@ msgid ""
 "Warning: This compression level is outside of the streamable subset. This "
 "means that a decoder may not be able to start playing it mid-stream. It may "
 "also affect the performance of hardware decoders."
-msgstr ""
+msgstr "Warning: This compression level is outside of the streamable subset. This means that a decoder may not be able to start playing it mid-stream. It may also affect the performance of hardware decoders."
 
 #: core/song.cpp:447 transcoder/transcoder.cpp:257
 msgid "Wav"
@@ -5790,7 +5790,7 @@ msgstr "Year - Album"
 
 #: playlist/playlist.cpp:1392
 msgid "Year - original"
-msgstr ""
+msgstr "Year - original"
 
 #: smartplaylists/searchterm.cpp:427
 msgid "Years"
@@ -5839,7 +5839,7 @@ msgid ""
 "You can find <a href=\"%1\">here on GitHub</a> the new cross platform "
 "remote.<br/>It is available on <b>Linux</b>, <b>MacOS</b> and "
 "<b>Windows</b><br/>"
-msgstr ""
+msgstr "You can find <a href=\"%1\">here on GitHub</a> the new cross platform remote.<br/>It is available on <b>Linux</b>, <b>MacOS</b> and <b>Windows</b><br/>"
 
 #: internet/magnatune/magnatunesettingspage.cpp:59
 msgid ""
@@ -5971,7 +5971,7 @@ msgstr "bpm"
 msgid ""
 "coma separated list of the allowed extensions that will be visible from the "
 "network remote (ex: m3u,mp3,flac,ogg,wav)"
-msgstr ""
+msgstr "coma separated list of the allowed extensions that will be visible from the network remote (ex: m3u,mp3,flac,ogg,wav)"
 
 #: smartplaylists/searchterm.cpp:249
 msgid "contains"
@@ -5979,7 +5979,7 @@ msgstr "contains"
 
 #: ../bin/src/ui_networkremotesettingspage.h:382
 msgid "desktop_remote"
-msgstr ""
+msgstr "desktop_remote"
 
 #: ../bin/src/ui_transcoderoptionsspeex.h:221
 #: ../bin/src/ui_transcoderoptionsvorbis.h:206
@@ -5998,7 +5998,7 @@ msgstr "does not contain"
 
 #: ../bin/src/ui_console.h:133
 msgid "dump"
-msgstr ""
+msgstr "dump"
 
 #: smartplaylists/searchterm.cpp:265
 msgid "empty"
@@ -6089,7 +6089,7 @@ msgstr "options"
 #: ../bin/src/ui_networkremotesettingspage.h:384
 #: ../bin/src/ui_networkremotesettingspage.h:386
 msgid "or scan the QR code: "
-msgstr ""
+msgstr "or scan the QR code: "
 
 #: widgets/didyoumean.cpp:56
 msgid "press enter"

--- a/src/translations/en_GB.po
+++ b/src/translations/en_GB.po
@@ -10,8 +10,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-21 13:58+0000\n"
-"Last-Translator: Andi Chandler <andi@gowling.com>\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
+"Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: English (United Kingdom) (http://www.transifex.com/davidsansome/clementine/language/en_GB/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -164,19 +164,19 @@ msgstr "%L1 tracks"
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n failed"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n finished"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -194,7 +194,7 @@ msgstr "&Centre"
 msgid "&Custom"
 msgstr "&Custom"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Extras"
 
@@ -202,7 +202,7 @@ msgstr "&Extras"
 msgid "&Grouping"
 msgstr "&Grouping"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "Help"
 
@@ -227,7 +227,7 @@ msgstr "&Lock Rating"
 msgid "&Lyrics"
 msgstr "&Lyrics"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "Music"
 
@@ -235,15 +235,15 @@ msgstr "Music"
 msgid "&None"
 msgstr "&None"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "Playlist"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Quit"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "Repeat mode"
 
@@ -251,7 +251,7 @@ msgstr "Repeat mode"
 msgid "&Right"
 msgstr "&Right"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Shuffle mode"
 
@@ -259,7 +259,7 @@ msgstr "Shuffle mode"
 msgid "&Stretch columns to fit window"
 msgstr "&Stretch columns to fit window"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Tools"
 
@@ -448,11 +448,11 @@ msgstr "Abort"
 msgid "About %1"
 msgstr "About %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "About Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "About Qt..."
 
@@ -512,32 +512,32 @@ msgstr "Add another stream..."
 msgid "Add directory..."
 msgstr "Add directory..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Add file"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Add file to transcoder"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Add file(s) to transcoder"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Add file..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Add files to transcode"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Add folder"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Add folder..."
 
@@ -549,7 +549,7 @@ msgstr "Add new folder..."
 msgid "Add podcast"
 msgstr "Add podcast"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Add podcast..."
 
@@ -625,7 +625,7 @@ msgstr "Add song track tag"
 msgid "Add song year tag"
 msgstr "Add song year tag"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Add stream..."
 
@@ -637,7 +637,7 @@ msgstr "Add to Spotify playlists"
 msgid "Add to Spotify starred"
 msgstr "Add to Spotify starred"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Add to another playlist"
 
@@ -731,7 +731,7 @@ msgstr "All"
 msgid "All Files (*)"
 msgstr "All Files (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "All Glory to the Hypnotoad!"
@@ -1122,7 +1122,7 @@ msgstr "Check for new episodes"
 msgid "Check for updates"
 msgstr "Check for updates"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Check for updates..."
 
@@ -1171,18 +1171,18 @@ msgstr "Classical"
 msgid "Cleaning up"
 msgstr "Cleaning up"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Clear"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Clear playlist"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1327,7 +1327,7 @@ msgstr "Comment"
 msgid "Complete tags automatically"
 msgstr "Complete tags automatically"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Complete tags automatically..."
 
@@ -1362,7 +1362,7 @@ msgstr "Configure Subsonic..."
 msgid "Configure global search..."
 msgstr "Configure global search..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Configure library..."
 
@@ -1405,7 +1405,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Connection timed out, check server URL. Example: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Console"
 
@@ -1434,11 +1434,11 @@ msgid "Copy to clipboard"
 msgstr "Copy to clipboard"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Copy to device..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Copy to library..."
@@ -1481,14 +1481,14 @@ msgstr "Could not log in to Last.fm. Please try again."
 msgid "Couldn't create playlist"
 msgstr "Couldn't create playlist"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Couldn't find a muxer for %1, check you have the correct GStreamer plugins installed"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1503,7 +1503,7 @@ msgstr "Couldn't open output file %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Cover Manager"
 
@@ -1656,7 +1656,7 @@ msgid "Delete downloaded data"
 msgstr "Delete downloaded data"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Delete files"
 
@@ -1664,7 +1664,7 @@ msgstr "Delete files"
 msgid "Delete from device..."
 msgstr "Delete from device..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Delete from disk..."
@@ -1697,11 +1697,11 @@ msgstr "Deleting files"
 msgid "Depth"
 msgstr "Depth"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Dequeue selected tracks"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Dequeue track"
 
@@ -1802,7 +1802,7 @@ msgstr "Display options"
 msgid "Display the on-screen-display"
 msgstr "Display the on-screen-display"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Do a full library rescan"
 
@@ -1981,12 +1981,12 @@ msgstr "Dynamic random mix"
 msgid "Edit smart playlist..."
 msgstr "Edit smart playlist..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Edit tag \"%1\"..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Edit tag..."
 
@@ -1999,7 +1999,7 @@ msgid "Edit track information"
 msgstr "Edit track information"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Edit track information..."
 
@@ -2107,7 +2107,7 @@ msgstr "Entire collection"
 msgid "Episode information"
 msgstr "Episode information"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Equalizer"
 
@@ -2120,8 +2120,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Equivalent to --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Error"
 
@@ -2156,7 +2156,7 @@ msgstr "Error loading %1"
 msgid "Error loading di.fm playlist"
 msgstr "Error loading di.fm playlist"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Error processing %1: %2"
@@ -2239,7 +2239,11 @@ msgstr "Export finished"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "Exported %1 covers out of %2 (%3 skipped)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2263,7 +2267,7 @@ msgstr "Fading"
 msgid "Fading duration"
 msgstr "Fading duration"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Failed reading CD drive"
 
@@ -2545,11 +2549,11 @@ msgstr "Give it a name:"
 msgid "Go"
 msgstr "Go"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Go to next playlist tab"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Go to previous playlist tab"
 
@@ -2882,7 +2886,7 @@ msgstr "Jamendo database"
 msgid "Jump to previous song right away"
 msgstr "Jump to previous song right away"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Jump to the currently playing track"
 
@@ -2906,7 +2910,7 @@ msgstr "Keep running in the background when the window is closed"
 msgid "Keep the original files"
 msgstr "Keep the original files"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Kittens"
@@ -2998,7 +3002,7 @@ msgstr "Library"
 msgid "Library advanced grouping"
 msgstr "Library advanced grouping"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Library rescan notice"
 
@@ -3038,7 +3042,7 @@ msgstr "Load cover from disk..."
 msgid "Load playlist"
 msgstr "Load playlist"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Load playlist..."
 
@@ -3099,11 +3103,15 @@ msgstr "Login"
 msgid "Login failed"
 msgstr "Login failed"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Long term prediction profile (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Love"
 
@@ -3138,11 +3146,11 @@ msgstr "Lyrics from %1"
 msgid "Lyrics from the tag"
 msgstr "Lyrics from the tag"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3184,7 +3192,7 @@ msgstr "Main profile (MAIN)"
 msgid "Make it so!"
 msgstr "Make it so!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Make it so!"
@@ -3322,7 +3330,7 @@ msgstr "Mount points"
 msgid "Move down"
 msgstr "Move down"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Move to library..."
 
@@ -3331,7 +3339,7 @@ msgstr "Move to library..."
 msgid "Move up"
 msgstr "Move up"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Music"
 
@@ -3344,7 +3352,7 @@ msgid "Music extensions remotely visible"
 msgstr "Music extensions remotely visible"
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Mute"
 
@@ -3393,7 +3401,7 @@ msgstr "Never start playing"
 msgid "New folder"
 msgstr "New folder"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "New playlist"
 
@@ -3421,8 +3429,12 @@ msgstr "Newest tracks"
 msgid "Next"
 msgstr "Next"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Next track"
 
@@ -3460,7 +3472,7 @@ msgstr "No short blocks"
 msgid "None"
 msgstr "None"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "None of the selected songs were suitable for copying to a device"
 
@@ -3545,19 +3557,19 @@ msgstr "Off"
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3601,7 +3613,7 @@ msgstr "Opacity"
 msgid "Open %1 in browser"
 msgstr "Open %1 in browser"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Open &audio CD..."
 
@@ -3613,7 +3625,7 @@ msgstr "Open OPML file"
 msgid "Open OPML file..."
 msgstr "Open OPML file..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Open a directory to import music from"
 
@@ -3621,7 +3633,7 @@ msgstr "Open a directory to import music from"
 msgid "Open device"
 msgstr "Open device"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Open file..."
 
@@ -3675,7 +3687,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organise Files"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Organise files..."
 
@@ -3759,7 +3771,7 @@ msgstr "Party"
 msgid "Password"
 msgstr "Password"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pause"
@@ -3783,6 +3795,10 @@ msgstr "Performer"
 msgid "Pipeline"
 msgstr "Pipeline"
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Pixel"
@@ -3791,10 +3807,10 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Plain sidebar"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Play"
 
@@ -3815,11 +3831,11 @@ msgstr "Play if stopped, pause if playing"
 msgid "Play if there is nothing already playing"
 msgstr "Play if there is nothing already playing"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Play next"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Play selected tracks next"
 
@@ -3918,7 +3934,7 @@ msgstr "Preference"
 msgid "Preferences"
 msgstr "Preferences"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Preferences..."
 
@@ -3978,7 +3994,7 @@ msgid "Previous"
 msgstr "Previous"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Previous track"
 
@@ -4036,16 +4052,16 @@ msgstr "Quality"
 msgid "Querying device..."
 msgstr "Querying device..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Queue Manager"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Queue selected tracks"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Queue track"
 
@@ -4061,7 +4077,7 @@ msgstr "Radio (equal loudness for all tracks)"
 msgid "Rain"
 msgstr "Rain"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Rain"
@@ -4173,7 +4189,7 @@ msgstr "Remove action"
 msgid "Remove current song from playlist"
 msgstr "Remove current song from playlist"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Remove duplicates from playlist"
 
@@ -4181,7 +4197,7 @@ msgstr "Remove duplicates from playlist"
 msgid "Remove folder"
 msgstr "Remove folder"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Remove from playlist"
 
@@ -4193,7 +4209,7 @@ msgstr "Remove playlist"
 msgid "Remove playlists"
 msgstr "Remove playlists"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Remove unavailable tracks from playlist"
 
@@ -4205,7 +4221,7 @@ msgstr "Rename playlist"
 msgid "Rename playlist..."
 msgstr "Rename playlist..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Renumber tracks in this order..."
 
@@ -4296,7 +4312,7 @@ msgstr "Rip"
 msgid "Rip CD"
 msgstr "Rip CD"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Rip audio CD"
 
@@ -4374,7 +4390,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Save playlist"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Save playlist..."
 
@@ -4461,7 +4477,7 @@ msgstr "Search Subsonic"
 msgid "Search automatically"
 msgstr "Search automatically"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Search for album"
 
@@ -4474,7 +4490,7 @@ msgstr "Search for album covers..."
 msgid "Search for anything"
 msgstr "Search for anything"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Search for artist"
 
@@ -4599,7 +4615,7 @@ msgstr "Server details"
 msgid "Service offline"
 msgstr "Service offline"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Set %1 to \"%2\"..."
@@ -4608,7 +4624,7 @@ msgstr "Set %1 to \"%2\"..."
 msgid "Set the volume to <value> percent"
 msgstr "Set the volume to <value> percent"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Set value for all selected tracks..."
 
@@ -4679,7 +4695,7 @@ msgstr "Show a pretty OSD"
 msgid "Show above status bar"
 msgstr "Show above status bar"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Show all songs"
 
@@ -4699,12 +4715,12 @@ msgstr "Show dividers"
 msgid "Show fullsize..."
 msgstr "Show fullsize..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Show in file browser..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Show in library..."
 
@@ -4716,15 +4732,15 @@ msgstr "Show in various artists"
 msgid "Show moodbar"
 msgstr "Show moodbar"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Show only duplicates"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Show only untagged"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Show or hide the sidebar"
 
@@ -4732,7 +4748,7 @@ msgstr "Show or hide the sidebar"
 msgid "Show search suggestions"
 msgstr "Show search suggestions"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Show sidebar"
 
@@ -4768,7 +4784,7 @@ msgstr "Shuffle albums"
 msgid "Shuffle all"
 msgstr "Shuffle all"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Shuffle playlist"
 
@@ -4812,11 +4828,15 @@ msgstr "Skip count"
 msgid "Skip forwards in playlist"
 msgstr "Skip forwards in playlist"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Skip selected tracks"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Skip track"
 
@@ -4933,7 +4953,7 @@ msgstr "Start ripping"
 msgid "Start the playlist currently playing"
 msgstr "Start the playlist currently playing"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Start transcoding"
 
@@ -4943,7 +4963,7 @@ msgid ""
 "list"
 msgstr "Start typing something on the search box above to fill this search results list"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Starting %1"
@@ -4953,7 +4973,7 @@ msgid "Starting..."
 msgstr "Starting..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Stop"
 
@@ -4969,7 +4989,7 @@ msgstr "Stop after each track"
 msgid "Stop after every track"
 msgstr "Stop after every track"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Stop after this track"
 
@@ -5137,7 +5157,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "The trial period for the Subsonic server is over. Please donate to get a license key. Visit subsonic.org for details."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5179,7 +5199,7 @@ msgid ""
 "continue?"
 msgstr "These files will be deleted from the device, are you sure you want to continue?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5281,11 +5301,11 @@ msgstr "Toggle Pretty OSD"
 msgid "Toggle fullscreen"
 msgstr "Toggle fullscreen"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Toggle queue status"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Toggle scrobbling"
 
@@ -5330,19 +5350,19 @@ msgstr "Trac&k"
 msgid "Track"
 msgstr "Track"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Transcode Music"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Transcoder Log"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Transcoding"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Transcoding %1 files using %2 threads"
@@ -5419,11 +5439,11 @@ msgstr "Unknown error"
 msgid "Unset cover"
 msgstr "Unset cover"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Unskip selected tracks"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Unskip track"
 
@@ -5440,7 +5460,7 @@ msgstr "Upcoming Concerts"
 msgid "Update all podcasts"
 msgstr "Update all podcasts"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Update changed library folders"
 
@@ -5601,7 +5621,7 @@ msgstr "Version %1"
 msgid "View"
 msgstr "View"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "View Stream Details"
 
@@ -5609,7 +5629,7 @@ msgstr "View Stream Details"
 msgid "Visualization mode"
 msgstr "Visualisation mode"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Visualisations"
 
@@ -5650,7 +5670,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr "Warning: This compression level is outside of the streamable subset. This means that a decoder may not be able to start playing it mid-stream. It may also affect the performance of hardware decoders."
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5746,7 +5766,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media audio"
 
@@ -5760,7 +5780,7 @@ msgid ""
 "well?"
 msgstr "Would you like to move the other songs in this album to Various Artists as well?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Would you like to run a full rescan right now?"
 

--- a/src/translations/eo.po
+++ b/src/translations/eo.po
@@ -513,7 +513,7 @@ msgstr "Aldoni plian fluon..."
 msgid "Add directory..."
 msgstr "Aldoni dosierujon..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Aldoni dosieron"
 
@@ -533,7 +533,7 @@ msgstr "Aldoni dosieron..."
 msgid "Add files to transcode"
 msgstr "Aldoni dosierojn transkodigotajn"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Aldoni dosierujon"
@@ -638,7 +638,7 @@ msgstr "Aldoni al ludlistojn de Spotify"
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Aldoni al alian ludliston"
 
@@ -860,7 +860,7 @@ msgstr ""
 msgid "Artist"
 msgstr "Artisto"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Informoj pri la artisto"
 
@@ -1123,7 +1123,7 @@ msgstr "Kontroli ĉu estas novaj epizodoj"
 msgid "Check for updates"
 msgstr "Kontroli ĉu estas ĝisdatigoj"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Kontroli ĉu estas ĝisdatigoj..."
 
@@ -1363,7 +1363,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr ""
 
@@ -1435,11 +1435,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1657,7 +1657,7 @@ msgid "Delete downloaded data"
 msgstr "Forigi elŝutintajn datumojn"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Forigi dosierojn"
 
@@ -1665,7 +1665,7 @@ msgstr "Forigi dosierojn"
 msgid "Delete from device..."
 msgstr "Forigi el la aparato…"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1698,11 +1698,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr ""
 
@@ -1731,7 +1731,7 @@ msgstr ""
 msgid "Device properties..."
 msgstr ""
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Aparatoj"
 
@@ -1982,7 +1982,7 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Redakti etikedon „%1”…"
@@ -2121,8 +2121,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Eraro"
 
@@ -2268,7 +2268,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2391,7 +2391,7 @@ msgstr ""
 msgid "Filename"
 msgstr "Dosiernomo"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Dosieroj"
 
@@ -2806,7 +2806,7 @@ msgstr ""
 msgid "Integrity check"
 msgstr ""
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Interreto"
 
@@ -2994,7 +2994,7 @@ msgstr "Maldekstro"
 msgid "Length"
 msgstr ""
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Kolekto"
@@ -3003,7 +3003,7 @@ msgstr "Kolekto"
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3331,7 +3331,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3340,7 +3340,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Muziko"
 
@@ -3402,7 +3402,7 @@ msgstr ""
 msgid "New folder"
 msgstr "Nova dosierujo"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nova ludlisto"
 
@@ -3473,7 +3473,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3688,7 +3688,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr ""
 
@@ -3772,7 +3772,7 @@ msgstr ""
 msgid "Password"
 msgstr "Pasvorto"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Paŭzigi"
@@ -3808,8 +3808,8 @@ msgstr "Bildero"
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3832,11 +3832,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3875,7 +3875,7 @@ msgstr ""
 msgid "Playlist type"
 msgstr ""
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Ludlistoj"
 
@@ -4057,12 +4057,12 @@ msgstr ""
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr ""
 
@@ -4453,7 +4453,7 @@ msgstr ""
 msgid "Search"
 msgstr "Serĉi"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Serĉi"
@@ -4478,7 +4478,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4491,7 +4491,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4616,7 +4616,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4696,7 +4696,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr ""
 
@@ -4716,12 +4716,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr ""
 
@@ -4733,11 +4733,11 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr ""
 
@@ -4829,7 +4829,7 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr ""
 
@@ -4837,7 +4837,7 @@ msgstr ""
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr ""
 
@@ -4869,7 +4869,7 @@ msgstr ""
 msgid "Song Information"
 msgstr ""
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr ""
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5158,7 +5158,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5200,7 +5200,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5302,7 +5302,7 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr ""
 
@@ -5440,11 +5440,11 @@ msgstr ""
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr ""
 
@@ -5781,7 +5781,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/eo.po
+++ b/src/translations/eo.po
@@ -11,7 +11,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Esperanto (http://www.transifex.com/davidsansome/clementine/language/eo/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -165,19 +165,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n malsukcesis"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n finiĝis"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -195,7 +195,7 @@ msgstr ""
 msgid "&Custom"
 msgstr "&Propra"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "&Grouping"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Helpo"
 
@@ -228,7 +228,7 @@ msgstr ""
 msgid "&Lyrics"
 msgstr "&Teksto"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Musiko"
 
@@ -236,15 +236,15 @@ msgstr "&Musiko"
 msgid "&None"
 msgstr "&Nenio"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&Ludlisto"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Eliri"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr ""
 
@@ -252,7 +252,7 @@ msgstr ""
 msgid "&Right"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr ""
 
@@ -260,7 +260,7 @@ msgstr ""
 msgid "&Stretch columns to fit window"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Iloj"
 
@@ -449,11 +449,11 @@ msgstr ""
 msgid "About %1"
 msgstr "Pri %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Pri Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Pri Qt..."
 
@@ -513,32 +513,32 @@ msgstr "Aldoni plian fluon..."
 msgid "Add directory..."
 msgstr "Aldoni dosierujon..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Aldoni dosieron"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Aldoni dosieron..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Aldoni dosierojn transkodigotajn"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Aldoni dosierujon"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Aldoni dosierujon..."
 
@@ -550,7 +550,7 @@ msgstr "Aldoni novan dosierujon..."
 msgid "Add podcast"
 msgstr "Aldoni podkaston"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Aldoni podkaston…"
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Add song year tag"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Aldoni fluon..."
 
@@ -638,7 +638,7 @@ msgstr "Aldoni al ludlistojn de Spotify"
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Aldoni al alian ludliston"
 
@@ -732,7 +732,7 @@ msgstr "Ĉiuj"
 msgid "All Files (*)"
 msgstr "Ĉiuj dosieroj (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Ĉiun gloron al la Hipnobufo!"
@@ -1123,7 +1123,7 @@ msgstr "Kontroli ĉu estas novaj epizodoj"
 msgid "Check for updates"
 msgstr "Kontroli ĉu estas ĝisdatigoj"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Kontroli ĉu estas ĝisdatigoj..."
 
@@ -1172,18 +1172,18 @@ msgstr "Klazika"
 msgid "Cleaning up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr ""
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1328,7 +1328,7 @@ msgstr "Komento"
 msgid "Complete tags automatically"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr ""
 
@@ -1363,7 +1363,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr ""
 
@@ -1406,7 +1406,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr ""
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr ""
 
@@ -1435,11 +1435,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1482,14 +1482,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr ""
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1504,7 +1504,7 @@ msgstr ""
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr ""
 
@@ -1657,7 +1657,7 @@ msgid "Delete downloaded data"
 msgstr "Forigi elŝutintajn datumojn"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Forigi dosierojn"
 
@@ -1665,7 +1665,7 @@ msgstr "Forigi dosierojn"
 msgid "Delete from device..."
 msgstr "Forigi el la aparato…"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1698,11 +1698,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr ""
 
@@ -1803,7 +1803,7 @@ msgstr ""
 msgid "Display the on-screen-display"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr ""
 
@@ -1982,12 +1982,12 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Redakti etikedon „%1”…"
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Redakti etikedon…"
 
@@ -2000,7 +2000,7 @@ msgid "Edit track information"
 msgstr ""
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr ""
 
@@ -2108,7 +2108,7 @@ msgstr ""
 msgid "Episode information"
 msgstr "Informoj pri la epizodo"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Egalizilo"
 
@@ -2121,8 +2121,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Eraro"
 
@@ -2157,7 +2157,7 @@ msgstr ""
 msgid "Error loading di.fm playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr ""
@@ -2240,7 +2240,11 @@ msgstr ""
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr ""
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2264,7 +2268,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2546,11 +2550,11 @@ msgstr ""
 msgid "Go"
 msgstr "Iri"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr ""
 
@@ -2883,7 +2887,7 @@ msgstr ""
 msgid "Jump to previous song right away"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr ""
 
@@ -2907,7 +2911,7 @@ msgstr ""
 msgid "Keep the original files"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Katidoj"
@@ -2999,7 +3003,7 @@ msgstr "Kolekto"
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3039,7 +3043,7 @@ msgstr ""
 msgid "Load playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr ""
 
@@ -3100,11 +3104,15 @@ msgstr "Ensaluti"
 msgid "Login failed"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr ""
 
@@ -3139,11 +3147,11 @@ msgstr ""
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr ""
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3185,7 +3193,7 @@ msgstr ""
 msgid "Make it so!"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr ""
@@ -3323,7 +3331,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3332,7 +3340,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Muziko"
 
@@ -3345,7 +3353,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Silentigi"
 
@@ -3394,7 +3402,7 @@ msgstr ""
 msgid "New folder"
 msgstr "Nova dosierujo"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nova ludlisto"
 
@@ -3422,8 +3430,12 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr ""
 
@@ -3461,7 +3473,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3546,19 +3558,19 @@ msgstr ""
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr ""
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr ""
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3602,7 +3614,7 @@ msgstr "Opakeco"
 msgid "Open %1 in browser"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr ""
 
@@ -3614,7 +3626,7 @@ msgstr ""
 msgid "Open OPML file..."
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr ""
 
@@ -3622,7 +3634,7 @@ msgstr ""
 msgid "Open device"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr ""
 
@@ -3676,7 +3688,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr ""
 
@@ -3760,7 +3772,7 @@ msgstr ""
 msgid "Password"
 msgstr "Pasvorto"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Paŭzigi"
@@ -3784,6 +3796,10 @@ msgstr ""
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Bildero"
@@ -3792,10 +3808,10 @@ msgstr "Bildero"
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Ludi"
 
@@ -3816,11 +3832,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3919,7 +3935,7 @@ msgstr ""
 msgid "Preferences"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr ""
 
@@ -3979,7 +3995,7 @@ msgid "Previous"
 msgstr ""
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr ""
 
@@ -4037,16 +4053,16 @@ msgstr "Kvalito"
 msgid "Querying device..."
 msgstr ""
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr ""
 
@@ -4062,7 +4078,7 @@ msgstr ""
 msgid "Rain"
 msgstr "Pluvo"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Pluvo"
@@ -4174,7 +4190,7 @@ msgstr ""
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr ""
 
@@ -4182,7 +4198,7 @@ msgstr ""
 msgid "Remove folder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr ""
 
@@ -4194,7 +4210,7 @@ msgstr ""
 msgid "Remove playlists"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr ""
 
@@ -4206,7 +4222,7 @@ msgstr ""
 msgid "Rename playlist..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr ""
 
@@ -4297,7 +4313,7 @@ msgstr ""
 msgid "Rip CD"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr ""
 
@@ -4375,7 +4391,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Konservi ludliston"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Konservi ludliston…"
 
@@ -4462,7 +4478,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4475,7 +4491,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4600,7 +4616,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4609,7 +4625,7 @@ msgstr ""
 msgid "Set the volume to <value> percent"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr ""
 
@@ -4680,7 +4696,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr ""
 
@@ -4700,12 +4716,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr ""
 
@@ -4717,15 +4733,15 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4733,7 +4749,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4769,7 +4785,7 @@ msgstr ""
 msgid "Shuffle all"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr ""
 
@@ -4813,11 +4829,15 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr ""
 
@@ -4934,7 +4954,7 @@ msgstr ""
 msgid "Start the playlist currently playing"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr ""
 
@@ -4944,7 +4964,7 @@ msgid ""
 "list"
 msgstr ""
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr ""
@@ -4954,7 +4974,7 @@ msgid "Starting..."
 msgstr ""
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr ""
 
@@ -4970,7 +4990,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5138,7 +5158,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5180,7 +5200,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5282,11 +5302,11 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr ""
 
@@ -5331,19 +5351,19 @@ msgstr ""
 msgid "Track"
 msgstr "Kanto"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr ""
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
 msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr ""
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr ""
@@ -5420,11 +5440,11 @@ msgstr ""
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr ""
 
@@ -5441,7 +5461,7 @@ msgstr ""
 msgid "Update all podcasts"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr ""
 
@@ -5602,7 +5622,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5610,7 +5630,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr ""
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr ""
 
@@ -5651,7 +5671,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5747,7 +5767,7 @@ msgstr ""
 msgid "Windows Media 64k"
 msgstr ""
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr ""
 
@@ -5761,7 +5781,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/es.po
+++ b/src/translations/es.po
@@ -43,7 +43,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Spanish (http://www.transifex.com/davidsansome/clementine/language/es/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -197,19 +197,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n falló"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n completados"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -227,7 +227,7 @@ msgstr "&Centro"
 msgid "&Custom"
 msgstr "&Personalizado"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Extras"
 
@@ -235,7 +235,7 @@ msgstr "&Extras"
 msgid "&Grouping"
 msgstr "&Agrupamiento"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "Ay&uda"
 
@@ -260,7 +260,7 @@ msgstr "&Bloquear la valoración"
 msgid "&Lyrics"
 msgstr "&Letras"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Música"
 
@@ -268,15 +268,15 @@ msgstr "&Música"
 msgid "&None"
 msgstr "&Ninguno"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&Lista de reproducción"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Salir"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "Modo de &repetición"
 
@@ -284,7 +284,7 @@ msgstr "Modo de &repetición"
 msgid "&Right"
 msgstr "&Derecha"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Modo &aleatorio"
 
@@ -292,7 +292,7 @@ msgstr "Modo &aleatorio"
 msgid "&Stretch columns to fit window"
 msgstr "&Ajustar columnas a la ventana"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Herramientas"
 
@@ -481,11 +481,11 @@ msgstr "Interrumpir"
 msgid "About %1"
 msgstr "Acerca de %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Acerca de Clementine"
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Acerca de Qt"
 
@@ -545,32 +545,32 @@ msgstr "Añadir otra transmisión…"
 msgid "Add directory..."
 msgstr "Añadir una carpeta…"
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Añadir archivo"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Añadir un archivo al convertidor"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Añadir archivo(s) al convertidor"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Añadir un archivo…"
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Añadir archivos para convertir"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Añadir una carpeta"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Añadir una carpeta…"
 
@@ -582,7 +582,7 @@ msgstr "Añadir carpeta nueva…"
 msgid "Add podcast"
 msgstr "Añadir un pódcast"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Añadir un pódcast…"
 
@@ -658,7 +658,7 @@ msgstr "Añadir etiqueta de pista a la canción"
 msgid "Add song year tag"
 msgstr "Añadir etiqueta de año a la canción"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Añadir una transmisión…"
 
@@ -670,7 +670,7 @@ msgstr "Añadir a listas de Spotify"
 msgid "Add to Spotify starred"
 msgstr "Añadir a las destacadas de Spotify"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Añadir a otra lista de reproducción"
 
@@ -764,7 +764,7 @@ msgstr "Todo"
 msgid "All Files (*)"
 msgstr "Todos los archivos (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "¡Alabemos todos al hipnosapo!"
@@ -1155,7 +1155,7 @@ msgstr "Buscar episodios nuevos"
 msgid "Check for updates"
 msgstr "Buscar actualizaciones"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Buscar actualizaciones…"
 
@@ -1204,18 +1204,18 @@ msgstr "Clásica"
 msgid "Cleaning up"
 msgstr "Limpieza"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Vaciar"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Vaciar lista de reproducción"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1360,7 +1360,7 @@ msgstr "Comentario"
 msgid "Complete tags automatically"
 msgstr "Completar etiquetas automáticamente"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Completar etiquetas automáticamente…"
 
@@ -1395,7 +1395,7 @@ msgstr "Configurar Subsonic…"
 msgid "Configure global search..."
 msgstr "Configurar búsqueda global…"
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Configurar fonoteca…"
 
@@ -1438,7 +1438,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Se agotó el tiempo de espera de la conexión. Compruebe el URL del servidor. Ejemplo: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Consola"
 
@@ -1467,11 +1467,11 @@ msgid "Copy to clipboard"
 msgstr "Copiar en el portapapeles"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Copiar en un dispositivo…"
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Copiar en la fonoteca…"
@@ -1514,14 +1514,14 @@ msgstr "No se pudo acceder a Last.fm. Inténtelo de nuevo."
 msgid "Couldn't create playlist"
 msgstr "No se pudo crear la lista de reproducción"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "No se pudo encontrar un muxer para %1, compruebe que tiene instalados los complementos correctos de GStreamer"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1536,7 +1536,7 @@ msgstr "No se pudo abrir el archivo de salida %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Gestor de carátulas"
 
@@ -1689,7 +1689,7 @@ msgid "Delete downloaded data"
 msgstr "Eliminar datos descargados"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Eliminar archivos"
 
@@ -1697,7 +1697,7 @@ msgstr "Eliminar archivos"
 msgid "Delete from device..."
 msgstr "Eliminar del dispositivo…"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Eliminar del disco…"
@@ -1730,11 +1730,11 @@ msgstr "Eliminando los archivos"
 msgid "Depth"
 msgstr "Profundidad"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Quitar las pistas seleccionadas de la cola"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Quitar la pista de la cola"
 
@@ -1835,7 +1835,7 @@ msgstr "Opciones de visualización"
 msgid "Display the on-screen-display"
 msgstr "Mostrar el mensaje en pantalla (OSD)"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Volver a analizar toda la fonoteca"
 
@@ -2014,12 +2014,12 @@ msgstr "Mezcla dinámica aleatoria"
 msgid "Edit smart playlist..."
 msgstr "Editar lista de reproducción inteligente…"
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Editar la etiqueta «%1»…"
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Editar etiqueta…"
 
@@ -2032,7 +2032,7 @@ msgid "Edit track information"
 msgstr "Editar información de la pista"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Editar información de la pista…"
 
@@ -2140,7 +2140,7 @@ msgstr "Colección completa"
 msgid "Episode information"
 msgstr "Información del episodio"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Ecualizador"
 
@@ -2153,8 +2153,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Equivalente a --log-levels*:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Error"
 
@@ -2189,7 +2189,7 @@ msgstr "Error al cargar %1"
 msgid "Error loading di.fm playlist"
 msgstr "Error al cargar la lista de reproducción de di.fm"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Error al procesar %1: %2"
@@ -2272,7 +2272,11 @@ msgstr "Exportación finalizada"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "Se exportaron %1 carátulas de %2 (se omitieron %3)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2296,7 +2300,7 @@ msgstr "Fundido"
 msgid "Fading duration"
 msgstr "Duración del fundido"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Falló la lectura de la unidad de CD"
 
@@ -2578,11 +2582,11 @@ msgstr "Dele un nombre:"
 msgid "Go"
 msgstr "Ir"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Ir a la siguiente lista de reproducción"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Ir a la lista de reproducción anterior"
 
@@ -2915,7 +2919,7 @@ msgstr "Base de datos de Jamendo"
 msgid "Jump to previous song right away"
 msgstr "Ir a la pista anterior"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Saltar a la pista en reproducción"
 
@@ -2939,7 +2943,7 @@ msgstr "Seguir ejecutando el programa en el fondo al cerrar la ventana"
 msgid "Keep the original files"
 msgstr "Mantener los archivos originales"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Gatitos"
@@ -3031,7 +3035,7 @@ msgstr "Fonoteca"
 msgid "Library advanced grouping"
 msgstr "Agrupamiento avanzado de la fonoteca"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Aviso de reanálisis de la fonoteca"
 
@@ -3071,7 +3075,7 @@ msgstr "Cargar carátula desde disco…"
 msgid "Load playlist"
 msgstr "Cargar lista de reproducción"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Cargar lista de reproducción…"
 
@@ -3132,11 +3136,15 @@ msgstr "Acceder"
 msgid "Login failed"
 msgstr "Falló el inicio de sesión"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Perfil de predicción a largo plazo (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Me encanta"
 
@@ -3171,11 +3179,11 @@ msgstr "Letra de %1"
 msgid "Lyrics from the tag"
 msgstr "Letra de la etiqueta"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "MP4 AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3217,7 +3225,7 @@ msgstr "Perfil principal (MAIN)"
 msgid "Make it so!"
 msgstr "Así sea"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Así sea"
@@ -3355,7 +3363,7 @@ msgstr "Puntos de montaje"
 msgid "Move down"
 msgstr "Bajar"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Mover a la fonoteca…"
 
@@ -3364,7 +3372,7 @@ msgstr "Mover a la fonoteca…"
 msgid "Move up"
 msgstr "Subir"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Música"
 
@@ -3377,7 +3385,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Silenciar"
 
@@ -3426,7 +3434,7 @@ msgstr "Nunca comenzar la reproducción"
 msgid "New folder"
 msgstr "Carpeta nueva"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Lista de reproducción nueva"
 
@@ -3454,8 +3462,12 @@ msgstr "Pistas más recientes"
 msgid "Next"
 msgstr "Siguiente"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Pista siguiente"
 
@@ -3493,7 +3505,7 @@ msgstr "Sin bloques cortos"
 msgid "None"
 msgstr "Ninguno"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Ninguna de las canciones seleccionadas fue apta para copiarse en un dispositivo"
 
@@ -3578,19 +3590,19 @@ msgstr "Desactivado"
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3634,7 +3646,7 @@ msgstr "Opacidad"
 msgid "Open %1 in browser"
 msgstr "Abrir %1 en el navegador"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Abrir un &CD de sonido…"
 
@@ -3646,7 +3658,7 @@ msgstr "Abrir un archivo OPML"
 msgid "Open OPML file..."
 msgstr "Abrir un archivo OPML…"
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Abra una carpeta de la que importar música"
 
@@ -3654,7 +3666,7 @@ msgstr "Abra una carpeta de la que importar música"
 msgid "Open device"
 msgstr "Abrir dispositivo"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Abrir un archivo…"
 
@@ -3708,7 +3720,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organizar archivos"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Organizar archivos…"
 
@@ -3792,7 +3804,7 @@ msgstr "Fiesta"
 msgid "Password"
 msgstr "Contraseña"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pausar"
@@ -3816,6 +3828,10 @@ msgstr "Intérprete"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Píxel"
@@ -3824,10 +3840,10 @@ msgstr "Píxel"
 msgid "Plain sidebar"
 msgstr "Barra lateral simple"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Reproducir"
 
@@ -3848,11 +3864,11 @@ msgstr "Reproducir si está detenida, pausar si se está reproduciendo"
 msgid "Play if there is nothing already playing"
 msgstr "Reproducir si no hay nada en reproducción"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Reproducir a continuación"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Reproducir pistas seleccionadas a continuación"
 
@@ -3951,7 +3967,7 @@ msgstr "Preferencia"
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Preferencias…"
 
@@ -4011,7 +4027,7 @@ msgid "Previous"
 msgstr "Anterior"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Pista anterior"
 
@@ -4069,16 +4085,16 @@ msgstr "Calidad"
 msgid "Querying device..."
 msgstr "Consultando dispositivo…"
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Gestor de la cola"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Añadir las pistas seleccionadas a la cola"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Añadir a la cola de reproducción"
 
@@ -4094,7 +4110,7 @@ msgstr "Radio (volumen igual para todas las pistas)"
 msgid "Rain"
 msgstr "Lluvia"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Lluvia"
@@ -4206,7 +4222,7 @@ msgstr "Eliminar acción"
 msgid "Remove current song from playlist"
 msgstr "Quitar la canción actual de la lista"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Eliminar duplicados de la lista de reproducción"
 
@@ -4214,7 +4230,7 @@ msgstr "Eliminar duplicados de la lista de reproducción"
 msgid "Remove folder"
 msgstr "Quitar carpeta"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Eliminar de la lista de reproducción"
 
@@ -4226,7 +4242,7 @@ msgstr "Eliminar lista de reproducción"
 msgid "Remove playlists"
 msgstr "Eliminar listas de reproducción"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Quitar pistas no disponibles de la lista de reproducción"
 
@@ -4238,7 +4254,7 @@ msgstr "Renombrar lista de reproducción"
 msgid "Rename playlist..."
 msgstr "Renombrar lista de reproducción…"
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Reenumerar pistas en este orden…"
 
@@ -4329,7 +4345,7 @@ msgstr "Extraer"
 msgid "Rip CD"
 msgstr "Extraer CD"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Extraer CD de sonido"
 
@@ -4407,7 +4423,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Guardar lista de reproducción"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Guardar lista de reproducción…"
 
@@ -4494,7 +4510,7 @@ msgstr "Buscar en Subsonic"
 msgid "Search automatically"
 msgstr "Buscar automáticamente"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Buscar álbum"
 
@@ -4507,7 +4523,7 @@ msgstr "Buscar la carátula del álbum…"
 msgid "Search for anything"
 msgstr "Buscar cualquier cosa"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Buscar artista"
 
@@ -4632,7 +4648,7 @@ msgstr "Detalles del servidor"
 msgid "Service offline"
 msgstr "Servicio fuera de línea"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Establecer %1 a «%2»…"
@@ -4641,7 +4657,7 @@ msgstr "Establecer %1 a «%2»…"
 msgid "Set the volume to <value> percent"
 msgstr "Establecer el volumen en <valor> por ciento"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Establecer valor para todas las pistas seleccionadas…"
 
@@ -4712,7 +4728,7 @@ msgstr "Mostrar OSD estético"
 msgid "Show above status bar"
 msgstr "Mostrar sobre la barra de estado"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Mostrar todas las canciones"
 
@@ -4732,12 +4748,12 @@ msgstr "Mostrar divisores"
 msgid "Show fullsize..."
 msgstr "Mostrar a tamaño completo…"
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Mostrar en el gestor de archivos…"
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Mostrar en la fonoteca…"
 
@@ -4749,15 +4765,15 @@ msgstr "Mostrar en Varios artistas"
 msgid "Show moodbar"
 msgstr "Mostrar barra de ánimo"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Mostrar solo los duplicados"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Solo mostrar no etiquetadas"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Mostrar u ocultar la barra lateral"
 
@@ -4765,7 +4781,7 @@ msgstr "Mostrar u ocultar la barra lateral"
 msgid "Show search suggestions"
 msgstr "Mostrar sugerencias de búsqueda"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Mostrar barra lateral"
 
@@ -4801,7 +4817,7 @@ msgstr "Mezclar álbumes"
 msgid "Shuffle all"
 msgstr "Mezclar todo"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Mezclar lista de reproducción"
 
@@ -4845,11 +4861,15 @@ msgstr "N.º de omisiones"
 msgid "Skip forwards in playlist"
 msgstr "Saltar hacia adelante en la lista de reproducción"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Omitir pistas seleccionadas"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Omitir pista"
 
@@ -4966,7 +4986,7 @@ msgstr "Iniciar extracción"
 msgid "Start the playlist currently playing"
 msgstr "Iniciar la lista de reproducción actualmente en reproducción"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Iniciar la conversión"
 
@@ -4976,7 +4996,7 @@ msgid ""
 "list"
 msgstr "Comience a escribir en el cuadro de búsqueda anterior para obtener resultados en esta lista"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Iniciando %1"
@@ -4986,7 +5006,7 @@ msgid "Starting..."
 msgstr "Iniciando…"
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Detener"
 
@@ -5002,7 +5022,7 @@ msgstr "Detener reproducción al finalizar cada pista"
 msgid "Stop after every track"
 msgstr "Detener reproducción al finalizar cada pista"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Detener reproducción al finalizar la pista"
 
@@ -5170,7 +5190,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Ha terminado el período de prueba del servidor de Subsonic. Haga una donación para obtener una clave de licencia. Visite subsonic.org para más detalles."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5212,7 +5232,7 @@ msgid ""
 "continue?"
 msgstr "Se eliminarán estos archivos del dispositivo. ¿Confirma que quiere continuar?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5314,11 +5334,11 @@ msgstr "Conmutar OSD estético"
 msgid "Toggle fullscreen"
 msgstr "Pantalla completa"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Cambiar estado de la cola"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Activar o desactivar scrobbling"
 
@@ -5363,19 +5383,19 @@ msgstr "Pista"
 msgid "Track"
 msgstr "Pista"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Convertir música"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Registro del convertidor"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Conversión"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Convirtiendo %1 archivos usando %2 procesos"
@@ -5452,11 +5472,11 @@ msgstr "Error desconocido"
 msgid "Unset cover"
 msgstr "Eliminar la carátula"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "No omitir pistas seleccionadas"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "No omitir pista"
 
@@ -5473,7 +5493,7 @@ msgstr "Próximos conciertos"
 msgid "Update all podcasts"
 msgstr "Actualizar todos los pódcast"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Actualizar carpetas de la fonoteca modificadas"
 
@@ -5634,7 +5654,7 @@ msgstr "Versión %1"
 msgid "View"
 msgstr "Ver"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Ver detalles de la transmisión"
 
@@ -5642,7 +5662,7 @@ msgstr "Ver detalles de la transmisión"
 msgid "Visualization mode"
 msgstr "Modo de visualización"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Visualizaciones"
 
@@ -5683,7 +5703,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5779,7 +5799,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Audio de Windows Media"
 
@@ -5793,7 +5813,7 @@ msgid ""
 "well?"
 msgstr "¿Le gustaría mover también las otras canciones de este álbum a Varios artistas?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "¿Quiere ejecutar un reanálisis completo ahora?"
 

--- a/src/translations/es.po
+++ b/src/translations/es.po
@@ -545,7 +545,7 @@ msgstr "Añadir otra transmisión…"
 msgid "Add directory..."
 msgstr "Añadir una carpeta…"
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Añadir archivo"
 
@@ -565,7 +565,7 @@ msgstr "Añadir un archivo…"
 msgid "Add files to transcode"
 msgstr "Añadir archivos para convertir"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Añadir una carpeta"
@@ -670,7 +670,7 @@ msgstr "Añadir a listas de Spotify"
 msgid "Add to Spotify starred"
 msgstr "Añadir a las destacadas de Spotify"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Añadir a otra lista de reproducción"
 
@@ -892,7 +892,7 @@ msgstr "¿Confirma que quiere almacenar las estadísticas en todos los archivos 
 msgid "Artist"
 msgstr "Artista"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Inf. artista"
 
@@ -1155,7 +1155,7 @@ msgstr "Buscar episodios nuevos"
 msgid "Check for updates"
 msgstr "Buscar actualizaciones"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Buscar actualizaciones…"
 
@@ -1395,7 +1395,7 @@ msgstr "Configurar Subsonic…"
 msgid "Configure global search..."
 msgstr "Configurar búsqueda global…"
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Configurar fonoteca…"
 
@@ -1467,11 +1467,11 @@ msgid "Copy to clipboard"
 msgstr "Copiar en el portapapeles"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Copiar en un dispositivo…"
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Copiar en la fonoteca…"
@@ -1689,7 +1689,7 @@ msgid "Delete downloaded data"
 msgstr "Eliminar datos descargados"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Eliminar archivos"
 
@@ -1697,7 +1697,7 @@ msgstr "Eliminar archivos"
 msgid "Delete from device..."
 msgstr "Eliminar del dispositivo…"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Eliminar del disco…"
@@ -1730,11 +1730,11 @@ msgstr "Eliminando los archivos"
 msgid "Depth"
 msgstr "Profundidad"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Quitar las pistas seleccionadas de la cola"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Quitar la pista de la cola"
 
@@ -1763,7 +1763,7 @@ msgstr "Nombre del dispositivo"
 msgid "Device properties..."
 msgstr "Propiedades del dispositivo…"
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Dispositivos"
 
@@ -2014,7 +2014,7 @@ msgstr "Mezcla dinámica aleatoria"
 msgid "Edit smart playlist..."
 msgstr "Editar lista de reproducción inteligente…"
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Editar la etiqueta «%1»…"
@@ -2153,8 +2153,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Equivalente a --log-levels*:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Error"
 
@@ -2300,7 +2300,7 @@ msgstr "Fundido"
 msgid "Fading duration"
 msgstr "Duración del fundido"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Falló la lectura de la unidad de CD"
 
@@ -2423,7 +2423,7 @@ msgstr "Tipo de archivo"
 msgid "Filename"
 msgstr "Nombre del archivo"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Archivos"
 
@@ -2838,7 +2838,7 @@ msgstr "Instalado"
 msgid "Integrity check"
 msgstr "Comprobación de integridad"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -3026,7 +3026,7 @@ msgstr "Izquierda"
 msgid "Length"
 msgstr "Duración"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Fonoteca"
@@ -3035,7 +3035,7 @@ msgstr "Fonoteca"
 msgid "Library advanced grouping"
 msgstr "Agrupamiento avanzado de la fonoteca"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Aviso de reanálisis de la fonoteca"
 
@@ -3363,7 +3363,7 @@ msgstr "Puntos de montaje"
 msgid "Move down"
 msgstr "Bajar"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Mover a la fonoteca…"
 
@@ -3372,7 +3372,7 @@ msgstr "Mover a la fonoteca…"
 msgid "Move up"
 msgstr "Subir"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Música"
 
@@ -3434,7 +3434,7 @@ msgstr "Nunca comenzar la reproducción"
 msgid "New folder"
 msgstr "Carpeta nueva"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Lista de reproducción nueva"
 
@@ -3505,7 +3505,7 @@ msgstr "Sin bloques cortos"
 msgid "None"
 msgstr "Ninguno"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Ninguna de las canciones seleccionadas fue apta para copiarse en un dispositivo"
 
@@ -3720,7 +3720,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organizar archivos"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Organizar archivos…"
 
@@ -3804,7 +3804,7 @@ msgstr "Fiesta"
 msgid "Password"
 msgstr "Contraseña"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pausar"
@@ -3840,8 +3840,8 @@ msgstr "Píxel"
 msgid "Plain sidebar"
 msgstr "Barra lateral simple"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3864,11 +3864,11 @@ msgstr "Reproducir si está detenida, pausar si se está reproduciendo"
 msgid "Play if there is nothing already playing"
 msgstr "Reproducir si no hay nada en reproducción"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Reproducir a continuación"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Reproducir pistas seleccionadas a continuación"
 
@@ -3907,7 +3907,7 @@ msgstr "Opciones de la lista de reproducción"
 msgid "Playlist type"
 msgstr "Tipo de lista de reproducción"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Listas"
 
@@ -4089,12 +4089,12 @@ msgstr "Consultando dispositivo…"
 msgid "Queue Manager"
 msgstr "Gestor de la cola"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Añadir las pistas seleccionadas a la cola"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Añadir a la cola de reproducción"
 
@@ -4485,7 +4485,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Buscar"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Buscar"
@@ -4510,7 +4510,7 @@ msgstr "Buscar en Subsonic"
 msgid "Search automatically"
 msgstr "Buscar automáticamente"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Buscar álbum"
 
@@ -4523,7 +4523,7 @@ msgstr "Buscar la carátula del álbum…"
 msgid "Search for anything"
 msgstr "Buscar cualquier cosa"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Buscar artista"
 
@@ -4648,7 +4648,7 @@ msgstr "Detalles del servidor"
 msgid "Service offline"
 msgstr "Servicio fuera de línea"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Establecer %1 a «%2»…"
@@ -4728,7 +4728,7 @@ msgstr "Mostrar OSD estético"
 msgid "Show above status bar"
 msgstr "Mostrar sobre la barra de estado"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Mostrar todas las canciones"
 
@@ -4748,12 +4748,12 @@ msgstr "Mostrar divisores"
 msgid "Show fullsize..."
 msgstr "Mostrar a tamaño completo…"
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Mostrar en el gestor de archivos…"
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Mostrar en la fonoteca…"
 
@@ -4765,11 +4765,11 @@ msgstr "Mostrar en Varios artistas"
 msgid "Show moodbar"
 msgstr "Mostrar barra de ánimo"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Mostrar solo los duplicados"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Solo mostrar no etiquetadas"
 
@@ -4861,7 +4861,7 @@ msgstr "N.º de omisiones"
 msgid "Skip forwards in playlist"
 msgstr "Saltar hacia adelante en la lista de reproducción"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Omitir pistas seleccionadas"
 
@@ -4869,7 +4869,7 @@ msgstr "Omitir pistas seleccionadas"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Omitir pista"
 
@@ -4901,7 +4901,7 @@ msgstr "Soft rock"
 msgid "Song Information"
 msgstr "Información de la canción"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Inf. canción"
 
@@ -5022,7 +5022,7 @@ msgstr "Detener reproducción al finalizar cada pista"
 msgid "Stop after every track"
 msgstr "Detener reproducción al finalizar cada pista"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Detener reproducción al finalizar la pista"
 
@@ -5190,7 +5190,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Ha terminado el período de prueba del servidor de Subsonic. Haga una donación para obtener una clave de licencia. Visite subsonic.org para más detalles."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5232,7 +5232,7 @@ msgid ""
 "continue?"
 msgstr "Se eliminarán estos archivos del dispositivo. ¿Confirma que quiere continuar?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5334,7 +5334,7 @@ msgstr "Conmutar OSD estético"
 msgid "Toggle fullscreen"
 msgstr "Pantalla completa"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Cambiar estado de la cola"
 
@@ -5472,11 +5472,11 @@ msgstr "Error desconocido"
 msgid "Unset cover"
 msgstr "Eliminar la carátula"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "No omitir pistas seleccionadas"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "No omitir pista"
 
@@ -5813,7 +5813,7 @@ msgid ""
 "well?"
 msgstr "¿Le gustaría mover también las otras canciones de este álbum a Varios artistas?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "¿Quiere ejecutar un reanálisis completo ahora?"
 

--- a/src/translations/et.po
+++ b/src/translations/et.po
@@ -12,8 +12,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-13 16:48+0000\n"
-"Last-Translator: Priit Jõerüüt <transifex@joeruut.com>\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
+"Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Estonian (http://www.transifex.com/davidsansome/clementine/language/et/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -166,19 +166,19 @@ msgstr "%L1 pala"
 msgid "%filename%"
 msgstr "%failinimi%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n ebaõnnestus"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n lõpetatud"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -196,7 +196,7 @@ msgstr "&Keskele"
 msgid "&Custom"
 msgstr "&Kohandatud"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "Lisad"
 
@@ -204,7 +204,7 @@ msgstr "Lisad"
 msgid "&Grouping"
 msgstr "&Rühmitamine"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "Abi"
 
@@ -229,7 +229,7 @@ msgstr "&Lukusta hinnang"
 msgid "&Lyrics"
 msgstr "&Laulusõnad"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "Muusika"
 
@@ -237,15 +237,15 @@ msgstr "Muusika"
 msgid "&None"
 msgstr "&Puudub"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "Esitusloend"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Välju"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "Kordav režiim"
 
@@ -253,7 +253,7 @@ msgstr "Kordav režiim"
 msgid "&Right"
 msgstr "&Paremale"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Segatud režiim"
 
@@ -261,7 +261,7 @@ msgstr "Segatud režiim"
 msgid "&Stretch columns to fit window"
 msgstr "Venita veerud akna laiuse järgi"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "Töövahendid"
 
@@ -450,11 +450,11 @@ msgstr "Katkesta"
 msgid "About %1"
 msgstr "%1 info"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Clementine info..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Qt info..."
 
@@ -514,32 +514,32 @@ msgstr "Lisa veel üks raadiovoog..."
 msgid "Add directory..."
 msgstr "Lisa kaust..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Lisa fail"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Lisa fail transkodeerimiseks"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Lisa fail(id) transkodeerimiseks"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Lisa fail..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Lisa failid transkodeerimiseks"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Lisa kaust"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Lisa kaust..."
 
@@ -551,7 +551,7 @@ msgstr "Lisa uus kaust..."
 msgid "Add podcast"
 msgstr "Lisa taskuhääling"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Lisa taskuhääling..."
 
@@ -627,7 +627,7 @@ msgstr "Lisa loole plaadijärjekorra silt"
 msgid "Add song year tag"
 msgstr "Lisa loole aasta silt"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Lisa raadiovoog..."
 
@@ -639,7 +639,7 @@ msgstr "Lisa Spotify esitusloendisse"
 msgid "Add to Spotify starred"
 msgstr "Lisa Spotify tärniga lugude hulka"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Lisa teise esitusloendisse"
 
@@ -733,7 +733,7 @@ msgstr "Kõik"
 msgid "All Files (*)"
 msgstr "Kõik failid (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Kogu au unisele kärnkonnale!"
@@ -1124,7 +1124,7 @@ msgstr "Kontrolli kas on uusi episoode"
 msgid "Check for updates"
 msgstr "Kontrolli uuendusi"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Kontrolli uuendusi..."
 
@@ -1173,18 +1173,18 @@ msgstr "Klassikaline"
 msgid "Cleaning up"
 msgstr "Tühjendamine"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Tühjenda"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Tühjenda esitusloend"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1329,7 +1329,7 @@ msgstr "Märkus"
 msgid "Complete tags automatically"
 msgstr "Täida sildid automaatselt"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Täida sildid automaatselt..."
 
@@ -1364,7 +1364,7 @@ msgstr "Subsonicu seadistamine..."
 msgid "Configure global search..."
 msgstr "Üldotsingu seadistamine..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Kogu seadistamine..."
 
@@ -1407,7 +1407,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Ühendus aegus, kontrolli serveri URL'i. Näiteks: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Konsool"
 
@@ -1436,11 +1436,11 @@ msgid "Copy to clipboard"
 msgstr "Kopeeri lõikelauale"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopeeri seadmesse..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kopeeri kogusse..."
@@ -1483,14 +1483,14 @@ msgstr "Last.fm teenusesse sisselogimine ebaõnnestus. Palun proovi uuesti."
 msgid "Couldn't create playlist"
 msgstr "Ei suutnud luua esitusloendit"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Ei leidnud mukserit %1 jaoks, palun kontrolli et arvutis oleks paigaldatud õiged GStreamer'i pistikprogrammid"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1505,7 +1505,7 @@ msgstr "Ei suuda avada väljund faili %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Kaanepildi haldur"
 
@@ -1658,7 +1658,7 @@ msgid "Delete downloaded data"
 msgstr "Kustuta allalaetud andmed"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Kustuta failid"
 
@@ -1666,7 +1666,7 @@ msgstr "Kustuta failid"
 msgid "Delete from device..."
 msgstr "Kustuta seadmest..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Kustuta kettalt..."
@@ -1699,11 +1699,11 @@ msgstr "Failide kustutamine"
 msgid "Depth"
 msgstr "Sügavus"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Eemalda valitud lood järjekorrast"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Eemalda järjekorrast"
 
@@ -1804,7 +1804,7 @@ msgstr "Kuvamise valikud"
 msgid "Display the on-screen-display"
 msgstr "Luba ekraanimenüü"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Tee uus helikogu täisanalüüs"
 
@@ -1983,12 +1983,12 @@ msgstr "Dünaamiline juhuslik valik"
 msgid "Edit smart playlist..."
 msgstr "Muuda nutikat esitusloendit..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Muuda silti \"%1\"..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Muuda silti..."
 
@@ -2001,7 +2001,7 @@ msgid "Edit track information"
 msgstr "Muuda loo infot"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Muuda loo infot..."
 
@@ -2109,7 +2109,7 @@ msgstr "Terve helikogu"
 msgid "Episode information"
 msgstr "Andmed episoodi kohta"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Ekvalaiser"
 
@@ -2122,8 +2122,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Võrdne käivitusvõtmega --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Viga"
 
@@ -2158,7 +2158,7 @@ msgstr "Viga %1 laadimisel"
 msgid "Error loading di.fm playlist"
 msgstr "Viga di.fm esitusloendi laadimisel"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Viga %1 töötlemisel: %2"
@@ -2241,7 +2241,11 @@ msgstr "Eksport on valmis"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "Eksportisin %1 kaanepilti %2'st (%3 jäi vahele)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2265,7 +2269,7 @@ msgstr "Hajumine"
 msgid "Fading duration"
 msgstr "Hajumise kestus"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Ei õnnestunud lugeda andmeid CD-seadmest"
 
@@ -2547,11 +2551,11 @@ msgstr "Anna talle nimi:"
 msgid "Go"
 msgstr "Mine"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Mine järgmise esitusloendi kaardi juurde"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Mine eelmise esitusloendi kaardi juurde"
 
@@ -2884,7 +2888,7 @@ msgstr "Jamendo andmebaas"
 msgid "Jump to previous song right away"
 msgstr "Liigu kohe eelmise loo juurde"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Mine hetkel esitatava loo juurde"
 
@@ -2908,7 +2912,7 @@ msgstr "Jäta taustal tööle ka siis, kui programmiaken on suletud"
 msgid "Keep the original files"
 msgstr "Säilita algsed failid"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Kassipojad"
@@ -3000,7 +3004,7 @@ msgstr "Helikogu"
 msgid "Library advanced grouping"
 msgstr "Helikogu täpsem rühmitamine"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Helikogu täisanalüüsi teade"
 
@@ -3040,7 +3044,7 @@ msgstr "Lae kaanepilt kettalt..."
 msgid "Load playlist"
 msgstr "Lae esitusloend"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Lae esitusloend..."
 
@@ -3101,11 +3105,15 @@ msgstr "Logi sisse"
 msgid "Login failed"
 msgstr "Sisselogimine ebaõnnestus"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Meeldib"
 
@@ -3140,11 +3148,11 @@ msgstr "Laulusõnad saidilt %1"
 msgid "Lyrics from the tag"
 msgstr "Helifaili salvestatud laulusõnad"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3186,7 +3194,7 @@ msgstr ""
 msgid "Make it so!"
 msgstr "Anna minna!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Anna minna!"
@@ -3324,7 +3332,7 @@ msgstr "Haakepunktid"
 msgid "Move down"
 msgstr "Liiguta alla"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Tõsta helikogusse..."
 
@@ -3333,7 +3341,7 @@ msgstr "Tõsta helikogusse..."
 msgid "Move up"
 msgstr "Liiguta üles"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Muusika"
 
@@ -3346,7 +3354,7 @@ msgid "Music extensions remotely visible"
 msgstr "Kaughaldusliidesest nähtavad muusikafailid"
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Vaigista"
 
@@ -3395,7 +3403,7 @@ msgstr "Ära kunagi alusta esitust"
 msgid "New folder"
 msgstr "Uus kaust"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Uus esitusloend"
 
@@ -3423,8 +3431,12 @@ msgstr "Uusimad lood"
 msgid "Next"
 msgstr "Järgmine"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Järgmine lugu"
 
@@ -3462,7 +3474,7 @@ msgstr "Ära kasuta lühikesi blokke"
 msgid "None"
 msgstr "Puudub"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Valitud lood ei olnud sobilikud seadmesse kopeerimiseks"
 
@@ -3547,19 +3559,19 @@ msgstr "Väljas"
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3603,7 +3615,7 @@ msgstr "Läbipaistmatus"
 msgid "Open %1 in browser"
 msgstr "Ava %1 brauseris"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Ava &audio CD..."
 
@@ -3615,7 +3627,7 @@ msgstr "Ava OPML fail"
 msgid "Open OPML file..."
 msgstr "Ava OPML fail..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Ava kaust kust importida muusikat"
 
@@ -3623,7 +3635,7 @@ msgstr "Ava kaust kust importida muusikat"
 msgid "Open device"
 msgstr "Ava seade"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Ava fail..."
 
@@ -3677,7 +3689,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Halda faile"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Halda faile..."
 
@@ -3761,7 +3773,7 @@ msgstr "Pidu"
 msgid "Password"
 msgstr "Salasõna"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Paus"
@@ -3785,6 +3797,10 @@ msgstr "Esineja"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Piksel"
@@ -3793,10 +3809,10 @@ msgstr "Piksel"
 msgid "Plain sidebar"
 msgstr "Täielik külgriba"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Mängi"
 
@@ -3817,11 +3833,11 @@ msgstr "Mängi, kui on peatatud, paus, kui mängitakse"
 msgid "Play if there is nothing already playing"
 msgstr "Esita, kui hetkel juba pole midagi esitamisel"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Esita järgmisena"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Esita valitud lood järgmisena"
 
@@ -3920,7 +3936,7 @@ msgstr "Seadistus"
 msgid "Preferences"
 msgstr "Seadistused"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Seadistused..."
 
@@ -3980,7 +3996,7 @@ msgid "Previous"
 msgstr "Eelmine"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Eelmine lugu"
 
@@ -4038,16 +4054,16 @@ msgstr "Kvaliteet"
 msgid "Querying device..."
 msgstr "Vaatan mis seadmes leidub"
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Järjekorrahaldur"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Lisa valitud lood järjekorda"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Lisa järjekorda"
 
@@ -4063,7 +4079,7 @@ msgstr "Raadio (kõigil paladel võrdne valjus)"
 msgid "Rain"
 msgstr "Vihm"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Vihm"
@@ -4175,7 +4191,7 @@ msgstr "Eemalda toiming"
 msgid "Remove current song from playlist"
 msgstr "Eemalda see lugu esitusloendist"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Eemalda topeltlood esitusloendist"
 
@@ -4183,7 +4199,7 @@ msgstr "Eemalda topeltlood esitusloendist"
 msgid "Remove folder"
 msgstr "Eemalda kaust"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Eemalda esitusloendist"
 
@@ -4195,7 +4211,7 @@ msgstr "Eemalda esitusloend"
 msgid "Remove playlists"
 msgstr "Eemalda esitusloendid"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Eemalda kadunud lood esitusloendist"
 
@@ -4207,7 +4223,7 @@ msgstr "Nimeta esitusloend ümber"
 msgid "Rename playlist..."
 msgstr "Nimeta esitusloend ümber..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Muuda lugude nummerdust selles järjekorras..."
 
@@ -4298,7 +4314,7 @@ msgstr "Ripi"
 msgid "Rip CD"
 msgstr "Ripi CD"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Ripi audio-CD"
 
@@ -4376,7 +4392,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Salvesta esitusloend"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Salvesta esitusloend..."
 
@@ -4463,7 +4479,7 @@ msgstr "Otsi Subsonic'ust"
 msgid "Search automatically"
 msgstr "Otsi automaatselt"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Otsi albumit"
 
@@ -4476,7 +4492,7 @@ msgstr "Otsi albumi kaanepilte..."
 msgid "Search for anything"
 msgstr "Otsi mida iganes vaja"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Otsi esitajat"
 
@@ -4601,7 +4617,7 @@ msgstr "Detailne teave serveri kohta"
 msgid "Service offline"
 msgstr "Teenus on võrguühenduseta"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Seadista %1 väärtuseks „%2“..."
@@ -4610,7 +4626,7 @@ msgstr "Seadista %1 väärtuseks „%2“..."
 msgid "Set the volume to <value> percent"
 msgstr "Määra helivaljuseks <value> protsenti"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Määra väärtus kõikidel valitud lugudel..."
 
@@ -4681,7 +4697,7 @@ msgstr "Näita ilusat ekraanimenüüd"
 msgid "Show above status bar"
 msgstr "Näita olekuriba kohal"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Näita kõiki lugusid"
 
@@ -4701,12 +4717,12 @@ msgstr "Näita eraldajaid"
 msgid "Show fullsize..."
 msgstr "Näita täissuuruses..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Näita failihalduris..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Näita helikogus..."
 
@@ -4718,15 +4734,15 @@ msgstr "Näita erinevate esitajate all"
 msgid "Show moodbar"
 msgstr "Näita meeleoluribasid"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Näita vaid duplikaate"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Näita vaid sildistamata lugusid"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Kuva või peida külgriba"
 
@@ -4734,7 +4750,7 @@ msgstr "Kuva või peida külgriba"
 msgid "Show search suggestions"
 msgstr "Näita otsingusoovitusi"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Kuva külgriba"
 
@@ -4770,7 +4786,7 @@ msgstr "Sega kõik albumid"
 msgid "Shuffle all"
 msgstr "Sega kõik"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Sega esitusloend"
 
@@ -4814,11 +4830,15 @@ msgstr "Vahelejätmiskorrad"
 msgid "Skip forwards in playlist"
 msgstr "Samm lugude nimekirjas edasi"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Jäta valituid lood vahele"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Jäta lugu vahele"
 
@@ -4935,7 +4955,7 @@ msgstr "Alusta rippimist"
 msgid "Start the playlist currently playing"
 msgstr "Alusta hetkel esitatavat esitusloendit uuesti algusest"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Alusta kodeerimist"
 
@@ -4945,7 +4965,7 @@ msgid ""
 "list"
 msgstr "Kirjuta midagi ülalolevasse otsingukasti ja näe vastvaid otsingutulemusi loendina"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Käivitatakse %1"
@@ -4955,7 +4975,7 @@ msgid "Starting..."
 msgstr "Alustamine..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Peata"
 
@@ -4971,7 +4991,7 @@ msgstr "Peata pärast iga lugu"
 msgid "Stop after every track"
 msgstr "Peata pärast iga lugu"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Peata pärast seda lugu"
 
@@ -5139,7 +5159,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Sunsonic'u serveri kasutamise prooviperiood on läbi. Litsentsivõtme saamiseks palun tee annetus. Täpsem teave leidub subsonic.org veebisaidis."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5181,7 +5201,7 @@ msgid ""
 "continue?"
 msgstr "Need failid kustutatakse seadmest. Kas sa kindlasti soovid jätkata?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5283,11 +5303,11 @@ msgstr "Lülita ilus ekraanimenüü sisse või välja"
 msgid "Toggle fullscreen"
 msgstr "Lülita täisekraan sisse või välja"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Vaheta staatus esitusjärjekorras"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Lülita kraasimine sisse või välja"
 
@@ -5332,19 +5352,19 @@ msgstr "Pala"
 msgid "Track"
 msgstr "Lugu"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Muuda muusikafailide kodeeringut"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Transkodeerimislogi"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Kodeerimine"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Kasutades %2 lõime transkodeerin %1 faili"
@@ -5421,11 +5441,11 @@ msgstr "Tundmatu viga"
 msgid "Unset cover"
 msgstr "Määramata kaanepilt"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Tühista valitud lugude vahelejätmine"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Tühista loo vahelejätmine"
 
@@ -5442,7 +5462,7 @@ msgstr "Tulevased kontserdid"
 msgid "Update all podcasts"
 msgstr "Uuenda kõiki taskuhäälinguid"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Uuenda helikogu kui kaustades on muutusi"
 
@@ -5603,7 +5623,7 @@ msgstr "Versioon %1"
 msgid "View"
 msgstr "Vaade"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Vaata detailset teavet esitusvoo kohta"
 
@@ -5611,7 +5631,7 @@ msgstr "Vaata detailset teavet esitusvoo kohta"
 msgid "Visualization mode"
 msgstr "Visualiseerimise režiim"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Visualiseeringud"
 
@@ -5652,7 +5672,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5748,7 +5768,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media audio"
 
@@ -5762,7 +5782,7 @@ msgid ""
 "well?"
 msgstr "Kas sa soovid ka muud selle albumi lood liigitada erinevate esitajate alla"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Kas sa soovid teha uut helikogu täisanalüüsi?"
 

--- a/src/translations/et.po
+++ b/src/translations/et.po
@@ -514,7 +514,7 @@ msgstr "Lisa veel üks raadiovoog..."
 msgid "Add directory..."
 msgstr "Lisa kaust..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Lisa fail"
 
@@ -534,7 +534,7 @@ msgstr "Lisa fail..."
 msgid "Add files to transcode"
 msgstr "Lisa failid transkodeerimiseks"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Lisa kaust"
@@ -639,7 +639,7 @@ msgstr "Lisa Spotify esitusloendisse"
 msgid "Add to Spotify starred"
 msgstr "Lisa Spotify tärniga lugude hulka"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Lisa teise esitusloendisse"
 
@@ -861,7 +861,7 @@ msgstr "Kas sa oled kindel, et soovid kõikidesse muusikakogu lugude failidesse 
 msgid "Artist"
 msgstr "Esitaja"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Esitaja info"
 
@@ -1124,7 +1124,7 @@ msgstr "Kontrolli kas on uusi episoode"
 msgid "Check for updates"
 msgstr "Kontrolli uuendusi"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Kontrolli uuendusi..."
 
@@ -1364,7 +1364,7 @@ msgstr "Subsonicu seadistamine..."
 msgid "Configure global search..."
 msgstr "Üldotsingu seadistamine..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Kogu seadistamine..."
 
@@ -1436,11 +1436,11 @@ msgid "Copy to clipboard"
 msgstr "Kopeeri lõikelauale"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopeeri seadmesse..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kopeeri kogusse..."
@@ -1658,7 +1658,7 @@ msgid "Delete downloaded data"
 msgstr "Kustuta allalaetud andmed"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Kustuta failid"
 
@@ -1666,7 +1666,7 @@ msgstr "Kustuta failid"
 msgid "Delete from device..."
 msgstr "Kustuta seadmest..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Kustuta kettalt..."
@@ -1699,11 +1699,11 @@ msgstr "Failide kustutamine"
 msgid "Depth"
 msgstr "Sügavus"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Eemalda valitud lood järjekorrast"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Eemalda järjekorrast"
 
@@ -1732,7 +1732,7 @@ msgstr "Seadme nimi"
 msgid "Device properties..."
 msgstr "Seadme omadused..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Seadmed"
 
@@ -1983,7 +1983,7 @@ msgstr "Dünaamiline juhuslik valik"
 msgid "Edit smart playlist..."
 msgstr "Muuda nutikat esitusloendit..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Muuda silti \"%1\"..."
@@ -2122,8 +2122,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Võrdne käivitusvõtmega --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Viga"
 
@@ -2269,7 +2269,7 @@ msgstr "Hajumine"
 msgid "Fading duration"
 msgstr "Hajumise kestus"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Ei õnnestunud lugeda andmeid CD-seadmest"
 
@@ -2392,7 +2392,7 @@ msgstr "Faili tüüp"
 msgid "Filename"
 msgstr "Faili nimi"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Failid"
 
@@ -2807,7 +2807,7 @@ msgstr "Paigaldatud"
 msgid "Integrity check"
 msgstr "Terviklikkuse kontroll"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -2995,7 +2995,7 @@ msgstr "Vasakul"
 msgid "Length"
 msgstr "Kestus"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Helikogu"
@@ -3004,7 +3004,7 @@ msgstr "Helikogu"
 msgid "Library advanced grouping"
 msgstr "Helikogu täpsem rühmitamine"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Helikogu täisanalüüsi teade"
 
@@ -3332,7 +3332,7 @@ msgstr "Haakepunktid"
 msgid "Move down"
 msgstr "Liiguta alla"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Tõsta helikogusse..."
 
@@ -3341,7 +3341,7 @@ msgstr "Tõsta helikogusse..."
 msgid "Move up"
 msgstr "Liiguta üles"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Muusika"
 
@@ -3403,7 +3403,7 @@ msgstr "Ära kunagi alusta esitust"
 msgid "New folder"
 msgstr "Uus kaust"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Uus esitusloend"
 
@@ -3474,7 +3474,7 @@ msgstr "Ära kasuta lühikesi blokke"
 msgid "None"
 msgstr "Puudub"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Valitud lood ei olnud sobilikud seadmesse kopeerimiseks"
 
@@ -3689,7 +3689,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Halda faile"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Halda faile..."
 
@@ -3773,7 +3773,7 @@ msgstr "Pidu"
 msgid "Password"
 msgstr "Salasõna"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Paus"
@@ -3809,8 +3809,8 @@ msgstr "Piksel"
 msgid "Plain sidebar"
 msgstr "Täielik külgriba"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3833,11 +3833,11 @@ msgstr "Mängi, kui on peatatud, paus, kui mängitakse"
 msgid "Play if there is nothing already playing"
 msgstr "Esita, kui hetkel juba pole midagi esitamisel"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Esita järgmisena"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Esita valitud lood järgmisena"
 
@@ -3876,7 +3876,7 @@ msgstr "Esitusnimekirja valikud"
 msgid "Playlist type"
 msgstr "Esitusloendi tüüp"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Esitusloendid"
 
@@ -4058,12 +4058,12 @@ msgstr "Vaatan mis seadmes leidub"
 msgid "Queue Manager"
 msgstr "Järjekorrahaldur"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Lisa valitud lood järjekorda"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Lisa järjekorda"
 
@@ -4454,7 +4454,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Otsing"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Otsing"
@@ -4479,7 +4479,7 @@ msgstr "Otsi Subsonic'ust"
 msgid "Search automatically"
 msgstr "Otsi automaatselt"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Otsi albumit"
 
@@ -4492,7 +4492,7 @@ msgstr "Otsi albumi kaanepilte..."
 msgid "Search for anything"
 msgstr "Otsi mida iganes vaja"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Otsi esitajat"
 
@@ -4617,7 +4617,7 @@ msgstr "Detailne teave serveri kohta"
 msgid "Service offline"
 msgstr "Teenus on võrguühenduseta"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Seadista %1 väärtuseks „%2“..."
@@ -4697,7 +4697,7 @@ msgstr "Näita ilusat ekraanimenüüd"
 msgid "Show above status bar"
 msgstr "Näita olekuriba kohal"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Näita kõiki lugusid"
 
@@ -4717,12 +4717,12 @@ msgstr "Näita eraldajaid"
 msgid "Show fullsize..."
 msgstr "Näita täissuuruses..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Näita failihalduris..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Näita helikogus..."
 
@@ -4734,11 +4734,11 @@ msgstr "Näita erinevate esitajate all"
 msgid "Show moodbar"
 msgstr "Näita meeleoluribasid"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Näita vaid duplikaate"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Näita vaid sildistamata lugusid"
 
@@ -4830,7 +4830,7 @@ msgstr "Vahelejätmiskorrad"
 msgid "Skip forwards in playlist"
 msgstr "Samm lugude nimekirjas edasi"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Jäta valituid lood vahele"
 
@@ -4838,7 +4838,7 @@ msgstr "Jäta valituid lood vahele"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Jäta lugu vahele"
 
@@ -4870,7 +4870,7 @@ msgstr "Soft Rock"
 msgid "Song Information"
 msgstr "Loo andmed"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Loo andmed"
 
@@ -4991,7 +4991,7 @@ msgstr "Peata pärast iga lugu"
 msgid "Stop after every track"
 msgstr "Peata pärast iga lugu"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Peata pärast seda lugu"
 
@@ -5159,7 +5159,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Sunsonic'u serveri kasutamise prooviperiood on läbi. Litsentsivõtme saamiseks palun tee annetus. Täpsem teave leidub subsonic.org veebisaidis."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5201,7 +5201,7 @@ msgid ""
 "continue?"
 msgstr "Need failid kustutatakse seadmest. Kas sa kindlasti soovid jätkata?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5303,7 +5303,7 @@ msgstr "Lülita ilus ekraanimenüü sisse või välja"
 msgid "Toggle fullscreen"
 msgstr "Lülita täisekraan sisse või välja"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Vaheta staatus esitusjärjekorras"
 
@@ -5441,11 +5441,11 @@ msgstr "Tundmatu viga"
 msgid "Unset cover"
 msgstr "Määramata kaanepilt"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Tühista valitud lugude vahelejätmine"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Tühista loo vahelejätmine"
 
@@ -5782,7 +5782,7 @@ msgid ""
 "well?"
 msgstr "Kas sa soovid ka muud selle albumi lood liigitada erinevate esitajate alla"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Kas sa soovid teha uut helikogu täisanalüüsi?"
 

--- a/src/translations/eu.po
+++ b/src/translations/eu.po
@@ -11,7 +11,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Basque (http://www.transifex.com/davidsansome/clementine/language/eu/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -165,19 +165,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n-(e)k huts egin du"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n amaituta"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -195,7 +195,7 @@ msgstr "&Zentratu"
 msgid "&Custom"
 msgstr "&Pertsonalizatua"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Gehigarriak"
 
@@ -203,7 +203,7 @@ msgstr "&Gehigarriak"
 msgid "&Grouping"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Laguntza"
 
@@ -228,7 +228,7 @@ msgstr ""
 msgid "&Lyrics"
 msgstr "&Letrak"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Musika"
 
@@ -236,15 +236,15 @@ msgstr "&Musika"
 msgid "&None"
 msgstr "&Bat ere ez"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&Erreprodukzio-zerrenda"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Itxi"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "E&rrepikatze-modua"
 
@@ -252,7 +252,7 @@ msgstr "E&rrepikatze-modua"
 msgid "&Right"
 msgstr "E&skuinera"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Au&sazko modua"
 
@@ -260,7 +260,7 @@ msgstr "Au&sazko modua"
 msgid "&Stretch columns to fit window"
 msgstr "&Tiratu zutabeak leihoan egokitzeko"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Tresnak"
 
@@ -449,11 +449,11 @@ msgstr ""
 msgid "About %1"
 msgstr "%1-(r)i buruz"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Clementine-ri buruz..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Qt-ri buruz..."
 
@@ -513,32 +513,32 @@ msgstr "Gehitu beste jario bat..."
 msgid "Add directory..."
 msgstr "Gehitu direktorioa..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Gehitu fitxategia"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Gehitu fitxategia..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Gehitu transkodetzeko fitxategiak"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Gehitu karpeta"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Gehitu karpeta..."
 
@@ -550,7 +550,7 @@ msgstr "Gehitu karpeta berria..."
 msgid "Add podcast"
 msgstr "Podcast-a gehitu"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Podcast-a gehitu..."
 
@@ -626,7 +626,7 @@ msgstr "Gehitu pista etiketa kantari"
 msgid "Add song year tag"
 msgstr "Gehitu urtea etiketa kantari"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Gehitu jarioa..."
 
@@ -638,7 +638,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Gehitu beste erreprodukzio-zerrenda batera"
 
@@ -732,7 +732,7 @@ msgstr ""
 msgid "All Files (*)"
 msgstr "Fitxategi guztiak (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr ""
@@ -1123,7 +1123,7 @@ msgstr "Atal berriak bilatu"
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Eguneraketak bilatu..."
 
@@ -1172,18 +1172,18 @@ msgstr "Klasikoa"
 msgid "Cleaning up"
 msgstr "Garbiketa"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Garbitu"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Erreprodukzio-zerrenda garbitu"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1328,7 +1328,7 @@ msgstr "Iruzkina"
 msgid "Complete tags automatically"
 msgstr "Bete etiketak automatikoki"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Bete etiketak automatikoki..."
 
@@ -1363,7 +1363,7 @@ msgstr "Subsonic konfiguratu"
 msgid "Configure global search..."
 msgstr "Bilaketa globala konfiguratu..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Konfiguratu bilduma..."
 
@@ -1406,7 +1406,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr ""
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Kontsola"
 
@@ -1435,11 +1435,11 @@ msgid "Copy to clipboard"
 msgstr "Kopiatu arbelean"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopiatu gailura..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kopiatu bildumara..."
@@ -1482,14 +1482,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Ezin izan da %1-(r)entzako multiplexadorea aurkitu, begiratu GStreamer plugin egokiak instalatuta dauden"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1504,7 +1504,7 @@ msgstr "Ezin izan da %1 irteera-fitxategia ireki"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Azal-kudeatzailea"
 
@@ -1657,7 +1657,7 @@ msgid "Delete downloaded data"
 msgstr "Ezabatu deskargatutako datuak"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Ezabatu fitxategiak"
 
@@ -1665,7 +1665,7 @@ msgstr "Ezabatu fitxategiak"
 msgid "Delete from device..."
 msgstr "Ezabatu gailutik..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Ezabatu diskotik..."
@@ -1698,11 +1698,11 @@ msgstr "Fitxategiak ezabatzen"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Atera aukeraturiko pistak ilaratik"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Atera pista ilaratik"
 
@@ -1803,7 +1803,7 @@ msgstr "Erakutsi aukerak"
 msgid "Display the on-screen-display"
 msgstr "Erakutsi pantailako bistaratzailea"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Bildumaren berreskaneo osoa egin"
 
@@ -1982,12 +1982,12 @@ msgstr "Ausazko nahasketa dinamikoa"
 msgid "Edit smart playlist..."
 msgstr "Editatu erreprodukzio-zerrenda adimenduna..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Editatu etiketa..."
 
@@ -2000,7 +2000,7 @@ msgid "Edit track information"
 msgstr "Editatu pistaren informazioa"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Editatu pistaren informazioa..."
 
@@ -2108,7 +2108,7 @@ msgstr "Bilduma osoa"
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Ekualizadorea"
 
@@ -2121,8 +2121,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "--log-levels *:3-en baliokidea"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Errorea"
 
@@ -2157,7 +2157,7 @@ msgstr "Errorea %1 kargatzean"
 msgid "Error loading di.fm playlist"
 msgstr "Errorea di.fm erreprodukzio-zerrenda kargatzean"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Errorea %1 prozesatzean: %2"
@@ -2240,7 +2240,11 @@ msgstr ""
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr ""
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2264,7 +2268,7 @@ msgstr "Iraungitzea"
 msgid "Fading duration"
 msgstr "Iraungitzearen iraupena"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2546,11 +2550,11 @@ msgstr "Izendatu:"
 msgid "Go"
 msgstr "Joan"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Hurrengo erreprodukzio-zerrendara joan"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Aurreko erreprodukzio-zerrendara joan"
 
@@ -2883,7 +2887,7 @@ msgstr "Jamendo datu-basea"
 msgid "Jump to previous song right away"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Erreproduzitzen ari den pistara jauzi egin"
 
@@ -2907,7 +2911,7 @@ msgstr "Jarraitu atzealdean exekutatzen leihoa ixten denean"
 msgid "Keep the original files"
 msgstr "Jatorrizko fitxategiak mantendu"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr ""
@@ -2999,7 +3003,7 @@ msgstr "Bilduma"
 msgid "Library advanced grouping"
 msgstr "Bildumaren taldekatze aurreratua"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Bildumaren berreskaneoaren abisua"
 
@@ -3039,7 +3043,7 @@ msgstr "Kargatu azala diskotik..."
 msgid "Load playlist"
 msgstr "Kargatu erreprodukzio-zerrenda"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Kargatu erreprodukzio-zerrenda..."
 
@@ -3100,11 +3104,15 @@ msgstr "Saio-hasiera"
 msgid "Login failed"
 msgstr "Saio hasieraren huts egitea"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Epe luzerako predikzio profila (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Oso gustukoa"
 
@@ -3139,11 +3147,11 @@ msgstr "%1-eko letrak"
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr ""
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3185,7 +3193,7 @@ msgstr "Profil nagusia (MAIN)"
 msgid "Make it so!"
 msgstr "Egin ezazu!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr ""
@@ -3323,7 +3331,7 @@ msgstr "Muntatze-puntuak"
 msgid "Move down"
 msgstr "Eraman behera"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Eraman bildumara..."
 
@@ -3332,7 +3340,7 @@ msgstr "Eraman bildumara..."
 msgid "Move up"
 msgstr "Eraman gora"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Musika"
 
@@ -3345,7 +3353,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Mututu"
 
@@ -3394,7 +3402,7 @@ msgstr "Inoiz ez hasi erreproduzitzen"
 msgid "New folder"
 msgstr "Karpeta berria"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Erreprodukzio-zerrenda berria"
 
@@ -3422,8 +3430,12 @@ msgstr "Pista berrienak"
 msgid "Next"
 msgstr "Hurrengoa"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Hurrengo pista"
 
@@ -3461,7 +3473,7 @@ msgstr "Bloke laburrik ez"
 msgid "None"
 msgstr "Bat ere ez"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Aukeraturiko abestietako bat ere ez zen aproposa gailu batera kopiatzeko"
 
@@ -3546,19 +3558,19 @@ msgstr ""
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3602,7 +3614,7 @@ msgstr ""
 msgid "Open %1 in browser"
 msgstr "%1 nabigatzailean ireki"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Ireki &audio CDa..."
 
@@ -3614,7 +3626,7 @@ msgstr "OPML fitxategia ireki"
 msgid "Open OPML file..."
 msgstr "OPML fitxategia ireki"
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr ""
 
@@ -3622,7 +3634,7 @@ msgstr ""
 msgid "Open device"
 msgstr "Ireki gailua"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Ireki fitxategia..."
 
@@ -3676,7 +3688,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr "Antolatu fitxategiak"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Antolatu fitxategiak..."
 
@@ -3760,7 +3772,7 @@ msgstr "Jaia"
 msgid "Password"
 msgstr "Pasahitza"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pausarazi"
@@ -3784,6 +3796,10 @@ msgstr "Aktuatzailea"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Pixel"
@@ -3792,10 +3808,10 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Albo-barra sinplea"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Erreproduzitu"
 
@@ -3816,11 +3832,11 @@ msgstr "Erreproduzitu pausatua badago, pausarazi erreproduzitzen ari bada"
 msgid "Play if there is nothing already playing"
 msgstr "Erreproduzitu ez badago ezer aurretik erreproduzitzen"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3919,7 +3935,7 @@ msgstr "Hobespena"
 msgid "Preferences"
 msgstr "Hobespenak"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Hobespenak..."
 
@@ -3979,7 +3995,7 @@ msgid "Previous"
 msgstr "Aurrekoa"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Aurreko pista"
 
@@ -4037,16 +4053,16 @@ msgstr "Kalitatea"
 msgid "Querying device..."
 msgstr "Gailua galdekatzen..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Ilara-kudeatzailea"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Aukeraturiko pistak ilaran jarri"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Pista ilaran jarri"
 
@@ -4062,7 +4078,7 @@ msgstr "Irratia (ozentasun berdina pista denentzat)"
 msgid "Rain"
 msgstr "Euria"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Euria"
@@ -4174,7 +4190,7 @@ msgstr "Kendu ekintza"
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Abesti bikoiztuak kendu erreprodukzio-zerrendatik "
 
@@ -4182,7 +4198,7 @@ msgstr "Abesti bikoiztuak kendu erreprodukzio-zerrendatik "
 msgid "Remove folder"
 msgstr "Kendu karpeta"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Kendu erreprodukzio-zerrendatik"
 
@@ -4194,7 +4210,7 @@ msgstr ""
 msgid "Remove playlists"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr ""
 
@@ -4206,7 +4222,7 @@ msgstr "Berrizendatu erreprodukzio-zerrenda"
 msgid "Rename playlist..."
 msgstr "Berrizendatu erreprodukzio-zerrenda..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Zenbakitu berriro pistak ordena honetan..."
 
@@ -4297,7 +4313,7 @@ msgstr ""
 msgid "Rip CD"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr ""
 
@@ -4375,7 +4391,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr ""
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Gorde erreprodukzio-zerrenda..."
 
@@ -4462,7 +4478,7 @@ msgstr "Subsonic-en bilatu"
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4475,7 +4491,7 @@ msgstr "Bilatu albumetako azalak"
 msgid "Search for anything"
 msgstr "Bilatu edozer"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4600,7 +4616,7 @@ msgstr "Zerbitzariaren xehetasunak"
 msgid "Service offline"
 msgstr "Zerbitzua lineaz kanpo"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Ezarri %1 \"%2\"-(e)ra..."
@@ -4609,7 +4625,7 @@ msgstr "Ezarri %1 \"%2\"-(e)ra..."
 msgid "Set the volume to <value> percent"
 msgstr "Ezarri bolumena ehuneko <value>-ra"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Ezarri balioa aukeratutako pista guztiei..."
 
@@ -4680,7 +4696,7 @@ msgstr "Erakutsi OSD itxurosoa"
 msgid "Show above status bar"
 msgstr "Erakutsi egoera-barraren gainean"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Erakutsi abesti guztiak"
 
@@ -4700,12 +4716,12 @@ msgstr "Erakutsi zatitzaileak"
 msgid "Show fullsize..."
 msgstr "Erakutsi tamaina osoan..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Erakutsi fitxategi arakatzailean..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr ""
 
@@ -4717,15 +4733,15 @@ msgstr "Erakutsi hainbat artista"
 msgid "Show moodbar"
 msgstr "Aldarte-barra erakutsi"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Erakutsi bakarrik errepikapenak"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Erakutsi etiketa gabeak bakarrik"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4733,7 +4749,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr "Bilaketaren iradokizunak erakutsi"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4769,7 +4785,7 @@ msgstr "Albumak nahastu"
 msgid "Shuffle all"
 msgstr "Dena nahastu"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Erreprodukzio-zerrenda nahastu"
 
@@ -4813,11 +4829,15 @@ msgstr "Saltatu kontagailua"
 msgid "Skip forwards in playlist"
 msgstr "Saltatu aurrerantz erreprodukzio-zerrendan"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr ""
 
@@ -4934,7 +4954,7 @@ msgstr ""
 msgid "Start the playlist currently playing"
 msgstr "Hasi oraingo erreprodukzio-zerrenda"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Hasi transkodetzen"
 
@@ -4944,7 +4964,7 @@ msgid ""
 "list"
 msgstr "Hasi idazten aurreko bilaketa eremuan emaitzak jaso ahal izateko"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "%1 hasten"
@@ -4954,7 +4974,7 @@ msgid "Starting..."
 msgstr "Hasten..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Gelditu"
 
@@ -4970,7 +4990,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Gelditu pista honen ondoren"
 
@@ -5138,7 +5158,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5180,7 +5200,7 @@ msgid ""
 "continue?"
 msgstr "Fitxategi hauek gailutik ezabatuko dira, jarraitu nahi duzu?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5282,11 +5302,11 @@ msgstr "Txandakatu OSD itxurosoa"
 msgid "Toggle fullscreen"
 msgstr "Txandakatu pantaila-osoa"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Txandakatu ilara-egoera"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Txandakatu partekatzea"
 
@@ -5331,19 +5351,19 @@ msgstr ""
 msgid "Track"
 msgstr "Pista"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Transkodetu musika"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Transkodetzearen loga"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Transkodeketa"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "%1 fitxategi %2 hari erabiliz transkodetzen"
@@ -5420,11 +5440,11 @@ msgstr "Errore ezezaguna"
 msgid "Unset cover"
 msgstr "Ezarri gabeko azala"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr ""
 
@@ -5441,7 +5461,7 @@ msgstr "Hurrengo Kontzertuak"
 msgid "Update all podcasts"
 msgstr "Eguneratu podcast guztiak"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Eguneratu bildumako aldatutako karpetak"
 
@@ -5602,7 +5622,7 @@ msgstr "%1 bertsioa"
 msgid "View"
 msgstr "Ikusi"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5610,7 +5630,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr "Bistaratze-modua"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Bistaratzeak"
 
@@ -5651,7 +5671,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5747,7 +5767,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media audio"
 
@@ -5761,7 +5781,7 @@ msgid ""
 "well?"
 msgstr "Beste abestiak ere Hainbat artistara mugitzea nahi duzu?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Berreskaneo osoa orain egitea nahi duzu?"
 

--- a/src/translations/eu.po
+++ b/src/translations/eu.po
@@ -513,7 +513,7 @@ msgstr "Gehitu beste jario bat..."
 msgid "Add directory..."
 msgstr "Gehitu direktorioa..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Gehitu fitxategia"
 
@@ -533,7 +533,7 @@ msgstr "Gehitu fitxategia..."
 msgid "Add files to transcode"
 msgstr "Gehitu transkodetzeko fitxategiak"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Gehitu karpeta"
@@ -638,7 +638,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Gehitu beste erreprodukzio-zerrenda batera"
 
@@ -860,7 +860,7 @@ msgstr ""
 msgid "Artist"
 msgstr "Artista"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Artis. infor."
 
@@ -1123,7 +1123,7 @@ msgstr "Atal berriak bilatu"
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Eguneraketak bilatu..."
 
@@ -1363,7 +1363,7 @@ msgstr "Subsonic konfiguratu"
 msgid "Configure global search..."
 msgstr "Bilaketa globala konfiguratu..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Konfiguratu bilduma..."
 
@@ -1435,11 +1435,11 @@ msgid "Copy to clipboard"
 msgstr "Kopiatu arbelean"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopiatu gailura..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kopiatu bildumara..."
@@ -1657,7 +1657,7 @@ msgid "Delete downloaded data"
 msgstr "Ezabatu deskargatutako datuak"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Ezabatu fitxategiak"
 
@@ -1665,7 +1665,7 @@ msgstr "Ezabatu fitxategiak"
 msgid "Delete from device..."
 msgstr "Ezabatu gailutik..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Ezabatu diskotik..."
@@ -1698,11 +1698,11 @@ msgstr "Fitxategiak ezabatzen"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Atera aukeraturiko pistak ilaratik"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Atera pista ilaratik"
 
@@ -1731,7 +1731,7 @@ msgstr "Gailuaren izena"
 msgid "Device properties..."
 msgstr "Gailuaren propietateak..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Gailuak"
 
@@ -1982,7 +1982,7 @@ msgstr "Ausazko nahasketa dinamikoa"
 msgid "Edit smart playlist..."
 msgstr "Editatu erreprodukzio-zerrenda adimenduna..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
@@ -2121,8 +2121,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "--log-levels *:3-en baliokidea"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Errorea"
 
@@ -2268,7 +2268,7 @@ msgstr "Iraungitzea"
 msgid "Fading duration"
 msgstr "Iraungitzearen iraupena"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2391,7 +2391,7 @@ msgstr "Fitxategi-mota"
 msgid "Filename"
 msgstr "Fitxategi-izena"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Fitxategiak"
 
@@ -2806,7 +2806,7 @@ msgstr "Instalatuta"
 msgid "Integrity check"
 msgstr "Osotasunaren egiaztapena"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -2994,7 +2994,7 @@ msgstr ""
 msgid "Length"
 msgstr "Iraupena"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Bilduma"
@@ -3003,7 +3003,7 @@ msgstr "Bilduma"
 msgid "Library advanced grouping"
 msgstr "Bildumaren taldekatze aurreratua"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Bildumaren berreskaneoaren abisua"
 
@@ -3331,7 +3331,7 @@ msgstr "Muntatze-puntuak"
 msgid "Move down"
 msgstr "Eraman behera"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Eraman bildumara..."
 
@@ -3340,7 +3340,7 @@ msgstr "Eraman bildumara..."
 msgid "Move up"
 msgstr "Eraman gora"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Musika"
 
@@ -3402,7 +3402,7 @@ msgstr "Inoiz ez hasi erreproduzitzen"
 msgid "New folder"
 msgstr "Karpeta berria"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Erreprodukzio-zerrenda berria"
 
@@ -3473,7 +3473,7 @@ msgstr "Bloke laburrik ez"
 msgid "None"
 msgstr "Bat ere ez"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Aukeraturiko abestietako bat ere ez zen aproposa gailu batera kopiatzeko"
 
@@ -3688,7 +3688,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr "Antolatu fitxategiak"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Antolatu fitxategiak..."
 
@@ -3772,7 +3772,7 @@ msgstr "Jaia"
 msgid "Password"
 msgstr "Pasahitza"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pausarazi"
@@ -3808,8 +3808,8 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Albo-barra sinplea"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3832,11 +3832,11 @@ msgstr "Erreproduzitu pausatua badago, pausarazi erreproduzitzen ari bada"
 msgid "Play if there is nothing already playing"
 msgstr "Erreproduzitu ez badago ezer aurretik erreproduzitzen"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3875,7 +3875,7 @@ msgstr "Erreprodukzio-zerrendaren aukerak"
 msgid "Playlist type"
 msgstr "Erreprodukzio-zerrenda mota"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Erreprodukzio-zerrendak"
 
@@ -4057,12 +4057,12 @@ msgstr "Gailua galdekatzen..."
 msgid "Queue Manager"
 msgstr "Ilara-kudeatzailea"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Aukeraturiko pistak ilaran jarri"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Pista ilaran jarri"
 
@@ -4453,7 +4453,7 @@ msgstr ""
 msgid "Search"
 msgstr "Bilatu"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr ""
@@ -4478,7 +4478,7 @@ msgstr "Subsonic-en bilatu"
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4491,7 +4491,7 @@ msgstr "Bilatu albumetako azalak"
 msgid "Search for anything"
 msgstr "Bilatu edozer"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4616,7 +4616,7 @@ msgstr "Zerbitzariaren xehetasunak"
 msgid "Service offline"
 msgstr "Zerbitzua lineaz kanpo"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Ezarri %1 \"%2\"-(e)ra..."
@@ -4696,7 +4696,7 @@ msgstr "Erakutsi OSD itxurosoa"
 msgid "Show above status bar"
 msgstr "Erakutsi egoera-barraren gainean"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Erakutsi abesti guztiak"
 
@@ -4716,12 +4716,12 @@ msgstr "Erakutsi zatitzaileak"
 msgid "Show fullsize..."
 msgstr "Erakutsi tamaina osoan..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Erakutsi fitxategi arakatzailean..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr ""
 
@@ -4733,11 +4733,11 @@ msgstr "Erakutsi hainbat artista"
 msgid "Show moodbar"
 msgstr "Aldarte-barra erakutsi"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Erakutsi bakarrik errepikapenak"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Erakutsi etiketa gabeak bakarrik"
 
@@ -4829,7 +4829,7 @@ msgstr "Saltatu kontagailua"
 msgid "Skip forwards in playlist"
 msgstr "Saltatu aurrerantz erreprodukzio-zerrendan"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr ""
 
@@ -4837,7 +4837,7 @@ msgstr ""
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr ""
 
@@ -4869,7 +4869,7 @@ msgstr "Soft Rock"
 msgid "Song Information"
 msgstr "Abestiaren informazioa"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Abes. infor."
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Gelditu pista honen ondoren"
 
@@ -5158,7 +5158,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5200,7 +5200,7 @@ msgid ""
 "continue?"
 msgstr "Fitxategi hauek gailutik ezabatuko dira, jarraitu nahi duzu?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5302,7 +5302,7 @@ msgstr "Txandakatu OSD itxurosoa"
 msgid "Toggle fullscreen"
 msgstr "Txandakatu pantaila-osoa"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Txandakatu ilara-egoera"
 
@@ -5440,11 +5440,11 @@ msgstr "Errore ezezaguna"
 msgid "Unset cover"
 msgstr "Ezarri gabeko azala"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr ""
 
@@ -5781,7 +5781,7 @@ msgid ""
 "well?"
 msgstr "Beste abestiak ere Hainbat artistara mugitzea nahi duzu?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Berreskaneo osoa orain egitea nahi duzu?"
 

--- a/src/translations/fa.po
+++ b/src/translations/fa.po
@@ -13,7 +13,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Persian (http://www.transifex.com/davidsansome/clementine/language/fa/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -167,19 +167,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n ناکام ماند"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n پایان یافت"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -197,7 +197,7 @@ msgstr "&میانه"
 msgid "&Custom"
 msgstr "&سفارشی‌"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "ا&فزونه‌ها"
 
@@ -205,7 +205,7 @@ msgstr "ا&فزونه‌ها"
 msgid "&Grouping"
 msgstr "گروه‌بندی"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&راهنما"
 
@@ -230,7 +230,7 @@ msgstr "قفل کردن درجه‌بندی"
 msgid "&Lyrics"
 msgstr "متن ترانه"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "آ&هنگ"
 
@@ -238,15 +238,15 @@ msgstr "آ&هنگ"
 msgid "&None"
 msgstr "&هیچ‌کدام‌"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&لیست‌پخش"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&برونرفتن"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "سبک &تکرار"
 
@@ -254,7 +254,7 @@ msgstr "سبک &تکرار"
 msgid "&Right"
 msgstr "&راست‌"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "سبک &درهم"
 
@@ -262,7 +262,7 @@ msgstr "سبک &درهم"
 msgid "&Stretch columns to fit window"
 msgstr "&کشیدن ستون‌ها برای پرکردن پنجره"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&ابزارها‌"
 
@@ -451,11 +451,11 @@ msgstr "لغو"
 msgid "About %1"
 msgstr "درباره‌ی %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "درباره‌ی کلمنتاین..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "درباره‌ی کیو‌ت..."
 
@@ -515,32 +515,32 @@ msgstr "افزودن جریان دیگر..."
 msgid "Add directory..."
 msgstr "افزودن پوشه..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "افزودن پرونده"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "افزودن پرونده..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "افزودن پرونده‌ها به تراکد"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "افزودن پوشه"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "افزودن پوشه..."
 
@@ -552,7 +552,7 @@ msgstr "افزودن پوشه‌ی نو..."
 msgid "Add podcast"
 msgstr "افزودن پادکست"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "افزودن پادکست..."
 
@@ -628,7 +628,7 @@ msgstr "افزودن برچسب ترک آهنگ"
 msgid "Add song year tag"
 msgstr "افزودن برچسب سال آهنگ"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "افزودن جریان..."
 
@@ -640,7 +640,7 @@ msgstr "افزودن به فهرست پخش Spotify"
 msgid "Add to Spotify starred"
 msgstr "افزودن به ستاره‌دارهای Spotify"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "افزودن به لیست‌پخش دیگر"
 
@@ -734,7 +734,7 @@ msgstr "همه"
 msgid "All Files (*)"
 msgstr "همه‌ی پرونده‌ها(*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr ""
@@ -1125,7 +1125,7 @@ msgstr "بررسی برای داستان‌های تازه"
 msgid "Check for updates"
 msgstr "بررسی بروز رسانی"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "بررسی به‌روز رسانی..."
 
@@ -1174,18 +1174,18 @@ msgstr "کلاسیک"
 msgid "Cleaning up"
 msgstr "پالایش"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "پاک کن"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "پاک کردن لیست‌پخش"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "کلمنتاین"
 
@@ -1330,7 +1330,7 @@ msgstr "توضیح"
 msgid "Complete tags automatically"
 msgstr "تکمیل خودکار برچسب‌ها"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "تکمیل خودکار برچسب‌ها..."
 
@@ -1365,7 +1365,7 @@ msgstr "پیکربندی ساب‌سونیک..."
 msgid "Configure global search..."
 msgstr "پیکربندی جستجوی سراسری..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "پیکربندی کتابخانه..."
 
@@ -1408,7 +1408,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "ارتباط لغو شد،سرور را بررسی نمایید به طور مثال:/http://localhost:4040"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "پیشانه"
 
@@ -1437,11 +1437,11 @@ msgid "Copy to clipboard"
 msgstr "کپی به کلیپ‌بورد"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "کپی‌کردن در دستگاه..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "کپی‌کردن در کتابخانه..."
@@ -1484,14 +1484,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "نمی‌توانم موکسر را برای %1 پیدا کنم، بررسی کنید که افزونه‌ی مناسب GStream را نصب کرده‌اید"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1506,7 +1506,7 @@ msgstr "نمی‌توانم پرونده‌ی بروندادی %1 را باز ک
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "مدیریت جلد"
 
@@ -1659,7 +1659,7 @@ msgid "Delete downloaded data"
 msgstr "پاک‌کردن دانستنی‌های بارگیری شده"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "پاک کردن پرونده‌ها"
 
@@ -1667,7 +1667,7 @@ msgstr "پاک کردن پرونده‌ها"
 msgid "Delete from device..."
 msgstr "پاک کردن از دستگاه..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "پاک کردن از دیسک..."
@@ -1700,11 +1700,11 @@ msgstr "پاک کردن پرونده‌ها"
 msgid "Depth"
 msgstr "عمق"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "صف‌بندی دوباره‌ی ترک‌های برگزیده"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "صف‌بندی دوباره‌ی ترک"
 
@@ -1805,7 +1805,7 @@ msgstr "گزینه‌های نمایش"
 msgid "Display the on-screen-display"
 msgstr "نمایش نمایش پرده‌ای"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "انجام وارسی دوباره‌ی کامل کتابخانه"
 
@@ -1984,12 +1984,12 @@ msgstr "درهم‌ریختن تصادفی دینامیک"
 msgid "Edit smart playlist..."
 msgstr "ویرایش لیست‌پخش هوشمند..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "ویرایش برچسب..."
 
@@ -2002,7 +2002,7 @@ msgid "Edit track information"
 msgstr "ویرایش دانستنی‌های ترک"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "ویرایش دانستنی‌های ترک..."
 
@@ -2110,7 +2110,7 @@ msgstr "همه‌ی مجموعه"
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "برابرساز"
 
@@ -2123,8 +2123,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "برابر است با --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "خطا"
 
@@ -2159,7 +2159,7 @@ msgstr "خطا در فراخوانی %1"
 msgid "Error loading di.fm playlist"
 msgstr "خطا در بارگیری لیست پخش di.fm"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "خطای پردازش %1:%2"
@@ -2242,7 +2242,11 @@ msgstr "خروجی گرفتن به پایان رسید"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr ""
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2266,7 +2270,7 @@ msgstr "پژمردن"
 msgid "Fading duration"
 msgstr "زمان پژمردن"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2548,11 +2552,11 @@ msgstr "نامی به آن دهید:"
 msgid "Go"
 msgstr "برو"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "برو به نوار پسین لیست‌پخش"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "برو به نوار پیشین لیست‌پخش"
 
@@ -2885,7 +2889,7 @@ msgstr "پایگاه داده‌ی جامندو"
 msgid "Jump to previous song right away"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "پرش به ترک در حال پخش"
 
@@ -2909,7 +2913,7 @@ msgstr "پخش را در پس‌زمینه ادامه بده زمانی که پ�
 msgid "Keep the original files"
 msgstr "اصل پرونده‌ها را نگه دار"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "توله گربه‌ها"
@@ -3001,7 +3005,7 @@ msgstr "کتابخانه"
 msgid "Library advanced grouping"
 msgstr "گروه‌بندی پیشرفته‌ی کتابخانه"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "آگاه‌سازی پویش دوباره‌ی کتابخانه"
 
@@ -3041,7 +3045,7 @@ msgstr "بارگیری جلدها از دیسک"
 msgid "Load playlist"
 msgstr "بارگیری لیست‌پخش"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "بارگیری لیست‌پخش..."
 
@@ -3102,11 +3106,15 @@ msgstr "ورود به سیستم"
 msgid "Login failed"
 msgstr "ورود شکست خورد"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "نمایه‌ی پیش‌بینی بلندمدت"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "عشق"
 
@@ -3141,11 +3149,11 @@ msgstr "متن آهنگ از %1"
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr ""
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3187,7 +3195,7 @@ msgstr "نمایه‌ی اصلی (MAIN)"
 msgid "Make it so!"
 msgstr "همین‌جوریش کن!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "این کار رو بکنید!"
@@ -3325,7 +3333,7 @@ msgstr "سوارگاه‌ها"
 msgid "Move down"
 msgstr "پایین بردن"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "جابه‌جایی به کتابخانه..."
 
@@ -3334,7 +3342,7 @@ msgstr "جابه‌جایی به کتابخانه..."
 msgid "Move up"
 msgstr "بالا بردن"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "آهنگ"
 
@@ -3347,7 +3355,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "بی‌صدا"
 
@@ -3396,7 +3404,7 @@ msgstr "هرگز آغاز به پخش نمی‌کند"
 msgid "New folder"
 msgstr "پوشه‌ی تازه"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "لیست‌پخش تازه"
 
@@ -3424,8 +3432,12 @@ msgstr "تازه‌ترین ترک‌ها"
 msgid "Next"
 msgstr "پسین"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "ترک پسین"
 
@@ -3463,7 +3475,7 @@ msgstr "بدون بلوک‌های کوتاه"
 msgid "None"
 msgstr "هیچ‌کدام"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "هیچ‌کدام از آهنگ‌های برگزیده مناسب کپی کردن در دستگاه نیستند"
 
@@ -3548,19 +3560,19 @@ msgstr "خاموش"
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3604,7 +3616,7 @@ msgstr "تاری"
 msgid "Open %1 in browser"
 msgstr "گشودن %1 در مرورگر"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "گشودن &سی‌دی آوایی..."
 
@@ -3616,7 +3628,7 @@ msgstr "گشودن پرونده‌ی اوپی‌ام‌ال"
 msgid "Open OPML file..."
 msgstr "گشودن پرونده‌ی اوپی‌ام‌ال..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr ""
 
@@ -3624,7 +3636,7 @@ msgstr ""
 msgid "Open device"
 msgstr "گشودن دستگاه"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "گشودن پرونده..."
 
@@ -3678,7 +3690,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "سازماندهی پرونده‌ها"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "سازماندهی پرونده‌ها..."
 
@@ -3762,7 +3774,7 @@ msgstr "مهمانی"
 msgid "Password"
 msgstr "گذرواژه"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "درنگ"
@@ -3786,6 +3798,10 @@ msgstr "آهنگساز"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "پیکسل"
@@ -3794,10 +3810,10 @@ msgstr "پیکسل"
 msgid "Plain sidebar"
 msgstr "میله‌کنار ساده"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "پخش"
 
@@ -3818,11 +3834,11 @@ msgstr "پخش در صورت ایست، درنگ در صورت پخش"
 msgid "Play if there is nothing already playing"
 msgstr "آغاز به پخش می‌کند اگر چیزی در حال پخش نیست"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3921,7 +3937,7 @@ msgstr "ترجیح"
 msgid "Preferences"
 msgstr "تنظیم‌ها"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "تنظیم‌ها..."
 
@@ -3981,7 +3997,7 @@ msgid "Previous"
 msgstr "پیشین"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "ترک پیشین"
 
@@ -4039,16 +4055,16 @@ msgstr "کیفیت"
 msgid "Querying device..."
 msgstr "جستجوی دستگاه..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "مدیر به‌خط کردن"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "به‌خط کردن ترک‌های گزیده"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "به‌خط کردن ترک"
 
@@ -4064,7 +4080,7 @@ msgstr "رادیو (بلندی یکسان برای همه‌ی ترک‌ها)"
 msgid "Rain"
 msgstr "باران"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "باران"
@@ -4176,7 +4192,7 @@ msgstr "پاک کردن عملیات"
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "پاک‌کردن تکراری‌ها از لیست‌پخش"
 
@@ -4184,7 +4200,7 @@ msgstr "پاک‌کردن تکراری‌ها از لیست‌پخش"
 msgid "Remove folder"
 msgstr "پاک کردن پوشه"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "از لیست‌پخش پاک کن"
 
@@ -4196,7 +4212,7 @@ msgstr "حذف فهرست پخش"
 msgid "Remove playlists"
 msgstr "حذف فهرست‌های پخش"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr ""
 
@@ -4208,7 +4224,7 @@ msgstr "لیست‌پخش را دوباره نامگذاری کن"
 msgid "Rename playlist..."
 msgstr "لیست‌پخش را دوباره نامگذاری کن..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "ترک‌ها را به این ترتیب دوباره شماره‌گذاری کن..."
 
@@ -4299,7 +4315,7 @@ msgstr "برش دادن"
 msgid "Rip CD"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr ""
 
@@ -4377,7 +4393,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr ""
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "ذخیره‌ی لیست‌پخش..."
 
@@ -4464,7 +4480,7 @@ msgstr "جستجوی ساب‌سونیک"
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4477,7 +4493,7 @@ msgstr "جستجوی جلد آلبوم..."
 msgid "Search for anything"
 msgstr "جستجو برای هرچیزی"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4602,7 +4618,7 @@ msgstr "جزئیات سرور"
 msgid "Service offline"
 msgstr "سرویس برون‌خط"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "%1 را برابر \"%2‌\"قرار بده..."
@@ -4611,7 +4627,7 @@ msgstr "%1 را برابر \"%2‌\"قرار بده..."
 msgid "Set the volume to <value> percent"
 msgstr "بلندی صدا را برابر <value> درصد قرار بده"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "این مقدار را برای همه‌ی ترک‌های گزیده قرار بده..."
 
@@ -4682,7 +4698,7 @@ msgstr "نمایش یک OSD زیبا"
 msgid "Show above status bar"
 msgstr "نمایش در بالای میله‌ی وضعیت"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "نمایش همه‌ی آهنگ‌ها"
 
@@ -4702,12 +4718,12 @@ msgstr "نمایش جداسازها"
 msgid "Show fullsize..."
 msgstr "نمایش اندازه‌ی کامل..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "نمایش در مرورگر پرونده..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr ""
 
@@ -4719,15 +4735,15 @@ msgstr "نمایش در هنرمندان گوناگون"
 msgid "Show moodbar"
 msgstr "نمایش میله‌مود"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "نمایش تنها تکراری‌ها"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "نمایش تنها بی‌برچسب‌ها"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4735,7 +4751,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr "نمایش پیشنهادهای جستجو"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4771,7 +4787,7 @@ msgstr "برزدن آلبوم‌ها"
 msgid "Shuffle all"
 msgstr "پخش درهم همه"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "پخش درهم لیست‌پخش"
 
@@ -4815,11 +4831,15 @@ msgstr "پرش شمار"
 msgid "Skip forwards in playlist"
 msgstr "پرش پیش در لیست‌پخش"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr ""
 
@@ -4936,7 +4956,7 @@ msgstr ""
 msgid "Start the playlist currently playing"
 msgstr "شروع لیست‌پخش در حال پخش"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "آغاز تراکد"
 
@@ -4946,7 +4966,7 @@ msgid ""
 "list"
 msgstr "چیزی در جعبه‌ی جستجوی بالا بنویسید تا این لیست دستاوردهای جستجو را پرکنید"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "شروع %1"
@@ -4956,7 +4976,7 @@ msgid "Starting..."
 msgstr "شروع..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "ایست"
 
@@ -4972,7 +4992,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "ایست پس از این آهنگ"
 
@@ -5140,7 +5160,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "زمان آزمایشی سرور ساب‌سونیک پایان یافته است. خواهش می‌کنیم هزینه‌ای را کمک کنید تا کلید پروانه را دریافت کنید. برای راهنمایی انجام کار تارنمای subsonic.org را ببینید."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5182,7 +5202,7 @@ msgid ""
 "continue?"
 msgstr "این پرونده‌ها از دستگاه پاک خواهند شد، آیا مطمئنید که می‌خواهید ادامه دهید؟"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5284,11 +5304,11 @@ msgstr "تبدیل به OSD زیبا"
 msgid "Toggle fullscreen"
 msgstr "تبدیل به تمام‌صفحه"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "تبدیل به وضعیت صف"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "تبدیل به وارانی"
 
@@ -5333,19 +5353,19 @@ msgstr ""
 msgid "Track"
 msgstr "ترک"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "آهنگ‌های تراکد"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "صورت عملیات تراکدگر"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "تراکدکردن"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "تراکدکردن فایلهای %1 با استفاده از سرنخ‌های %2"
@@ -5422,11 +5442,11 @@ msgstr "خطای ناشناخته"
 msgid "Unset cover"
 msgstr "قرار ندادن جلد"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr ""
 
@@ -5443,7 +5463,7 @@ msgstr "کنسرت‌های پیش‌رو"
 msgid "Update all podcasts"
 msgstr "به‌روز رسانی همه‌ی پادکست‌ها"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "تغییرات پوشه‌های کتابخانه را به‌روز برسان"
 
@@ -5604,7 +5624,7 @@ msgstr "ویرایش %1"
 msgid "View"
 msgstr "نما"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5612,7 +5632,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr "روش فرتورسازی"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "فرتورسازی‌ها"
 
@@ -5653,7 +5673,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5749,7 +5769,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "فرمت آوایی مدیای ویندوز"
 
@@ -5763,7 +5783,7 @@ msgid ""
 "well?"
 msgstr "آیا می‌خواهید آهنگ‌های دیگر در این آلبوم را به «هنرمندان گوناگون» تراببرید؟"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "آیا مایل هستید که الان بازبینی کامل انجام دهید؟"
 

--- a/src/translations/fa.po
+++ b/src/translations/fa.po
@@ -515,7 +515,7 @@ msgstr "افزودن جریان دیگر..."
 msgid "Add directory..."
 msgstr "افزودن پوشه..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "افزودن پرونده"
 
@@ -535,7 +535,7 @@ msgstr "افزودن پرونده..."
 msgid "Add files to transcode"
 msgstr "افزودن پرونده‌ها به تراکد"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "افزودن پوشه"
@@ -640,7 +640,7 @@ msgstr "افزودن به فهرست پخش Spotify"
 msgid "Add to Spotify starred"
 msgstr "افزودن به ستاره‌دارهای Spotify"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "افزودن به لیست‌پخش دیگر"
 
@@ -862,7 +862,7 @@ msgstr ""
 msgid "Artist"
 msgstr "هنرمند"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "اطلاعات هنرمند"
 
@@ -1125,7 +1125,7 @@ msgstr "بررسی برای داستان‌های تازه"
 msgid "Check for updates"
 msgstr "بررسی بروز رسانی"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "بررسی به‌روز رسانی..."
 
@@ -1365,7 +1365,7 @@ msgstr "پیکربندی ساب‌سونیک..."
 msgid "Configure global search..."
 msgstr "پیکربندی جستجوی سراسری..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "پیکربندی کتابخانه..."
 
@@ -1437,11 +1437,11 @@ msgid "Copy to clipboard"
 msgstr "کپی به کلیپ‌بورد"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "کپی‌کردن در دستگاه..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "کپی‌کردن در کتابخانه..."
@@ -1659,7 +1659,7 @@ msgid "Delete downloaded data"
 msgstr "پاک‌کردن دانستنی‌های بارگیری شده"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "پاک کردن پرونده‌ها"
 
@@ -1667,7 +1667,7 @@ msgstr "پاک کردن پرونده‌ها"
 msgid "Delete from device..."
 msgstr "پاک کردن از دستگاه..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "پاک کردن از دیسک..."
@@ -1700,11 +1700,11 @@ msgstr "پاک کردن پرونده‌ها"
 msgid "Depth"
 msgstr "عمق"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "صف‌بندی دوباره‌ی ترک‌های برگزیده"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "صف‌بندی دوباره‌ی ترک"
 
@@ -1733,7 +1733,7 @@ msgstr "نام دستگاه"
 msgid "Device properties..."
 msgstr "ویژگی‌های دستگاه..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "‌دستگاه‌ها"
 
@@ -1984,7 +1984,7 @@ msgstr "درهم‌ریختن تصادفی دینامیک"
 msgid "Edit smart playlist..."
 msgstr "ویرایش لیست‌پخش هوشمند..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
@@ -2123,8 +2123,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "برابر است با --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "خطا"
 
@@ -2270,7 +2270,7 @@ msgstr "پژمردن"
 msgid "Fading duration"
 msgstr "زمان پژمردن"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2393,7 +2393,7 @@ msgstr "گونه‌ی پرونده"
 msgid "Filename"
 msgstr "نام‌پرونده"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "پرونده‌ها"
 
@@ -2808,7 +2808,7 @@ msgstr "نصب شد"
 msgid "Integrity check"
 msgstr "بررسی درستی"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "اینترنت"
 
@@ -2996,7 +2996,7 @@ msgstr "چپ"
 msgid "Length"
 msgstr "طول"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "کتابخانه"
@@ -3005,7 +3005,7 @@ msgstr "کتابخانه"
 msgid "Library advanced grouping"
 msgstr "گروه‌بندی پیشرفته‌ی کتابخانه"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "آگاه‌سازی پویش دوباره‌ی کتابخانه"
 
@@ -3333,7 +3333,7 @@ msgstr "سوارگاه‌ها"
 msgid "Move down"
 msgstr "پایین بردن"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "جابه‌جایی به کتابخانه..."
 
@@ -3342,7 +3342,7 @@ msgstr "جابه‌جایی به کتابخانه..."
 msgid "Move up"
 msgstr "بالا بردن"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "آهنگ"
 
@@ -3404,7 +3404,7 @@ msgstr "هرگز آغاز به پخش نمی‌کند"
 msgid "New folder"
 msgstr "پوشه‌ی تازه"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "لیست‌پخش تازه"
 
@@ -3475,7 +3475,7 @@ msgstr "بدون بلوک‌های کوتاه"
 msgid "None"
 msgstr "هیچ‌کدام"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "هیچ‌کدام از آهنگ‌های برگزیده مناسب کپی کردن در دستگاه نیستند"
 
@@ -3690,7 +3690,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "سازماندهی پرونده‌ها"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "سازماندهی پرونده‌ها..."
 
@@ -3774,7 +3774,7 @@ msgstr "مهمانی"
 msgid "Password"
 msgstr "گذرواژه"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "درنگ"
@@ -3810,8 +3810,8 @@ msgstr "پیکسل"
 msgid "Plain sidebar"
 msgstr "میله‌کنار ساده"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3834,11 +3834,11 @@ msgstr "پخش در صورت ایست، درنگ در صورت پخش"
 msgid "Play if there is nothing already playing"
 msgstr "آغاز به پخش می‌کند اگر چیزی در حال پخش نیست"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3877,7 +3877,7 @@ msgstr "گزینه‌های لیست‌پخش"
 msgid "Playlist type"
 msgstr "سبک لیست‌پخش"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "لیست‌های پخش"
 
@@ -4059,12 +4059,12 @@ msgstr "جستجوی دستگاه..."
 msgid "Queue Manager"
 msgstr "مدیر به‌خط کردن"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "به‌خط کردن ترک‌های گزیده"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "به‌خط کردن ترک"
 
@@ -4455,7 +4455,7 @@ msgstr ""
 msgid "Search"
 msgstr "جستجو"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "جستجو"
@@ -4480,7 +4480,7 @@ msgstr "جستجوی ساب‌سونیک"
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4493,7 +4493,7 @@ msgstr "جستجوی جلد آلبوم..."
 msgid "Search for anything"
 msgstr "جستجو برای هرچیزی"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4618,7 +4618,7 @@ msgstr "جزئیات سرور"
 msgid "Service offline"
 msgstr "سرویس برون‌خط"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "%1 را برابر \"%2‌\"قرار بده..."
@@ -4698,7 +4698,7 @@ msgstr "نمایش یک OSD زیبا"
 msgid "Show above status bar"
 msgstr "نمایش در بالای میله‌ی وضعیت"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "نمایش همه‌ی آهنگ‌ها"
 
@@ -4718,12 +4718,12 @@ msgstr "نمایش جداسازها"
 msgid "Show fullsize..."
 msgstr "نمایش اندازه‌ی کامل..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "نمایش در مرورگر پرونده..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr ""
 
@@ -4735,11 +4735,11 @@ msgstr "نمایش در هنرمندان گوناگون"
 msgid "Show moodbar"
 msgstr "نمایش میله‌مود"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "نمایش تنها تکراری‌ها"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "نمایش تنها بی‌برچسب‌ها"
 
@@ -4831,7 +4831,7 @@ msgstr "پرش شمار"
 msgid "Skip forwards in playlist"
 msgstr "پرش پیش در لیست‌پخش"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr ""
 
@@ -4839,7 +4839,7 @@ msgstr ""
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr ""
 
@@ -4871,7 +4871,7 @@ msgstr "راک ملایم"
 msgid "Song Information"
 msgstr "اطلاعات آهنگ"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "اطلاعات آهنگ"
 
@@ -4992,7 +4992,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "ایست پس از این آهنگ"
 
@@ -5160,7 +5160,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "زمان آزمایشی سرور ساب‌سونیک پایان یافته است. خواهش می‌کنیم هزینه‌ای را کمک کنید تا کلید پروانه را دریافت کنید. برای راهنمایی انجام کار تارنمای subsonic.org را ببینید."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5202,7 +5202,7 @@ msgid ""
 "continue?"
 msgstr "این پرونده‌ها از دستگاه پاک خواهند شد، آیا مطمئنید که می‌خواهید ادامه دهید؟"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5304,7 +5304,7 @@ msgstr "تبدیل به OSD زیبا"
 msgid "Toggle fullscreen"
 msgstr "تبدیل به تمام‌صفحه"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "تبدیل به وضعیت صف"
 
@@ -5442,11 +5442,11 @@ msgstr "خطای ناشناخته"
 msgid "Unset cover"
 msgstr "قرار ندادن جلد"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr ""
 
@@ -5783,7 +5783,7 @@ msgid ""
 "well?"
 msgstr "آیا می‌خواهید آهنگ‌های دیگر در این آلبوم را به «هنرمندان گوناگون» تراببرید؟"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "آیا مایل هستید که الان بازبینی کامل انجام دهید؟"
 

--- a/src/translations/fi.po
+++ b/src/translations/fi.po
@@ -13,8 +13,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-14 22:35+0000\n"
-"Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
+"Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Finnish (http://www.transifex.com/davidsansome/clementine/language/fi/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -167,19 +167,19 @@ msgstr "%L1 kappaletta"
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n epäonnistui"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n valmistui"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -197,7 +197,7 @@ msgstr "&Keskelle"
 msgid "&Custom"
 msgstr "&Oma"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Lisäosat"
 
@@ -205,7 +205,7 @@ msgstr "&Lisäosat"
 msgid "&Grouping"
 msgstr "&Ryhmittely"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "O&hje"
 
@@ -230,7 +230,7 @@ msgstr "&Lukitse arvostelu"
 msgid "&Lyrics"
 msgstr "&Sanoitus"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Musiikki"
 
@@ -238,15 +238,15 @@ msgstr "&Musiikki"
 msgid "&None"
 msgstr "&Ei mitään"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&Soittolista"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Lopeta"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "Kertaa"
 
@@ -254,7 +254,7 @@ msgstr "Kertaa"
 msgid "&Right"
 msgstr "&Oikealle"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Sekoita"
 
@@ -262,7 +262,7 @@ msgstr "Sekoita"
 msgid "&Stretch columns to fit window"
 msgstr "&Sovita sarakkeet ikkunan leveyteen"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Työkalut"
 
@@ -451,11 +451,11 @@ msgstr "Keskeytä"
 msgid "About %1"
 msgstr "Tietoja - %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Tietoja - Clementine"
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Tietoja - Qt"
 
@@ -515,32 +515,32 @@ msgstr "Lisää toinen suoratoisto..."
 msgid "Add directory..."
 msgstr "Lisää kansio..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Lisää tiedosto"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Lisää tiedosto muuntajaan"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Lisää tiedosto(ja) muuntajaan"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Lisää tiedosto..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Lisää tiedostoja muunnettavaksi"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Lisää kansio"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Lisää kansio..."
 
@@ -552,7 +552,7 @@ msgstr "Lisää uusi kansio..."
 msgid "Add podcast"
 msgstr "Lisää radio"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Lisää radiot..."
 
@@ -628,7 +628,7 @@ msgstr "Lisää tunniste "
 msgid "Add song year tag"
 msgstr "Lisää kappaleen levytysvuoden tunniste"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Lisää suoratoisto..."
 
@@ -640,7 +640,7 @@ msgstr "Lisää Spotify-soittolistoihin"
 msgid "Add to Spotify starred"
 msgstr "Lisää Spotifyn tähdellä varustettuihin"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Lisää toiseen soittolistaan"
 
@@ -734,7 +734,7 @@ msgstr "Kaikki"
 msgid "All Files (*)"
 msgstr "Kaikki tiedostot (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Kaikki kunnia Hypnotoadille!"
@@ -1125,7 +1125,7 @@ msgstr "Tarkista uudet jaksot"
 msgid "Check for updates"
 msgstr "Tarkista päivitykset"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Tarkista päivitykset..."
 
@@ -1174,18 +1174,18 @@ msgstr "Classical"
 msgid "Cleaning up"
 msgstr "Siivoaminen"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Tyhjennä"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Tyhjennä soittolista"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1330,7 +1330,7 @@ msgstr "Kommentti"
 msgid "Complete tags automatically"
 msgstr "Täydennä tunnisteet automaattisesti"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Täydennä tunnisteet automaattisesti..."
 
@@ -1365,7 +1365,7 @@ msgstr "Subsonicin asetukset..."
 msgid "Configure global search..."
 msgstr "Muokkaa hakua..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Kirjaston asetukset..."
 
@@ -1408,7 +1408,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Yhteys aikakatkaistiin, tarkista palvelimen osoite. Esimerkki: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Konsoli"
 
@@ -1437,11 +1437,11 @@ msgid "Copy to clipboard"
 msgstr "Kopioi leikepöydälle"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopioi laitteelle..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kopioi kirjastoon"
@@ -1484,14 +1484,14 @@ msgstr "Kirjautuminen Last.fm:ään ei onnistunut. Yritä uudelleen."
 msgid "Couldn't create playlist"
 msgstr "Soittolistan luominen epäonnistui"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Ei löydetty %1 -multiplekseriä, tarkista että sinulla on oikeat GStreamer-liitännäiset asennettuna"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1506,7 +1506,7 @@ msgstr "Ei voitu avata kohdetiedostoa %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Kansikuvaselain"
 
@@ -1659,7 +1659,7 @@ msgid "Delete downloaded data"
 msgstr "Poista ladattu data"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Poista tiedostot"
 
@@ -1667,7 +1667,7 @@ msgstr "Poista tiedostot"
 msgid "Delete from device..."
 msgstr "Poista laitteelta..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Poista levyltä..."
@@ -1700,11 +1700,11 @@ msgstr "Poistetaan tiedostoja"
 msgid "Depth"
 msgstr "Syvyys"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Poista valitut kappaleet jonosta"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Poista kappale jonosta"
 
@@ -1805,7 +1805,7 @@ msgstr "Näkymäasetukset"
 msgid "Display the on-screen-display"
 msgstr "Näytä kuvaruutunäyttö"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Tee kirjaston täydellinen läpikäynti"
 
@@ -1984,12 +1984,12 @@ msgstr "Dynaaminen satunnainen sekoitus"
 msgid "Edit smart playlist..."
 msgstr "Muokkaa älykästä soittolistaa..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Muokkaa tunnistetta \"%1\"..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Muokkaa tunnistetta..."
 
@@ -2002,7 +2002,7 @@ msgid "Edit track information"
 msgstr "Muokkaa kappaleen tietoja"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Muokkaa kappaleen tietoja..."
 
@@ -2110,7 +2110,7 @@ msgstr "Koko kokoelma"
 msgid "Episode information"
 msgstr "Jakson tiedot"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Taajuuskorjain"
 
@@ -2123,8 +2123,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Vastaa --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Virhe"
 
@@ -2159,7 +2159,7 @@ msgstr "Virhe ladattaessa %1"
 msgid "Error loading di.fm playlist"
 msgstr "Virhe ladattaessa di.fm soittolistaa"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Virhe käsitellessä %1:%2"
@@ -2242,7 +2242,11 @@ msgstr "Vienti valmistui"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "Vietiin %1/%2 kansikuvaa (%3 ohitettu)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2266,7 +2270,7 @@ msgstr "Häivytys"
 msgid "Fading duration"
 msgstr "Häivytyksen kesto"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "CD-aseman lukeminen epäonnistui"
 
@@ -2548,11 +2552,11 @@ msgstr "Anna nimi:"
 msgid "Go"
 msgstr "Mene"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Siirry seuraavaan soittolistaan"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Siirry edelliseen soittolistaan"
 
@@ -2885,7 +2889,7 @@ msgstr "Jamendo-tietokanta"
 msgid "Jump to previous song right away"
 msgstr "Siirry edelliseen kappaleeseen välittömästi"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Näytä parhaillaan soiva kappale"
 
@@ -2909,7 +2913,7 @@ msgstr "Pidä käynnissä taustalla, kun ikkuna suljetaan"
 msgid "Keep the original files"
 msgstr "Säilytä alkuperäiset tiedostot"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Kissanpentuja"
@@ -3001,7 +3005,7 @@ msgstr "Kirjasto"
 msgid "Library advanced grouping"
 msgstr "Kirjaston tarkennettu ryhmittely"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Ilmoitus kirjaston läpikäynnistä"
 
@@ -3041,7 +3045,7 @@ msgstr "Lataa kansikuva levyltä..."
 msgid "Load playlist"
 msgstr "Lataa soittolista"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Lataa soittolista..."
 
@@ -3102,11 +3106,15 @@ msgstr "Kirjaudu sisään"
 msgid "Login failed"
 msgstr "Kirjautuminen epäonnistui"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr "Lokit"
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Long term prediction -profiili (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Tykkää"
 
@@ -3141,11 +3149,11 @@ msgstr "Sanoitukset tarjoaa %1"
 msgid "Lyrics from the tag"
 msgstr "Sanoitukset tunnisteesta"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3187,7 +3195,7 @@ msgstr "Oletusprofiili (MAIN)"
 msgid "Make it so!"
 msgstr "Toteuta!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Toteuta!"
@@ -3325,7 +3333,7 @@ msgstr "Liitoskohdat"
 msgid "Move down"
 msgstr "Siirrä alas"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Siirrä kirjastoon..."
 
@@ -3334,7 +3342,7 @@ msgstr "Siirrä kirjastoon..."
 msgid "Move up"
 msgstr "Siirrä ylös"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Musiikki"
 
@@ -3347,7 +3355,7 @@ msgid "Music extensions remotely visible"
 msgstr "Musiikin tiedostopäätteet etänä näkyvissä"
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Vaimenna"
 
@@ -3396,7 +3404,7 @@ msgstr "Älä koskaan aloita toistoa"
 msgid "New folder"
 msgstr "Uusi kansio"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Uusi soittolista"
 
@@ -3424,8 +3432,12 @@ msgstr "Uusimmat kappaleet"
 msgid "Next"
 msgstr "Seuraava"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Seuraava kappale"
 
@@ -3463,7 +3475,7 @@ msgstr "Ei lyhyitä lohkoja"
 msgid "None"
 msgstr "Ei mitään"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Yksikään valitsemistasi kappaleista ei sovellu kopioitavaksi laitteelle"
 
@@ -3548,19 +3560,19 @@ msgstr "Pois"
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3604,7 +3616,7 @@ msgstr "Läpinäkyvyys"
 msgid "Open %1 in browser"
 msgstr "Avaa %1 selaimessa"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Avaa &ääni-CD..."
 
@@ -3616,7 +3628,7 @@ msgstr "Avaa OPML-tiedosto"
 msgid "Open OPML file..."
 msgstr "Avaa OPML-tiedosto..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Avaa kansio, josta musiikki tuodaan"
 
@@ -3624,7 +3636,7 @@ msgstr "Avaa kansio, josta musiikki tuodaan"
 msgid "Open device"
 msgstr "Avaa laite"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Avaa tiedosto..."
 
@@ -3678,7 +3690,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Hallitse tiedostoja"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Hallitse tiedostoja..."
 
@@ -3762,7 +3774,7 @@ msgstr "Party"
 msgid "Password"
 msgstr "Salasana"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Keskeytä"
@@ -3786,6 +3798,10 @@ msgstr "Esittäjä"
 msgid "Pipeline"
 msgstr "Putkisto"
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr "Putkisto"
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Pikseli"
@@ -3794,10 +3810,10 @@ msgstr "Pikseli"
 msgid "Plain sidebar"
 msgstr "Pelkistetty sivupalkki"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Toista"
 
@@ -3818,11 +3834,11 @@ msgstr "Aloittaa tai pysäyttää soittamisen"
 msgid "Play if there is nothing already playing"
 msgstr "Aloita toisto, jos mikään ei soi parhaillaan"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Toista seuraava"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Toista valitut kappaleet seuraavaksi"
 
@@ -3921,7 +3937,7 @@ msgstr "Etusija"
 msgid "Preferences"
 msgstr "Asetukset"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Asetukset..."
 
@@ -3981,7 +3997,7 @@ msgid "Previous"
 msgstr "Edellinen"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Edellinen kappale"
 
@@ -4039,16 +4055,16 @@ msgstr "Laatu"
 msgid "Querying device..."
 msgstr "Kysytään tietoja laitteelta..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Jonohallinta"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Aseta valitut kappaleet jonoon"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Aseta kappale jonoon"
 
@@ -4064,7 +4080,7 @@ msgstr "Radio (sama äänenvoimakkuus kaikille kappaleille)"
 msgid "Rain"
 msgstr "Sadetta"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Sadetta"
@@ -4176,7 +4192,7 @@ msgstr "Poista toiminto"
 msgid "Remove current song from playlist"
 msgstr "Poista nykyinen kappale soittolistasta"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Poista soittolistan kaksoiskappaleet"
 
@@ -4184,7 +4200,7 @@ msgstr "Poista soittolistan kaksoiskappaleet"
 msgid "Remove folder"
 msgstr "Poista kansio"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Poista soittolistalta"
 
@@ -4196,7 +4212,7 @@ msgstr "Poista soittolista"
 msgid "Remove playlists"
 msgstr "Poista soittolistat"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Poista soittolistasta kappaleet, jotka eivät ole käytettävissä"
 
@@ -4208,7 +4224,7 @@ msgstr "Nimeä soittolista uudelleen"
 msgid "Rename playlist..."
 msgstr "Nimeä soittolista uudelleen..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Numeroi kappaleet tässä järjestyksessä ..."
 
@@ -4299,7 +4315,7 @@ msgstr "Kopioi levy"
 msgid "Rip CD"
 msgstr "Kopioi CD:n sisältö"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Kopioi ääni-CD:n sisältö"
 
@@ -4377,7 +4393,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Tallenna soittolista"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Tallenna soittolista..."
 
@@ -4464,7 +4480,7 @@ msgstr "Etsi Subsonicista"
 msgid "Search automatically"
 msgstr "Etsi automaattisesti"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Etsi albumia"
 
@@ -4477,7 +4493,7 @@ msgstr "Etsi kansikuvia..."
 msgid "Search for anything"
 msgstr "Etsi mitä tahansa"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Etsi esittäjää"
 
@@ -4602,7 +4618,7 @@ msgstr "Palvelimen tiedot"
 msgid "Service offline"
 msgstr "Ei yhteyttä palveluun"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Aseta %1 %2:een"
@@ -4611,7 +4627,7 @@ msgstr "Aseta %1 %2:een"
 msgid "Set the volume to <value> percent"
 msgstr "Säädä äänenvoimakkuus <value> prosenttia"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Aseta arvo kaikille valituille kappaleille..."
 
@@ -4682,7 +4698,7 @@ msgstr "Näytä kuvaruutunäyttö"
 msgid "Show above status bar"
 msgstr "Näytä tilapalkin yläpuolella"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Näytä kaikki kappaleet"
 
@@ -4702,12 +4718,12 @@ msgstr "Näytä erottimet"
 msgid "Show fullsize..."
 msgstr "Näytä oikeassa koossa..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Näytä tiedostoselaimessa..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Näytä kirjastossa..."
 
@@ -4719,15 +4735,15 @@ msgstr "Näytä kohdassa \"Useita esittäjiä\""
 msgid "Show moodbar"
 msgstr "Näytä mielialapalkki"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Näytä vain kaksoiskappaleet"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Näytä vain vailla tunnistetta olevat"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Näytä tai piilota sivupalkki"
 
@@ -4735,7 +4751,7 @@ msgstr "Näytä tai piilota sivupalkki"
 msgid "Show search suggestions"
 msgstr "Näytä hakuehdotukset"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Näytä sivupalkki"
 
@@ -4771,7 +4787,7 @@ msgstr "Sekoita albumit"
 msgid "Shuffle all"
 msgstr "Sekoita kaikki"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Sekoita soittolista"
 
@@ -4815,11 +4831,15 @@ msgstr "Ohituskerrat"
 msgid "Skip forwards in playlist"
 msgstr "Siirry soittolistan seuraavaan kappaleeseen"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Ohita valitut kappaleet"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Ohita kappale"
 
@@ -4936,7 +4956,7 @@ msgstr "Aloita levyn kopiointi"
 msgid "Start the playlist currently playing"
 msgstr "Käynnistä toistettava soittolista"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Aloita muunnos"
 
@@ -4946,7 +4966,7 @@ msgid ""
 "list"
 msgstr "Kirjoita jotain yllä olevaan hakukenttään täyttääksesi tämän hakutuloslistan"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Aloittaa %1"
@@ -4956,7 +4976,7 @@ msgid "Starting..."
 msgstr "Aloittaa ..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Pysäytä"
 
@@ -4972,7 +4992,7 @@ msgstr "Lopeta jokaisen raidan jälkeen"
 msgid "Stop after every track"
 msgstr "Pysäytä jokaisen raidan jälkeen"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Pysäytä toistettavan kappaleen jälkeen"
 
@@ -5140,7 +5160,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Subsonic-palvelimen kokeiluaika on ohi. Lahjoita saadaksesi lisenssiavaimen. Lisätietoja osoitteessa subsonic.org."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5182,7 +5202,7 @@ msgid ""
 "continue?"
 msgstr "Nämä tiedostot poistetaan laitteelta, haluatko varmasti jatkaa?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5284,11 +5304,11 @@ msgstr "Kuvaruutunäyttö päälle / pois"
 msgid "Toggle fullscreen"
 msgstr "Koko näytön tila"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Vaihda jonon tila"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Valitse pyyhkäisy"
 
@@ -5333,19 +5353,19 @@ msgstr "&Kappale"
 msgid "Track"
 msgstr "Kappale"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Muunna eri muotoon"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Muunnosloki"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr "Muuntimen tiedot"
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Muunnos"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Muunnetaan %1 tiedostoa käyttäen %2 säiettä"
@@ -5422,11 +5442,11 @@ msgstr "Tuntematon virhe"
 msgid "Unset cover"
 msgstr "Poista kansikuva"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Valittujen kappaleiden ohitus"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Raidan ohittaminen"
 
@@ -5443,7 +5463,7 @@ msgstr "Tulevat konsertit"
 msgid "Update all podcasts"
 msgstr "Päivitä kaikki radiot"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Päivitä muuttuneet kirjastokansiot"
 
@@ -5604,7 +5624,7 @@ msgstr "Versio %1"
 msgid "View"
 msgstr "Näkymä"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Näytä suoratoiston tiedot"
 
@@ -5612,7 +5632,7 @@ msgstr "Näytä suoratoiston tiedot"
 msgid "Visualization mode"
 msgstr "Visualisointitila"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Visualisoinnit"
 
@@ -5653,7 +5673,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr "Varoitus: Tämä pakkaustaso on suoratoiston ulkopuolella. Tarkoittaa, että purkukoodaus ei välttämättä pysty aloittamaan toistoa keskeltä virtaa. Voi myös vaikuttaa laitteistokiihdytettyyn suorituskykyyn."
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5749,7 +5769,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media -ääni"
 
@@ -5763,7 +5783,7 @@ msgid ""
 "well?"
 msgstr "Haluatko siirtä albumin muut kappaleet luokkaan \"Useita esittäjiä\"?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Haluatko suorittaa kirjaston läpikäynnin nyt?"
 

--- a/src/translations/fi.po
+++ b/src/translations/fi.po
@@ -13,8 +13,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-26 23:47+0000\n"
-"Last-Translator: John Maguire <john.maguire@gmail.com>\n"
+"PO-Revision-Date: 2021-01-27 10:40+0000\n"
+"Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: Finnish (http://www.transifex.com/davidsansome/clementine/language/fi/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -515,7 +515,7 @@ msgstr "Lisää toinen suoratoisto..."
 msgid "Add directory..."
 msgstr "Lisää kansio..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Lisää tiedosto"
 
@@ -535,7 +535,7 @@ msgstr "Lisää tiedosto..."
 msgid "Add files to transcode"
 msgstr "Lisää tiedostoja muunnettavaksi"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Lisää kansio"
@@ -640,7 +640,7 @@ msgstr "Lisää Spotify-soittolistoihin"
 msgid "Add to Spotify starred"
 msgstr "Lisää Spotifyn tähdellä varustettuihin"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Lisää toiseen soittolistaan"
 
@@ -862,7 +862,7 @@ msgstr "Oletko varma että haluat kirjoittaa kaikkien kirjastosi kappleiden tila
 msgid "Artist"
 msgstr "Esittäjä"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Esittäjätiedot"
 
@@ -1125,7 +1125,7 @@ msgstr "Tarkista uudet jaksot"
 msgid "Check for updates"
 msgstr "Tarkista päivitykset"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Tarkista päivitykset..."
 
@@ -1365,7 +1365,7 @@ msgstr "Subsonicin asetukset..."
 msgid "Configure global search..."
 msgstr "Muokkaa hakua..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Kirjaston asetukset..."
 
@@ -1437,11 +1437,11 @@ msgid "Copy to clipboard"
 msgstr "Kopioi leikepöydälle"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopioi laitteelle..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kopioi kirjastoon"
@@ -1659,7 +1659,7 @@ msgid "Delete downloaded data"
 msgstr "Poista ladattu data"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Poista tiedostot"
 
@@ -1667,7 +1667,7 @@ msgstr "Poista tiedostot"
 msgid "Delete from device..."
 msgstr "Poista laitteelta..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Poista levyltä..."
@@ -1700,11 +1700,11 @@ msgstr "Poistetaan tiedostoja"
 msgid "Depth"
 msgstr "Syvyys"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Poista valitut kappaleet jonosta"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Poista kappale jonosta"
 
@@ -1733,7 +1733,7 @@ msgstr "Laitteen nimi"
 msgid "Device properties..."
 msgstr "Laitteen ominaisuudet..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Laitteet"
 
@@ -1984,7 +1984,7 @@ msgstr "Dynaaminen satunnainen sekoitus"
 msgid "Edit smart playlist..."
 msgstr "Muokkaa älykästä soittolistaa..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Muokkaa tunnistetta \"%1\"..."
@@ -2123,8 +2123,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Vastaa --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Virhe"
 
@@ -2244,7 +2244,7 @@ msgstr "Vietiin %1/%2 kansikuvaa (%3 ohitettu)"
 
 #: ../bin/src/ui_mainwindow.h:790
 msgid "F9"
-msgstr ""
+msgstr "F9"
 
 #: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
@@ -2270,7 +2270,7 @@ msgstr "Häivytys"
 msgid "Fading duration"
 msgstr "Häivytyksen kesto"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "CD-aseman lukeminen epäonnistui"
 
@@ -2393,7 +2393,7 @@ msgstr "Tiedostotyyppi"
 msgid "Filename"
 msgstr "Tiedostonimi"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Tiedostot"
 
@@ -2808,7 +2808,7 @@ msgstr "Asennettu"
 msgid "Integrity check"
 msgstr "Eheystarkistus"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -2996,7 +2996,7 @@ msgstr "Vasen"
 msgid "Length"
 msgstr "Kesto"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Kirjasto"
@@ -3005,7 +3005,7 @@ msgstr "Kirjasto"
 msgid "Library advanced grouping"
 msgstr "Kirjaston tarkennettu ryhmittely"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Ilmoitus kirjaston läpikäynnistä"
 
@@ -3333,7 +3333,7 @@ msgstr "Liitoskohdat"
 msgid "Move down"
 msgstr "Siirrä alas"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Siirrä kirjastoon..."
 
@@ -3342,7 +3342,7 @@ msgstr "Siirrä kirjastoon..."
 msgid "Move up"
 msgstr "Siirrä ylös"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Musiikki"
 
@@ -3404,7 +3404,7 @@ msgstr "Älä koskaan aloita toistoa"
 msgid "New folder"
 msgstr "Uusi kansio"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Uusi soittolista"
 
@@ -3434,7 +3434,7 @@ msgstr "Seuraava"
 
 #: ../bin/src/ui_mainwindow.h:785
 msgid "Next album"
-msgstr ""
+msgstr "Seuraava albumi"
 
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
 #: ../bin/src/ui_mainwindow.h:727
@@ -3475,7 +3475,7 @@ msgstr "Ei lyhyitä lohkoja"
 msgid "None"
 msgstr "Ei mitään"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Yksikään valitsemistasi kappaleista ei sovellu kopioitavaksi laitteelle"
 
@@ -3690,7 +3690,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Hallitse tiedostoja"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Hallitse tiedostoja..."
 
@@ -3774,7 +3774,7 @@ msgstr "Party"
 msgid "Password"
 msgstr "Salasana"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Keskeytä"
@@ -3810,8 +3810,8 @@ msgstr "Pikseli"
 msgid "Plain sidebar"
 msgstr "Pelkistetty sivupalkki"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3834,11 +3834,11 @@ msgstr "Aloittaa tai pysäyttää soittamisen"
 msgid "Play if there is nothing already playing"
 msgstr "Aloita toisto, jos mikään ei soi parhaillaan"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Toista seuraava"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Toista valitut kappaleet seuraavaksi"
 
@@ -3877,7 +3877,7 @@ msgstr "Soittolistan valinnat"
 msgid "Playlist type"
 msgstr "Soittolistan tyyppi"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Soittolistat"
 
@@ -4059,12 +4059,12 @@ msgstr "Kysytään tietoja laitteelta..."
 msgid "Queue Manager"
 msgstr "Jonohallinta"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Aseta valitut kappaleet jonoon"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Aseta kappale jonoon"
 
@@ -4455,7 +4455,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Etsi"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Haku"
@@ -4480,7 +4480,7 @@ msgstr "Etsi Subsonicista"
 msgid "Search automatically"
 msgstr "Etsi automaattisesti"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Etsi albumia"
 
@@ -4493,7 +4493,7 @@ msgstr "Etsi kansikuvia..."
 msgid "Search for anything"
 msgstr "Etsi mitä tahansa"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Etsi esittäjää"
 
@@ -4618,7 +4618,7 @@ msgstr "Palvelimen tiedot"
 msgid "Service offline"
 msgstr "Ei yhteyttä palveluun"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Aseta %1 %2:een"
@@ -4698,7 +4698,7 @@ msgstr "Näytä kuvaruutunäyttö"
 msgid "Show above status bar"
 msgstr "Näytä tilapalkin yläpuolella"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Näytä kaikki kappaleet"
 
@@ -4718,12 +4718,12 @@ msgstr "Näytä erottimet"
 msgid "Show fullsize..."
 msgstr "Näytä oikeassa koossa..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Näytä tiedostoselaimessa..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Näytä kirjastossa..."
 
@@ -4735,11 +4735,11 @@ msgstr "Näytä kohdassa \"Useita esittäjiä\""
 msgid "Show moodbar"
 msgstr "Näytä mielialapalkki"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Näytä vain kaksoiskappaleet"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Näytä vain vailla tunnistetta olevat"
 
@@ -4831,15 +4831,15 @@ msgstr "Ohituskerrat"
 msgid "Skip forwards in playlist"
 msgstr "Siirry soittolistan seuraavaan kappaleeseen"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Ohita valitut kappaleet"
 
 #: ../bin/src/ui_mainwindow.h:787
 msgid "Skip to the next album"
-msgstr ""
+msgstr "Siirry seuraavaan albumiin"
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Ohita kappale"
 
@@ -4871,7 +4871,7 @@ msgstr "Soft Rock"
 msgid "Song Information"
 msgstr "Kappaletiedot"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Kappaletiedot"
 
@@ -4992,7 +4992,7 @@ msgstr "Lopeta jokaisen raidan jälkeen"
 msgid "Stop after every track"
 msgstr "Pysäytä jokaisen raidan jälkeen"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Pysäytä toistettavan kappaleen jälkeen"
 
@@ -5160,7 +5160,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Subsonic-palvelimen kokeiluaika on ohi. Lahjoita saadaksesi lisenssiavaimen. Lisätietoja osoitteessa subsonic.org."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5202,7 +5202,7 @@ msgid ""
 "continue?"
 msgstr "Nämä tiedostot poistetaan laitteelta, haluatko varmasti jatkaa?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5304,7 +5304,7 @@ msgstr "Kuvaruutunäyttö päälle / pois"
 msgid "Toggle fullscreen"
 msgstr "Koko näytön tila"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Vaihda jonon tila"
 
@@ -5442,11 +5442,11 @@ msgstr "Tuntematon virhe"
 msgid "Unset cover"
 msgstr "Poista kansikuva"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Valittujen kappaleiden ohitus"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Raidan ohittaminen"
 
@@ -5783,7 +5783,7 @@ msgid ""
 "well?"
 msgstr "Haluatko siirtä albumin muut kappaleet luokkaan \"Useita esittäjiä\"?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Haluatko suorittaa kirjaston läpikäynnin nyt?"
 

--- a/src/translations/fr.po
+++ b/src/translations/fr.po
@@ -556,7 +556,7 @@ msgstr "Ajouter un autre flux..."
 msgid "Add directory..."
 msgstr "Ajouter un dossier..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Ajouter un fichier"
 
@@ -576,7 +576,7 @@ msgstr "Ajouter un fichier..."
 msgid "Add files to transcode"
 msgstr "Ajouter des fichiers à transcoder"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Ajouter un dossier"
@@ -681,7 +681,7 @@ msgstr "Ajouter aux listes de lecture Spotify"
 msgid "Add to Spotify starred"
 msgstr "Ajouter aux préférés de Spotify"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Ajouter à une autre liste de lecture"
 
@@ -903,7 +903,7 @@ msgstr "Êtes-vous sûr de vouloir enregistrer les statistiques du morceau dans 
 msgid "Artist"
 msgstr "Artiste"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Info artiste"
 
@@ -1166,7 +1166,7 @@ msgstr "Chercher de nouveaux épisodes"
 msgid "Check for updates"
 msgstr "Vérifier les mises à jour"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Vérifier les mises à jour"
 
@@ -1406,7 +1406,7 @@ msgstr "Configurer Subsonic..."
 msgid "Configure global search..."
 msgstr "Configurer la recherche globale..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Configurer votre bibliothèque..."
 
@@ -1478,11 +1478,11 @@ msgid "Copy to clipboard"
 msgstr "Copier dans le presse papier"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Copier sur le périphérique"
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Copier vers la bibliothèque..."
@@ -1700,7 +1700,7 @@ msgid "Delete downloaded data"
 msgstr "Effacer les données téléchargées"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Supprimer les fichiers"
 
@@ -1708,7 +1708,7 @@ msgstr "Supprimer les fichiers"
 msgid "Delete from device..."
 msgstr "Supprimer du périphérique..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Supprimer du disque..."
@@ -1741,11 +1741,11 @@ msgstr "Suppression des fichiers"
 msgid "Depth"
 msgstr "Profondeur"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Enlever les pistes sélectionnées de la file d'attente"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Enlever cette piste de la file d'attente"
 
@@ -1774,7 +1774,7 @@ msgstr "Nom du périphérique"
 msgid "Device properties..."
 msgstr "Propriétés du périphérique..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Périphériques"
 
@@ -2025,7 +2025,7 @@ msgstr "Mix aléatoire dynamique"
 msgid "Edit smart playlist..."
 msgstr "Éditer la liste de lecture intelligente..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Modifier le tag « %1 »..."
@@ -2164,8 +2164,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Equivalent à --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Erreur"
 
@@ -2311,7 +2311,7 @@ msgstr "Fondu"
 msgid "Fading duration"
 msgstr "Durée du fondu"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Échec lors de la lecture du CD"
 
@@ -2434,7 +2434,7 @@ msgstr "Type de fichier"
 msgid "Filename"
 msgstr "Nom du fichier"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Fichiers"
 
@@ -2849,7 +2849,7 @@ msgstr "Installé"
 msgid "Integrity check"
 msgstr "Vérification de l'intégrité"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -3037,7 +3037,7 @@ msgstr "Gauche"
 msgid "Length"
 msgstr "Durée"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Bibliothèque"
@@ -3046,7 +3046,7 @@ msgstr "Bibliothèque"
 msgid "Library advanced grouping"
 msgstr "Groupement avancé de la bibliothèque"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Avertissement de mise à jour de la bibliothèque"
 
@@ -3374,7 +3374,7 @@ msgstr "Points de montage"
 msgid "Move down"
 msgstr "Déplacer vers le bas"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Déplacer vers la bibliothèque..."
 
@@ -3383,7 +3383,7 @@ msgstr "Déplacer vers la bibliothèque..."
 msgid "Move up"
 msgstr "Déplacer vers le haut"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Musique"
 
@@ -3445,7 +3445,7 @@ msgstr "Ne jamais commencer à lire"
 msgid "New folder"
 msgstr "Nouveau dossier"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nouvelle liste de lecture"
 
@@ -3516,7 +3516,7 @@ msgstr "Pas de bloc court"
 msgid "None"
 msgstr "Aucun"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Aucun des morceaux sélectionnés n'était valide pour la copie vers un périphérique"
 
@@ -3731,7 +3731,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organiser les fichiers"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Organisation des fichiers..."
 
@@ -3815,7 +3815,7 @@ msgstr "Soirée"
 msgid "Password"
 msgstr "Mot de passe"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pause"
@@ -3851,8 +3851,8 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Barre latérale simple"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3875,11 +3875,11 @@ msgstr "Lire ou mettre en pause, selon l'état courant"
 msgid "Play if there is nothing already playing"
 msgstr "Lire s'il n'y a rien d'autre en cours de lecture"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Lire le suivant"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Lire les pistes sélectionnées ensuite"
 
@@ -3918,7 +3918,7 @@ msgstr "Options de la liste de lecture"
 msgid "Playlist type"
 msgstr "Type de liste de lecture"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Listes de lecture"
 
@@ -4100,12 +4100,12 @@ msgstr "Interrogation périphérique"
 msgid "Queue Manager"
 msgstr "Gestionnaire de file d'attente"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Mettre les pistes sélectionnées en liste d'attente"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Mettre cette piste en liste d'attente"
 
@@ -4496,7 +4496,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Recherche"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Recherche"
@@ -4521,7 +4521,7 @@ msgstr "Recherche Subsonic"
 msgid "Search automatically"
 msgstr "Rechercher automatiquement"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Rechercher l'album"
 
@@ -4534,7 +4534,7 @@ msgstr "Chercher des pochettes pour cet album..."
 msgid "Search for anything"
 msgstr "Recherche globale"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Rechercher l'artiste"
 
@@ -4659,7 +4659,7 @@ msgstr "Détails du serveur"
 msgid "Service offline"
 msgstr "Service hors-ligne"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Définir %1 à la valeur « %2 »..."
@@ -4739,7 +4739,7 @@ msgstr "Utiliser l'affichage à l'écran (OSD)"
 msgid "Show above status bar"
 msgstr "Afficher au dessus de la barre d'état"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Afficher tous les morceaux"
 
@@ -4759,12 +4759,12 @@ msgstr "Afficher les séparateurs"
 msgid "Show fullsize..."
 msgstr "Afficher en taille réelle..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Afficher dans le navigateur de fichiers"
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Afficher dans la bibliothèque..."
 
@@ -4776,11 +4776,11 @@ msgstr "Classer dans la catégorie « Compilations d'artistes »"
 msgid "Show moodbar"
 msgstr "Afficher la barre d'humeur"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Afficher uniquement les doublons"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Afficher uniquement les morceaux sans tag"
 
@@ -4872,7 +4872,7 @@ msgstr "Compteur de morceaux sautés"
 msgid "Skip forwards in playlist"
 msgstr "Lire la piste suivante"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Passer les pistes sélectionnées"
 
@@ -4880,7 +4880,7 @@ msgstr "Passer les pistes sélectionnées"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Passer la piste"
 
@@ -4912,7 +4912,7 @@ msgstr "Soft Rock"
 msgid "Song Information"
 msgstr "Informations sur le morceau"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Info morceau"
 
@@ -5033,7 +5033,7 @@ msgstr "Arrêter après chaque piste"
 msgid "Stop after every track"
 msgstr "Arrêter après chaque piste"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Arrêter la lecture après cette piste"
 
@@ -5201,7 +5201,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "La période d'essai pour le serveur Subsonic est terminée. Merci de faire un don pour avoir un clef de licence. Visitez subsonic.org pour plus d'informations."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5243,7 +5243,7 @@ msgid ""
 "continue?"
 msgstr "Ces fichiers vont être supprimés du périphérique, êtes-vous sûr de vouloir continuer ?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5345,7 +5345,7 @@ msgstr "Basculer l'affichage de l'OSD"
 msgid "Toggle fullscreen"
 msgstr "Basculer en mode plein écran"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Basculer l'état de la file d'attente"
 
@@ -5483,11 +5483,11 @@ msgstr "Erreur de type inconnu"
 msgid "Unset cover"
 msgstr "Enlever cette pochette"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Ne pas passer les pistes sélectionnées"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Ne pas passer la piste"
 
@@ -5824,7 +5824,7 @@ msgid ""
 "well?"
 msgstr "Voulez-vous aussi déplacer les autres morceaux de cet album dans la catégorie « Compilations d'artistes » ?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Voulez-vous effectuer une analyse complète de la bibliothèque maintenant ?"
 

--- a/src/translations/fr.po
+++ b/src/translations/fr.po
@@ -54,7 +54,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: French (http://www.transifex.com/davidsansome/clementine/language/fr/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -208,19 +208,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n échoué"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n terminé"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -238,7 +238,7 @@ msgstr "&Centrer"
 msgid "&Custom"
 msgstr "&Personnaliser"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Extras"
 
@@ -246,7 +246,7 @@ msgstr "&Extras"
 msgid "&Grouping"
 msgstr "&Regroupement"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Aide"
 
@@ -271,7 +271,7 @@ msgstr "&Verrouiller la note"
 msgid "&Lyrics"
 msgstr "&Paroles"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Musique"
 
@@ -279,15 +279,15 @@ msgstr "&Musique"
 msgid "&None"
 msgstr "Aucu&n"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&Liste de lecture"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Quitter"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "Mode répétition"
 
@@ -295,7 +295,7 @@ msgstr "Mode répétition"
 msgid "&Right"
 msgstr "&Droite"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Mode aléatoire"
 
@@ -303,7 +303,7 @@ msgstr "Mode aléatoire"
 msgid "&Stretch columns to fit window"
 msgstr "Étirer les &colonnes pour s'adapter à la fenêtre"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Outils"
 
@@ -492,11 +492,11 @@ msgstr "Abandonner"
 msgid "About %1"
 msgstr "À propos de %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "À propos de Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "À propos de Qt..."
 
@@ -556,32 +556,32 @@ msgstr "Ajouter un autre flux..."
 msgid "Add directory..."
 msgstr "Ajouter un dossier..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Ajouter un fichier"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Ajouter un fichier à transcoder"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Ajouter des fichiers à transcoder"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Ajouter un fichier..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Ajouter des fichiers à transcoder"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Ajouter un dossier"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Ajouter un dossier..."
 
@@ -593,7 +593,7 @@ msgstr "Ajouter un nouveau dossier..."
 msgid "Add podcast"
 msgstr "Ajouter un podcast"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Ajouter un podcast..."
 
@@ -669,7 +669,7 @@ msgstr "Ajouter le tag piste du morceau"
 msgid "Add song year tag"
 msgstr "Ajouter le tag année du morceau"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Ajouter un flux..."
 
@@ -681,7 +681,7 @@ msgstr "Ajouter aux listes de lecture Spotify"
 msgid "Add to Spotify starred"
 msgstr "Ajouter aux préférés de Spotify"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Ajouter à une autre liste de lecture"
 
@@ -775,7 +775,7 @@ msgstr "Tout"
 msgid "All Files (*)"
 msgstr "Tous les fichiers (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Gloire au crapaud hypnotique!"
@@ -1166,7 +1166,7 @@ msgstr "Chercher de nouveaux épisodes"
 msgid "Check for updates"
 msgstr "Vérifier les mises à jour"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Vérifier les mises à jour"
 
@@ -1215,18 +1215,18 @@ msgstr "Classique"
 msgid "Cleaning up"
 msgstr "Nettoyage en cours"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Effacer"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Vider la liste de lecture"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1371,7 +1371,7 @@ msgstr "Commentaire"
 msgid "Complete tags automatically"
 msgstr "Compléter les tags automatiquement"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Compléter les tags automatiquement..."
 
@@ -1406,7 +1406,7 @@ msgstr "Configurer Subsonic..."
 msgid "Configure global search..."
 msgstr "Configurer la recherche globale..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Configurer votre bibliothèque..."
 
@@ -1449,7 +1449,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Connexion expirée. Vérifiez l'URL du serveur. Exemple : http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Console"
 
@@ -1478,11 +1478,11 @@ msgid "Copy to clipboard"
 msgstr "Copier dans le presse papier"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Copier sur le périphérique"
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Copier vers la bibliothèque..."
@@ -1525,14 +1525,14 @@ msgstr "Impossible de se connecter à Last.fm. Veuillez réessayer."
 msgid "Couldn't create playlist"
 msgstr "La liste de lecture n'a pas pu être créée"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Impossible de trouver un multiplexeur pour %1, vérifiez que les bons modules externes GStreamer sont installés."
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1547,7 +1547,7 @@ msgstr "Impossible d'ouvrir le fichier de sortie %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Gestionnaire de pochettes"
 
@@ -1700,7 +1700,7 @@ msgid "Delete downloaded data"
 msgstr "Effacer les données téléchargées"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Supprimer les fichiers"
 
@@ -1708,7 +1708,7 @@ msgstr "Supprimer les fichiers"
 msgid "Delete from device..."
 msgstr "Supprimer du périphérique..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Supprimer du disque..."
@@ -1741,11 +1741,11 @@ msgstr "Suppression des fichiers"
 msgid "Depth"
 msgstr "Profondeur"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Enlever les pistes sélectionnées de la file d'attente"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Enlever cette piste de la file d'attente"
 
@@ -1846,7 +1846,7 @@ msgstr "Options d'affichage"
 msgid "Display the on-screen-display"
 msgstr "Afficher le menu à l'écran"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Refaire une analyse complète de la bibliothèque"
 
@@ -2025,12 +2025,12 @@ msgstr "Mix aléatoire dynamique"
 msgid "Edit smart playlist..."
 msgstr "Éditer la liste de lecture intelligente..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Modifier le tag « %1 »..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Modifier le tag..."
 
@@ -2043,7 +2043,7 @@ msgid "Edit track information"
 msgstr "Modifier la description de la piste"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Modifier la description de la piste..."
 
@@ -2151,7 +2151,7 @@ msgstr "Collection complète"
 msgid "Episode information"
 msgstr "Informations sur l'épisode"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Égaliseur"
 
@@ -2164,8 +2164,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Equivalent à --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Erreur"
 
@@ -2200,7 +2200,7 @@ msgstr "Erreur lors du chargement de %1"
 msgid "Error loading di.fm playlist"
 msgstr "Erreur du chargement de la liste de lecture di.fm"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Erreur lors du traitement de %1 : %2"
@@ -2283,7 +2283,11 @@ msgstr "Export terminé"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "%1 pochettes exportées sur %2 (%3 ignorées)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2307,7 +2311,7 @@ msgstr "Fondu"
 msgid "Fading duration"
 msgstr "Durée du fondu"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Échec lors de la lecture du CD"
 
@@ -2589,11 +2593,11 @@ msgstr "Donner un nom"
 msgid "Go"
 msgstr "Go"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Aller à la liste de lecture suivante"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Aller à la liste de lecture précédente"
 
@@ -2926,7 +2930,7 @@ msgstr "Base de données Jamendo"
 msgid "Jump to previous song right away"
 msgstr "Aller tout de suite à la piste précédente"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Aller à la piste jouée actuellement"
 
@@ -2950,7 +2954,7 @@ msgstr "Laisser tourner en arrière plan lorsque la fenêtre est fermée"
 msgid "Keep the original files"
 msgstr "Conserver les fichiers originaux"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Chatons"
@@ -3042,7 +3046,7 @@ msgstr "Bibliothèque"
 msgid "Library advanced grouping"
 msgstr "Groupement avancé de la bibliothèque"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Avertissement de mise à jour de la bibliothèque"
 
@@ -3082,7 +3086,7 @@ msgstr "Charger la pochette depuis le disque..."
 msgid "Load playlist"
 msgstr "Charger une liste de lecture"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Charger une liste de lecture..."
 
@@ -3143,11 +3147,15 @@ msgstr "Se connecter"
 msgid "Login failed"
 msgstr "Erreur lors de la connexion"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Profil de prédiction à long terme (PLT)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "J'aime"
 
@@ -3182,11 +3190,11 @@ msgstr "Paroles récupérées depuis %1"
 msgid "Lyrics from the tag"
 msgstr "Paroles récupérées depuis le tag"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3228,7 +3236,7 @@ msgstr "Profil principal (MAIN)"
 msgid "Make it so!"
 msgstr "Voilà!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Ainsi soit-il!"
@@ -3366,7 +3374,7 @@ msgstr "Points de montage"
 msgid "Move down"
 msgstr "Déplacer vers le bas"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Déplacer vers la bibliothèque..."
 
@@ -3375,7 +3383,7 @@ msgstr "Déplacer vers la bibliothèque..."
 msgid "Move up"
 msgstr "Déplacer vers le haut"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Musique"
 
@@ -3388,7 +3396,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Sourdine"
 
@@ -3437,7 +3445,7 @@ msgstr "Ne jamais commencer à lire"
 msgid "New folder"
 msgstr "Nouveau dossier"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nouvelle liste de lecture"
 
@@ -3465,8 +3473,12 @@ msgstr "Nouvelles pistes"
 msgid "Next"
 msgstr "Suivant"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Piste suivante"
 
@@ -3504,7 +3516,7 @@ msgstr "Pas de bloc court"
 msgid "None"
 msgstr "Aucun"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Aucun des morceaux sélectionnés n'était valide pour la copie vers un périphérique"
 
@@ -3589,19 +3601,19 @@ msgstr "Désactivé"
 msgid "Ogg FLAC"
 msgstr "FLAC ogg"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3645,7 +3657,7 @@ msgstr "Opacité"
 msgid "Open %1 in browser"
 msgstr "Ouvrir %1 dans le navigateur"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Lire un CD &audio"
 
@@ -3657,7 +3669,7 @@ msgstr "Ouvrir un fichier OPML"
 msgid "Open OPML file..."
 msgstr "Ouvrir un fichier OPML..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Ouvrir un répertoire pour en importer la musique"
 
@@ -3665,7 +3677,7 @@ msgstr "Ouvrir un répertoire pour en importer la musique"
 msgid "Open device"
 msgstr "Ouvrir le périphérique"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Ouvrir un fichier..."
 
@@ -3719,7 +3731,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organiser les fichiers"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Organisation des fichiers..."
 
@@ -3803,7 +3815,7 @@ msgstr "Soirée"
 msgid "Password"
 msgstr "Mot de passe"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pause"
@@ -3827,6 +3839,10 @@ msgstr "Interprète"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Pixel"
@@ -3835,10 +3851,10 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Barre latérale simple"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Lecture"
 
@@ -3859,11 +3875,11 @@ msgstr "Lire ou mettre en pause, selon l'état courant"
 msgid "Play if there is nothing already playing"
 msgstr "Lire s'il n'y a rien d'autre en cours de lecture"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Lire le suivant"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Lire les pistes sélectionnées ensuite"
 
@@ -3962,7 +3978,7 @@ msgstr "Préférences"
 msgid "Preferences"
 msgstr "Préférences"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Préférences..."
 
@@ -4022,7 +4038,7 @@ msgid "Previous"
 msgstr "Précédent"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Piste précédente"
 
@@ -4080,16 +4096,16 @@ msgstr "Qualité"
 msgid "Querying device..."
 msgstr "Interrogation périphérique"
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Gestionnaire de file d'attente"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Mettre les pistes sélectionnées en liste d'attente"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Mettre cette piste en liste d'attente"
 
@@ -4105,7 +4121,7 @@ msgstr "Radio (volume égalisé pour toutes les pistes)"
 msgid "Rain"
 msgstr "Pluie"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Pluie"
@@ -4217,7 +4233,7 @@ msgstr "Effacer l'action"
 msgid "Remove current song from playlist"
 msgstr "Retirer le morceau actuel de la liste de lecture"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Supprimer les doublons de la liste de lecture"
 
@@ -4225,7 +4241,7 @@ msgstr "Supprimer les doublons de la liste de lecture"
 msgid "Remove folder"
 msgstr "Supprimer un dossier"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Supprimer de la liste de lecture"
 
@@ -4237,7 +4253,7 @@ msgstr "Supprimer la liste de lecture"
 msgid "Remove playlists"
 msgstr "Supprimer les listes de lecture"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Supprimer les pistes indisponibles dans la liste de lecture"
 
@@ -4249,7 +4265,7 @@ msgstr "Renommer la liste de lecture"
 msgid "Rename playlist..."
 msgstr "Renommer la liste de lecture..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Renuméroter les pistes dans cet ordre..."
 
@@ -4340,7 +4356,7 @@ msgstr "Extraire"
 msgid "Rip CD"
 msgstr "Extraire le CD"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Extraire le CD audio"
 
@@ -4418,7 +4434,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Sauvegarder la liste de lecture"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Enregistrer la liste de lecture..."
 
@@ -4505,7 +4521,7 @@ msgstr "Recherche Subsonic"
 msgid "Search automatically"
 msgstr "Rechercher automatiquement"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Rechercher l'album"
 
@@ -4518,7 +4534,7 @@ msgstr "Chercher des pochettes pour cet album..."
 msgid "Search for anything"
 msgstr "Recherche globale"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Rechercher l'artiste"
 
@@ -4643,7 +4659,7 @@ msgstr "Détails du serveur"
 msgid "Service offline"
 msgstr "Service hors-ligne"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Définir %1 à la valeur « %2 »..."
@@ -4652,7 +4668,7 @@ msgstr "Définir %1 à la valeur « %2 »..."
 msgid "Set the volume to <value> percent"
 msgstr "Définir le volume à <value> pourcents"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Définir une valeur pour toutes les pistes sélectionnées..."
 
@@ -4723,7 +4739,7 @@ msgstr "Utiliser l'affichage à l'écran (OSD)"
 msgid "Show above status bar"
 msgstr "Afficher au dessus de la barre d'état"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Afficher tous les morceaux"
 
@@ -4743,12 +4759,12 @@ msgstr "Afficher les séparateurs"
 msgid "Show fullsize..."
 msgstr "Afficher en taille réelle..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Afficher dans le navigateur de fichiers"
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Afficher dans la bibliothèque..."
 
@@ -4760,15 +4776,15 @@ msgstr "Classer dans la catégorie « Compilations d'artistes »"
 msgid "Show moodbar"
 msgstr "Afficher la barre d'humeur"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Afficher uniquement les doublons"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Afficher uniquement les morceaux sans tag"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Afficher ou masquer la barre latérale"
 
@@ -4776,7 +4792,7 @@ msgstr "Afficher ou masquer la barre latérale"
 msgid "Show search suggestions"
 msgstr "Afficher les suggestions de recherche"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Afficher la barre latérale"
 
@@ -4812,7 +4828,7 @@ msgstr "Aléatoire : albums"
 msgid "Shuffle all"
 msgstr "Aléatoire : tout"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Mélanger la liste de lecture"
 
@@ -4856,11 +4872,15 @@ msgstr "Compteur de morceaux sautés"
 msgid "Skip forwards in playlist"
 msgstr "Lire la piste suivante"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Passer les pistes sélectionnées"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Passer la piste"
 
@@ -4977,7 +4997,7 @@ msgstr "Démarrer l'extraction"
 msgid "Start the playlist currently playing"
 msgstr "Commencer la liste de lecture jouée actuellement"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Démarrer transcodage"
 
@@ -4987,7 +5007,7 @@ msgid ""
 "list"
 msgstr "Commencer à écrire dans le champ de recherche ci-dessus pour remplir cette liste de résultats"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Lancement de %1"
@@ -4997,7 +5017,7 @@ msgid "Starting..."
 msgstr "Démarrage..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Stop"
 
@@ -5013,7 +5033,7 @@ msgstr "Arrêter après chaque piste"
 msgid "Stop after every track"
 msgstr "Arrêter après chaque piste"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Arrêter la lecture après cette piste"
 
@@ -5181,7 +5201,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "La période d'essai pour le serveur Subsonic est terminée. Merci de faire un don pour avoir un clef de licence. Visitez subsonic.org pour plus d'informations."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5223,7 +5243,7 @@ msgid ""
 "continue?"
 msgstr "Ces fichiers vont être supprimés du périphérique, êtes-vous sûr de vouloir continuer ?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5325,11 +5345,11 @@ msgstr "Basculer l'affichage de l'OSD"
 msgid "Toggle fullscreen"
 msgstr "Basculer en mode plein écran"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Basculer l'état de la file d'attente"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Basculer le scrobbling"
 
@@ -5374,19 +5394,19 @@ msgstr "Titr&e"
 msgid "Track"
 msgstr "Piste"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Transcoder de la musique"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Journal du transcodeur"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Transcodage"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Transcodage de %1 fichiers en utilisant %2 threads"
@@ -5463,11 +5483,11 @@ msgstr "Erreur de type inconnu"
 msgid "Unset cover"
 msgstr "Enlever cette pochette"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Ne pas passer les pistes sélectionnées"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Ne pas passer la piste"
 
@@ -5484,7 +5504,7 @@ msgstr "Concerts à venir"
 msgid "Update all podcasts"
 msgstr "Mettre à jour tous les podcasts"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Mettre à jour les dossiers de la bibliothèque"
 
@@ -5645,7 +5665,7 @@ msgstr "Version %1"
 msgid "View"
 msgstr "Vue"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Afficher détails du flux"
 
@@ -5653,7 +5673,7 @@ msgstr "Afficher détails du flux"
 msgid "Visualization mode"
 msgstr "Mode de visualisation"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Visualisations"
 
@@ -5694,7 +5714,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5790,7 +5810,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "audio Windows Media"
 
@@ -5804,7 +5824,7 @@ msgid ""
 "well?"
 msgstr "Voulez-vous aussi déplacer les autres morceaux de cet album dans la catégorie « Compilations d'artistes » ?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Voulez-vous effectuer une analyse complète de la bibliothèque maintenant ?"
 

--- a/src/translations/ga.po
+++ b/src/translations/ga.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Irish (http://www.transifex.com/davidsansome/clementine/language/ga/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -162,19 +162,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%comhadainm%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n teipthe"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n críochnaithe"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -192,7 +192,7 @@ msgstr "&Lár"
 msgid "&Custom"
 msgstr "&Saincheaptha"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Breiseáin"
 
@@ -200,7 +200,7 @@ msgstr "&Breiseáin"
 msgid "&Grouping"
 msgstr "&Grúpáil"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Cabhair"
 
@@ -225,7 +225,7 @@ msgstr "&Rátáil Glasáil"
 msgid "&Lyrics"
 msgstr "&Liricí"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Ceol"
 
@@ -233,15 +233,15 @@ msgstr "&Ceol"
 msgid "&None"
 msgstr "&Dada"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Scoir"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr ""
 
@@ -249,7 +249,7 @@ msgstr ""
 msgid "&Right"
 msgstr "&Deas"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr ""
 
@@ -257,7 +257,7 @@ msgstr ""
 msgid "&Stretch columns to fit window"
 msgstr "&Sín colúin chun an fhuinneog a líonadh"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Uirlisí"
 
@@ -446,11 +446,11 @@ msgstr ""
 msgid "About %1"
 msgstr "Maidir le %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Maidir le Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Maidir le Qt..."
 
@@ -510,32 +510,32 @@ msgstr "Cuir sruth eile leis..."
 msgid "Add directory..."
 msgstr "Cuir comhadlann leis..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Cuir comhad leis"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Cuir comhad leis..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Cuir fillteán leis"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Cuir fillteán leis..."
 
@@ -547,7 +547,7 @@ msgstr "Cuir fillteán nua leis..."
 msgid "Add podcast"
 msgstr "Cuir podchraoladh leis"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Cuir podchraoladh leis..."
 
@@ -623,7 +623,7 @@ msgstr ""
 msgid "Add song year tag"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Cuir sruth leis..."
 
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr ""
 
@@ -729,7 +729,7 @@ msgstr ""
 msgid "All Files (*)"
 msgstr "Gach Comhad (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr ""
@@ -1120,7 +1120,7 @@ msgstr "Lorg cláir nua"
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Lorg nuashonruithe..."
 
@@ -1169,18 +1169,18 @@ msgstr ""
 msgid "Cleaning up"
 msgstr "Ag glanadh"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Glan"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr ""
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1325,7 +1325,7 @@ msgstr "Trácht"
 msgid "Complete tags automatically"
 msgstr "Críochnaigh clibeanna go huathoibríoch"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Críochnaigh clibeanna go huathoibríoch"
 
@@ -1360,7 +1360,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Cumraigh leabharlann..."
 
@@ -1403,7 +1403,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr ""
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr ""
 
@@ -1432,11 +1432,11 @@ msgid "Copy to clipboard"
 msgstr "Macasamhlaigh go dtí an ngearrthaisce"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Macasamhlaigh go gléas..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Macasamhlaigh go leabharlann..."
@@ -1479,14 +1479,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr ""
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1501,7 +1501,7 @@ msgstr ""
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr ""
 
@@ -1654,7 +1654,7 @@ msgid "Delete downloaded data"
 msgstr "Scrios sonraí íosluchtaithe"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Scrios comhaid"
 
@@ -1662,7 +1662,7 @@ msgstr "Scrios comhaid"
 msgid "Delete from device..."
 msgstr "Scrios ón ngléas..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Scrios ón ndiosca..."
@@ -1695,11 +1695,11 @@ msgstr "Ag scriosadh comhaid"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Bain an rian as an scuaine"
 
@@ -1800,7 +1800,7 @@ msgstr "Roghanna taispeána"
 msgid "Display the on-screen-display"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr ""
 
@@ -1979,12 +1979,12 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Cuir clib in eagar..."
 
@@ -1997,7 +1997,7 @@ msgid "Edit track information"
 msgstr ""
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr ""
 
@@ -2105,7 +2105,7 @@ msgstr "An cnuasach ar fad"
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Cothromóir"
 
@@ -2118,8 +2118,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Botún"
 
@@ -2154,7 +2154,7 @@ msgstr ""
 msgid "Error loading di.fm playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr ""
@@ -2237,7 +2237,11 @@ msgstr ""
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr ""
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2261,7 +2265,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2543,11 +2547,11 @@ msgstr "Tabhair ainm dó:"
 msgid "Go"
 msgstr "Téigh"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr ""
 
@@ -2880,7 +2884,7 @@ msgstr "Bunachar sonraí Jamendo"
 msgid "Jump to previous song right away"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Léim chuig an rian atá á seinm faoi láthair"
 
@@ -2904,7 +2908,7 @@ msgstr ""
 msgid "Keep the original files"
 msgstr "Coinnigh na comhaid bhunaidh"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr ""
@@ -2996,7 +3000,7 @@ msgstr "Leabharlann"
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3036,7 +3040,7 @@ msgstr ""
 msgid "Load playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr ""
 
@@ -3097,11 +3101,15 @@ msgstr "Síniú isteach"
 msgid "Login failed"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Grá"
 
@@ -3136,11 +3144,11 @@ msgstr "Liricí ó %1"
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr ""
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3182,7 +3190,7 @@ msgstr ""
 msgid "Make it so!"
 msgstr "Bíodh sé mar sin!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr ""
@@ -3320,7 +3328,7 @@ msgstr ""
 msgid "Move down"
 msgstr "Bog síos"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Bog go dtí an leabharlann..."
 
@@ -3329,7 +3337,7 @@ msgstr "Bog go dtí an leabharlann..."
 msgid "Move up"
 msgstr "Bog suas"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Ceol"
 
@@ -3342,7 +3350,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Balbhaigh"
 
@@ -3391,7 +3399,7 @@ msgstr "Ná tosaigh ag seinm riamh"
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3419,8 +3427,12 @@ msgstr "Na rianta is nuaí"
 msgid "Next"
 msgstr "Ar aghaidh"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Rian ar aghaidh"
 
@@ -3458,7 +3470,7 @@ msgstr ""
 msgid "None"
 msgstr "Dada"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3543,19 +3555,19 @@ msgstr ""
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr ""
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3599,7 +3611,7 @@ msgstr ""
 msgid "Open %1 in browser"
 msgstr "Oscail %1 i líonléitheoir"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr ""
 
@@ -3611,7 +3623,7 @@ msgstr ""
 msgid "Open OPML file..."
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr ""
 
@@ -3619,7 +3631,7 @@ msgstr ""
 msgid "Open device"
 msgstr "Oscail gléas"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Oscail comhad..."
 
@@ -3673,7 +3685,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr "Eagraigh comhaid"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Eagraigh comhaid..."
 
@@ -3757,7 +3769,7 @@ msgstr "Cóisir"
 msgid "Password"
 msgstr "Focal faire"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Cuir ar sos"
@@ -3781,6 +3793,10 @@ msgstr ""
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr ""
@@ -3789,10 +3805,10 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Seinn"
 
@@ -3813,11 +3829,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr "Seinn mura bhfuil aon rud eile ag seinm cheana féin"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3916,7 +3932,7 @@ msgstr ""
 msgid "Preferences"
 msgstr "Sainroghanna"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Sainroghanna..."
 
@@ -3976,7 +3992,7 @@ msgid "Previous"
 msgstr "Roimhe"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "An rian roimhe"
 
@@ -4034,16 +4050,16 @@ msgstr ""
 msgid "Querying device..."
 msgstr ""
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Bainisteoir na Scuaine"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Cuir na rianta roghnaithe i scuaine"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Cuir an rian i scuaine"
 
@@ -4059,7 +4075,7 @@ msgstr ""
 msgid "Rain"
 msgstr "Báisteach"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr ""
@@ -4171,7 +4187,7 @@ msgstr "Bain gníomh"
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr ""
 
@@ -4179,7 +4195,7 @@ msgstr ""
 msgid "Remove folder"
 msgstr "Bain fillteán"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr ""
 
@@ -4191,7 +4207,7 @@ msgstr ""
 msgid "Remove playlists"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr ""
 
@@ -4203,7 +4219,7 @@ msgstr ""
 msgid "Rename playlist..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr ""
 
@@ -4294,7 +4310,7 @@ msgstr ""
 msgid "Rip CD"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr ""
 
@@ -4372,7 +4388,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr ""
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr ""
 
@@ -4459,7 +4475,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4472,7 +4488,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr "Cuardaigh i gcomhair aon rud"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4597,7 +4613,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Socraigh %1 go \"%2\"..."
@@ -4606,7 +4622,7 @@ msgstr "Socraigh %1 go \"%2\"..."
 msgid "Set the volume to <value> percent"
 msgstr "Socraigh an airde chuig <value> faoin gcéad"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Socraigh luach do gach rian roghnaithe..."
 
@@ -4677,7 +4693,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Taispeáin gach amhrán"
 
@@ -4697,12 +4713,12 @@ msgstr "Taispeáin roinnteoirí"
 msgid "Show fullsize..."
 msgstr "Taispeáin lánmhéid..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Taispeáin i siortaitheoir na gcomhad..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr ""
 
@@ -4714,15 +4730,15 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Taispeáin na cinn nach bhfuil clib orthu amháin"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4730,7 +4746,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4766,7 +4782,7 @@ msgstr "Seinn na halbaim go fánach"
 msgid "Shuffle all"
 msgstr "Seinn uile go fánach"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr ""
 
@@ -4810,11 +4826,15 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr ""
 
@@ -4931,7 +4951,7 @@ msgstr ""
 msgid "Start the playlist currently playing"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr ""
 
@@ -4941,7 +4961,7 @@ msgid ""
 "list"
 msgstr ""
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Ag tosú %1"
@@ -4951,7 +4971,7 @@ msgid "Starting..."
 msgstr "Ag tosú..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Stad"
 
@@ -4967,7 +4987,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Stad i ndiaidh an rian seo"
 
@@ -5135,7 +5155,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5177,7 +5197,7 @@ msgid ""
 "continue?"
 msgstr "Scriosfar na comhaid seo ón ngléas, an bhfuil tú cinnte gur mian leat leanúint ar aghaidh?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5279,11 +5299,11 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr "Scoránaigh lánscáileán"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr ""
 
@@ -5328,19 +5348,19 @@ msgstr ""
 msgid "Track"
 msgstr "Rian"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr ""
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
 msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr ""
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr ""
@@ -5417,11 +5437,11 @@ msgstr "Botún anaithnid"
 msgid "Unset cover"
 msgstr "Díshocraigh an clúdach"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr ""
 
@@ -5438,7 +5458,7 @@ msgstr ""
 msgid "Update all podcasts"
 msgstr "Nuashonraigh gach podchraoladh"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr ""
 
@@ -5599,7 +5619,7 @@ msgstr "Leagan %1"
 msgid "View"
 msgstr "Amharc"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5607,7 +5627,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr ""
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Amharcléirithe"
 
@@ -5648,7 +5668,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5744,7 +5764,7 @@ msgstr ""
 msgid "Windows Media 64k"
 msgstr ""
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Fuaim Windows Media"
 
@@ -5758,7 +5778,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/ga.po
+++ b/src/translations/ga.po
@@ -510,7 +510,7 @@ msgstr "Cuir sruth eile leis..."
 msgid "Add directory..."
 msgstr "Cuir comhadlann leis..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Cuir comhad leis"
 
@@ -530,7 +530,7 @@ msgstr "Cuir comhad leis..."
 msgid "Add files to transcode"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Cuir fillteán leis"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr ""
 
@@ -857,7 +857,7 @@ msgstr ""
 msgid "Artist"
 msgstr "Ealaíontóir"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr ""
 
@@ -1120,7 +1120,7 @@ msgstr "Lorg cláir nua"
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Lorg nuashonruithe..."
 
@@ -1360,7 +1360,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Cumraigh leabharlann..."
 
@@ -1432,11 +1432,11 @@ msgid "Copy to clipboard"
 msgstr "Macasamhlaigh go dtí an ngearrthaisce"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Macasamhlaigh go gléas..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Macasamhlaigh go leabharlann..."
@@ -1654,7 +1654,7 @@ msgid "Delete downloaded data"
 msgstr "Scrios sonraí íosluchtaithe"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Scrios comhaid"
 
@@ -1662,7 +1662,7 @@ msgstr "Scrios comhaid"
 msgid "Delete from device..."
 msgstr "Scrios ón ngléas..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Scrios ón ndiosca..."
@@ -1695,11 +1695,11 @@ msgstr "Ag scriosadh comhaid"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Bain an rian as an scuaine"
 
@@ -1728,7 +1728,7 @@ msgstr "Ainm an ghléis"
 msgid "Device properties..."
 msgstr "Airíonna an ghléis..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Gléasanna"
 
@@ -1979,7 +1979,7 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
@@ -2118,8 +2118,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Botún"
 
@@ -2265,7 +2265,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2388,7 +2388,7 @@ msgstr "Cineál comhad"
 msgid "Filename"
 msgstr "Comhadainm"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Comhaid"
 
@@ -2803,7 +2803,7 @@ msgstr "Suiteáilte"
 msgid "Integrity check"
 msgstr "Dearbháil sláine"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Idirlíon"
 
@@ -2991,7 +2991,7 @@ msgstr ""
 msgid "Length"
 msgstr "Aga"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Leabharlann"
@@ -3000,7 +3000,7 @@ msgstr "Leabharlann"
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3328,7 +3328,7 @@ msgstr ""
 msgid "Move down"
 msgstr "Bog síos"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Bog go dtí an leabharlann..."
 
@@ -3337,7 +3337,7 @@ msgstr "Bog go dtí an leabharlann..."
 msgid "Move up"
 msgstr "Bog suas"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Ceol"
 
@@ -3399,7 +3399,7 @@ msgstr "Ná tosaigh ag seinm riamh"
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3470,7 +3470,7 @@ msgstr ""
 msgid "None"
 msgstr "Dada"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3685,7 +3685,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr "Eagraigh comhaid"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Eagraigh comhaid..."
 
@@ -3769,7 +3769,7 @@ msgstr "Cóisir"
 msgid "Password"
 msgstr "Focal faire"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Cuir ar sos"
@@ -3805,8 +3805,8 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3829,11 +3829,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr "Seinn mura bhfuil aon rud eile ag seinm cheana féin"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3872,7 +3872,7 @@ msgstr ""
 msgid "Playlist type"
 msgstr ""
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr ""
 
@@ -4054,12 +4054,12 @@ msgstr ""
 msgid "Queue Manager"
 msgstr "Bainisteoir na Scuaine"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Cuir na rianta roghnaithe i scuaine"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Cuir an rian i scuaine"
 
@@ -4450,7 +4450,7 @@ msgstr ""
 msgid "Search"
 msgstr "Cuardaigh"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr ""
@@ -4475,7 +4475,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4488,7 +4488,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr "Cuardaigh i gcomhair aon rud"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4613,7 +4613,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Socraigh %1 go \"%2\"..."
@@ -4693,7 +4693,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Taispeáin gach amhrán"
 
@@ -4713,12 +4713,12 @@ msgstr "Taispeáin roinnteoirí"
 msgid "Show fullsize..."
 msgstr "Taispeáin lánmhéid..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Taispeáin i siortaitheoir na gcomhad..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr ""
 
@@ -4730,11 +4730,11 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Taispeáin na cinn nach bhfuil clib orthu amháin"
 
@@ -4826,7 +4826,7 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr ""
 
@@ -4834,7 +4834,7 @@ msgstr ""
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr ""
 
@@ -4866,7 +4866,7 @@ msgstr "Rac bog"
 msgid "Song Information"
 msgstr "Faisnéis an amhráin"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Faisnéis an amhráin"
 
@@ -4987,7 +4987,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Stad i ndiaidh an rian seo"
 
@@ -5155,7 +5155,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5197,7 +5197,7 @@ msgid ""
 "continue?"
 msgstr "Scriosfar na comhaid seo ón ngléas, an bhfuil tú cinnte gur mian leat leanúint ar aghaidh?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5299,7 +5299,7 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr "Scoránaigh lánscáileán"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr ""
 
@@ -5437,11 +5437,11 @@ msgstr "Botún anaithnid"
 msgid "Unset cover"
 msgstr "Díshocraigh an clúdach"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr ""
 
@@ -5778,7 +5778,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/gl.po
+++ b/src/translations/gl.po
@@ -12,7 +12,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Galician (http://www.transifex.com/davidsansome/clementine/language/gl/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -166,19 +166,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n fallou"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n completado(s)"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -196,7 +196,7 @@ msgstr "&Centrar"
 msgid "&Custom"
 msgstr "&Personalizado"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Complementos"
 
@@ -204,7 +204,7 @@ msgstr "&Complementos"
 msgid "&Grouping"
 msgstr "&Agrupar"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Axuda"
 
@@ -229,7 +229,7 @@ msgstr "&Bloquear puntuación"
 msgid "&Lyrics"
 msgstr "&Letras"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Música"
 
@@ -237,15 +237,15 @@ msgstr "&Música"
 msgid "&None"
 msgstr "&Ningunha"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&Lista de reprodución"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Saír"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "&Modo de repetición"
 
@@ -253,7 +253,7 @@ msgstr "&Modo de repetición"
 msgid "&Right"
 msgstr "&Direita"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "&Modo aleatorio"
 
@@ -261,7 +261,7 @@ msgstr "&Modo aleatorio"
 msgid "&Stretch columns to fit window"
 msgstr "&Axustar as columnas á xanela"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Ferramentas"
 
@@ -450,11 +450,11 @@ msgstr "Cancelar"
 msgid "About %1"
 msgstr "Acerca do %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Acerca de Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Acerca Qt..."
 
@@ -514,32 +514,32 @@ msgstr "Engadir outro fluxo…"
 msgid "Add directory..."
 msgstr "Engadir un cartafol…"
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Engadir un ficheiro"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Engadir arquivo ó transcodificador"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Engadir arquivo(s) ó transcodificador"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Engadir ficheiro..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Engadir ficheiros para converter"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Engadir cartafol"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Engadir cartafol..."
 
@@ -551,7 +551,7 @@ msgstr "Engadir novo cartafol"
 msgid "Add podcast"
 msgstr "Engadir un podcast"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Engadir un podcast…"
 
@@ -627,7 +627,7 @@ msgstr "Engadir a etiqueta da pista"
 msgid "Add song year tag"
 msgstr "Engadir a etiqueta do ano"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Engadir fluxo..."
 
@@ -639,7 +639,7 @@ msgstr "Engadir á lista do Spotify"
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Engadir a outra lista de reprodución"
 
@@ -733,7 +733,7 @@ msgstr "Todos"
 msgid "All Files (*)"
 msgstr "Todos os ficheiros"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Gloria ó Hipnosapo!"
@@ -1124,7 +1124,7 @@ msgstr "Buscar novos episodios"
 msgid "Check for updates"
 msgstr "Comprobar actualizacións"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Verificar se há actualizazóns..."
 
@@ -1173,18 +1173,18 @@ msgstr "Clásica"
 msgid "Cleaning up"
 msgstr "Facendo limpeza…"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Limpar"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Baleirar a lista de reprodución"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1329,7 +1329,7 @@ msgstr "Comentario"
 msgid "Complete tags automatically"
 msgstr "Completar as etiquetas automaticamente."
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Completar as etiquetas automaticamente…"
 
@@ -1364,7 +1364,7 @@ msgstr "Configurar Subsonic…"
 msgid "Configure global search..."
 msgstr "Configurar a busca global…"
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Configurar a biblioteca..."
 
@@ -1407,7 +1407,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Conexión fora de tempo, comprobe o URL do servidor. Por exemplo: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Consola"
 
@@ -1436,11 +1436,11 @@ msgid "Copy to clipboard"
 msgstr "Copiar no portapapeis"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Copiar para o dispositivo"
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Copiar para a biblioteca"
@@ -1483,14 +1483,14 @@ msgstr "Non se puido iniciar sesión en Last.fm. Ténteo de novo."
 msgid "Couldn't create playlist"
 msgstr "Non se puido crear a lista de reproducción"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Non é posíbel atopar un multiplexor para %1. Asegúrese de que ten instalado os complementos GStreamer necesarios."
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1505,7 +1505,7 @@ msgstr "Non se puido abrir o arquivo externo %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Xestor de portadas"
 
@@ -1658,7 +1658,7 @@ msgid "Delete downloaded data"
 msgstr "Eliminar os datos descargados"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Eliminar arquivos "
 
@@ -1666,7 +1666,7 @@ msgstr "Eliminar arquivos "
 msgid "Delete from device..."
 msgstr "Eliminar do dispositivo"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Eliminar do disco"
@@ -1699,11 +1699,11 @@ msgstr "Eliminando os ficheiros…"
 msgid "Depth"
 msgstr "Profundidade"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Quitar as pistas seleccionadas da cola"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Quitar da cola"
 
@@ -1804,7 +1804,7 @@ msgstr "Opcións de visualización"
 msgid "Display the on-screen-display"
 msgstr "Amosar a mensaxe en pantalla"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Analizar completamente a biblioteca"
 
@@ -1983,12 +1983,12 @@ msgstr "Mestura aleatoria dinámica"
 msgid "Edit smart playlist..."
 msgstr "Editar a lista intelixente…"
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Editar etiqueta \"%1\"..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Editar etiqueta..."
 
@@ -2001,7 +2001,7 @@ msgid "Edit track information"
 msgstr "Editar información da pista"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Editar información da pista..."
 
@@ -2109,7 +2109,7 @@ msgstr "Colección completa"
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Ecualizador"
 
@@ -2122,8 +2122,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Equivalente a «--log-levels *:3»."
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Erro"
 
@@ -2158,7 +2158,7 @@ msgstr "Non foi posíbel cargar %1"
 msgid "Error loading di.fm playlist"
 msgstr "Erro ao cargar a lista de reprodución di.fm"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Erro ao procesarr %1: %2"
@@ -2241,7 +2241,11 @@ msgstr "Exportación acabada"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "Exportada %1 portada de %2 (%3 saltada/s)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2265,7 +2269,7 @@ msgstr "Desvanecendo"
 msgid "Fading duration"
 msgstr "Duración do desvanecimento"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2547,11 +2551,11 @@ msgstr "Noméeo:"
 msgid "Go"
 msgstr "Ir"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Ir á seguinte lapela de lista"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Ir á lapela anterior de lista"
 
@@ -2884,7 +2888,7 @@ msgstr "Base de dados de Jamendo"
 msgid "Jump to previous song right away"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Ir á pista que se está a reproducir"
 
@@ -2908,7 +2912,7 @@ msgstr "Continuar a execución en segundo plano ao pechar a xanela."
 msgid "Keep the original files"
 msgstr "Gardar os arquivos orixinais"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr ""
@@ -3000,7 +3004,7 @@ msgstr "Biblioteca"
 msgid "Library advanced grouping"
 msgstr "Agrupamento avanzado da biblioteca"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Nota de análise da biblioteca"
 
@@ -3040,7 +3044,7 @@ msgstr "Cargar a portada do computador…"
 msgid "Load playlist"
 msgstr "Cargar unha lista"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Cargar unha lista…"
 
@@ -3101,11 +3105,15 @@ msgstr "Acceder"
 msgid "Login failed"
 msgstr "Non se puido acceder."
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Perfil de predición a longo prazo (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Gústame"
 
@@ -3140,11 +3148,11 @@ msgstr "Letra de %1"
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3186,7 +3194,7 @@ msgstr "Perfil principal (MAIN)"
 msgid "Make it so!"
 msgstr "Que así sexa!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Faino!"
@@ -3324,7 +3332,7 @@ msgstr "Pontos de montaxe"
 msgid "Move down"
 msgstr "Mover para abaixo"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Mover para a biblioteca..."
 
@@ -3333,7 +3341,7 @@ msgstr "Mover para a biblioteca..."
 msgid "Move up"
 msgstr "Mover para acima"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Música"
 
@@ -3346,7 +3354,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Silencio"
 
@@ -3395,7 +3403,7 @@ msgstr "Nunca comezar reproducindo"
 msgid "New folder"
 msgstr "Novo cartafol"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nova lista de reprodución"
 
@@ -3423,8 +3431,12 @@ msgstr "Últimas pistas"
 msgid "Next"
 msgstr "Próximo"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Seguinte pista"
 
@@ -3462,7 +3474,7 @@ msgstr "Non hai bloques pequenos."
 msgid "None"
 msgstr "Nengún"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Nengunha das cancións seleccionadas é axeitada para sera copiada a un dispositivo "
 
@@ -3547,19 +3559,19 @@ msgstr ""
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3603,7 +3615,7 @@ msgstr "Opacidade"
 msgid "Open %1 in browser"
 msgstr "Abrir %1 no navegador"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Abrir un CD de &son…"
 
@@ -3615,7 +3627,7 @@ msgstr "Abrir un ficheiro OPML"
 msgid "Open OPML file..."
 msgstr "Abrir un ficheiro OPML…"
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Abre un directorio para importar música"
 
@@ -3623,7 +3635,7 @@ msgstr "Abre un directorio para importar música"
 msgid "Open device"
 msgstr "Abrir o dispositivo"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Abrir un ficheiro…"
 
@@ -3677,7 +3689,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organizar os ficheiros"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Organizar os ficheiros…"
 
@@ -3761,7 +3773,7 @@ msgstr "Festa"
 msgid "Password"
 msgstr "Contrasinal"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pausa"
@@ -3785,6 +3797,10 @@ msgstr "Intérprete"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Pixel"
@@ -3793,10 +3809,10 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Barra lateral simple"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Reproducir"
 
@@ -3817,11 +3833,11 @@ msgstr "Reproducir se está detido, pausar se está a reproducir"
 msgid "Play if there is nothing already playing"
 msgstr "Reproducir se non hai nada reproducíndose aínda."
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Reproducir a seguinte"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3920,7 +3936,7 @@ msgstr ""
 msgid "Preferences"
 msgstr "Configuración"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Configuración…"
 
@@ -3980,7 +3996,7 @@ msgid "Previous"
 msgstr "Anterior"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Pista anterior"
 
@@ -4038,16 +4054,16 @@ msgstr ""
 msgid "Querying device..."
 msgstr "Investigando no dispositivo"
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Xestor da fila"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Engadir á lista"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Engadir á lista"
 
@@ -4063,7 +4079,7 @@ msgstr "Radio (mesmo volume para todas as pistas)"
 msgid "Rain"
 msgstr "Chuvia"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Choiva"
@@ -4175,7 +4191,7 @@ msgstr "Eliminar acción"
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Eliminar as entradas duplicadas da lista"
 
@@ -4183,7 +4199,7 @@ msgstr "Eliminar as entradas duplicadas da lista"
 msgid "Remove folder"
 msgstr "Eliminar cartafol"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Eliminar da lista de reprodución"
 
@@ -4195,7 +4211,7 @@ msgstr "Eliminar lista de reproducción"
 msgid "Remove playlists"
 msgstr "Eliminar listas de reprodución"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr ""
 
@@ -4207,7 +4223,7 @@ msgstr "Renomear lista de reprodución"
 msgid "Rename playlist..."
 msgstr "Renomear lista de reprodución"
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Volver numerar as pistas na seguinte orde…"
 
@@ -4298,7 +4314,7 @@ msgstr ""
 msgid "Rip CD"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr ""
 
@@ -4376,7 +4392,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr ""
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Gardar lista de reprodución..."
 
@@ -4463,7 +4479,7 @@ msgstr "Buscar en Subsonic"
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4476,7 +4492,7 @@ msgstr "Buscar portadas de álbums…"
 msgid "Search for anything"
 msgstr "Buscar calquera cousa"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4601,7 +4617,7 @@ msgstr "Detalles do servidor"
 msgid "Service offline"
 msgstr "Servizo Inválido"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Colocar %1 para \"%2\"..."
@@ -4610,7 +4626,7 @@ msgstr "Colocar %1 para \"%2\"..."
 msgid "Set the volume to <value> percent"
 msgstr "Axusta o volume a <value> por cento"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Axusta o volume para todos os cortes seleccionados"
 
@@ -4681,7 +4697,7 @@ msgstr "Amosar unha pantalla xeitosa"
 msgid "Show above status bar"
 msgstr "Mostrar"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Amosar todas as cancións"
 
@@ -4701,12 +4717,12 @@ msgstr "Amosar as divisións"
 msgid "Show fullsize..."
 msgstr "Mostrar  tamaño completo "
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Mostrar no buscador de arquivos"
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr ""
 
@@ -4718,15 +4734,15 @@ msgstr "Amosar en varios intérpretes"
 msgid "Show moodbar"
 msgstr "Amosar a barra do ánimo."
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Mostrar somente os duplicados"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Só amosar o que non estea etiquetado."
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4734,7 +4750,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr "Fornecer suxestións para a busca."
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4770,7 +4786,7 @@ msgstr "Desordenar os álbums"
 msgid "Shuffle all"
 msgstr "Desordenalo todo"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Desordenar a lista"
 
@@ -4814,11 +4830,15 @@ msgstr "Saltar a conta"
 msgid "Skip forwards in playlist"
 msgstr "Saltar cara adiante na lista de reprodución"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr ""
 
@@ -4935,7 +4955,7 @@ msgstr ""
 msgid "Start the playlist currently playing"
 msgstr "Reproducir a playlist actualmente reproducindo"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Iniciar a conversión"
 
@@ -4945,7 +4965,7 @@ msgid ""
 "list"
 msgstr "Comece a escribir algo na caixa de busca da parte superior para ir enchendo esta lista de resultados."
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Iniciando %1…"
@@ -4955,7 +4975,7 @@ msgid "Starting..."
 msgstr "Iniciando…"
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Deter"
 
@@ -4971,7 +4991,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Deter a reprodución despois da pista actual"
 
@@ -5139,7 +5159,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Acabou o período de proba do servidor de Subsonic. Faga unha doazón para conseguir unha chave de acceso. Visite subsonic.org para máis información."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5181,7 +5201,7 @@ msgid ""
 "continue?"
 msgstr "Estes arquivos serán eliminados do dispositivo, estás seguro de querer continuar?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5283,11 +5303,11 @@ msgstr "Alternar o OSD xeitoso"
 msgid "Toggle fullscreen"
 msgstr "Pantalla completa"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Alternar o estado da cola"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Alternar o envío de escoitas"
 
@@ -5332,19 +5352,19 @@ msgstr ""
 msgid "Track"
 msgstr "Pista"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Conversión de música"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Rexistro de conversión"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Convertendo…"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Convertendo %1 ficheiro empregando %2 fíos."
@@ -5421,11 +5441,11 @@ msgstr "Erro descoñecido"
 msgid "Unset cover"
 msgstr "Anular a escolla da portada"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr ""
 
@@ -5442,7 +5462,7 @@ msgstr "Vindeiros concertos"
 msgid "Update all podcasts"
 msgstr "Actualizar todos os podcasts"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Actualizar os cartafoles da biblioteca con cambios"
 
@@ -5603,7 +5623,7 @@ msgstr "Versón %1"
 msgid "View"
 msgstr "Vista"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5611,7 +5631,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr "Modo de visualización"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Visualizacións"
 
@@ -5652,7 +5672,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5748,7 +5768,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Son de Windows Media"
 
@@ -5762,7 +5782,7 @@ msgid ""
 "well?"
 msgstr "Quere mover tamén o resto das cancións do álbum a «Varios Intérpretes»?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Quere realizar unha análise completa agora?"
 

--- a/src/translations/gl.po
+++ b/src/translations/gl.po
@@ -514,7 +514,7 @@ msgstr "Engadir outro fluxo…"
 msgid "Add directory..."
 msgstr "Engadir un cartafol…"
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Engadir un ficheiro"
 
@@ -534,7 +534,7 @@ msgstr "Engadir ficheiro..."
 msgid "Add files to transcode"
 msgstr "Engadir ficheiros para converter"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Engadir cartafol"
@@ -639,7 +639,7 @@ msgstr "Engadir á lista do Spotify"
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Engadir a outra lista de reprodución"
 
@@ -861,7 +861,7 @@ msgstr "Seguro que quere escribir as estadísticas das cancións nos ficheiros p
 msgid "Artist"
 msgstr "Intérprete"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Información do intérprete"
 
@@ -1124,7 +1124,7 @@ msgstr "Buscar novos episodios"
 msgid "Check for updates"
 msgstr "Comprobar actualizacións"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Verificar se há actualizazóns..."
 
@@ -1364,7 +1364,7 @@ msgstr "Configurar Subsonic…"
 msgid "Configure global search..."
 msgstr "Configurar a busca global…"
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Configurar a biblioteca..."
 
@@ -1436,11 +1436,11 @@ msgid "Copy to clipboard"
 msgstr "Copiar no portapapeis"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Copiar para o dispositivo"
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Copiar para a biblioteca"
@@ -1658,7 +1658,7 @@ msgid "Delete downloaded data"
 msgstr "Eliminar os datos descargados"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Eliminar arquivos "
 
@@ -1666,7 +1666,7 @@ msgstr "Eliminar arquivos "
 msgid "Delete from device..."
 msgstr "Eliminar do dispositivo"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Eliminar do disco"
@@ -1699,11 +1699,11 @@ msgstr "Eliminando os ficheiros…"
 msgid "Depth"
 msgstr "Profundidade"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Quitar as pistas seleccionadas da cola"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Quitar da cola"
 
@@ -1732,7 +1732,7 @@ msgstr "Nome do dispositivo"
 msgid "Device properties..."
 msgstr "Propiedades do dispositivo…"
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Dispositivos"
 
@@ -1983,7 +1983,7 @@ msgstr "Mestura aleatoria dinámica"
 msgid "Edit smart playlist..."
 msgstr "Editar a lista intelixente…"
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Editar etiqueta \"%1\"..."
@@ -2122,8 +2122,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Equivalente a «--log-levels *:3»."
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Erro"
 
@@ -2269,7 +2269,7 @@ msgstr "Desvanecendo"
 msgid "Fading duration"
 msgstr "Duración do desvanecimento"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2392,7 +2392,7 @@ msgstr "Tipo de ficheiro"
 msgid "Filename"
 msgstr "Ruta"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Ficheiros"
 
@@ -2807,7 +2807,7 @@ msgstr "Instalado"
 msgid "Integrity check"
 msgstr "Comprobación da integridade"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -2995,7 +2995,7 @@ msgstr "Esquerda"
 msgid "Length"
 msgstr "Duración"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Biblioteca"
@@ -3004,7 +3004,7 @@ msgstr "Biblioteca"
 msgid "Library advanced grouping"
 msgstr "Agrupamento avanzado da biblioteca"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Nota de análise da biblioteca"
 
@@ -3332,7 +3332,7 @@ msgstr "Pontos de montaxe"
 msgid "Move down"
 msgstr "Mover para abaixo"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Mover para a biblioteca..."
 
@@ -3341,7 +3341,7 @@ msgstr "Mover para a biblioteca..."
 msgid "Move up"
 msgstr "Mover para acima"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Música"
 
@@ -3403,7 +3403,7 @@ msgstr "Nunca comezar reproducindo"
 msgid "New folder"
 msgstr "Novo cartafol"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nova lista de reprodución"
 
@@ -3474,7 +3474,7 @@ msgstr "Non hai bloques pequenos."
 msgid "None"
 msgstr "Nengún"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Nengunha das cancións seleccionadas é axeitada para sera copiada a un dispositivo "
 
@@ -3689,7 +3689,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organizar os ficheiros"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Organizar os ficheiros…"
 
@@ -3773,7 +3773,7 @@ msgstr "Festa"
 msgid "Password"
 msgstr "Contrasinal"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pausa"
@@ -3809,8 +3809,8 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Barra lateral simple"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3833,11 +3833,11 @@ msgstr "Reproducir se está detido, pausar se está a reproducir"
 msgid "Play if there is nothing already playing"
 msgstr "Reproducir se non hai nada reproducíndose aínda."
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Reproducir a seguinte"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3876,7 +3876,7 @@ msgstr "Opcións da lista de reprodución"
 msgid "Playlist type"
 msgstr "Tipo de lista"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Listas de reprodución"
 
@@ -4058,12 +4058,12 @@ msgstr "Investigando no dispositivo"
 msgid "Queue Manager"
 msgstr "Xestor da fila"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Engadir á lista"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Engadir á lista"
 
@@ -4454,7 +4454,7 @@ msgstr ""
 msgid "Search"
 msgstr "Buscar"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr ""
@@ -4479,7 +4479,7 @@ msgstr "Buscar en Subsonic"
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4492,7 +4492,7 @@ msgstr "Buscar portadas de álbums…"
 msgid "Search for anything"
 msgstr "Buscar calquera cousa"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4617,7 +4617,7 @@ msgstr "Detalles do servidor"
 msgid "Service offline"
 msgstr "Servizo Inválido"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Colocar %1 para \"%2\"..."
@@ -4697,7 +4697,7 @@ msgstr "Amosar unha pantalla xeitosa"
 msgid "Show above status bar"
 msgstr "Mostrar"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Amosar todas as cancións"
 
@@ -4717,12 +4717,12 @@ msgstr "Amosar as divisións"
 msgid "Show fullsize..."
 msgstr "Mostrar  tamaño completo "
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Mostrar no buscador de arquivos"
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr ""
 
@@ -4734,11 +4734,11 @@ msgstr "Amosar en varios intérpretes"
 msgid "Show moodbar"
 msgstr "Amosar a barra do ánimo."
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Mostrar somente os duplicados"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Só amosar o que non estea etiquetado."
 
@@ -4830,7 +4830,7 @@ msgstr "Saltar a conta"
 msgid "Skip forwards in playlist"
 msgstr "Saltar cara adiante na lista de reprodución"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr ""
 
@@ -4838,7 +4838,7 @@ msgstr ""
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr ""
 
@@ -4870,7 +4870,7 @@ msgstr "Soft Rock"
 msgid "Song Information"
 msgstr "Información da canción"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Información"
 
@@ -4991,7 +4991,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Deter a reprodución despois da pista actual"
 
@@ -5159,7 +5159,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Acabou o período de proba do servidor de Subsonic. Faga unha doazón para conseguir unha chave de acceso. Visite subsonic.org para máis información."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5201,7 +5201,7 @@ msgid ""
 "continue?"
 msgstr "Estes arquivos serán eliminados do dispositivo, estás seguro de querer continuar?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5303,7 +5303,7 @@ msgstr "Alternar o OSD xeitoso"
 msgid "Toggle fullscreen"
 msgstr "Pantalla completa"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Alternar o estado da cola"
 
@@ -5441,11 +5441,11 @@ msgstr "Erro descoñecido"
 msgid "Unset cover"
 msgstr "Anular a escolla da portada"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr ""
 
@@ -5782,7 +5782,7 @@ msgid ""
 "well?"
 msgstr "Quere mover tamén o resto das cancións do álbum a «Varios Intérpretes»?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Quere realizar unha análise completa agora?"
 

--- a/src/translations/he.po
+++ b/src/translations/he.po
@@ -516,7 +516,7 @@ msgstr "הוספת תזרים אחר..."
 msgid "Add directory..."
 msgstr "הוספת תיקייה..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "הוספת קובץ"
 
@@ -536,7 +536,7 @@ msgstr "הוספת קובץ..."
 msgid "Add files to transcode"
 msgstr "הוספת קובצי מוזיקה להמרה"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "הוספת תיקייה"
@@ -641,7 +641,7 @@ msgstr "הוסף לרשימת ההשמעה של Spotify"
 msgid "Add to Spotify starred"
 msgstr "הוסף למועדפים של Spotify"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "הוספה לרשימת השמעה אחרת"
 
@@ -863,7 +863,7 @@ msgstr ""
 msgid "Artist"
 msgstr "אמן"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "מידע על האמן"
 
@@ -1126,7 +1126,7 @@ msgstr "בדיקת פרקים חדשים"
 msgid "Check for updates"
 msgstr "בדוק עדכונים"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "בדיקת עדכונים..."
 
@@ -1366,7 +1366,7 @@ msgstr "הגדרת תת קולי"
 msgid "Configure global search..."
 msgstr "מגדיר חיפוש "
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "הגדרת הספרייה..."
 
@@ -1438,11 +1438,11 @@ msgid "Copy to clipboard"
 msgstr "העתקה אל הלוח"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "העתקה להתקן.."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "העתקה לספרייה..."
@@ -1660,7 +1660,7 @@ msgid "Delete downloaded data"
 msgstr "מחיקת מידע שהתקבל"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "מחיקת קבצים"
 
@@ -1668,7 +1668,7 @@ msgstr "מחיקת קבצים"
 msgid "Delete from device..."
 msgstr "מחיקה מתוך התקן..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "מחיקה מתוך דיסק..."
@@ -1701,11 +1701,11 @@ msgstr "הקבצים נמחקים"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "הסרת הרצועות הנבחרות מהתור"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "הסרת הרצועה מהתור"
 
@@ -1734,7 +1734,7 @@ msgstr "שם ההתקן"
 msgid "Device properties..."
 msgstr "מאפייני ההתקן..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "התקנים"
 
@@ -1985,7 +1985,7 @@ msgstr "מיקס דינמי אקראי"
 msgid "Edit smart playlist..."
 msgstr "עריכת רשימת השמעה חכמה..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
@@ -2124,8 +2124,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "זהה לאפשרות--log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "שגיאה"
 
@@ -2271,7 +2271,7 @@ msgstr "עמעום מוזיקה"
 msgid "Fading duration"
 msgstr "משך זמן עמעום המוזיקה"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2394,7 +2394,7 @@ msgstr "סוג הקובץ"
 msgid "Filename"
 msgstr "שם הקובץ"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "קבצים"
 
@@ -2809,7 +2809,7 @@ msgstr "הותקן"
 msgid "Integrity check"
 msgstr "בדיקת שלמות"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "אינטרנט"
 
@@ -2997,7 +2997,7 @@ msgstr "שמאל"
 msgid "Length"
 msgstr "אורך"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "ספרייה"
@@ -3006,7 +3006,7 @@ msgstr "ספרייה"
 msgid "Library advanced grouping"
 msgstr "קיבוץ מתקדם של הספרייה"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "הודעה על סריקה מחודשת של הספרייה"
 
@@ -3334,7 +3334,7 @@ msgstr "נקודות עגינה"
 msgid "Move down"
 msgstr "הזזה מטה"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "העברה לספרייה..."
 
@@ -3343,7 +3343,7 @@ msgstr "העברה לספרייה..."
 msgid "Move up"
 msgstr "הזזה מעלה"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "מוזיקה"
 
@@ -3405,7 +3405,7 @@ msgstr "אין להתחיל להשמיע אף פעם"
 msgid "New folder"
 msgstr "תיקייה חדשה"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "רשימת השמעה חדשה"
 
@@ -3476,7 +3476,7 @@ msgstr "ללא מקטעים קצרים"
 msgid "None"
 msgstr "אין"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "אף אחד מהשירים הנבחרים לא היה ראוי להעתקה להתקן"
 
@@ -3691,7 +3691,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr "ארגון קבצים"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "ארגון קבצים..."
 
@@ -3775,7 +3775,7 @@ msgstr "מסיבה"
 msgid "Password"
 msgstr "ססמה"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "השהייה"
@@ -3811,8 +3811,8 @@ msgstr "פיקסל"
 msgid "Plain sidebar"
 msgstr "סרגל צד פשוט"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3835,11 +3835,11 @@ msgstr "ניגון אם מושהה, השהייה אם מנגן"
 msgid "Play if there is nothing already playing"
 msgstr "השמעה אם אין שום שמושמע כרגע"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3878,7 +3878,7 @@ msgstr "אפשרויות רשימת ההשמעה"
 msgid "Playlist type"
 msgstr "סוג רשימת ההשמעה"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "רשימות השמעה"
 
@@ -4060,12 +4060,12 @@ msgstr "התקן מתושאל..."
 msgid "Queue Manager"
 msgstr "מנהל התור"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "הוספת הרצועות הנבחרות"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "הוספת הרצועה לתור"
 
@@ -4456,7 +4456,7 @@ msgstr ""
 msgid "Search"
 msgstr "חיפוש"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr ""
@@ -4481,7 +4481,7 @@ msgstr "חיפוש Subsonic"
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4494,7 +4494,7 @@ msgstr "חיפוש אחר עטיפות אלבום..."
 msgid "Search for anything"
 msgstr "חיפוש הכול"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4619,7 +4619,7 @@ msgstr "פרטי שרת"
 msgid "Service offline"
 msgstr "שירות לא מקוון"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "הגדרת %1 בתור „%2“..."
@@ -4699,7 +4699,7 @@ msgstr "הצגת חיווי מסך נאה"
 msgid "Show above status bar"
 msgstr "הצגה מעל לשורת המצב"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "הצגת כל השירים"
 
@@ -4719,12 +4719,12 @@ msgstr "הצגת חוצצים"
 msgid "Show fullsize..."
 msgstr "הצגה על מסך מלא..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "הצגה בסייר הקבצים..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr ""
 
@@ -4736,11 +4736,11 @@ msgstr "הצגה תחת אמנים שונים"
 msgid "Show moodbar"
 msgstr "הצגת סרגל האווירה"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "הצגת כפילויות בלבד"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "הצגת לא מתוייגים בלבד"
 
@@ -4832,7 +4832,7 @@ msgstr "מונה דילוגים"
 msgid "Skip forwards in playlist"
 msgstr "דילוג קדימה ברשימת ההשמעה"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr ""
 
@@ -4840,7 +4840,7 @@ msgstr ""
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr ""
 
@@ -4872,7 +4872,7 @@ msgstr "רוק קל"
 msgid "Song Information"
 msgstr "מידע על השיר"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "מידע על השיר"
 
@@ -4993,7 +4993,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "הפסקה אחרי רצועה זו"
 
@@ -5161,7 +5161,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "תמה תקופת הניסיון לשרת Subsonic. נא תרומתך לקבלת מפתח רישיון. לפרטים, נא לבקר ב subsonic.org "
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5203,7 +5203,7 @@ msgid ""
 "continue?"
 msgstr "קבצים אלו ימחקו מההתקן, האם להמשיך?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5305,7 +5305,7 @@ msgstr "החלפה ל/ממצב חיווי נאה"
 msgid "Toggle fullscreen"
 msgstr "הפעלה או כיבוי של מסך מלא"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "החלף מצב התור"
 
@@ -5443,11 +5443,11 @@ msgstr "שגיאה לא ידועה"
 msgid "Unset cover"
 msgstr "הסרת עטיפה"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr ""
 
@@ -5784,7 +5784,7 @@ msgid ""
 "well?"
 msgstr "האם ברצונך להעביר גם את שאר השירים באלבום לאמנים שונים?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "האם ברצונך לבצע סריקה חוזרת כעת?"
 

--- a/src/translations/he.po
+++ b/src/translations/he.po
@@ -14,7 +14,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Hebrew (http://www.transifex.com/davidsansome/clementine/language/he/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -168,19 +168,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n נכשלו"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n הושלמו"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -198,7 +198,7 @@ msgstr "מ&רכז"
 msgid "&Custom"
 msgstr "ה&תאמה אישית"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "תוספות"
 
@@ -206,7 +206,7 @@ msgstr "תוספות"
 msgid "&Grouping"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "ע&זרה"
 
@@ -231,7 +231,7 @@ msgstr ""
 msgid "&Lyrics"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "מוזיקה"
 
@@ -239,15 +239,15 @@ msgstr "מוזיקה"
 msgid "&None"
 msgstr "&ללא"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "רשימת השמעה"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "י&ציאה"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "מצב חזרה"
 
@@ -255,7 +255,7 @@ msgstr "מצב חזרה"
 msgid "&Right"
 msgstr "&ימין"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "מצב ערבוב"
 
@@ -263,7 +263,7 @@ msgstr "מצב ערבוב"
 msgid "&Stretch columns to fit window"
 msgstr "&מתיחת עמודות בהתאמה לחלון"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&כלים"
 
@@ -452,11 +452,11 @@ msgstr "בטל"
 msgid "About %1"
 msgstr "בערך %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "על אודות Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "על אודות Qt..."
 
@@ -516,32 +516,32 @@ msgstr "הוספת תזרים אחר..."
 msgid "Add directory..."
 msgstr "הוספת תיקייה..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "הוספת קובץ"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "הוסף קובץ לממיר"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "הוסף קבצים לממיר"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "הוספת קובץ..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "הוספת קובצי מוזיקה להמרה"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "הוספת תיקייה"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "הוספת תיקייה..."
 
@@ -553,7 +553,7 @@ msgstr "הוספת תיקייה חדשה..."
 msgid "Add podcast"
 msgstr "הוספת פודקאסט"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "הוספת פודקאסט..."
 
@@ -629,7 +629,7 @@ msgstr "הוספת תג פסקול לשיר"
 msgid "Add song year tag"
 msgstr "הוספת תג שנה לשיר"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "הוספת תזרים"
 
@@ -641,7 +641,7 @@ msgstr "הוסף לרשימת ההשמעה של Spotify"
 msgid "Add to Spotify starred"
 msgstr "הוסף למועדפים של Spotify"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "הוספה לרשימת השמעה אחרת"
 
@@ -735,7 +735,7 @@ msgstr "הכל"
 msgid "All Files (*)"
 msgstr "כל הקבצים (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr ""
@@ -1126,7 +1126,7 @@ msgstr "בדיקת פרקים חדשים"
 msgid "Check for updates"
 msgstr "בדוק עדכונים"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "בדיקת עדכונים..."
 
@@ -1175,18 +1175,18 @@ msgstr "קלסית"
 msgid "Cleaning up"
 msgstr "מנקה"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "ניקוי"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "ניקוי רשימת ההשמעה"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1331,7 +1331,7 @@ msgstr "הערה"
 msgid "Complete tags automatically"
 msgstr "השלמת תג אוטומטית"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "השלמת תגים אוטומטית..."
 
@@ -1366,7 +1366,7 @@ msgstr "הגדרת תת קולי"
 msgid "Configure global search..."
 msgstr "מגדיר חיפוש "
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "הגדרת הספרייה..."
 
@@ -1409,7 +1409,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr ""
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "קונסול"
 
@@ -1438,11 +1438,11 @@ msgid "Copy to clipboard"
 msgstr "העתקה אל הלוח"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "העתקה להתקן.."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "העתקה לספרייה..."
@@ -1485,14 +1485,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "לא ניתן למצוא מרבב עבור %1, נא לוודא שתוספי ה־GStreamer הנכונים מותקנים כראוי"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1507,7 +1507,7 @@ msgstr "לא ניתן לפתוח את קובץ הפלט %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "מנהל העטיפות"
 
@@ -1660,7 +1660,7 @@ msgid "Delete downloaded data"
 msgstr "מחיקת מידע שהתקבל"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "מחיקת קבצים"
 
@@ -1668,7 +1668,7 @@ msgstr "מחיקת קבצים"
 msgid "Delete from device..."
 msgstr "מחיקה מתוך התקן..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "מחיקה מתוך דיסק..."
@@ -1701,11 +1701,11 @@ msgstr "הקבצים נמחקים"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "הסרת הרצועות הנבחרות מהתור"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "הסרת הרצועה מהתור"
 
@@ -1806,7 +1806,7 @@ msgstr "הגדרות תצוגה"
 msgid "Display the on-screen-display"
 msgstr "הצגת חיווי מסך"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "ביצוע סריקה חוזרת לכל הספרייה"
 
@@ -1985,12 +1985,12 @@ msgstr "מיקס דינמי אקראי"
 msgid "Edit smart playlist..."
 msgstr "עריכת רשימת השמעה חכמה..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "עריכת תגית..."
 
@@ -2003,7 +2003,7 @@ msgid "Edit track information"
 msgstr "עריכת פרטי הרצועה"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "עריכת פרטי הרצועה..."
 
@@ -2111,7 +2111,7 @@ msgstr "כל האוסף"
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "אקולייזר"
 
@@ -2124,8 +2124,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "זהה לאפשרות--log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "שגיאה"
 
@@ -2160,7 +2160,7 @@ msgstr "שגיאה בטעינת %1"
 msgid "Error loading di.fm playlist"
 msgstr "שגיאה בטעינת רשימת ההשמעה של di.fm"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "שגיאה בעיבוד %1: %2"
@@ -2243,7 +2243,11 @@ msgstr ""
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "ייצא %1 עטיפות מתוך %2(%3 דולגו)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2267,7 +2271,7 @@ msgstr "עמעום מוזיקה"
 msgid "Fading duration"
 msgstr "משך זמן עמעום המוזיקה"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2549,11 +2553,11 @@ msgstr "שם עבור הפריט:"
 msgid "Go"
 msgstr "מעבר"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "מעבר ללשונית רשימת ההשמעה הבאה"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "מעבר ללשונית רשימת ההשמעה הקודמת"
 
@@ -2886,7 +2890,7 @@ msgstr "מסד הנתונים של Jamendo"
 msgid "Jump to previous song right away"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "קפיצה לרצועה המתנגנת כעת"
 
@@ -2910,7 +2914,7 @@ msgstr "להמשיך ולהריץ ברקע כאשר החלון סגור"
 msgid "Keep the original files"
 msgstr "שמירה על הקבצים המקוריים"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr ""
@@ -3002,7 +3006,7 @@ msgstr "ספרייה"
 msgid "Library advanced grouping"
 msgstr "קיבוץ מתקדם של הספרייה"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "הודעה על סריקה מחודשת של הספרייה"
 
@@ -3042,7 +3046,7 @@ msgstr "טעינת עטיפה מהדיסק..."
 msgid "Load playlist"
 msgstr "טעינת רשימת השמעה"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "טעינת רשימת השמעה..."
 
@@ -3103,11 +3107,15 @@ msgstr "כניסה"
 msgid "Login failed"
 msgstr "ההתחברות נכשלה"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "פרופיל תחזית ארוכת טווח(LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "אהוב"
 
@@ -3142,11 +3150,11 @@ msgstr "מילות השיר מתוך %1"
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr ""
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3188,7 +3196,7 @@ msgstr "הפרופיל הראשי (ראשי)"
 msgid "Make it so!"
 msgstr "ביצוע!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr ""
@@ -3326,7 +3334,7 @@ msgstr "נקודות עגינה"
 msgid "Move down"
 msgstr "הזזה מטה"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "העברה לספרייה..."
 
@@ -3335,7 +3343,7 @@ msgstr "העברה לספרייה..."
 msgid "Move up"
 msgstr "הזזה מעלה"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "מוזיקה"
 
@@ -3348,7 +3356,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "השתקה"
 
@@ -3397,7 +3405,7 @@ msgstr "אין להתחיל להשמיע אף פעם"
 msgid "New folder"
 msgstr "תיקייה חדשה"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "רשימת השמעה חדשה"
 
@@ -3425,8 +3433,12 @@ msgstr "הרצועות הכי חדשות"
 msgid "Next"
 msgstr "הבא"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "הרצועה הבאה"
 
@@ -3464,7 +3476,7 @@ msgstr "ללא מקטעים קצרים"
 msgid "None"
 msgstr "אין"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "אף אחד מהשירים הנבחרים לא היה ראוי להעתקה להתקן"
 
@@ -3549,19 +3561,19 @@ msgstr ""
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr ""
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3605,7 +3617,7 @@ msgstr "שקיפות"
 msgid "Open %1 in browser"
 msgstr "פתיחת %1 בדפדפן"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "פתיחת &דיסק שמע..."
 
@@ -3617,7 +3629,7 @@ msgstr "פתיחת קובץ "
 msgid "Open OPML file..."
 msgstr "פתיחת קובץ "
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr ""
 
@@ -3625,7 +3637,7 @@ msgstr ""
 msgid "Open device"
 msgstr "פתיחת התקן"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "פתיחת קובץ..."
 
@@ -3679,7 +3691,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr "ארגון קבצים"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "ארגון קבצים..."
 
@@ -3763,7 +3775,7 @@ msgstr "מסיבה"
 msgid "Password"
 msgstr "ססמה"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "השהייה"
@@ -3787,6 +3799,10 @@ msgstr "מבצע"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "פיקסל"
@@ -3795,10 +3811,10 @@ msgstr "פיקסל"
 msgid "Plain sidebar"
 msgstr "סרגל צד פשוט"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "נגינה"
 
@@ -3819,11 +3835,11 @@ msgstr "ניגון אם מושהה, השהייה אם מנגן"
 msgid "Play if there is nothing already playing"
 msgstr "השמעה אם אין שום שמושמע כרגע"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3922,7 +3938,7 @@ msgstr ""
 msgid "Preferences"
 msgstr "מאפיינים"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "מאפיינים..."
 
@@ -3982,7 +3998,7 @@ msgid "Previous"
 msgstr "הקודם"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "רצועה קודמת"
 
@@ -4040,16 +4056,16 @@ msgstr ""
 msgid "Querying device..."
 msgstr "התקן מתושאל..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "מנהל התור"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "הוספת הרצועות הנבחרות"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "הוספת הרצועה לתור"
 
@@ -4065,7 +4081,7 @@ msgstr "רדיו (עצמה זהה לכל הרצועות)"
 msgid "Rain"
 msgstr "גשם"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr ""
@@ -4177,7 +4193,7 @@ msgstr "הסרת הפעולה"
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "הסרת כפילויות מרשימת ההשמעה"
 
@@ -4185,7 +4201,7 @@ msgstr "הסרת כפילויות מרשימת ההשמעה"
 msgid "Remove folder"
 msgstr "הסרת תיקייה"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "הסרה מרשימת ההשמעה"
 
@@ -4197,7 +4213,7 @@ msgstr "הסר רשימת השמעה"
 msgid "Remove playlists"
 msgstr "הסר רשימות השמעה"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr ""
 
@@ -4209,7 +4225,7 @@ msgstr "שינוי שם רשימת ההשמעה"
 msgid "Rename playlist..."
 msgstr "שינוי שם רשימת ההשמעה..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "מספור הרצועות מחדש על פי הסדר הנוכחי..."
 
@@ -4300,7 +4316,7 @@ msgstr ""
 msgid "Rip CD"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr ""
 
@@ -4378,7 +4394,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr ""
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "שמירת רשימת ההשמעה..."
 
@@ -4465,7 +4481,7 @@ msgstr "חיפוש Subsonic"
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4478,7 +4494,7 @@ msgstr "חיפוש אחר עטיפות אלבום..."
 msgid "Search for anything"
 msgstr "חיפוש הכול"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4603,7 +4619,7 @@ msgstr "פרטי שרת"
 msgid "Service offline"
 msgstr "שירות לא מקוון"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "הגדרת %1 בתור „%2“..."
@@ -4612,7 +4628,7 @@ msgstr "הגדרת %1 בתור „%2“..."
 msgid "Set the volume to <value> percent"
 msgstr "הגדרת עצמת השמע ל־<value> אחוזים"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "הגדרת הערך לכל הרצועות הנבחרות..."
 
@@ -4683,7 +4699,7 @@ msgstr "הצגת חיווי מסך נאה"
 msgid "Show above status bar"
 msgstr "הצגה מעל לשורת המצב"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "הצגת כל השירים"
 
@@ -4703,12 +4719,12 @@ msgstr "הצגת חוצצים"
 msgid "Show fullsize..."
 msgstr "הצגה על מסך מלא..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "הצגה בסייר הקבצים..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr ""
 
@@ -4720,15 +4736,15 @@ msgstr "הצגה תחת אמנים שונים"
 msgid "Show moodbar"
 msgstr "הצגת סרגל האווירה"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "הצגת כפילויות בלבד"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "הצגת לא מתוייגים בלבד"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4736,7 +4752,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr "הצגת הצעות חיפוש"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4772,7 +4788,7 @@ msgstr "ערבוב אלבומים"
 msgid "Shuffle all"
 msgstr "ערבוב עם הכול"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "ערבוב רשימת ההשמעה"
 
@@ -4816,11 +4832,15 @@ msgstr "מונה דילוגים"
 msgid "Skip forwards in playlist"
 msgstr "דילוג קדימה ברשימת ההשמעה"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr ""
 
@@ -4937,7 +4957,7 @@ msgstr ""
 msgid "Start the playlist currently playing"
 msgstr "התחלת רשימת ההשמעה המתנגנת כעת"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "התחלת ההתמרה"
 
@@ -4947,7 +4967,7 @@ msgid ""
 "list"
 msgstr "נא להקליד משהו בתיבת החיפוש למעלה כדי למלא את רשימת תוצאות חיפוש זה"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "התחלת המרת %1"
@@ -4957,7 +4977,7 @@ msgid "Starting..."
 msgstr "מופעל..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "הפסקה"
 
@@ -4973,7 +4993,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "הפסקה אחרי רצועה זו"
 
@@ -5141,7 +5161,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "תמה תקופת הניסיון לשרת Subsonic. נא תרומתך לקבלת מפתח רישיון. לפרטים, נא לבקר ב subsonic.org "
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5183,7 +5203,7 @@ msgid ""
 "continue?"
 msgstr "קבצים אלו ימחקו מההתקן, האם להמשיך?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5285,11 +5305,11 @@ msgstr "החלפה ל/ממצב חיווי נאה"
 msgid "Toggle fullscreen"
 msgstr "הפעלה או כיבוי של מסך מלא"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "החלף מצב התור"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "החלפה לscrobbling"
 
@@ -5334,19 +5354,19 @@ msgstr ""
 msgid "Track"
 msgstr "רצועה"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "ממיר קבצי המוזיקה"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "יומן ממיר קבצי המוזיקה"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "ממיר"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "התחלת המרת %1 קבצים בעזרת %2 תהליכים"
@@ -5423,11 +5443,11 @@ msgstr "שגיאה לא ידועה"
 msgid "Unset cover"
 msgstr "הסרת עטיפה"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr ""
 
@@ -5444,7 +5464,7 @@ msgstr "קונצרטים צפויים"
 msgid "Update all podcasts"
 msgstr "עדכון כל הפודקאסטים"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "עדכון תיקיות שהשתנו בספרייה"
 
@@ -5605,7 +5625,7 @@ msgstr "גרסה %1"
 msgid "View"
 msgstr "הצגה"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5613,7 +5633,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr "מצב אפקטים חזותיים"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "אפקטים חזותיים"
 
@@ -5654,7 +5674,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5750,7 +5770,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "שמע של Windows Media"
 
@@ -5764,7 +5784,7 @@ msgid ""
 "well?"
 msgstr "האם ברצונך להעביר גם את שאר השירים באלבום לאמנים שונים?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "האם ברצונך לבצע סריקה חוזרת כעת?"
 

--- a/src/translations/he_IL.po
+++ b/src/translations/he_IL.po
@@ -508,7 +508,7 @@ msgstr ""
 msgid "Add directory..."
 msgstr ""
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgstr ""
 msgid "Add files to transcode"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr ""
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr ""
 
@@ -855,7 +855,7 @@ msgstr ""
 msgid "Artist"
 msgstr ""
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr ""
 
@@ -1118,7 +1118,7 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr ""
 
@@ -1430,11 +1430,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1652,7 +1652,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr ""
 
@@ -1660,7 +1660,7 @@ msgstr ""
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1693,11 +1693,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr ""
 
@@ -1726,7 +1726,7 @@ msgstr ""
 msgid "Device properties..."
 msgstr ""
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr ""
 
@@ -1977,7 +1977,7 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
@@ -2116,8 +2116,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr ""
 
@@ -2263,7 +2263,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2386,7 +2386,7 @@ msgstr ""
 msgid "Filename"
 msgstr ""
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr ""
 
@@ -2801,7 +2801,7 @@ msgstr ""
 msgid "Integrity check"
 msgstr ""
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr ""
 
@@ -2989,7 +2989,7 @@ msgstr ""
 msgid "Length"
 msgstr ""
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr ""
@@ -2998,7 +2998,7 @@ msgstr ""
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3326,7 +3326,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3335,7 +3335,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr ""
 
@@ -3397,7 +3397,7 @@ msgstr ""
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3468,7 +3468,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3683,7 +3683,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr ""
 
@@ -3767,7 +3767,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr ""
@@ -3803,8 +3803,8 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3827,11 +3827,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3870,7 +3870,7 @@ msgstr ""
 msgid "Playlist type"
 msgstr ""
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr ""
 
@@ -4052,12 +4052,12 @@ msgstr ""
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr ""
 
@@ -4448,7 +4448,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr ""
@@ -4473,7 +4473,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4486,7 +4486,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4611,7 +4611,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4691,7 +4691,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr ""
 
@@ -4711,12 +4711,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr ""
 
@@ -4728,11 +4728,11 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr ""
 
@@ -4824,7 +4824,7 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr ""
 
@@ -4832,7 +4832,7 @@ msgstr ""
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr ""
 
@@ -4864,7 +4864,7 @@ msgstr ""
 msgid "Song Information"
 msgstr ""
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr ""
 
@@ -4985,7 +4985,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5153,7 +5153,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5195,7 +5195,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5297,7 +5297,7 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr ""
 
@@ -5435,11 +5435,11 @@ msgstr ""
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr ""
 
@@ -5776,7 +5776,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/he_IL.po
+++ b/src/translations/he_IL.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Hebrew (Israel) (http://www.transifex.com/davidsansome/clementine/language/he_IL/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -160,19 +160,19 @@ msgstr ""
 msgid "%filename%"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -190,7 +190,7 @@ msgstr ""
 msgid "&Custom"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr ""
 
@@ -198,7 +198,7 @@ msgstr ""
 msgid "&Grouping"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr ""
 
@@ -223,7 +223,7 @@ msgstr ""
 msgid "&Lyrics"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr ""
 
@@ -231,15 +231,15 @@ msgstr ""
 msgid "&None"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr ""
 
@@ -247,7 +247,7 @@ msgstr ""
 msgid "&Right"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr ""
 
@@ -255,7 +255,7 @@ msgstr ""
 msgid "&Stretch columns to fit window"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr ""
 
@@ -444,11 +444,11 @@ msgstr ""
 msgid "About %1"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr ""
 
@@ -508,32 +508,32 @@ msgstr ""
 msgid "Add directory..."
 msgstr ""
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Add podcast"
 msgstr ""
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr ""
 
@@ -621,7 +621,7 @@ msgstr ""
 msgid "Add song year tag"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr ""
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr ""
 
@@ -727,7 +727,7 @@ msgstr ""
 msgid "All Files (*)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr ""
@@ -1118,7 +1118,7 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr ""
 
@@ -1167,18 +1167,18 @@ msgstr ""
 msgid "Cleaning up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr ""
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr ""
 
@@ -1323,7 +1323,7 @@ msgstr ""
 msgid "Complete tags automatically"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr ""
 
@@ -1401,7 +1401,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr ""
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr ""
 
@@ -1430,11 +1430,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1477,14 +1477,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr ""
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1499,7 +1499,7 @@ msgstr ""
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr ""
 
@@ -1660,7 +1660,7 @@ msgstr ""
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1693,11 +1693,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr ""
 
@@ -1798,7 +1798,7 @@ msgstr ""
 msgid "Display the on-screen-display"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr ""
 
@@ -1977,12 +1977,12 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr ""
 
@@ -1995,7 +1995,7 @@ msgid "Edit track information"
 msgstr ""
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr ""
 
@@ -2103,7 +2103,7 @@ msgstr ""
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr ""
 
@@ -2116,8 +2116,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr ""
 
@@ -2152,7 +2152,7 @@ msgstr ""
 msgid "Error loading di.fm playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr ""
@@ -2235,7 +2235,11 @@ msgstr ""
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr ""
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2259,7 +2263,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2541,11 +2545,11 @@ msgstr ""
 msgid "Go"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr ""
 
@@ -2878,7 +2882,7 @@ msgstr ""
 msgid "Jump to previous song right away"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr ""
 
@@ -2902,7 +2906,7 @@ msgstr ""
 msgid "Keep the original files"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr ""
@@ -2994,7 +2998,7 @@ msgstr ""
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3034,7 +3038,7 @@ msgstr ""
 msgid "Load playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr ""
 
@@ -3095,11 +3099,15 @@ msgstr ""
 msgid "Login failed"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr ""
 
@@ -3134,11 +3142,11 @@ msgstr ""
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr ""
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr ""
@@ -3180,7 +3188,7 @@ msgstr ""
 msgid "Make it so!"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr ""
@@ -3318,7 +3326,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3327,7 +3335,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr ""
 
@@ -3340,7 +3348,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr ""
 
@@ -3389,7 +3397,7 @@ msgstr ""
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3417,8 +3425,12 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr ""
 
@@ -3456,7 +3468,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3541,19 +3553,19 @@ msgstr ""
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr ""
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr ""
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr ""
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3597,7 +3609,7 @@ msgstr ""
 msgid "Open %1 in browser"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr ""
 
@@ -3609,7 +3621,7 @@ msgstr ""
 msgid "Open OPML file..."
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr ""
 
@@ -3617,7 +3629,7 @@ msgstr ""
 msgid "Open device"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr ""
 
@@ -3671,7 +3683,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr ""
 
@@ -3755,7 +3767,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr ""
@@ -3779,6 +3791,10 @@ msgstr ""
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr ""
@@ -3787,10 +3803,10 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr ""
 
@@ -3811,11 +3827,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3914,7 +3930,7 @@ msgstr ""
 msgid "Preferences"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr ""
 
@@ -3974,7 +3990,7 @@ msgid "Previous"
 msgstr ""
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr ""
 
@@ -4032,16 +4048,16 @@ msgstr ""
 msgid "Querying device..."
 msgstr ""
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr ""
 
@@ -4057,7 +4073,7 @@ msgstr ""
 msgid "Rain"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr ""
@@ -4169,7 +4185,7 @@ msgstr ""
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr ""
 
@@ -4177,7 +4193,7 @@ msgstr ""
 msgid "Remove folder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr ""
 
@@ -4189,7 +4205,7 @@ msgstr ""
 msgid "Remove playlists"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr ""
 
@@ -4201,7 +4217,7 @@ msgstr ""
 msgid "Rename playlist..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr ""
 
@@ -4292,7 +4308,7 @@ msgstr ""
 msgid "Rip CD"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr ""
 
@@ -4370,7 +4386,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr ""
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr ""
 
@@ -4457,7 +4473,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4470,7 +4486,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4595,7 +4611,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4604,7 +4620,7 @@ msgstr ""
 msgid "Set the volume to <value> percent"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr ""
 
@@ -4675,7 +4691,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr ""
 
@@ -4695,12 +4711,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr ""
 
@@ -4712,15 +4728,15 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4728,7 +4744,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4764,7 +4780,7 @@ msgstr ""
 msgid "Shuffle all"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr ""
 
@@ -4808,11 +4824,15 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr ""
 
@@ -4929,7 +4949,7 @@ msgstr ""
 msgid "Start the playlist currently playing"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr ""
 
@@ -4939,7 +4959,7 @@ msgid ""
 "list"
 msgstr ""
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr ""
@@ -4949,7 +4969,7 @@ msgid "Starting..."
 msgstr ""
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr ""
 
@@ -4965,7 +4985,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5133,7 +5153,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5175,7 +5195,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5277,11 +5297,11 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr ""
 
@@ -5326,19 +5346,19 @@ msgstr ""
 msgid "Track"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr ""
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
 msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr ""
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr ""
@@ -5415,11 +5435,11 @@ msgstr ""
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr ""
 
@@ -5436,7 +5456,7 @@ msgstr ""
 msgid "Update all podcasts"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr ""
 
@@ -5597,7 +5617,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5605,7 +5625,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr ""
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr ""
 
@@ -5646,7 +5666,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr ""
 
@@ -5742,7 +5762,7 @@ msgstr ""
 msgid "Windows Media 64k"
 msgstr ""
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr ""
 
@@ -5756,7 +5776,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/hi.po
+++ b/src/translations/hi.po
@@ -511,7 +511,7 @@ msgstr ""
 msgid "Add directory..."
 msgstr ""
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr ""
 
@@ -531,7 +531,7 @@ msgstr ""
 msgid "Add files to transcode"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr ""
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Artist"
 msgstr "Kalakar"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr ""
 
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr ""
 
@@ -1433,11 +1433,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1655,7 +1655,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr ""
 
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1696,11 +1696,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr ""
 
@@ -1729,7 +1729,7 @@ msgstr ""
 msgid "Device properties..."
 msgstr ""
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr ""
 
@@ -1980,7 +1980,7 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
@@ -2119,8 +2119,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr ""
 
@@ -2266,7 +2266,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2389,7 +2389,7 @@ msgstr ""
 msgid "Filename"
 msgstr ""
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr ""
 
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "Integrity check"
 msgstr ""
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr ""
 
@@ -2992,7 +2992,7 @@ msgstr ""
 msgid "Length"
 msgstr ""
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr ""
@@ -3001,7 +3001,7 @@ msgstr ""
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3329,7 +3329,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3338,7 +3338,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr ""
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3471,7 +3471,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3686,7 +3686,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr ""
 
@@ -3770,7 +3770,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr ""
@@ -3806,8 +3806,8 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3830,11 +3830,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3873,7 +3873,7 @@ msgstr ""
 msgid "Playlist type"
 msgstr ""
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr ""
 
@@ -4055,12 +4055,12 @@ msgstr ""
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr ""
 
@@ -4451,7 +4451,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr ""
@@ -4476,7 +4476,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4489,7 +4489,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4614,7 +4614,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4694,7 +4694,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr ""
 
@@ -4714,12 +4714,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr ""
 
@@ -4731,11 +4731,11 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr ""
 
@@ -4835,7 +4835,7 @@ msgstr ""
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr ""
 
@@ -4867,7 +4867,7 @@ msgstr ""
 msgid "Song Information"
 msgstr ""
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr ""
 
@@ -4988,7 +4988,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5156,7 +5156,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5198,7 +5198,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5300,7 +5300,7 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr ""
 
@@ -5438,11 +5438,11 @@ msgstr ""
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr ""
 
@@ -5779,7 +5779,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/hi.po
+++ b/src/translations/hi.po
@@ -9,7 +9,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Hindi (http://www.transifex.com/davidsansome/clementine/language/hi/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -163,19 +163,19 @@ msgstr ""
 msgid "%filename%"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n असफल "
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n samapt"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -193,7 +193,7 @@ msgstr "&kendra"
 msgid "&Custom"
 msgstr "&anukul"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr ""
 
@@ -201,7 +201,7 @@ msgstr ""
 msgid "&Grouping"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&saha"
 
@@ -226,7 +226,7 @@ msgstr ""
 msgid "&Lyrics"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr ""
 
@@ -234,15 +234,15 @@ msgstr ""
 msgid "&None"
 msgstr "&कोई nahi"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&बंद"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "&Right"
 msgstr "&dayen"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr ""
 
@@ -258,7 +258,7 @@ msgstr ""
 msgid "&Stretch columns to fit window"
 msgstr "&खीचे कॉलम विंडो फिट करने के लिए"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&upkaran"
 
@@ -447,11 +447,11 @@ msgstr ""
 msgid "About %1"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr ""
 
@@ -511,32 +511,32 @@ msgstr ""
 msgid "Add directory..."
 msgstr ""
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr ""
 
@@ -548,7 +548,7 @@ msgstr ""
 msgid "Add podcast"
 msgstr ""
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Add song year tag"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr ""
 
@@ -730,7 +730,7 @@ msgstr ""
 msgid "All Files (*)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr ""
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr ""
 
@@ -1170,18 +1170,18 @@ msgstr ""
 msgid "Cleaning up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr ""
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr ""
 
@@ -1326,7 +1326,7 @@ msgstr ""
 msgid "Complete tags automatically"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr ""
 
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr ""
 
@@ -1404,7 +1404,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr ""
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr ""
 
@@ -1433,11 +1433,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1480,14 +1480,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr ""
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1502,7 +1502,7 @@ msgstr ""
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr ""
 
@@ -1655,7 +1655,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr ""
 
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1696,11 +1696,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr ""
 
@@ -1801,7 +1801,7 @@ msgstr ""
 msgid "Display the on-screen-display"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr ""
 
@@ -1980,12 +1980,12 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr ""
 
@@ -1998,7 +1998,7 @@ msgid "Edit track information"
 msgstr ""
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr ""
 
@@ -2106,7 +2106,7 @@ msgstr ""
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr ""
 
@@ -2119,8 +2119,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr ""
 
@@ -2155,7 +2155,7 @@ msgstr ""
 msgid "Error loading di.fm playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr ""
@@ -2238,7 +2238,11 @@ msgstr ""
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr ""
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2262,7 +2266,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2544,11 +2548,11 @@ msgstr ""
 msgid "Go"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr ""
 
@@ -2881,7 +2885,7 @@ msgstr ""
 msgid "Jump to previous song right away"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr ""
 
@@ -2905,7 +2909,7 @@ msgstr ""
 msgid "Keep the original files"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr ""
@@ -2997,7 +3001,7 @@ msgstr ""
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3037,7 +3041,7 @@ msgstr ""
 msgid "Load playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr ""
 
@@ -3098,11 +3102,15 @@ msgstr ""
 msgid "Login failed"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr ""
 
@@ -3137,11 +3145,11 @@ msgstr ""
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr ""
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr ""
@@ -3183,7 +3191,7 @@ msgstr ""
 msgid "Make it so!"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr ""
@@ -3321,7 +3329,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3330,7 +3338,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr ""
 
@@ -3343,7 +3351,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr ""
 
@@ -3392,7 +3400,7 @@ msgstr ""
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3420,8 +3428,12 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr ""
 
@@ -3459,7 +3471,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3544,19 +3556,19 @@ msgstr ""
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr ""
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr ""
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr ""
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3600,7 +3612,7 @@ msgstr ""
 msgid "Open %1 in browser"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr ""
 
@@ -3612,7 +3624,7 @@ msgstr ""
 msgid "Open OPML file..."
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr ""
 
@@ -3620,7 +3632,7 @@ msgstr ""
 msgid "Open device"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr ""
 
@@ -3674,7 +3686,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr ""
 
@@ -3758,7 +3770,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr ""
@@ -3782,6 +3794,10 @@ msgstr ""
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr ""
@@ -3790,10 +3806,10 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr ""
 
@@ -3814,11 +3830,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3917,7 +3933,7 @@ msgstr ""
 msgid "Preferences"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr ""
 
@@ -3977,7 +3993,7 @@ msgid "Previous"
 msgstr ""
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr ""
 
@@ -4035,16 +4051,16 @@ msgstr ""
 msgid "Querying device..."
 msgstr ""
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr ""
 
@@ -4060,7 +4076,7 @@ msgstr ""
 msgid "Rain"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr ""
@@ -4172,7 +4188,7 @@ msgstr ""
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr ""
 
@@ -4180,7 +4196,7 @@ msgstr ""
 msgid "Remove folder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr ""
 
@@ -4192,7 +4208,7 @@ msgstr ""
 msgid "Remove playlists"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr ""
 
@@ -4204,7 +4220,7 @@ msgstr ""
 msgid "Rename playlist..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr ""
 
@@ -4295,7 +4311,7 @@ msgstr ""
 msgid "Rip CD"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr ""
 
@@ -4373,7 +4389,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr ""
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr ""
 
@@ -4460,7 +4476,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4473,7 +4489,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4598,7 +4614,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4607,7 +4623,7 @@ msgstr ""
 msgid "Set the volume to <value> percent"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr ""
 
@@ -4678,7 +4694,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr ""
 
@@ -4698,12 +4714,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr ""
 
@@ -4715,15 +4731,15 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4731,7 +4747,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4767,7 +4783,7 @@ msgstr ""
 msgid "Shuffle all"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr ""
 
@@ -4811,11 +4827,15 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr ""
 
@@ -4932,7 +4952,7 @@ msgstr ""
 msgid "Start the playlist currently playing"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr ""
 
@@ -4942,7 +4962,7 @@ msgid ""
 "list"
 msgstr ""
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr ""
@@ -4952,7 +4972,7 @@ msgid "Starting..."
 msgstr ""
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr ""
 
@@ -4968,7 +4988,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5136,7 +5156,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5178,7 +5198,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5280,11 +5300,11 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr ""
 
@@ -5329,19 +5349,19 @@ msgstr ""
 msgid "Track"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr ""
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
 msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr ""
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr ""
@@ -5418,11 +5438,11 @@ msgstr ""
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr ""
 
@@ -5439,7 +5459,7 @@ msgstr ""
 msgid "Update all podcasts"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr ""
 
@@ -5600,7 +5620,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5608,7 +5628,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr ""
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr ""
 
@@ -5649,7 +5669,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr ""
 
@@ -5745,7 +5765,7 @@ msgstr ""
 msgid "Windows Media 64k"
 msgstr ""
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr ""
 
@@ -5759,7 +5779,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/hr.po
+++ b/src/translations/hr.po
@@ -514,7 +514,7 @@ msgstr "Dodajte novi stream..."
 msgid "Add directory..."
 msgstr "Dodajte direktorij..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Dodaj datoteku"
 
@@ -534,7 +534,7 @@ msgstr "Dodajte datoteku..."
 msgid "Add files to transcode"
 msgstr "Dodajte datoteku za transkôdiranje..."
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Dodajte mapu"
@@ -639,7 +639,7 @@ msgstr "Dodaj na Spotify popis izvođenja"
 msgid "Add to Spotify starred"
 msgstr "Dodaj u Spotify ocjenjeno"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Dodajte na drugi popis izvođenja"
 
@@ -861,7 +861,7 @@ msgstr "Sigurno želite zapisati statistiku pjesama u datoteke pjesama za sve pj
 msgid "Artist"
 msgstr "Izvođač"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Info izvođača"
 
@@ -1124,7 +1124,7 @@ msgstr "Provjeri za nove epizode"
 msgid "Check for updates"
 msgstr "Provjeri nadopune"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Provjeri ima li nadogradnja"
 
@@ -1364,7 +1364,7 @@ msgstr "Podesi Subsonic..."
 msgid "Configure global search..."
 msgstr "Podesite globalno pretraživanje..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Podesi fonoteku..."
 
@@ -1436,11 +1436,11 @@ msgid "Copy to clipboard"
 msgstr "Kopiraj u međuspremnik"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopirajte na uređaj..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kopirajte u fonoteku..."
@@ -1658,7 +1658,7 @@ msgid "Delete downloaded data"
 msgstr "Obriši preuzete podatke"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Obrišite datoteku"
 
@@ -1666,7 +1666,7 @@ msgstr "Obrišite datoteku"
 msgid "Delete from device..."
 msgstr "Obrišite s uređaja..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Obrišite s diska..."
@@ -1699,11 +1699,11 @@ msgstr "Brisanje datoteka"
 msgid "Depth"
 msgstr "Dubina"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Uklonite označenu pjesmu s reprodukcije"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Uklonite označenu pjesmu za reprodukciju"
 
@@ -1732,7 +1732,7 @@ msgstr "Naziv uređaja"
 msgid "Device properties..."
 msgstr "Mogućnosti uređaja..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Uređaji"
 
@@ -1983,7 +1983,7 @@ msgstr "Dinamičan naizmjeničan mix"
 msgid "Edit smart playlist..."
 msgstr "Uredite pametni popis izvođenja..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Uredi oznaku \"%1\"..."
@@ -2122,8 +2122,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Odgovara --log-levels *: 3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Greška"
 
@@ -2269,7 +2269,7 @@ msgstr "Utišavanje"
 msgid "Fading duration"
 msgstr "Trajanje utišavanja"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Nemoguće čitanje CD uređaja"
 
@@ -2392,7 +2392,7 @@ msgstr "Vrsta datoteke"
 msgid "Filename"
 msgstr "Naziv datoteke"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Datoteke"
 
@@ -2807,7 +2807,7 @@ msgstr "Instaliran"
 msgid "Integrity check"
 msgstr "Provjera integriteta"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -2995,7 +2995,7 @@ msgstr "Lijevo"
 msgid "Length"
 msgstr "Trajanje"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Fonoteka"
@@ -3004,7 +3004,7 @@ msgstr "Fonoteka"
 msgid "Library advanced grouping"
 msgstr "Napredno grupiranje fonoteke"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Obavijest o ponovnom pretraživanju fonoteke"
 
@@ -3332,7 +3332,7 @@ msgstr "Točka montiranja"
 msgid "Move down"
 msgstr "Pomakni dolje"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Premjesti u fonoteku..."
 
@@ -3341,7 +3341,7 @@ msgstr "Premjesti u fonoteku..."
 msgid "Move up"
 msgstr "Pomakni gore"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Glazba"
 
@@ -3403,7 +3403,7 @@ msgstr "Nikada ne započinji reprodukciju glazbe"
 msgid "New folder"
 msgstr "Nova mapa"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Novi popis izvođenja"
 
@@ -3474,7 +3474,7 @@ msgstr "Bez kratkih blokova"
 msgid "None"
 msgstr "Ništa"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Nijedna od odabranih pjesama nije prikladna za kopiranje na uređaj"
 
@@ -3689,7 +3689,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organizirajte datoteke"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Organizirajte datoteke..."
 
@@ -3773,7 +3773,7 @@ msgstr "Party"
 msgid "Password"
 msgstr "Lozinka"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pauziraj reprodukciju"
@@ -3809,8 +3809,8 @@ msgstr "Piksela"
 msgid "Plain sidebar"
 msgstr "Jednostavna bočna traka"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3833,11 +3833,11 @@ msgstr "Reproduciraj ako se zaustavi, pauziraj ako svira"
 msgid "Play if there is nothing already playing"
 msgstr "Reproduciraj glazbu ako se trenutno ništa ne reproducira"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Reproduciraj sljedeće"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Reproduciraj sljedeće odabranu pjesmu"
 
@@ -3876,7 +3876,7 @@ msgstr "Mogućnosti popisa izvođenja"
 msgid "Playlist type"
 msgstr "Vrsta popisa izvođenja"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Popis izvođenja"
 
@@ -4058,12 +4058,12 @@ msgstr "Tražim uređaj..."
 msgid "Queue Manager"
 msgstr "Upravljanje odabranim pjesmama za reprodukciju"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Odaberite označenu pjesmu za reprodukciju"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Odaberite pjesmu za reprodukciju"
 
@@ -4454,7 +4454,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Traži"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Traži"
@@ -4479,7 +4479,7 @@ msgstr "Subsonic pretraživanje"
 msgid "Search automatically"
 msgstr "Pretraži automatski"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Pretražite album"
 
@@ -4492,7 +4492,7 @@ msgstr "Pretražite omote albuma..."
 msgid "Search for anything"
 msgstr "Upišite pretragu"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Pretražite izvođača"
 
@@ -4617,7 +4617,7 @@ msgstr "Pojedinosti poslužitelja"
 msgid "Service offline"
 msgstr "Usluga nedostupna"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Postavite %1 na \"%2\"..."
@@ -4697,7 +4697,7 @@ msgstr "Prikaži ljepši OSD"
 msgid "Show above status bar"
 msgstr "Prikaži iznad trake stanja"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Prikaži sve pjesme"
 
@@ -4717,12 +4717,12 @@ msgstr "Prikaži razdjelnike u stablu fonoteke"
 msgid "Show fullsize..."
 msgstr "Prikaži u punoj veličini..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Prikaži u pregledniku datoteka..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Prikaži u fonoteci..."
 
@@ -4734,11 +4734,11 @@ msgstr "Prikaži u različitim izvođačima"
 msgid "Show moodbar"
 msgstr "Prikaži traku tonaliteta"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Prikaži samo duplicirane pjesme"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Prikaži samo neoznačene pjesme"
 
@@ -4830,7 +4830,7 @@ msgstr "Preskoči računanje"
 msgid "Skip forwards in playlist"
 msgstr "Preskoči unaprijed u popisu izvođenja"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Preskoči odabrane pjesme"
 
@@ -4838,7 +4838,7 @@ msgstr "Preskoči odabrane pjesme"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Preskoči pjesmu"
 
@@ -4870,7 +4870,7 @@ msgstr "Soft Rock"
 msgid "Song Information"
 msgstr "Informacije o pjesmi"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Info pjesme"
 
@@ -4991,7 +4991,7 @@ msgstr "Zaustavi reprodukciju nakon pojedine pjesme"
 msgid "Stop after every track"
 msgstr "Zaustavi reprodukciju nakon svake pjesme"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Zaustavi reprodukciju nakon ove pjesme"
 
@@ -5159,7 +5159,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Probno razdoblje za Subsonic poslužitelj je završeno. Molim, donirajte za dobivanje ključa licence. Posjetite subsonic.org za više pojedinosti."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5201,7 +5201,7 @@ msgid ""
 "continue?"
 msgstr "Ove datoteke bit će obrisane sa uređaja, sigurno želite nastaviti?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5303,7 +5303,7 @@ msgstr "Uključi/Isključi ljepši OSD"
 msgid "Toggle fullscreen"
 msgstr "Cijelozaslonski prikaz"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Uključi/isključi stanje reda čekanja"
 
@@ -5441,11 +5441,11 @@ msgstr "Nepoznata greška"
 msgid "Unset cover"
 msgstr "Uklonite omot"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Ukloni preskakanje odabrane pjesme"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Ukloni preskakanje pjesme"
 
@@ -5782,7 +5782,7 @@ msgid ""
 "well?"
 msgstr "Želite li preseliti druge pjesme s ovog albuma u razne izvođače?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Želite li pokrenuti ponovnu potpunu prtetragu odmah?"
 

--- a/src/translations/hr.po
+++ b/src/translations/hr.po
@@ -12,7 +12,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Croatian (http://www.transifex.com/davidsansome/clementine/language/hr/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -166,19 +166,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%imefajla%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n nije uspjelo"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n završeno"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -196,7 +196,7 @@ msgstr "&Centriraj"
 msgid "&Custom"
 msgstr "&Podešeno"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "Dodaci"
 
@@ -204,7 +204,7 @@ msgstr "Dodaci"
 msgid "&Grouping"
 msgstr "&Grupiranje"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "Pomoć"
 
@@ -229,7 +229,7 @@ msgstr "&Zaključaj ocjenu"
 msgid "&Lyrics"
 msgstr "&Tekst pjesame"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "Glazba"
 
@@ -237,15 +237,15 @@ msgstr "Glazba"
 msgid "&None"
 msgstr "&Nijedan"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "Popis izvođenja"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Zatvorite Clementine"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "Način ponavljanja"
 
@@ -253,7 +253,7 @@ msgstr "Način ponavljanja"
 msgid "&Right"
 msgstr "&Desno"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Način naizmjeničnog sviranja"
 
@@ -261,7 +261,7 @@ msgstr "Način naizmjeničnog sviranja"
 msgid "&Stretch columns to fit window"
 msgstr "&Rastegni stupce da stanu u prozor"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "Alati"
 
@@ -450,11 +450,11 @@ msgstr "Prekini"
 msgid "About %1"
 msgstr "O %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "O Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "O Qt..."
 
@@ -514,32 +514,32 @@ msgstr "Dodajte novi stream..."
 msgid "Add directory..."
 msgstr "Dodajte direktorij..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Dodaj datoteku"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Dodaj datoteku u enkôder"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Dodaj datoteku(e) u enkôder"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Dodajte datoteku..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Dodajte datoteku za transkôdiranje..."
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Dodajte mapu"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Dodajte mapu..."
 
@@ -551,7 +551,7 @@ msgstr "Dodajte novu mapu"
 msgid "Add podcast"
 msgstr "Dodajte podcast"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Dodajte podcast..."
 
@@ -627,7 +627,7 @@ msgstr "Dodajte oznaku broja pjesme"
 msgid "Add song year tag"
 msgstr "Dodajte oznaku godine pjesme"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Dodajte stream..."
 
@@ -639,7 +639,7 @@ msgstr "Dodaj na Spotify popis izvođenja"
 msgid "Add to Spotify starred"
 msgstr "Dodaj u Spotify ocjenjeno"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Dodajte na drugi popis izvođenja"
 
@@ -733,7 +733,7 @@ msgstr "Svi"
 msgid "All Files (*)"
 msgstr "Sve datoteke"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Sva slava Hypnotoadu!"
@@ -1124,7 +1124,7 @@ msgstr "Provjeri za nove epizode"
 msgid "Check for updates"
 msgstr "Provjeri nadopune"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Provjeri ima li nadogradnja"
 
@@ -1173,18 +1173,18 @@ msgstr "Klasičan"
 msgid "Cleaning up"
 msgstr "Brisanje"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Isprazni"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Ispraznite popis izvođenja"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1329,7 +1329,7 @@ msgstr "Komentar"
 msgid "Complete tags automatically"
 msgstr "Završi oznake automatski"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Završite oznake automatski..."
 
@@ -1364,7 +1364,7 @@ msgstr "Podesi Subsonic..."
 msgid "Configure global search..."
 msgstr "Podesite globalno pretraživanje..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Podesi fonoteku..."
 
@@ -1407,7 +1407,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Povezivanje je isteklo, provjerite URL poslužitelja. Npr. http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Konzola"
 
@@ -1436,11 +1436,11 @@ msgid "Copy to clipboard"
 msgstr "Kopiraj u međuspremnik"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopirajte na uređaj..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kopirajte u fonoteku..."
@@ -1483,14 +1483,14 @@ msgstr "Nemoguća prijava na Last.fm. Pokušajte ponovno."
 msgid "Couldn't create playlist"
 msgstr "Nemoguće stvaranje popisa izvođenja"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Nije moguče pronaći muxer %1, provjerite imate li sve GStreamer pluginove instalirane"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1505,7 +1505,7 @@ msgstr "Nije moguće otvoriti izlaznu datoteku %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Upravljanje omotima"
 
@@ -1658,7 +1658,7 @@ msgid "Delete downloaded data"
 msgstr "Obriši preuzete podatke"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Obrišite datoteku"
 
@@ -1666,7 +1666,7 @@ msgstr "Obrišite datoteku"
 msgid "Delete from device..."
 msgstr "Obrišite s uređaja..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Obrišite s diska..."
@@ -1699,11 +1699,11 @@ msgstr "Brisanje datoteka"
 msgid "Depth"
 msgstr "Dubina"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Uklonite označenu pjesmu s reprodukcije"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Uklonite označenu pjesmu za reprodukciju"
 
@@ -1804,7 +1804,7 @@ msgstr "Mogućnosti zaslona"
 msgid "Display the on-screen-display"
 msgstr "Prikaži zaslonski prikaz (OSD)"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Pretražite ponovno cijelu fonoteku"
 
@@ -1983,12 +1983,12 @@ msgstr "Dinamičan naizmjeničan mix"
 msgid "Edit smart playlist..."
 msgstr "Uredite pametni popis izvođenja..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Uredi oznaku \"%1\"..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Uredite oznake..."
 
@@ -2001,7 +2001,7 @@ msgid "Edit track information"
 msgstr "Uredite informacije o pjesmi"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Uredite informacije o pjesmi..."
 
@@ -2109,7 +2109,7 @@ msgstr "Cijelu kolekciju"
 msgid "Episode information"
 msgstr "Informacije epizode"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Ekvalizator"
 
@@ -2122,8 +2122,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Odgovara --log-levels *: 3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Greška"
 
@@ -2158,7 +2158,7 @@ msgstr "Greška pri učitavanju %1"
 msgid "Error loading di.fm playlist"
 msgstr "Greška pri učitavanju di.fm popisa izvođenja"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Greška pri obradi %1: %2"
@@ -2241,7 +2241,11 @@ msgstr "Izvoz završen"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "Izvezeno %1 omota od ukupno %2 (%3 preskočena)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2265,7 +2269,7 @@ msgstr "Utišavanje"
 msgid "Fading duration"
 msgstr "Trajanje utišavanja"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Nemoguće čitanje CD uređaja"
 
@@ -2547,11 +2551,11 @@ msgstr "Upišite naziv streama:"
 msgid "Go"
 msgstr "Idi"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Idi na sljedeću karticu popisa izvođenja"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Idi na prijašnju karticu popisa izvođenja"
 
@@ -2884,7 +2888,7 @@ msgstr "Jamendo baza podataka"
 msgid "Jump to previous song right away"
 msgstr "Skočiti odmah na prijašnju pjesmu"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Prebaci na trenutno reproduciranu pjesmu"
 
@@ -2908,7 +2912,7 @@ msgstr "Nastavi izvođenje u pozadini kada je prozor zatvoren"
 msgid "Keep the original files"
 msgstr "Zadrži izvorne datoteke"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Mačići"
@@ -3000,7 +3004,7 @@ msgstr "Fonoteka"
 msgid "Library advanced grouping"
 msgstr "Napredno grupiranje fonoteke"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Obavijest o ponovnom pretraživanju fonoteke"
 
@@ -3040,7 +3044,7 @@ msgstr "Učitajte omot s diska..."
 msgid "Load playlist"
 msgstr "Otvorite popis izvođenja"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Otvorite popis izvođenja..."
 
@@ -3101,11 +3105,15 @@ msgstr "Prijava"
 msgid "Login failed"
 msgstr "Neuspjela prijava"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Profil dugoročnog predviđanja (DP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Sviđa mi se"
 
@@ -3140,11 +3148,11 @@ msgstr "Tekstovi pjesama sa %1"
 msgid "Lyrics from the tag"
 msgstr "Tekst pjesme sa oznake"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3186,7 +3194,7 @@ msgstr "Glavni profil (GLAVNI)"
 msgid "Make it so!"
 msgstr "Učinite tako!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Učinite tako!"
@@ -3324,7 +3332,7 @@ msgstr "Točka montiranja"
 msgid "Move down"
 msgstr "Pomakni dolje"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Premjesti u fonoteku..."
 
@@ -3333,7 +3341,7 @@ msgstr "Premjesti u fonoteku..."
 msgid "Move up"
 msgstr "Pomakni gore"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Glazba"
 
@@ -3346,7 +3354,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Utišaj"
 
@@ -3395,7 +3403,7 @@ msgstr "Nikada ne započinji reprodukciju glazbe"
 msgid "New folder"
 msgstr "Nova mapa"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Novi popis izvođenja"
 
@@ -3423,8 +3431,12 @@ msgstr "Najnovija pjesma"
 msgid "Next"
 msgstr "Sljedeća pjesma"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Sljedeća pjesma"
 
@@ -3462,7 +3474,7 @@ msgstr "Bez kratkih blokova"
 msgid "None"
 msgstr "Ništa"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Nijedna od odabranih pjesama nije prikladna za kopiranje na uređaj"
 
@@ -3547,19 +3559,19 @@ msgstr "Isključi"
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3603,7 +3615,7 @@ msgstr "Zasjenjenost"
 msgid "Open %1 in browser"
 msgstr "Otvori %1 u pregledniku"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Otvorite &glazbeni CD..."
 
@@ -3615,7 +3627,7 @@ msgstr "Otvori OPML datoteku"
 msgid "Open OPML file..."
 msgstr "Otvori OPML datoteku..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Otvori direktorij za uvoz glazbe iz"
 
@@ -3623,7 +3635,7 @@ msgstr "Otvori direktorij za uvoz glazbe iz"
 msgid "Open device"
 msgstr "Otvorite uređaj"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Otvorite datoteku..."
 
@@ -3677,7 +3689,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organizirajte datoteke"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Organizirajte datoteke..."
 
@@ -3761,7 +3773,7 @@ msgstr "Party"
 msgid "Password"
 msgstr "Lozinka"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pauziraj reprodukciju"
@@ -3785,6 +3797,10 @@ msgstr "Izvođač"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Piksela"
@@ -3793,10 +3809,10 @@ msgstr "Piksela"
 msgid "Plain sidebar"
 msgstr "Jednostavna bočna traka"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Pokreni reprodukciju"
 
@@ -3817,11 +3833,11 @@ msgstr "Reproduciraj ako se zaustavi, pauziraj ako svira"
 msgid "Play if there is nothing already playing"
 msgstr "Reproduciraj glazbu ako se trenutno ništa ne reproducira"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Reproduciraj sljedeće"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Reproduciraj sljedeće odabranu pjesmu"
 
@@ -3920,7 +3936,7 @@ msgstr "Osobitost"
 msgid "Preferences"
 msgstr "Mogućnosti"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Mogućnosti..."
 
@@ -3980,7 +3996,7 @@ msgid "Previous"
 msgstr "Prijašnja pjesma"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Prijašnja pjesma"
 
@@ -4038,16 +4054,16 @@ msgstr "Kvaliteta"
 msgid "Querying device..."
 msgstr "Tražim uređaj..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Upravljanje odabranim pjesmama za reprodukciju"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Odaberite označenu pjesmu za reprodukciju"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Odaberite pjesmu za reprodukciju"
 
@@ -4063,7 +4079,7 @@ msgstr "Radio (jednaka glasnoća za sve pjesme)"
 msgid "Rain"
 msgstr "Kiša"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Kiša"
@@ -4175,7 +4191,7 @@ msgstr "Uklonite radnju"
 msgid "Remove current song from playlist"
 msgstr "Uklonite trenutnu pjesmu iz popisa izvođenja"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Ukloni duplikate iz popisa izvođenja"
 
@@ -4183,7 +4199,7 @@ msgstr "Ukloni duplikate iz popisa izvođenja"
 msgid "Remove folder"
 msgstr "Uklonite mapu"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Uklonite iz popisa izvođenja"
 
@@ -4195,7 +4211,7 @@ msgstr "Ukloni popis izvođenja"
 msgid "Remove playlists"
 msgstr "Ukloni popise izvođenja"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Ukloni nedostupne pjesme s popisa izvođenja"
 
@@ -4207,7 +4223,7 @@ msgstr "Preimenujte popis izvođenja"
 msgid "Rename playlist..."
 msgstr "Preimenujte popis izvođenja..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Promjenite redosljed pjesama ovim redosljedom..."
 
@@ -4298,7 +4314,7 @@ msgstr "Ripaj"
 msgid "Rip CD"
 msgstr "Ripaj CD"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Ripaj glazbeni CD"
 
@@ -4376,7 +4392,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Spremite popis izvođenja"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Spremite popis izvođenja..."
 
@@ -4463,7 +4479,7 @@ msgstr "Subsonic pretraživanje"
 msgid "Search automatically"
 msgstr "Pretraži automatski"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Pretražite album"
 
@@ -4476,7 +4492,7 @@ msgstr "Pretražite omote albuma..."
 msgid "Search for anything"
 msgstr "Upišite pretragu"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Pretražite izvođača"
 
@@ -4601,7 +4617,7 @@ msgstr "Pojedinosti poslužitelja"
 msgid "Service offline"
 msgstr "Usluga nedostupna"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Postavite %1 na \"%2\"..."
@@ -4610,7 +4626,7 @@ msgstr "Postavite %1 na \"%2\"..."
 msgid "Set the volume to <value> percent"
 msgstr "Postavi glasnoću zvuka na <value> posto"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Postavi vrijednosti za sve odabrane pjesme..."
 
@@ -4681,7 +4697,7 @@ msgstr "Prikaži ljepši OSD"
 msgid "Show above status bar"
 msgstr "Prikaži iznad trake stanja"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Prikaži sve pjesme"
 
@@ -4701,12 +4717,12 @@ msgstr "Prikaži razdjelnike u stablu fonoteke"
 msgid "Show fullsize..."
 msgstr "Prikaži u punoj veličini..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Prikaži u pregledniku datoteka..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Prikaži u fonoteci..."
 
@@ -4718,15 +4734,15 @@ msgstr "Prikaži u različitim izvođačima"
 msgid "Show moodbar"
 msgstr "Prikaži traku tonaliteta"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Prikaži samo duplicirane pjesme"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Prikaži samo neoznačene pjesme"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Prikaži ili sakrij bočnu traku"
 
@@ -4734,7 +4750,7 @@ msgstr "Prikaži ili sakrij bočnu traku"
 msgid "Show search suggestions"
 msgstr "Prikaži prijedloge pretraživanja"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Prikaži bočnu traku"
 
@@ -4770,7 +4786,7 @@ msgstr "Sviraj naizmjenično albume"
 msgid "Shuffle all"
 msgstr "Sviraj naizmjenično sve"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Izmješajte popis izvođenja"
 
@@ -4814,11 +4830,15 @@ msgstr "Preskoči računanje"
 msgid "Skip forwards in playlist"
 msgstr "Preskoči unaprijed u popisu izvođenja"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Preskoči odabrane pjesme"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Preskoči pjesmu"
 
@@ -4935,7 +4955,7 @@ msgstr "Pokreni ripanje"
 msgid "Start the playlist currently playing"
 msgstr "Pokrenite popis izvođenja koji se trenutno izvodi"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Započni enkôdiranje"
 
@@ -4945,7 +4965,7 @@ msgid ""
 "list"
 msgstr "Počnite tipkati nešto iznad u okvir za pretragu da bi ispunili taj popis rezultata pretraživanja"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Započinjem %1"
@@ -4955,7 +4975,7 @@ msgid "Starting..."
 msgstr "Započinjem..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Zaustavi reprodukciju"
 
@@ -4971,7 +4991,7 @@ msgstr "Zaustavi reprodukciju nakon pojedine pjesme"
 msgid "Stop after every track"
 msgstr "Zaustavi reprodukciju nakon svake pjesme"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Zaustavi reprodukciju nakon ove pjesme"
 
@@ -5139,7 +5159,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Probno razdoblje za Subsonic poslužitelj je završeno. Molim, donirajte za dobivanje ključa licence. Posjetite subsonic.org za više pojedinosti."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5181,7 +5201,7 @@ msgid ""
 "continue?"
 msgstr "Ove datoteke bit će obrisane sa uređaja, sigurno želite nastaviti?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5283,11 +5303,11 @@ msgstr "Uključi/Isključi ljepši OSD"
 msgid "Toggle fullscreen"
 msgstr "Cijelozaslonski prikaz"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Uključi/isključi stanje reda čekanja"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Uključi/Isključi skrobblanje"
 
@@ -5332,19 +5352,19 @@ msgstr "Broj &pjesme"
 msgid "Track"
 msgstr "Broj"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Enkôdiranje glazbe"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Log enkôdiranja"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Enkôdiranje"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Enkôdiranje %1 datoteka koristeći %2 zadana"
@@ -5421,11 +5441,11 @@ msgstr "Nepoznata greška"
 msgid "Unset cover"
 msgstr "Uklonite omot"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Ukloni preskakanje odabrane pjesme"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Ukloni preskakanje pjesme"
 
@@ -5442,7 +5462,7 @@ msgstr "Nadolazeći koncerti"
 msgid "Update all podcasts"
 msgstr "Nadopuni sve podcaste"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Nadopuni promjene u mapi fonoteke"
 
@@ -5603,7 +5623,7 @@ msgstr "Inačica %1"
 msgid "View"
 msgstr "Pogled"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Pogledaj pojedinosti toka"
 
@@ -5611,7 +5631,7 @@ msgstr "Pogledaj pojedinosti toka"
 msgid "Visualization mode"
 msgstr "Način vizualizacije"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Vizualizacija"
 
@@ -5652,7 +5672,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5748,7 +5768,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media audio"
 
@@ -5762,7 +5782,7 @@ msgid ""
 "well?"
 msgstr "Želite li preseliti druge pjesme s ovog albuma u razne izvođače?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Želite li pokrenuti ponovnu potpunu prtetragu odmah?"
 

--- a/src/translations/hu.po
+++ b/src/translations/hu.po
@@ -18,8 +18,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 15:32+0000\n"
-"Last-Translator: Balázs Meskó <meskobalazs@mailbox.org>\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
+"Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Hungarian (http://www.transifex.com/davidsansome/clementine/language/hu/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -172,19 +172,19 @@ msgstr "%L1 szám"
 msgid "%filename%"
 msgstr "%fájlnév%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n sikertelen"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n befejezve"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -202,7 +202,7 @@ msgstr "&Középre"
 msgid "&Custom"
 msgstr "&Egyéni"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Extrák"
 
@@ -210,7 +210,7 @@ msgstr "&Extrák"
 msgid "&Grouping"
 msgstr "Cs&oportosítás"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Súgó"
 
@@ -235,7 +235,7 @@ msgstr "Értékelés &zárolása"
 msgid "&Lyrics"
 msgstr "&Dalszövegek"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Zene"
 
@@ -243,15 +243,15 @@ msgstr "&Zene"
 msgid "&None"
 msgstr "&Egyik sem"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&Lejátszólista"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Kilépés"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "&Ismétlési mód"
 
@@ -259,7 +259,7 @@ msgstr "&Ismétlési mód"
 msgid "&Right"
 msgstr "&Jobbra"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Véletlenszerű lejátszási mód"
 
@@ -267,7 +267,7 @@ msgstr "Véletlenszerű lejátszási mód"
 msgid "&Stretch columns to fit window"
 msgstr "&Oszlopszélességek igazítása az ablakhoz"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Eszközök"
 
@@ -456,11 +456,11 @@ msgstr "Megszakítás"
 msgid "About %1"
 msgstr "A(z) %1 névjegye"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "A Clementine névjegye…"
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "A Qt névjegye…"
 
@@ -520,32 +520,32 @@ msgstr "Új közvetítés hozzáadása"
 msgid "Add directory..."
 msgstr "Mappa hozzáadása"
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Új fájl"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Fájl hozzáadása az átkódoláshoz"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Fájl(ok) hozzáadása az átkódoláshoz"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Fájl hozzáadása"
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Fájlok felvétele átkódoláshoz"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Mappa hozzáadása"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Mappa hozzáadása…"
 
@@ -557,7 +557,7 @@ msgstr "Új mappa hozzáadása…"
 msgid "Add podcast"
 msgstr "Podcast hozzáadása"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Podcast hozzáadása…"
 
@@ -633,7 +633,7 @@ msgstr "Szám sorszáma címke hozzáadása"
 msgid "Add song year tag"
 msgstr "Szám éve címke hozzáadása"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Közvetítés hozzáadása…"
 
@@ -645,7 +645,7 @@ msgstr "Hozzáadás a Spotify lejátszólistához"
 msgid "Add to Spotify starred"
 msgstr "Hozzáadás a Spotify-on csillagozottakhoz"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Hozzáadás másik lejátszólistához"
 
@@ -739,7 +739,7 @@ msgstr "Mind"
 msgid "All Files (*)"
 msgstr "Minden fájl (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Minden dicsőség a Hypnotoadnak!"
@@ -1130,7 +1130,7 @@ msgstr "Új epizódok keresése"
 msgid "Check for updates"
 msgstr "Frissítések keresése"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Frissítés keresése…"
 
@@ -1179,18 +1179,18 @@ msgstr "Klasszikus"
 msgid "Cleaning up"
 msgstr "Tisztítás"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Kiürítés"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Lejátszólista ürítése"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1335,7 +1335,7 @@ msgstr "Megjegyzés"
 msgid "Complete tags automatically"
 msgstr "Címkék automatikus kiegészítése"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Címkék automatikus kiegészítése…"
 
@@ -1370,7 +1370,7 @@ msgstr "Subsonic beállítása…"
 msgid "Configure global search..."
 msgstr "Globális keresés beállítása…"
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Zenetár beállítása…"
 
@@ -1413,7 +1413,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "A kapcsolat időtúllépés miatt sikertelen, ellenőrizd a kiszolgáló URL-jét. Példa: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Konzol"
 
@@ -1442,11 +1442,11 @@ msgid "Copy to clipboard"
 msgstr "Másolás vágólapra"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Másolás eszközre…"
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Másolás a zenetárba…"
@@ -1489,14 +1489,14 @@ msgstr "Nem sikerült bejelentkezni a Last.fm-be. Próbálja újra."
 msgid "Couldn't create playlist"
 msgstr "Nem lehet létrehozni a lejátszólistát"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "%1 kódolásához nem található muxer, ellenőrizze, hogy telepítve van-e a megfelelő GStreamer beépülő"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1511,7 +1511,7 @@ msgstr "A(z) %1 célfájl megnyitása sikertelen"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Borítókezelő"
 
@@ -1664,7 +1664,7 @@ msgid "Delete downloaded data"
 msgstr "Letöltött adatok törlése"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Fájlok törlése"
 
@@ -1672,7 +1672,7 @@ msgstr "Fájlok törlése"
 msgid "Delete from device..."
 msgstr "Törlés az eszközről..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Törlés a lemezről..."
@@ -1705,11 +1705,11 @@ msgstr "Fájlok törlése"
 msgid "Depth"
 msgstr "Mélység"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Kiválasztott számok törlése a sorból"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Szám törlése a sorból"
 
@@ -1810,7 +1810,7 @@ msgstr "Beállítások megtekintése"
 msgid "Display the on-screen-display"
 msgstr "OSD megjelenítése"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Teljes zenetár újraolvasása"
 
@@ -1967,7 +1967,7 @@ msgstr "Dubstep"
 
 #: ../bin/src/ui_gstenginedebug.h:68
 msgid "Dump Pipeline Graph"
-msgstr "Csővezeték grafikon eldobása"
+msgstr "Futószalag grafikon eldobása"
 
 #: ../bin/src/ui_console.h:132
 msgid "Dump To Logs"
@@ -1989,12 +1989,12 @@ msgstr "Dinamikus véletlenszerű mix"
 msgid "Edit smart playlist..."
 msgstr "Intelligens lejátszólista szerkesztése…"
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "„%1” címke szerkesztése…"
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Címke szerkesztése…"
 
@@ -2007,7 +2007,7 @@ msgid "Edit track information"
 msgstr "Száminformációk szerkesztése"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Száminformációk szerkesztése…"
 
@@ -2115,7 +2115,7 @@ msgstr "A teljes gyűjtemény"
 msgid "Episode information"
 msgstr "Epizód információk"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Hangszínszabályzó"
 
@@ -2128,8 +2128,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Megegyezik a --log-levels *:3 kapcsolóval"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Hiba"
 
@@ -2164,7 +2164,7 @@ msgstr "Hiba a(z) %1 betöltésekor"
 msgid "Error loading di.fm playlist"
 msgstr "Hiba a di.fm lejátszólista letöltésekor"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Hiba a(z) %1 feldolgozásakor: %2"
@@ -2247,7 +2247,11 @@ msgstr "Exportálás befejezve"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "%1/%2 borító exportálva (%3 sikertelen)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2271,7 +2275,7 @@ msgstr "Elhalkulás"
 msgid "Fading duration"
 msgstr "Elhalkulás hossza"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Nem lehet olvasni a CD meghajtót"
 
@@ -2553,11 +2557,11 @@ msgstr "Adjon meg egy nevet:"
 msgid "Go"
 msgstr "Ugrás"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Váltás a következő lejátszólista lapra"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Váltás az előző lejátszólista lapra"
 
@@ -2890,7 +2894,7 @@ msgstr "Jamendo adatbázis"
 msgid "Jump to previous song right away"
 msgstr "Azonnali ugrás az előző számra"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Ugrás a most játszott számra"
 
@@ -2914,7 +2918,7 @@ msgstr "Futás a háttérben bezárt ablak esetén is"
 msgid "Keep the original files"
 msgstr "Eredeti fájlok megőrzése"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Kismacskák"
@@ -3006,7 +3010,7 @@ msgstr "Zenetár"
 msgid "Library advanced grouping"
 msgstr "Zenetár speciális csoportosítása"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Zenetár újraolvasási figyelmeztetés"
 
@@ -3046,7 +3050,7 @@ msgstr "Borító betöltése lemezről…"
 msgid "Load playlist"
 msgstr "Lejátszólista betöltése"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Lejátszólista betöltése…"
 
@@ -3107,11 +3111,15 @@ msgstr "Bejelentkezés"
 msgid "Login failed"
 msgstr "Sikertelen bejelentkezés"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr "Naplók"
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Hosszú távú előrejelzésen alapuló profil (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Kedvenc"
 
@@ -3146,11 +3154,11 @@ msgstr "Dalszöveg innen: %1"
 msgid "Lyrics from the tag"
 msgstr "Dalszöveg a címkéből"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "MP4 AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3192,7 +3200,7 @@ msgstr "Fő profil (MAIN)"
 msgid "Make it so!"
 msgstr "Csinálják!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Csinálják!"
@@ -3330,7 +3338,7 @@ msgstr "Csatolási pontok"
 msgid "Move down"
 msgstr "Mozgatás lefelé"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Áthelyezés a zenetárba…"
 
@@ -3339,7 +3347,7 @@ msgstr "Áthelyezés a zenetárba…"
 msgid "Move up"
 msgstr "Mozgatás felfelé"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Zene"
 
@@ -3352,7 +3360,7 @@ msgid "Music extensions remotely visible"
 msgstr "Távolról látható zenei kiterjesztések"
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Némítás"
 
@@ -3401,7 +3409,7 @@ msgstr "Soha ne indítsa el a lejátszást"
 msgid "New folder"
 msgstr "Új mappa"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Új lejátszólista"
 
@@ -3429,8 +3437,12 @@ msgstr "Legújabb számok"
 msgid "Next"
 msgstr "Következő"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Következő szám"
 
@@ -3468,7 +3480,7 @@ msgstr "Rövid blokkok nélkül"
 msgid "None"
 msgstr "Egyik sem"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Egy kiválasztott szám sem alkalmas az eszközre való másoláshoz"
 
@@ -3553,19 +3565,19 @@ msgstr "Kikapcsolás"
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3609,7 +3621,7 @@ msgstr "Átlátszatlanság"
 msgid "Open %1 in browser"
 msgstr "%1 megnyitása a böngészőben"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "&Hang CD megnyitása…"
 
@@ -3621,7 +3633,7 @@ msgstr "OPML-fájl megnyitása"
 msgid "Open OPML file..."
 msgstr "OPML-fájl megnyitása…"
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Könyvtár megnyitása zene importáláshoz"
 
@@ -3629,7 +3641,7 @@ msgstr "Könyvtár megnyitása zene importáláshoz"
 msgid "Open device"
 msgstr "Eszköz megnyitása"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Fájl megnyitása…"
 
@@ -3683,7 +3695,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Fájlok rendezése"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Fájlok rendezése…"
 
@@ -3767,7 +3779,7 @@ msgstr "Party"
 msgid "Password"
 msgstr "Jelszó"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Szünet"
@@ -3789,7 +3801,11 @@ msgstr "Előadó"
 
 #: ../bin/src/ui_gstenginedebug.h:67
 msgid "Pipeline"
-msgstr "Csővezeték"
+msgstr "Futószalag"
+
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr "Futószalagok"
 
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
@@ -3799,10 +3815,10 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Egyszerű oldalsáv"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Lejátszás"
 
@@ -3823,11 +3839,11 @@ msgstr "Lejátszás, ha le van állítva, különben szünet"
 msgid "Play if there is nothing already playing"
 msgstr "Lejátszás, ha nincs lejátszás folyamatban"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Következő lejátszása"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "A kiválasztott számok lejátszása a mostani után"
 
@@ -3926,7 +3942,7 @@ msgstr "Beállítás"
 msgid "Preferences"
 msgstr "Beállítások"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Beállítások…"
 
@@ -3986,7 +4002,7 @@ msgid "Previous"
 msgstr "Előző"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Előző szám"
 
@@ -4044,16 +4060,16 @@ msgstr "Minőség"
 msgid "Querying device..."
 msgstr "Eszköz lekérdezése…"
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Sorkezelő"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Sorba állítja a kiválasztott számokat"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Szám sorba állítása"
 
@@ -4069,7 +4085,7 @@ msgstr "Rádió (egyenlő hangerő minden számhoz)"
 msgid "Rain"
 msgstr "Eső"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Eső"
@@ -4181,7 +4197,7 @@ msgstr "Esemény eltávolítása"
 msgid "Remove current song from playlist"
 msgstr "Jelenlegi szám eltávolítása a lejátszólistáról"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Ismétlődések eltávolítása a lejátszólistáról"
 
@@ -4189,7 +4205,7 @@ msgstr "Ismétlődések eltávolítása a lejátszólistáról"
 msgid "Remove folder"
 msgstr "Mappa eltávolítása"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Eltávolítás a lejátszólistáról"
 
@@ -4201,7 +4217,7 @@ msgstr "Lejátszólista eltávolítása"
 msgid "Remove playlists"
 msgstr "Lejátszólista eltávolítása"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Az elérhetetlen számok törlése a lejátszólistáról"
 
@@ -4213,7 +4229,7 @@ msgstr "Lejátszólista átnevezése"
 msgid "Rename playlist..."
 msgstr "Lejátszólista átnevezése…"
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Számok újraszámozása ebben a sorrendben..."
 
@@ -4304,7 +4320,7 @@ msgstr "Beolvasás"
 msgid "Rip CD"
 msgstr "CD beolvasása"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Zenei CD beolvasása"
 
@@ -4382,7 +4398,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Lejátszólista mentése"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Lejátszólista mentése…"
 
@@ -4469,7 +4485,7 @@ msgstr "Keresés a Subsonicban"
 msgid "Search automatically"
 msgstr "Automatikus keresés"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Album keresése"
 
@@ -4482,7 +4498,7 @@ msgstr "Albumborítók keresése…"
 msgid "Search for anything"
 msgstr "Keresés bármire"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Előadó keresése"
 
@@ -4607,7 +4623,7 @@ msgstr "Kiszolgáló részletei"
 msgid "Service offline"
 msgstr "A szolgáltatás nem üzemel"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "%1 beállítása erre: „%2”…"
@@ -4616,7 +4632,7 @@ msgstr "%1 beállítása erre: „%2”…"
 msgid "Set the volume to <value> percent"
 msgstr "Hangerő beállítása <value> százalékra"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Érték beállítása minden kiválasztott számnál…"
 
@@ -4687,7 +4703,7 @@ msgstr "Pretty OSD megjelenítése"
 msgid "Show above status bar"
 msgstr "Megjelenítése az állapotsáv fölött"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Minden szám megjelenítése"
 
@@ -4707,12 +4723,12 @@ msgstr "Elválasztók megjelenítése"
 msgid "Show fullsize..."
 msgstr "Megjelenítés teljes méretben…"
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Megjelenítés fájlböngészőben…"
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Megjelenítés a zenetárban…"
 
@@ -4724,15 +4740,15 @@ msgstr "Megjelenítés a különböző előadók között"
 msgid "Show moodbar"
 msgstr "Hangulatsáv megjelenítése"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Csak az ismétlődések megjelenítése"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Csak a címke nélküliek megjelenítése"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Oldalsáv megjelenítése vagy elrejtése"
 
@@ -4740,7 +4756,7 @@ msgstr "Oldalsáv megjelenítése vagy elrejtése"
 msgid "Show search suggestions"
 msgstr "Keresési javaslatok megjelenítése"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Oldalsáv megjelenítése"
 
@@ -4776,7 +4792,7 @@ msgstr "Albumok véletlenszerűen"
 msgid "Shuffle all"
 msgstr "Az összes véletlenszerűen"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Lejátszólista véletlenszerűen"
 
@@ -4820,11 +4836,15 @@ msgstr "Kihagyások száma"
 msgid "Skip forwards in playlist"
 msgstr "Léptetés előre a lejátszólistában"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Kiválasztott számok kihagyása"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Szám kihagyása"
 
@@ -4941,7 +4961,7 @@ msgstr "Beolvasás indítása"
 msgid "Start the playlist currently playing"
 msgstr "Az éppen játszott lejátszólista indítása"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Átkódolás indítása"
 
@@ -4951,7 +4971,7 @@ msgid ""
 "list"
 msgstr "Kezdjen el írni valamit a keresési mezőbe, hogy kitöltse ezt a keresési eredmény listát"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "%1 indítása"
@@ -4961,7 +4981,7 @@ msgid "Starting..."
 msgstr "Indítás…"
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Leállítás"
 
@@ -4977,7 +4997,7 @@ msgstr "Leállítás minden egyes szám után"
 msgid "Stop after every track"
 msgstr "Leállítás az összes szám után"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Leállítás a jelenlegi szám után"
 
@@ -5145,7 +5165,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "A Subsonic kiszolgáló próbaideje lejárt. Adományozzon, hogy licenckulcsot kapjon. A részletekért keresse fel a subsonic.org oldalt."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5187,7 +5207,7 @@ msgid ""
 "continue?"
 msgstr "Ezek a fájlok törölve lesznek az eszközről. Biztos benne, hogy folytatja?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5289,11 +5309,11 @@ msgstr "Pretty OSD be/ki"
 msgid "Toggle fullscreen"
 msgstr "Teljes képernyő be/ki"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Sorállapot be/ki"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Scrobble funkció be/ki"
 
@@ -5338,19 +5358,19 @@ msgstr "Szá&m"
 msgid "Track"
 msgstr "Szám"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Zene átkódolása"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Átkódolási napló"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr "Átkódoló részletei"
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Átkódolás"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "%1 fájl átkódolása %2 folyamat használatával"
@@ -5427,11 +5447,11 @@ msgstr "Ismeretlen hiba"
 msgid "Unset cover"
 msgstr "Borító törlése"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "A kiválasztott számok lejátszása"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Szám lejátszása"
 
@@ -5448,7 +5468,7 @@ msgstr "Következő koncertek"
 msgid "Update all podcasts"
 msgstr "Összes podcast frissítése"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Megváltozott zenetárbeli könyvtárak frissítése"
 
@@ -5609,7 +5629,7 @@ msgstr "%1 verzió"
 msgid "View"
 msgstr "Nézet"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Közvetítés részleteinek megtekintése"
 
@@ -5617,7 +5637,7 @@ msgstr "Közvetítés részleteinek megtekintése"
 msgid "Visualization mode"
 msgstr "Megjelenítés módja"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Megjelenítések"
 
@@ -5658,7 +5678,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr "Figyelem: Ez a tömörítési szint kívül esik a közvetíthető részhalmazon. Ez azt jelenti, hogy a dekódoló lehet, hogy nem lesz képes elindítani a lejátszást a közvetítés közben. A hardveres dekódolók teljesítményre is hatással lehet."
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "WAV"
 
@@ -5754,7 +5774,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media audio"
 
@@ -5768,7 +5788,7 @@ msgid ""
 "well?"
 msgstr "Szeretné a többi számot ebből az albumból áthelyezni a Vegyes előadók közé is?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Szeretne most teljes újraolvasást végezni?"
 

--- a/src/translations/hu.po
+++ b/src/translations/hu.po
@@ -520,7 +520,7 @@ msgstr "Új közvetítés hozzáadása"
 msgid "Add directory..."
 msgstr "Mappa hozzáadása"
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Új fájl"
 
@@ -540,7 +540,7 @@ msgstr "Fájl hozzáadása"
 msgid "Add files to transcode"
 msgstr "Fájlok felvétele átkódoláshoz"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Mappa hozzáadása"
@@ -645,7 +645,7 @@ msgstr "Hozzáadás a Spotify lejátszólistához"
 msgid "Add to Spotify starred"
 msgstr "Hozzáadás a Spotify-on csillagozottakhoz"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Hozzáadás másik lejátszólistához"
 
@@ -867,7 +867,7 @@ msgstr "Biztos, hogy beleírja a szám statisztikáit az összes a zenetárban s
 msgid "Artist"
 msgstr "Előadó"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Előadó infó"
 
@@ -1130,7 +1130,7 @@ msgstr "Új epizódok keresése"
 msgid "Check for updates"
 msgstr "Frissítések keresése"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Frissítés keresése…"
 
@@ -1370,7 +1370,7 @@ msgstr "Subsonic beállítása…"
 msgid "Configure global search..."
 msgstr "Globális keresés beállítása…"
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Zenetár beállítása…"
 
@@ -1442,11 +1442,11 @@ msgid "Copy to clipboard"
 msgstr "Másolás vágólapra"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Másolás eszközre…"
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Másolás a zenetárba…"
@@ -1664,7 +1664,7 @@ msgid "Delete downloaded data"
 msgstr "Letöltött adatok törlése"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Fájlok törlése"
 
@@ -1672,7 +1672,7 @@ msgstr "Fájlok törlése"
 msgid "Delete from device..."
 msgstr "Törlés az eszközről..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Törlés a lemezről..."
@@ -1705,11 +1705,11 @@ msgstr "Fájlok törlése"
 msgid "Depth"
 msgstr "Mélység"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Kiválasztott számok törlése a sorból"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Szám törlése a sorból"
 
@@ -1738,7 +1738,7 @@ msgstr "Eszköznév"
 msgid "Device properties..."
 msgstr "Eszköztulajdonságok…"
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Eszközök"
 
@@ -1989,7 +1989,7 @@ msgstr "Dinamikus véletlenszerű mix"
 msgid "Edit smart playlist..."
 msgstr "Intelligens lejátszólista szerkesztése…"
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "„%1” címke szerkesztése…"
@@ -2128,8 +2128,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Megegyezik a --log-levels *:3 kapcsolóval"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Hiba"
 
@@ -2275,7 +2275,7 @@ msgstr "Elhalkulás"
 msgid "Fading duration"
 msgstr "Elhalkulás hossza"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Nem lehet olvasni a CD meghajtót"
 
@@ -2398,7 +2398,7 @@ msgstr "Fájltípus"
 msgid "Filename"
 msgstr "Fájlnév"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Fájlok"
 
@@ -2813,7 +2813,7 @@ msgstr "Telepítve"
 msgid "Integrity check"
 msgstr "Épség ellenőrzése"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -3001,7 +3001,7 @@ msgstr "Balra"
 msgid "Length"
 msgstr "Időtartam"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Zenetár"
@@ -3010,7 +3010,7 @@ msgstr "Zenetár"
 msgid "Library advanced grouping"
 msgstr "Zenetár speciális csoportosítása"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Zenetár újraolvasási figyelmeztetés"
 
@@ -3338,7 +3338,7 @@ msgstr "Csatolási pontok"
 msgid "Move down"
 msgstr "Mozgatás lefelé"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Áthelyezés a zenetárba…"
 
@@ -3347,7 +3347,7 @@ msgstr "Áthelyezés a zenetárba…"
 msgid "Move up"
 msgstr "Mozgatás felfelé"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Zene"
 
@@ -3409,7 +3409,7 @@ msgstr "Soha ne indítsa el a lejátszást"
 msgid "New folder"
 msgstr "Új mappa"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Új lejátszólista"
 
@@ -3480,7 +3480,7 @@ msgstr "Rövid blokkok nélkül"
 msgid "None"
 msgstr "Egyik sem"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Egy kiválasztott szám sem alkalmas az eszközre való másoláshoz"
 
@@ -3695,7 +3695,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Fájlok rendezése"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Fájlok rendezése…"
 
@@ -3779,7 +3779,7 @@ msgstr "Party"
 msgid "Password"
 msgstr "Jelszó"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Szünet"
@@ -3815,8 +3815,8 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Egyszerű oldalsáv"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3839,11 +3839,11 @@ msgstr "Lejátszás, ha le van állítva, különben szünet"
 msgid "Play if there is nothing already playing"
 msgstr "Lejátszás, ha nincs lejátszás folyamatban"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Következő lejátszása"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "A kiválasztott számok lejátszása a mostani után"
 
@@ -3882,7 +3882,7 @@ msgstr "Lejátszólista beállítások"
 msgid "Playlist type"
 msgstr "Lejátszólista típusa"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Lejátszólista"
 
@@ -4064,12 +4064,12 @@ msgstr "Eszköz lekérdezése…"
 msgid "Queue Manager"
 msgstr "Sorkezelő"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Sorba állítja a kiválasztott számokat"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Szám sorba állítása"
 
@@ -4460,7 +4460,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Keresés"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Keresés"
@@ -4485,7 +4485,7 @@ msgstr "Keresés a Subsonicban"
 msgid "Search automatically"
 msgstr "Automatikus keresés"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Album keresése"
 
@@ -4498,7 +4498,7 @@ msgstr "Albumborítók keresése…"
 msgid "Search for anything"
 msgstr "Keresés bármire"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Előadó keresése"
 
@@ -4623,7 +4623,7 @@ msgstr "Kiszolgáló részletei"
 msgid "Service offline"
 msgstr "A szolgáltatás nem üzemel"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "%1 beállítása erre: „%2”…"
@@ -4703,7 +4703,7 @@ msgstr "Pretty OSD megjelenítése"
 msgid "Show above status bar"
 msgstr "Megjelenítése az állapotsáv fölött"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Minden szám megjelenítése"
 
@@ -4723,12 +4723,12 @@ msgstr "Elválasztók megjelenítése"
 msgid "Show fullsize..."
 msgstr "Megjelenítés teljes méretben…"
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Megjelenítés fájlböngészőben…"
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Megjelenítés a zenetárban…"
 
@@ -4740,11 +4740,11 @@ msgstr "Megjelenítés a különböző előadók között"
 msgid "Show moodbar"
 msgstr "Hangulatsáv megjelenítése"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Csak az ismétlődések megjelenítése"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Csak a címke nélküliek megjelenítése"
 
@@ -4836,7 +4836,7 @@ msgstr "Kihagyások száma"
 msgid "Skip forwards in playlist"
 msgstr "Léptetés előre a lejátszólistában"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Kiválasztott számok kihagyása"
 
@@ -4844,7 +4844,7 @@ msgstr "Kiválasztott számok kihagyása"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Szám kihagyása"
 
@@ -4876,7 +4876,7 @@ msgstr "Soft Rock"
 msgid "Song Information"
 msgstr "Száminformációk"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Szám infó"
 
@@ -4997,7 +4997,7 @@ msgstr "Leállítás minden egyes szám után"
 msgid "Stop after every track"
 msgstr "Leállítás az összes szám után"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Leállítás a jelenlegi szám után"
 
@@ -5165,7 +5165,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "A Subsonic kiszolgáló próbaideje lejárt. Adományozzon, hogy licenckulcsot kapjon. A részletekért keresse fel a subsonic.org oldalt."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5207,7 +5207,7 @@ msgid ""
 "continue?"
 msgstr "Ezek a fájlok törölve lesznek az eszközről. Biztos benne, hogy folytatja?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5309,7 +5309,7 @@ msgstr "Pretty OSD be/ki"
 msgid "Toggle fullscreen"
 msgstr "Teljes képernyő be/ki"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Sorállapot be/ki"
 
@@ -5447,11 +5447,11 @@ msgstr "Ismeretlen hiba"
 msgid "Unset cover"
 msgstr "Borító törlése"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "A kiválasztott számok lejátszása"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Szám lejátszása"
 
@@ -5788,7 +5788,7 @@ msgid ""
 "well?"
 msgstr "Szeretné a többi számot ebből az albumból áthelyezni a Vegyes előadók közé is?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Szeretne most teljes újraolvasást végezni?"
 

--- a/src/translations/hy.po
+++ b/src/translations/hy.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Armenian (http://www.transifex.com/davidsansome/clementine/language/hy/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -161,19 +161,19 @@ msgstr ""
 msgid "%filename%"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n ավարտված"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -191,7 +191,7 @@ msgstr "&Կենտրոն"
 msgid "&Custom"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr ""
 
@@ -199,7 +199,7 @@ msgstr ""
 msgid "&Grouping"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Օգնություն"
 
@@ -224,7 +224,7 @@ msgstr ""
 msgid "&Lyrics"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr ""
 
@@ -232,15 +232,15 @@ msgstr ""
 msgid "&None"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Դուրս գալ"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr ""
 
@@ -248,7 +248,7 @@ msgstr ""
 msgid "&Right"
 msgstr "&Աջ"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr ""
 
@@ -256,7 +256,7 @@ msgstr ""
 msgid "&Stretch columns to fit window"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr ""
 
@@ -445,11 +445,11 @@ msgstr ""
 msgid "About %1"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr ""
 
@@ -509,32 +509,32 @@ msgstr ""
 msgid "Add directory..."
 msgstr ""
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr ""
 
@@ -546,7 +546,7 @@ msgstr ""
 msgid "Add podcast"
 msgstr ""
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr ""
 
@@ -622,7 +622,7 @@ msgstr ""
 msgid "Add song year tag"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr ""
 
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr ""
 
@@ -728,7 +728,7 @@ msgstr ""
 msgid "All Files (*)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr ""
@@ -1119,7 +1119,7 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr ""
 
@@ -1168,18 +1168,18 @@ msgstr ""
 msgid "Cleaning up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr ""
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr ""
 
@@ -1324,7 +1324,7 @@ msgstr ""
 msgid "Complete tags automatically"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr ""
 
@@ -1359,7 +1359,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr ""
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr ""
 
@@ -1431,11 +1431,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1478,14 +1478,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr ""
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1500,7 +1500,7 @@ msgstr ""
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr ""
 
@@ -1653,7 +1653,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr ""
 
@@ -1661,7 +1661,7 @@ msgstr ""
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1694,11 +1694,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr ""
 
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "Display the on-screen-display"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr ""
 
@@ -1978,12 +1978,12 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr ""
 
@@ -1996,7 +1996,7 @@ msgid "Edit track information"
 msgstr ""
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr ""
 
@@ -2104,7 +2104,7 @@ msgstr ""
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr ""
 
@@ -2117,8 +2117,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr ""
 
@@ -2153,7 +2153,7 @@ msgstr ""
 msgid "Error loading di.fm playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr ""
@@ -2236,7 +2236,11 @@ msgstr ""
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr ""
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2260,7 +2264,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2542,11 +2546,11 @@ msgstr ""
 msgid "Go"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr ""
 
@@ -2879,7 +2883,7 @@ msgstr ""
 msgid "Jump to previous song right away"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr ""
 
@@ -2903,7 +2907,7 @@ msgstr ""
 msgid "Keep the original files"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr ""
@@ -2995,7 +2999,7 @@ msgstr ""
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3035,7 +3039,7 @@ msgstr ""
 msgid "Load playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr ""
 
@@ -3096,11 +3100,15 @@ msgstr ""
 msgid "Login failed"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr ""
 
@@ -3135,11 +3143,11 @@ msgstr ""
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr ""
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr ""
@@ -3181,7 +3189,7 @@ msgstr ""
 msgid "Make it so!"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr ""
@@ -3319,7 +3327,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3328,7 +3336,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr ""
 
@@ -3341,7 +3349,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr ""
 
@@ -3390,7 +3398,7 @@ msgstr ""
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3418,8 +3426,12 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr ""
 
@@ -3457,7 +3469,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3542,19 +3554,19 @@ msgstr ""
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr ""
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr ""
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr ""
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3598,7 +3610,7 @@ msgstr ""
 msgid "Open %1 in browser"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr ""
 
@@ -3610,7 +3622,7 @@ msgstr ""
 msgid "Open OPML file..."
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr ""
 
@@ -3618,7 +3630,7 @@ msgstr ""
 msgid "Open device"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr ""
 
@@ -3672,7 +3684,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr ""
 
@@ -3756,7 +3768,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr ""
@@ -3780,6 +3792,10 @@ msgstr ""
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr ""
@@ -3788,10 +3804,10 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr ""
 
@@ -3812,11 +3828,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3915,7 +3931,7 @@ msgstr ""
 msgid "Preferences"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr ""
 
@@ -3975,7 +3991,7 @@ msgid "Previous"
 msgstr ""
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr ""
 
@@ -4033,16 +4049,16 @@ msgstr ""
 msgid "Querying device..."
 msgstr ""
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr ""
 
@@ -4058,7 +4074,7 @@ msgstr ""
 msgid "Rain"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr ""
@@ -4170,7 +4186,7 @@ msgstr ""
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr ""
 
@@ -4178,7 +4194,7 @@ msgstr ""
 msgid "Remove folder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr ""
 
@@ -4190,7 +4206,7 @@ msgstr ""
 msgid "Remove playlists"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr ""
 
@@ -4202,7 +4218,7 @@ msgstr ""
 msgid "Rename playlist..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr ""
 
@@ -4293,7 +4309,7 @@ msgstr ""
 msgid "Rip CD"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr ""
 
@@ -4371,7 +4387,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr ""
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr ""
 
@@ -4458,7 +4474,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4471,7 +4487,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4596,7 +4612,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4605,7 +4621,7 @@ msgstr ""
 msgid "Set the volume to <value> percent"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr ""
 
@@ -4676,7 +4692,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr ""
 
@@ -4696,12 +4712,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr ""
 
@@ -4713,15 +4729,15 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4729,7 +4745,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4765,7 +4781,7 @@ msgstr ""
 msgid "Shuffle all"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr ""
 
@@ -4809,11 +4825,15 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr ""
 
@@ -4930,7 +4950,7 @@ msgstr ""
 msgid "Start the playlist currently playing"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr ""
 
@@ -4940,7 +4960,7 @@ msgid ""
 "list"
 msgstr ""
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr ""
@@ -4950,7 +4970,7 @@ msgid "Starting..."
 msgstr ""
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr ""
 
@@ -4966,7 +4986,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5134,7 +5154,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5176,7 +5196,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5278,11 +5298,11 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr ""
 
@@ -5327,19 +5347,19 @@ msgstr ""
 msgid "Track"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr ""
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
 msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr ""
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr ""
@@ -5416,11 +5436,11 @@ msgstr ""
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr ""
 
@@ -5437,7 +5457,7 @@ msgstr ""
 msgid "Update all podcasts"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr ""
 
@@ -5598,7 +5618,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5606,7 +5626,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr ""
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr ""
 
@@ -5647,7 +5667,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr ""
 
@@ -5743,7 +5763,7 @@ msgstr ""
 msgid "Windows Media 64k"
 msgstr ""
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr ""
 
@@ -5757,7 +5777,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/hy.po
+++ b/src/translations/hy.po
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add directory..."
 msgstr ""
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgstr ""
 msgid "Add files to transcode"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr ""
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr ""
 
@@ -856,7 +856,7 @@ msgstr ""
 msgid "Artist"
 msgstr ""
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr ""
 
@@ -1119,7 +1119,7 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr ""
 
@@ -1359,7 +1359,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr ""
 
@@ -1431,11 +1431,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1653,7 +1653,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr ""
 
@@ -1661,7 +1661,7 @@ msgstr ""
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1694,11 +1694,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr ""
 
@@ -1727,7 +1727,7 @@ msgstr ""
 msgid "Device properties..."
 msgstr ""
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr ""
 
@@ -1978,7 +1978,7 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
@@ -2117,8 +2117,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr ""
 
@@ -2264,7 +2264,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2387,7 +2387,7 @@ msgstr ""
 msgid "Filename"
 msgstr ""
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr ""
 
@@ -2802,7 +2802,7 @@ msgstr ""
 msgid "Integrity check"
 msgstr ""
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr ""
 
@@ -2990,7 +2990,7 @@ msgstr ""
 msgid "Length"
 msgstr ""
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr ""
@@ -2999,7 +2999,7 @@ msgstr ""
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3327,7 +3327,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3336,7 +3336,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr ""
 
@@ -3398,7 +3398,7 @@ msgstr ""
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3469,7 +3469,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3684,7 +3684,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr ""
 
@@ -3768,7 +3768,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr ""
@@ -3804,8 +3804,8 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3828,11 +3828,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Playlist type"
 msgstr ""
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr ""
 
@@ -4053,12 +4053,12 @@ msgstr ""
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr ""
 
@@ -4449,7 +4449,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr ""
@@ -4474,7 +4474,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4487,7 +4487,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4692,7 +4692,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr ""
 
@@ -4712,12 +4712,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr ""
 
@@ -4729,11 +4729,11 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr ""
 
@@ -4825,7 +4825,7 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr ""
 
@@ -4833,7 +4833,7 @@ msgstr ""
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr ""
 
@@ -4865,7 +4865,7 @@ msgstr ""
 msgid "Song Information"
 msgstr ""
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr ""
 
@@ -4986,7 +4986,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5154,7 +5154,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5196,7 +5196,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5298,7 +5298,7 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr ""
 
@@ -5436,11 +5436,11 @@ msgstr ""
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr ""
 
@@ -5777,7 +5777,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/ia.po
+++ b/src/translations/ia.po
@@ -9,7 +9,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Interlingua (http://www.transifex.com/davidsansome/clementine/language/ia/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -163,19 +163,19 @@ msgstr ""
 msgid "%filename%"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -193,7 +193,7 @@ msgstr ""
 msgid "&Custom"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr ""
 
@@ -201,7 +201,7 @@ msgstr ""
 msgid "&Grouping"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Adjuta"
 
@@ -226,7 +226,7 @@ msgstr ""
 msgid "&Lyrics"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Musica"
 
@@ -234,15 +234,15 @@ msgstr "&Musica"
 msgid "&None"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr ""
 
@@ -250,7 +250,7 @@ msgstr ""
 msgid "&Right"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr ""
 
@@ -258,7 +258,7 @@ msgstr ""
 msgid "&Stretch columns to fit window"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "Instrumen&tos"
 
@@ -447,11 +447,11 @@ msgstr ""
 msgid "About %1"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr ""
 
@@ -511,32 +511,32 @@ msgstr ""
 msgid "Add directory..."
 msgstr ""
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr ""
 
@@ -548,7 +548,7 @@ msgstr ""
 msgid "Add podcast"
 msgstr ""
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Add song year tag"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr ""
 
@@ -730,7 +730,7 @@ msgstr ""
 msgid "All Files (*)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr ""
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr ""
 
@@ -1170,18 +1170,18 @@ msgstr ""
 msgid "Cleaning up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr ""
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr ""
 
@@ -1326,7 +1326,7 @@ msgstr ""
 msgid "Complete tags automatically"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr ""
 
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr ""
 
@@ -1404,7 +1404,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr ""
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr ""
 
@@ -1433,11 +1433,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1480,14 +1480,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr ""
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1502,7 +1502,7 @@ msgstr ""
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr ""
 
@@ -1655,7 +1655,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr ""
 
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1696,11 +1696,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr ""
 
@@ -1801,7 +1801,7 @@ msgstr ""
 msgid "Display the on-screen-display"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr ""
 
@@ -1980,12 +1980,12 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr ""
 
@@ -1998,7 +1998,7 @@ msgid "Edit track information"
 msgstr ""
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr ""
 
@@ -2106,7 +2106,7 @@ msgstr ""
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr ""
 
@@ -2119,8 +2119,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr ""
 
@@ -2155,7 +2155,7 @@ msgstr ""
 msgid "Error loading di.fm playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr ""
@@ -2238,7 +2238,11 @@ msgstr ""
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr ""
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2262,7 +2266,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2544,11 +2548,11 @@ msgstr ""
 msgid "Go"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr ""
 
@@ -2881,7 +2885,7 @@ msgstr ""
 msgid "Jump to previous song right away"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr ""
 
@@ -2905,7 +2909,7 @@ msgstr ""
 msgid "Keep the original files"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr ""
@@ -2997,7 +3001,7 @@ msgstr ""
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3037,7 +3041,7 @@ msgstr ""
 msgid "Load playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr ""
 
@@ -3098,11 +3102,15 @@ msgstr ""
 msgid "Login failed"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr ""
 
@@ -3137,11 +3145,11 @@ msgstr ""
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr ""
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr ""
@@ -3183,7 +3191,7 @@ msgstr ""
 msgid "Make it so!"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr ""
@@ -3321,7 +3329,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3330,7 +3338,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr ""
 
@@ -3343,7 +3351,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr ""
 
@@ -3392,7 +3400,7 @@ msgstr ""
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3420,8 +3428,12 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr ""
 
@@ -3459,7 +3471,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3544,19 +3556,19 @@ msgstr ""
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr ""
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr ""
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr ""
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3600,7 +3612,7 @@ msgstr ""
 msgid "Open %1 in browser"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr ""
 
@@ -3612,7 +3624,7 @@ msgstr ""
 msgid "Open OPML file..."
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr ""
 
@@ -3620,7 +3632,7 @@ msgstr ""
 msgid "Open device"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr ""
 
@@ -3674,7 +3686,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr ""
 
@@ -3758,7 +3770,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr ""
@@ -3782,6 +3794,10 @@ msgstr ""
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr ""
@@ -3790,10 +3806,10 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr ""
 
@@ -3814,11 +3830,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3917,7 +3933,7 @@ msgstr ""
 msgid "Preferences"
 msgstr "Preferentias"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Preferentias..."
 
@@ -3977,7 +3993,7 @@ msgid "Previous"
 msgstr ""
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr ""
 
@@ -4035,16 +4051,16 @@ msgstr ""
 msgid "Querying device..."
 msgstr ""
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr ""
 
@@ -4060,7 +4076,7 @@ msgstr ""
 msgid "Rain"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr ""
@@ -4172,7 +4188,7 @@ msgstr ""
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr ""
 
@@ -4180,7 +4196,7 @@ msgstr ""
 msgid "Remove folder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr ""
 
@@ -4192,7 +4208,7 @@ msgstr ""
 msgid "Remove playlists"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr ""
 
@@ -4204,7 +4220,7 @@ msgstr ""
 msgid "Rename playlist..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr ""
 
@@ -4295,7 +4311,7 @@ msgstr ""
 msgid "Rip CD"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr ""
 
@@ -4373,7 +4389,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr ""
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr ""
 
@@ -4460,7 +4476,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4473,7 +4489,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4598,7 +4614,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4607,7 +4623,7 @@ msgstr ""
 msgid "Set the volume to <value> percent"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr ""
 
@@ -4678,7 +4694,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr ""
 
@@ -4698,12 +4714,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr ""
 
@@ -4715,15 +4731,15 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4731,7 +4747,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4767,7 +4783,7 @@ msgstr ""
 msgid "Shuffle all"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr ""
 
@@ -4811,11 +4827,15 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr ""
 
@@ -4932,7 +4952,7 @@ msgstr ""
 msgid "Start the playlist currently playing"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr ""
 
@@ -4942,7 +4962,7 @@ msgid ""
 "list"
 msgstr ""
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr ""
@@ -4952,7 +4972,7 @@ msgid "Starting..."
 msgstr ""
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr ""
 
@@ -4968,7 +4988,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5136,7 +5156,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5178,7 +5198,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5280,11 +5300,11 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr ""
 
@@ -5329,19 +5349,19 @@ msgstr ""
 msgid "Track"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr ""
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
 msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr ""
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr ""
@@ -5418,11 +5438,11 @@ msgstr "Error Incognite"
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr ""
 
@@ -5439,7 +5459,7 @@ msgstr ""
 msgid "Update all podcasts"
 msgstr "Actualisar omne podcasts"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr ""
 
@@ -5600,7 +5620,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5608,7 +5628,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr ""
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr ""
 
@@ -5649,7 +5669,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr ""
 
@@ -5745,7 +5765,7 @@ msgstr ""
 msgid "Windows Media 64k"
 msgstr ""
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr ""
 
@@ -5759,7 +5779,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/ia.po
+++ b/src/translations/ia.po
@@ -511,7 +511,7 @@ msgstr ""
 msgid "Add directory..."
 msgstr ""
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr ""
 
@@ -531,7 +531,7 @@ msgstr ""
 msgid "Add files to transcode"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr ""
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Artist"
 msgstr ""
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr ""
 
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr ""
 
@@ -1433,11 +1433,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1655,7 +1655,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr ""
 
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1696,11 +1696,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr ""
 
@@ -1729,7 +1729,7 @@ msgstr ""
 msgid "Device properties..."
 msgstr ""
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr ""
 
@@ -1980,7 +1980,7 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
@@ -2119,8 +2119,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr ""
 
@@ -2266,7 +2266,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2389,7 +2389,7 @@ msgstr ""
 msgid "Filename"
 msgstr ""
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr ""
 
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "Integrity check"
 msgstr ""
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr ""
 
@@ -2992,7 +2992,7 @@ msgstr ""
 msgid "Length"
 msgstr ""
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr ""
@@ -3001,7 +3001,7 @@ msgstr ""
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3329,7 +3329,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3338,7 +3338,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr ""
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3471,7 +3471,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3686,7 +3686,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr ""
 
@@ -3770,7 +3770,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr ""
@@ -3806,8 +3806,8 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3830,11 +3830,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3873,7 +3873,7 @@ msgstr ""
 msgid "Playlist type"
 msgstr ""
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr ""
 
@@ -4055,12 +4055,12 @@ msgstr ""
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr ""
 
@@ -4451,7 +4451,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr ""
@@ -4476,7 +4476,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4489,7 +4489,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4614,7 +4614,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4694,7 +4694,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr ""
 
@@ -4714,12 +4714,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr ""
 
@@ -4731,11 +4731,11 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr ""
 
@@ -4835,7 +4835,7 @@ msgstr ""
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr ""
 
@@ -4867,7 +4867,7 @@ msgstr ""
 msgid "Song Information"
 msgstr "Information de canto"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr ""
 
@@ -4988,7 +4988,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5156,7 +5156,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5198,7 +5198,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5300,7 +5300,7 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr ""
 
@@ -5438,11 +5438,11 @@ msgstr "Error Incognite"
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr ""
 
@@ -5779,7 +5779,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/id.po
+++ b/src/translations/id.po
@@ -530,7 +530,7 @@ msgstr "Tambah strim lainnya..."
 msgid "Add directory..."
 msgstr "Tambah direktori..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Tambah berkas"
 
@@ -550,7 +550,7 @@ msgstr "Tambah berkas..."
 msgid "Add files to transcode"
 msgstr "Tambah berkas untuk ditranskode"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Tambah folder"
@@ -655,7 +655,7 @@ msgstr "Tambahkan ke daftar-putar Spotify"
 msgid "Add to Spotify starred"
 msgstr "Tambahkan ke bintang Spotify"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Tambahkan ke daftar-putar lainnya"
 
@@ -877,7 +877,7 @@ msgstr "Apakah Anda yakin ingin menulis statistik lagu ke dalam berkas lagu untu
 msgid "Artist"
 msgstr "Artis"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Info artis"
 
@@ -1140,7 +1140,7 @@ msgstr "Periksa episode baru"
 msgid "Check for updates"
 msgstr "Periksa pembaruan"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Periksa pembaruan..."
 
@@ -1380,7 +1380,7 @@ msgstr "Konfigurasi Subsonic..."
 msgid "Configure global search..."
 msgstr "Konfigurasi pencarian global..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Konfigurasi pustaka..."
 
@@ -1452,11 +1452,11 @@ msgid "Copy to clipboard"
 msgstr "Salin ke papan klip"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Salin ke perangkat..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Salin ke pustaka..."
@@ -1674,7 +1674,7 @@ msgid "Delete downloaded data"
 msgstr "Hapus data yang sudah diunduh"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Hapus berkas"
 
@@ -1682,7 +1682,7 @@ msgstr "Hapus berkas"
 msgid "Delete from device..."
 msgstr "Hapus dari perangkat..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Hapus dari diska..."
@@ -1715,11 +1715,11 @@ msgstr "Menghapus berkas"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Buang antrean trek terpilih"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Buang antrean trek"
 
@@ -1748,7 +1748,7 @@ msgstr "Nama perangkat"
 msgid "Device properties..."
 msgstr "Properti perangkat..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Perangkat"
 
@@ -1999,7 +1999,7 @@ msgstr "Miks acak dinamis"
 msgid "Edit smart playlist..."
 msgstr "Sunting daftar-putar cerdas..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Sunting tag \"%1\"..."
@@ -2138,8 +2138,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Setara dengan --log-level *: 3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Galat"
 
@@ -2285,7 +2285,7 @@ msgstr "Melesap"
 msgid "Fading duration"
 msgstr "Durasi lesap"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Gagal membaca penggerak CD"
 
@@ -2408,7 +2408,7 @@ msgstr "Jenis berkas"
 msgid "Filename"
 msgstr "Nama berkas"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Berkas"
 
@@ -2823,7 +2823,7 @@ msgstr "Terpasang"
 msgid "Integrity check"
 msgstr "Periksa integritas"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -3011,7 +3011,7 @@ msgstr "Kiri"
 msgid "Length"
 msgstr "Durasi"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Pustaka"
@@ -3020,7 +3020,7 @@ msgstr "Pustaka"
 msgid "Library advanced grouping"
 msgstr "Pengelompokan pustaka lanjutan"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Pemberitahuan pemindaian ulang pustaka"
 
@@ -3348,7 +3348,7 @@ msgstr "Titik kait"
 msgid "Move down"
 msgstr "Pindah turun"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Pindah ke pustaka..."
 
@@ -3357,7 +3357,7 @@ msgstr "Pindah ke pustaka..."
 msgid "Move up"
 msgstr "Pindah naik"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Musik"
 
@@ -3419,7 +3419,7 @@ msgstr "Jangan mulai memutar"
 msgid "New folder"
 msgstr "Folder baru"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Daftar-putar baru"
 
@@ -3490,7 +3490,7 @@ msgstr "Tanpa blok pendek"
 msgid "None"
 msgstr "Nihil"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Tidak satu pun dari lagu yang dipilih cocok untuk disalin ke perangkat"
 
@@ -3705,7 +3705,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Atur Berkas"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Atur berkas..."
 
@@ -3789,7 +3789,7 @@ msgstr "Pesta"
 msgid "Password"
 msgstr "Sandi"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Jeda"
@@ -3825,8 +3825,8 @@ msgstr "Piksel"
 msgid "Plain sidebar"
 msgstr "Bilah sisi polos"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3849,11 +3849,11 @@ msgstr "Putar jika berhenti, jeda jika berputar"
 msgid "Play if there is nothing already playing"
 msgstr "Putar jika tidak ada yang sedang diputar"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3892,7 +3892,7 @@ msgstr "Opsi daftar-putar"
 msgid "Playlist type"
 msgstr "Tipe daftar-putar"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Daftar-putar"
 
@@ -4074,12 +4074,12 @@ msgstr "Meminta perangkat..."
 msgid "Queue Manager"
 msgstr "Pengelola antrean"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Antre trek terpilih"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Antre trek"
 
@@ -4470,7 +4470,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Cari"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Cari"
@@ -4495,7 +4495,7 @@ msgstr "Cari Subsonic"
 msgid "Search automatically"
 msgstr "Cari secara otomatis"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4508,7 +4508,7 @@ msgstr "Cari sampul album..."
 msgid "Search for anything"
 msgstr "Cari apapun"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4633,7 +4633,7 @@ msgstr "Detail server"
 msgid "Service offline"
 msgstr "Layanan luring"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Tetapkan %1 ke \"%2\"..."
@@ -4713,7 +4713,7 @@ msgstr "Tampilkan OSD cantik"
 msgid "Show above status bar"
 msgstr "Tampilkan di atas bilah status"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Tampilkan semua lagu"
 
@@ -4733,12 +4733,12 @@ msgstr "Tampilkan pembagi"
 msgid "Show fullsize..."
 msgstr "Tampilkan ukuran penuh..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Tampilkan di peramban berkas..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Tampilkan di pustaka..."
 
@@ -4750,11 +4750,11 @@ msgstr "Tampilkan di artis beragam"
 msgid "Show moodbar"
 msgstr "Tampilkan moodbar"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Tampilkan hanya duplikat"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Tampilkan hanya tidak bertag"
 
@@ -4846,7 +4846,7 @@ msgstr "Lewati hitungan"
 msgid "Skip forwards in playlist"
 msgstr "Lewati maju di dalam daftar-putar"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Lewati trek yang dipilih"
 
@@ -4854,7 +4854,7 @@ msgstr "Lewati trek yang dipilih"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Lewati trek"
 
@@ -4886,7 +4886,7 @@ msgstr "Soft Rock"
 msgid "Song Information"
 msgstr "Informasi Lagu"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Info lagu"
 
@@ -5007,7 +5007,7 @@ msgstr "Berhenti setelah masing-masing trek"
 msgid "Stop after every track"
 msgstr "Berhenti setelah setiap trek"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Berhenti setelah trek ini"
 
@@ -5175,7 +5175,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Masa uji coba untuk server Subsonic telah berakhir. Mohon donasi untuk mendapatkan kunci lisensi. Kunjungi subsonic.org untuk lebih perinci."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5217,7 +5217,7 @@ msgid ""
 "continue?"
 msgstr "Berkas-berkas ini akan dihapus dari perangkat, apakah Anda yakin ingin melanjutkan?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5319,7 +5319,7 @@ msgstr "Jungkit Pretty OSD"
 msgid "Toggle fullscreen"
 msgstr "Jungkit layar penuh"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Jungkit status antrean"
 
@@ -5457,11 +5457,11 @@ msgstr "Galat tidak diketahui"
 msgid "Unset cover"
 msgstr "Tak set sampul"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Taklewati trek yang dipilih"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Taklewati trek"
 
@@ -5798,7 +5798,7 @@ msgid ""
 "well?"
 msgstr "Apakah Anda ingin memindahkan lagu lainnya di dalam album ini ke Artis Beragam?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Apakah Anda ingin menjalankan pemindaian ulang menyeluruh sekarang?"
 

--- a/src/translations/id.po
+++ b/src/translations/id.po
@@ -28,7 +28,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Indonesian (http://www.transifex.com/davidsansome/clementine/language/id/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -182,19 +182,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%nama berkas%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n gagal"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n telah selesai"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -212,7 +212,7 @@ msgstr "&Tengah"
 msgid "&Custom"
 msgstr "&Ubahsuai"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Ekstra"
 
@@ -220,7 +220,7 @@ msgstr "&Ekstra"
 msgid "&Grouping"
 msgstr "&Pengelompokan"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Bantuan"
 
@@ -245,7 +245,7 @@ msgstr "&Kunci Peringkat"
 msgid "&Lyrics"
 msgstr "&Lirik"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Musik"
 
@@ -253,15 +253,15 @@ msgstr "&Musik"
 msgid "&None"
 msgstr "&Nihil"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&Daftar-putar"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Keluar"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "Mode pe&rulangan"
 
@@ -269,7 +269,7 @@ msgstr "Mode pe&rulangan"
 msgid "&Right"
 msgstr "&Kanan"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Mode &Karau"
 
@@ -277,7 +277,7 @@ msgstr "Mode &Karau"
 msgid "&Stretch columns to fit window"
 msgstr "&Regang kolom agar pas dengan jendela"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Perkakas"
 
@@ -466,11 +466,11 @@ msgstr "Batal"
 msgid "About %1"
 msgstr "Tentang %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Tentang Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Tentang Qt..."
 
@@ -530,32 +530,32 @@ msgstr "Tambah strim lainnya..."
 msgid "Add directory..."
 msgstr "Tambah direktori..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Tambah berkas"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Tambah berkas ke transkoder"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Tambah berkas ke transkoder"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Tambah berkas..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Tambah berkas untuk ditranskode"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Tambah folder"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Tambah folder..."
 
@@ -567,7 +567,7 @@ msgstr "Tambah folder baru..."
 msgid "Add podcast"
 msgstr "Tambah podcast"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Tambah podcast..."
 
@@ -643,7 +643,7 @@ msgstr "Tambahkan nomor trek"
 msgid "Add song year tag"
 msgstr "Tambahkan tahun rilis"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Tambah strim..."
 
@@ -655,7 +655,7 @@ msgstr "Tambahkan ke daftar-putar Spotify"
 msgid "Add to Spotify starred"
 msgstr "Tambahkan ke bintang Spotify"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Tambahkan ke daftar-putar lainnya"
 
@@ -749,7 +749,7 @@ msgstr "Semua"
 msgid "All Files (*)"
 msgstr "Semua Berkas (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Seluruh Kejayaan untuk Sang Hypnotoad!"
@@ -1140,7 +1140,7 @@ msgstr "Periksa episode baru"
 msgid "Check for updates"
 msgstr "Periksa pembaruan"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Periksa pembaruan..."
 
@@ -1189,18 +1189,18 @@ msgstr "Klasik"
 msgid "Cleaning up"
 msgstr "Pembersihan"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Bersihkan"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Bersihkan daftar-putar"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1345,7 +1345,7 @@ msgstr "Komentar"
 msgid "Complete tags automatically"
 msgstr "Lengkapi tag secara otomatis"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Lengkapi tag secara otomatis..."
 
@@ -1380,7 +1380,7 @@ msgstr "Konfigurasi Subsonic..."
 msgid "Configure global search..."
 msgstr "Konfigurasi pencarian global..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Konfigurasi pustaka..."
 
@@ -1423,7 +1423,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Koneksi melewati batas waktu, periksa URL server. Contoh: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Konsol"
 
@@ -1452,11 +1452,11 @@ msgid "Copy to clipboard"
 msgstr "Salin ke papan klip"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Salin ke perangkat..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Salin ke pustaka..."
@@ -1499,14 +1499,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr "Tidak bisa membuat daftar-putar"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Tidak dapat menemukan muxer untuk %1, periksa apakah Anda memiliki plugin GStreamer yang benar terpasang"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1521,7 +1521,7 @@ msgstr "Tidak dapat membuka berkas keluaran %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Pengelola Sampul"
 
@@ -1674,7 +1674,7 @@ msgid "Delete downloaded data"
 msgstr "Hapus data yang sudah diunduh"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Hapus berkas"
 
@@ -1682,7 +1682,7 @@ msgstr "Hapus berkas"
 msgid "Delete from device..."
 msgstr "Hapus dari perangkat..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Hapus dari diska..."
@@ -1715,11 +1715,11 @@ msgstr "Menghapus berkas"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Buang antrean trek terpilih"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Buang antrean trek"
 
@@ -1820,7 +1820,7 @@ msgstr "Opsi tampilan"
 msgid "Display the on-screen-display"
 msgstr "Tampilkan tampilan-pada-layar"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Lakukan pemindaian ulang pustaka menyeluruh"
 
@@ -1999,12 +1999,12 @@ msgstr "Miks acak dinamis"
 msgid "Edit smart playlist..."
 msgstr "Sunting daftar-putar cerdas..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Sunting tag \"%1\"..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Sunting tag..."
 
@@ -2017,7 +2017,7 @@ msgid "Edit track information"
 msgstr "Sunting informasi trek"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Sunting informasi trek..."
 
@@ -2125,7 +2125,7 @@ msgstr "Semua koleksi"
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Ekualiser"
 
@@ -2138,8 +2138,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Setara dengan --log-level *: 3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Galat"
 
@@ -2174,7 +2174,7 @@ msgstr "Galat memuat %1"
 msgid "Error loading di.fm playlist"
 msgstr "Galat memuat daftar-putar di.fm"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Galat memroses %1: %2"
@@ -2257,7 +2257,11 @@ msgstr "Ekspor selesai"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "Mengekspor %1 sampul dari %2 (%3 dilewati)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2281,7 +2285,7 @@ msgstr "Melesap"
 msgid "Fading duration"
 msgstr "Durasi lesap"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Gagal membaca penggerak CD"
 
@@ -2563,11 +2567,11 @@ msgstr "Berikan nama:"
 msgid "Go"
 msgstr "Jalankan"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Buka tab daftar-putar selanjutnya"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Buka tab daftar-putar sebelumnya"
 
@@ -2900,7 +2904,7 @@ msgstr "Basis data Jamendo"
 msgid "Jump to previous song right away"
 msgstr "Lompat ke lagu sebelumnya sesegera"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Lompat ke trek yang sedang diputar"
 
@@ -2924,7 +2928,7 @@ msgstr "Tetap jalankan di belakang layar ketika jendela ditutup"
 msgid "Keep the original files"
 msgstr "Simpan berkas yang asli"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Anak kucing"
@@ -3016,7 +3020,7 @@ msgstr "Pustaka"
 msgid "Library advanced grouping"
 msgstr "Pengelompokan pustaka lanjutan"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Pemberitahuan pemindaian ulang pustaka"
 
@@ -3056,7 +3060,7 @@ msgstr "Muat sampul dari diska..."
 msgid "Load playlist"
 msgstr "Muat daftar-putar"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Muat daftar-putar..."
 
@@ -3117,11 +3121,15 @@ msgstr "Masuk"
 msgid "Login failed"
 msgstr "Gagal masuk"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Profil prediksi jangka panjang (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Suka"
 
@@ -3156,11 +3164,11 @@ msgstr "Lirik dari %1"
 msgid "Lyrics from the tag"
 msgstr "Lirik dari tag"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3202,7 +3210,7 @@ msgstr "Profil utama (MAIN)"
 msgid "Make it so!"
 msgstr "Buatlah begitu!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Buatlah begitu!"
@@ -3340,7 +3348,7 @@ msgstr "Titik kait"
 msgid "Move down"
 msgstr "Pindah turun"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Pindah ke pustaka..."
 
@@ -3349,7 +3357,7 @@ msgstr "Pindah ke pustaka..."
 msgid "Move up"
 msgstr "Pindah naik"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Musik"
 
@@ -3362,7 +3370,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Bisu"
 
@@ -3411,7 +3419,7 @@ msgstr "Jangan mulai memutar"
 msgid "New folder"
 msgstr "Folder baru"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Daftar-putar baru"
 
@@ -3439,8 +3447,12 @@ msgstr "Trek terbaru"
 msgid "Next"
 msgstr "Lanjut"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Trek selanjutnya"
 
@@ -3478,7 +3490,7 @@ msgstr "Tanpa blok pendek"
 msgid "None"
 msgstr "Nihil"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Tidak satu pun dari lagu yang dipilih cocok untuk disalin ke perangkat"
 
@@ -3563,19 +3575,19 @@ msgstr "Mati"
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3619,7 +3631,7 @@ msgstr "Kelegapan"
 msgid "Open %1 in browser"
 msgstr "Buka %1 di peramban"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Buka CD &audio..."
 
@@ -3631,7 +3643,7 @@ msgstr "Buka berkas OPML"
 msgid "Open OPML file..."
 msgstr "Buka berkas OPML..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Buka sebuah direktori untuk mengimpor musik dari"
 
@@ -3639,7 +3651,7 @@ msgstr "Buka sebuah direktori untuk mengimpor musik dari"
 msgid "Open device"
 msgstr "Buka perangkat"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Buka berkas..."
 
@@ -3693,7 +3705,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Atur Berkas"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Atur berkas..."
 
@@ -3777,7 +3789,7 @@ msgstr "Pesta"
 msgid "Password"
 msgstr "Sandi"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Jeda"
@@ -3801,6 +3813,10 @@ msgstr "Penampil"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Piksel"
@@ -3809,10 +3825,10 @@ msgstr "Piksel"
 msgid "Plain sidebar"
 msgstr "Bilah sisi polos"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Putar"
 
@@ -3833,11 +3849,11 @@ msgstr "Putar jika berhenti, jeda jika berputar"
 msgid "Play if there is nothing already playing"
 msgstr "Putar jika tidak ada yang sedang diputar"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3936,7 +3952,7 @@ msgstr "Preferensi"
 msgid "Preferences"
 msgstr "Preferensi"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Preferensi..."
 
@@ -3996,7 +4012,7 @@ msgid "Previous"
 msgstr "Sebelumnya"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Trek sebelumnya"
 
@@ -4054,16 +4070,16 @@ msgstr "Kualitas"
 msgid "Querying device..."
 msgstr "Meminta perangkat..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Pengelola antrean"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Antre trek terpilih"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Antre trek"
 
@@ -4079,7 +4095,7 @@ msgstr "Radio (kenyaringan sama untuk semua trek)"
 msgid "Rain"
 msgstr "Hujan"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Hujan"
@@ -4191,7 +4207,7 @@ msgstr "Buang tindakan"
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Buang duplikat dari daftar-putar"
 
@@ -4199,7 +4215,7 @@ msgstr "Buang duplikat dari daftar-putar"
 msgid "Remove folder"
 msgstr "Buang folder"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Buang dari daftar-putar"
 
@@ -4211,7 +4227,7 @@ msgstr "Buang daftar-putar"
 msgid "Remove playlists"
 msgstr "Buang daftar-putar"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Buang trek yang tidak tersedia dari daftar-putar"
 
@@ -4223,7 +4239,7 @@ msgstr "Ubah nama daftar-putar"
 msgid "Rename playlist..."
 msgstr "Ubah nama daftar-putar.."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Beri nomor baru trek dalam urutan ini..."
 
@@ -4314,7 +4330,7 @@ msgstr "Rabit"
 msgid "Rip CD"
 msgstr "Rabit CD"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Rabit CD audio"
 
@@ -4392,7 +4408,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Simpan daftar-putar"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Simpan daftar-putar..."
 
@@ -4479,7 +4495,7 @@ msgstr "Cari Subsonic"
 msgid "Search automatically"
 msgstr "Cari secara otomatis"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4492,7 +4508,7 @@ msgstr "Cari sampul album..."
 msgid "Search for anything"
 msgstr "Cari apapun"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4617,7 +4633,7 @@ msgstr "Detail server"
 msgid "Service offline"
 msgstr "Layanan luring"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Tetapkan %1 ke \"%2\"..."
@@ -4626,7 +4642,7 @@ msgstr "Tetapkan %1 ke \"%2\"..."
 msgid "Set the volume to <value> percent"
 msgstr "Tetapkan volume ke <value> persen"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Tetapkan nilai untuk semua trek terpilih..."
 
@@ -4697,7 +4713,7 @@ msgstr "Tampilkan OSD cantik"
 msgid "Show above status bar"
 msgstr "Tampilkan di atas bilah status"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Tampilkan semua lagu"
 
@@ -4717,12 +4733,12 @@ msgstr "Tampilkan pembagi"
 msgid "Show fullsize..."
 msgstr "Tampilkan ukuran penuh..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Tampilkan di peramban berkas..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Tampilkan di pustaka..."
 
@@ -4734,15 +4750,15 @@ msgstr "Tampilkan di artis beragam"
 msgid "Show moodbar"
 msgstr "Tampilkan moodbar"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Tampilkan hanya duplikat"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Tampilkan hanya tidak bertag"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Tampil atau sembunyikan bilah sisi"
 
@@ -4750,7 +4766,7 @@ msgstr "Tampil atau sembunyikan bilah sisi"
 msgid "Show search suggestions"
 msgstr "Tampilkan saran pencarian"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Tampilkan bilah sisi"
 
@@ -4786,7 +4802,7 @@ msgstr "Karau album"
 msgid "Shuffle all"
 msgstr "Karau semua"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Karau daftar-putar"
 
@@ -4830,11 +4846,15 @@ msgstr "Lewati hitungan"
 msgid "Skip forwards in playlist"
 msgstr "Lewati maju di dalam daftar-putar"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Lewati trek yang dipilih"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Lewati trek"
 
@@ -4951,7 +4971,7 @@ msgstr "Mulai merabit"
 msgid "Start the playlist currently playing"
 msgstr "Mulai daftar-putar yang diputar saat ini"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Mulai transkode"
 
@@ -4961,7 +4981,7 @@ msgid ""
 "list"
 msgstr "Mulai mengetik sesuatu di kotak pencarian di atas untuk mengisi daftar hasil pencarian ini"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Memulai %1"
@@ -4971,7 +4991,7 @@ msgid "Starting..."
 msgstr "Memulai..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Berhenti"
 
@@ -4987,7 +5007,7 @@ msgstr "Berhenti setelah masing-masing trek"
 msgid "Stop after every track"
 msgstr "Berhenti setelah setiap trek"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Berhenti setelah trek ini"
 
@@ -5155,7 +5175,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Masa uji coba untuk server Subsonic telah berakhir. Mohon donasi untuk mendapatkan kunci lisensi. Kunjungi subsonic.org untuk lebih perinci."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5197,7 +5217,7 @@ msgid ""
 "continue?"
 msgstr "Berkas-berkas ini akan dihapus dari perangkat, apakah Anda yakin ingin melanjutkan?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5299,11 +5319,11 @@ msgstr "Jungkit Pretty OSD"
 msgid "Toggle fullscreen"
 msgstr "Jungkit layar penuh"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Jungkit status antrean"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Jungkit scrobbling"
 
@@ -5348,19 +5368,19 @@ msgstr "Tre&k"
 msgid "Track"
 msgstr "Trek"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Transkode Musik"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Log Transkoder"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Transkode"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Transkode berkas %1 menggunakan %2 thread"
@@ -5437,11 +5457,11 @@ msgstr "Galat tidak diketahui"
 msgid "Unset cover"
 msgstr "Tak set sampul"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Taklewati trek yang dipilih"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Taklewati trek"
 
@@ -5458,7 +5478,7 @@ msgstr "Konser Mendatang"
 msgid "Update all podcasts"
 msgstr "Perbarui semua podcast"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Perbarui perubahan folder pustaka "
 
@@ -5619,7 +5639,7 @@ msgstr "Versi %1"
 msgid "View"
 msgstr "Tampilan"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5627,7 +5647,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr "Mode visualisasi"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Visualisasi"
 
@@ -5668,7 +5688,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5764,7 +5784,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media audio"
 
@@ -5778,7 +5798,7 @@ msgid ""
 "well?"
 msgstr "Apakah Anda ingin memindahkan lagu lainnya di dalam album ini ke Artis Beragam?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Apakah Anda ingin menjalankan pemindaian ulang menyeluruh sekarang?"
 

--- a/src/translations/is.po
+++ b/src/translations/is.po
@@ -13,7 +13,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Icelandic (http://www.transifex.com/davidsansome/clementine/language/is/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -167,19 +167,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%skráarheiti%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n misheppnaðist"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n lokið"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -197,7 +197,7 @@ msgstr "&Miðjað"
 msgid "&Custom"
 msgstr "&Sérsnið"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Auka"
 
@@ -205,7 +205,7 @@ msgstr "&Auka"
 msgid "&Grouping"
 msgstr "&Hópun"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Hjálp"
 
@@ -230,7 +230,7 @@ msgstr "&Læsa einkunn"
 msgid "&Lyrics"
 msgstr "&Lagatextar"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Tónlist"
 
@@ -238,15 +238,15 @@ msgstr "&Tónlist"
 msgid "&None"
 msgstr "&Ekkert"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "S&pilunarlisti"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Hætta"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "&Endurtekning"
 
@@ -254,7 +254,7 @@ msgstr "&Endurtekning"
 msgid "&Right"
 msgstr "&Hægri"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "&Stokkun"
 
@@ -262,7 +262,7 @@ msgstr "&Stokkun"
 msgid "&Stretch columns to fit window"
 msgstr "&Teygja á dálkum til að koma glugga fyrir"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Verkfæri"
 
@@ -451,11 +451,11 @@ msgstr "Um"
 msgid "About %1"
 msgstr "Um %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Um Clementine"
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Um Qt..."
 
@@ -515,32 +515,32 @@ msgstr "Bæta við öðru streymi..."
 msgid "Add directory..."
 msgstr "Bæta við möppu..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Bæta við skrá"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Bæta skrá við umkóðara"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Bæta skrá(m) við umkóðara"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Bæta við skrá..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Bæta við skrá til að millikóða"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Bæta við möppu"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Bæta við möppu..."
 
@@ -552,7 +552,7 @@ msgstr "Bæta við nýrri möppu..."
 msgid "Add podcast"
 msgstr "Bæta við hlaðvarpi"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Bæta við hlaðvarpi..."
 
@@ -628,7 +628,7 @@ msgstr "Bæta við merki með spori lags"
 msgid "Add song year tag"
 msgstr "Bæta við merki með ártali lags"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Bæta við streymi..."
 
@@ -640,7 +640,7 @@ msgstr "Bæta við Spotify-spilunarlista"
 msgid "Add to Spotify starred"
 msgstr "Bæta við Spotify-stjörnumerkt"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Bæta við öðrum spilunarlista"
 
@@ -734,7 +734,7 @@ msgstr "Allt"
 msgid "All Files (*)"
 msgstr "Allar skrár (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Öll dýrðin!"
@@ -1125,7 +1125,7 @@ msgstr "Leita að nýjum þáttum"
 msgid "Check for updates"
 msgstr "Athuga með uppfærslur"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Athuga með uppfærslur..."
 
@@ -1174,18 +1174,18 @@ msgstr "Klassískt"
 msgid "Cleaning up"
 msgstr "Hreinsa til"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Hreinsa"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Hreinsa lagalista"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1330,7 +1330,7 @@ msgstr "Athugasemd"
 msgid "Complete tags automatically"
 msgstr "Ljúka merkjum sjálfkrafa"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Ljúka merkjum sjálfkrafa..."
 
@@ -1365,7 +1365,7 @@ msgstr "Stilla Subsonic..."
 msgid "Configure global search..."
 msgstr "Stilla altæka leit..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Stilla safn..."
 
@@ -1408,7 +1408,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Tenging féll á tímamörkum, athugaðu slóðina á þjóninn. Dæmi: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Stjórnskjár"
 
@@ -1437,11 +1437,11 @@ msgid "Copy to clipboard"
 msgstr "Afrita á klippispjald"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Afrita til tæki..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Afrita í safn..."
@@ -1484,14 +1484,14 @@ msgstr "Ekki tókst að skrá inn á Last.fm, reyndu aftur."
 msgid "Couldn't create playlist"
 msgstr "Gat ekki búið til spilunarlista"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Gat ekki fundið fléttara fyrir \"%1\" - gakktu úr skugga um að þú sért með réttar GStreamer viðbætur uppsettar"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1506,7 +1506,7 @@ msgstr "Gat ekki opnað úttaksskrána %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Umslagsstjóri"
 
@@ -1659,7 +1659,7 @@ msgid "Delete downloaded data"
 msgstr "Eyða sóttum gögnum"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Eyða skrám"
 
@@ -1667,7 +1667,7 @@ msgstr "Eyða skrám"
 msgid "Delete from device..."
 msgstr "Eyða frá tæki..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Eyða frá diski..."
@@ -1700,11 +1700,11 @@ msgstr "Eyði gögnum"
 msgid "Depth"
 msgstr "Dýpt"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Taka valin lög úr biðröð"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Taka lag úr biðröð"
 
@@ -1805,7 +1805,7 @@ msgstr "Skjástillingar"
 msgid "Display the on-screen-display"
 msgstr "Birta OSD-stjórntexta"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Skanna allt tónlistarsafnið"
 
@@ -1984,12 +1984,12 @@ msgstr "Breytilegt slembið mix"
 msgid "Edit smart playlist..."
 msgstr "Sýsla með snjallan spilunarlista..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Breyta merki \"%1\"..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Breyta merki..."
 
@@ -2002,7 +2002,7 @@ msgid "Edit track information"
 msgstr "Breyta upplýsingum um lag"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Breyta upplýsingum um lag..."
 
@@ -2110,7 +2110,7 @@ msgstr "Allt safnið"
 msgid "Episode information"
 msgstr "Upplýsingar um þátt"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Tónjafnari"
 
@@ -2123,8 +2123,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Samsvarar --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Villa"
 
@@ -2159,7 +2159,7 @@ msgstr "Villa við að hlaða inn %1"
 msgid "Error loading di.fm playlist"
 msgstr "Villa við að hlaða inn di.fm spilunarlista"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Villa við meðhöndlun %1: %2"
@@ -2242,7 +2242,11 @@ msgstr "Útflutningi lokið"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "Flutti út %1 umslög af %2 (%3 sleppt)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2266,7 +2270,7 @@ msgstr "Deyfing"
 msgid "Fading duration"
 msgstr "Tímalengd dofnunar"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Mistókst að lesa CD-drif"
 
@@ -2548,11 +2552,11 @@ msgstr "Gefðu því nafn:"
 msgid "Go"
 msgstr "Fara"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Fara á næsta spilunarlistaflipa"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Fara á fyrri spilunarlistaflipa"
 
@@ -2885,7 +2889,7 @@ msgstr "Jamendo gagnagrunnur"
 msgid "Jump to previous song right away"
 msgstr "Hoppa strax í fyrra lag"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Hoppa í lagið sem nú er í spilun"
 
@@ -2909,7 +2913,7 @@ msgstr "Halda opnu í bakgrunni þegar glugganum er lokað"
 msgid "Keep the original files"
 msgstr "Halda upprunalegum skrám"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Kettlingar"
@@ -3001,7 +3005,7 @@ msgstr "Safn"
 msgid "Library advanced grouping"
 msgstr "Þróuð flokkun safns"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Tilkynning um skönnun á tónlistarsafni"
 
@@ -3041,7 +3045,7 @@ msgstr "Hlaða umslagi af diski..."
 msgid "Load playlist"
 msgstr "Hlaða inn spilunarlista"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Hlaða inn spilunarlista..."
 
@@ -3102,11 +3106,15 @@ msgstr "Skrá inn"
 msgid "Login failed"
 msgstr "Innskráning mistókst"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Langtíma spásnið (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Líkar þetta"
 
@@ -3141,11 +3149,11 @@ msgstr "Lagatextar frá %1"
 msgid "Lyrics from the tag"
 msgstr "Lagatextar frá merkinu"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3187,7 +3195,7 @@ msgstr "Aðalsnið (MAIN)"
 msgid "Make it so!"
 msgstr "Láta það vaða!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Láta það vaða!"
@@ -3325,7 +3333,7 @@ msgstr "Tengipunktar"
 msgid "Move down"
 msgstr "Færa niður"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Flytja í safn..."
 
@@ -3334,7 +3342,7 @@ msgstr "Flytja í safn..."
 msgid "Move up"
 msgstr "Færa upp"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Tónlist"
 
@@ -3347,7 +3355,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Þagga"
 
@@ -3396,7 +3404,7 @@ msgstr "Aldrei hefja spilun"
 msgid "New folder"
 msgstr "Ný mappa"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nýr lagalisti"
 
@@ -3424,8 +3432,12 @@ msgstr "Nýjustu lögin"
 msgid "Next"
 msgstr "Næst"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Næsta lag"
 
@@ -3463,7 +3475,7 @@ msgstr "Engar stuttar blokkir"
 msgid "None"
 msgstr "Ekkert"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Ekkert af völdu lögunum henta til að afrita yfir á tæki"
 
@@ -3548,19 +3560,19 @@ msgstr "Af"
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3604,7 +3616,7 @@ msgstr "Ógegnsæi"
 msgid "Open %1 in browser"
 msgstr "Opna %1 í vafra"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Opn&a CD-hljóðdisk..."
 
@@ -3616,7 +3628,7 @@ msgstr "Opna OPML-skrá"
 msgid "Open OPML file..."
 msgstr "Opna OPML-skrá..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Opna möppu til að flytja tónlist inn úr"
 
@@ -3624,7 +3636,7 @@ msgstr "Opna möppu til að flytja tónlist inn úr"
 msgid "Open device"
 msgstr "Opna tæki"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Opna skrá..."
 
@@ -3678,7 +3690,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Skipuleggja skrár"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Skipuleggja skrár..."
 
@@ -3762,7 +3774,7 @@ msgstr "Partý"
 msgid "Password"
 msgstr "Lykilorð"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Í bið"
@@ -3786,6 +3798,10 @@ msgstr "Flytjandi"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Mynddíll"
@@ -3794,10 +3810,10 @@ msgstr "Mynddíll"
 msgid "Plain sidebar"
 msgstr "Einfalt hliðarspjald"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Spila"
 
@@ -3818,11 +3834,11 @@ msgstr "Spila ef stöðvað, setja í hlé ef spilandi"
 msgid "Play if there is nothing already playing"
 msgstr "Spila ef ekkert er þegar í afspilun"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Spila næsta"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Spila valin lög næst"
 
@@ -3921,7 +3937,7 @@ msgstr "Kjörstilling"
 msgid "Preferences"
 msgstr "Kjörstillingar"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Kjörstillingar..."
 
@@ -3981,7 +3997,7 @@ msgid "Previous"
 msgstr "Fyrri"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Fyrra lag"
 
@@ -4039,16 +4055,16 @@ msgstr "Gæði"
 msgid "Querying device..."
 msgstr "Skoða tæki..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Biðraðastjóri"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Setja valin lög í biðröð"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Setja í biðröð"
 
@@ -4064,7 +4080,7 @@ msgstr "Útvarp (jafn hljóðstyrkur fyrir öll lög)"
 msgid "Rain"
 msgstr "Rigning"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Rigning"
@@ -4176,7 +4192,7 @@ msgstr "Fjarlægja aðgerð"
 msgid "Remove current song from playlist"
 msgstr "Fjarlægja þetta lag af spilunarlistanum"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Fjarlægja tvítök af spilunarlistanum"
 
@@ -4184,7 +4200,7 @@ msgstr "Fjarlægja tvítök af spilunarlistanum"
 msgid "Remove folder"
 msgstr "Fjarlægja möppu"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Fjarlægja af spilunarlistanum"
 
@@ -4196,7 +4212,7 @@ msgstr "Fjarlægja lagalista"
 msgid "Remove playlists"
 msgstr "Fjarlægja spilunarlista"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Fjarlægja lög sem ekki eru tiltæk af spilunarlistanum"
 
@@ -4208,7 +4224,7 @@ msgstr "Gefa spilunarlistanum nýtt nafn"
 msgid "Rename playlist..."
 msgstr "Gefa spilunarlistanum nýtt nafn..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Endurnúmera lög í þessari röð..."
 
@@ -4299,7 +4315,7 @@ msgstr "Rippa"
 msgid "Rip CD"
 msgstr "Afrita disk"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Afrita CD-hljómdisk"
 
@@ -4377,7 +4393,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Vista spilunarlista"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Vista spilunarlista..."
 
@@ -4464,7 +4480,7 @@ msgstr "Leita á Subsonic"
 msgid "Search automatically"
 msgstr "Leita sjálfvirkt"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Leita að hljómplötu"
 
@@ -4477,7 +4493,7 @@ msgstr "Leita að plötuumslögum..."
 msgid "Search for anything"
 msgstr "Leita að einhverju"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Leita að flytjanda"
 
@@ -4602,7 +4618,7 @@ msgstr "Nánar um þjón "
 msgid "Service offline"
 msgstr "Þjónusta ekki á neti"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Setja %1 sem \"%2\"..."
@@ -4611,7 +4627,7 @@ msgstr "Setja %1 sem \"%2\"..."
 msgid "Set the volume to <value> percent"
 msgstr "Setja hljóðstyrk á <value> prósent"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Setja gildi fyrir öll valin lög..."
 
@@ -4682,7 +4698,7 @@ msgstr "Birta fegraðan OSD-stjórntexta"
 msgid "Show above status bar"
 msgstr "Birta fyrir ofan stöðustiku"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Birta öll lög"
 
@@ -4702,12 +4718,12 @@ msgstr "Sýna aðgreina"
 msgid "Show fullsize..."
 msgstr "Sýna fulla stærð..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Sýna í skráavafra..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Sýna í safni..."
 
@@ -4719,15 +4735,15 @@ msgstr "Birta undir ýmsum flytjendum"
 msgid "Show moodbar"
 msgstr "Birta skapbrigðastiku"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Aðeins birta tvítekningar"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Aðeins birta ómerkt"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Birta eða fela hliðarspjaldið"
 
@@ -4735,7 +4751,7 @@ msgstr "Birta eða fela hliðarspjaldið"
 msgid "Show search suggestions"
 msgstr "Birta uppástungur í leit"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Birta hliðarspjald"
 
@@ -4771,7 +4787,7 @@ msgstr "Stokka hljómplötur"
 msgid "Shuffle all"
 msgstr "Stokka allt"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Stokka spilunarlista"
 
@@ -4815,11 +4831,15 @@ msgstr "Sleppa talningu"
 msgid "Skip forwards in playlist"
 msgstr "Fara áfram í spilunarlista"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Sleppa völdum lögum"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Sleppa lagi"
 
@@ -4936,7 +4956,7 @@ msgstr "Hefja afritun"
 msgid "Start the playlist currently playing"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Hefja umkóðun"
 
@@ -4946,7 +4966,7 @@ msgid ""
 "list"
 msgstr "Byrjaðu að skrifa í leitarreitinn hér fyrir ofan og niðurstöðurnar munu birtast sjálfkrafa"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Ræsi %1"
@@ -4956,7 +4976,7 @@ msgid "Starting..."
 msgstr "Byrja..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Stöðva"
 
@@ -4972,7 +4992,7 @@ msgstr "Stoppa eftir hvert lag"
 msgid "Stop after every track"
 msgstr "Stoppa eftir öll lög"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Stoppa eftir þetta lag"
 
@@ -5140,7 +5160,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5182,7 +5202,7 @@ msgid ""
 "continue?"
 msgstr "Þessum skrám verður eytt af tækinu, ertu viss um að þú viljir halda áfram?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5284,11 +5304,11 @@ msgstr "Víxla af/á fegruðum OSD-stjórntexta"
 msgid "Toggle fullscreen"
 msgstr "Víxla heilskjá"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Víxla stöðu biðraðar"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Víxla af/á skráningu á hlustunarvenjum (scrobbling)"
 
@@ -5333,19 +5353,19 @@ msgstr "La&g"
 msgid "Track"
 msgstr "Lag"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Umkóða tónlist"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Annáll umkóðara"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Umkóðun"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Umkóða %1 skrár í %2 þráðum"
@@ -5422,11 +5442,11 @@ msgstr "Óþekkt villa"
 msgid "Unset cover"
 msgstr "Aftengja umslag"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Hætta við að sleppa völdum lögum"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Hætta við að sleppa lagi"
 
@@ -5443,7 +5463,7 @@ msgstr "Tónleikar á næstunni"
 msgid "Update all podcasts"
 msgstr "Uppfæra öll hlaðvörp"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Uppfæra breyttar möppur í safni"
 
@@ -5604,7 +5624,7 @@ msgstr "Útgáfa %1"
 msgid "View"
 msgstr "Skoða"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Sjá nánari upplýsingar um streymi"
 
@@ -5612,7 +5632,7 @@ msgstr "Sjá nánari upplýsingar um streymi"
 msgid "Visualization mode"
 msgstr "Sjóngervingahamur"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Sjóngervingar"
 
@@ -5653,7 +5673,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5749,7 +5769,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media hljóðskrá"
 
@@ -5763,7 +5783,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Viltu láta endurskanna allt safnið núna?"
 

--- a/src/translations/is.po
+++ b/src/translations/is.po
@@ -515,7 +515,7 @@ msgstr "Bæta við öðru streymi..."
 msgid "Add directory..."
 msgstr "Bæta við möppu..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Bæta við skrá"
 
@@ -535,7 +535,7 @@ msgstr "Bæta við skrá..."
 msgid "Add files to transcode"
 msgstr "Bæta við skrá til að millikóða"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Bæta við möppu"
@@ -640,7 +640,7 @@ msgstr "Bæta við Spotify-spilunarlista"
 msgid "Add to Spotify starred"
 msgstr "Bæta við Spotify-stjörnumerkt"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Bæta við öðrum spilunarlista"
 
@@ -862,7 +862,7 @@ msgstr "Ertu viss að þú viljir skrifa tölfræði allra laga í safninu í vi
 msgid "Artist"
 msgstr "Flytjandi"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Upplýsingar um höfund"
 
@@ -1125,7 +1125,7 @@ msgstr "Leita að nýjum þáttum"
 msgid "Check for updates"
 msgstr "Athuga með uppfærslur"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Athuga með uppfærslur..."
 
@@ -1365,7 +1365,7 @@ msgstr "Stilla Subsonic..."
 msgid "Configure global search..."
 msgstr "Stilla altæka leit..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Stilla safn..."
 
@@ -1437,11 +1437,11 @@ msgid "Copy to clipboard"
 msgstr "Afrita á klippispjald"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Afrita til tæki..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Afrita í safn..."
@@ -1659,7 +1659,7 @@ msgid "Delete downloaded data"
 msgstr "Eyða sóttum gögnum"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Eyða skrám"
 
@@ -1667,7 +1667,7 @@ msgstr "Eyða skrám"
 msgid "Delete from device..."
 msgstr "Eyða frá tæki..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Eyða frá diski..."
@@ -1700,11 +1700,11 @@ msgstr "Eyði gögnum"
 msgid "Depth"
 msgstr "Dýpt"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Taka valin lög úr biðröð"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Taka lag úr biðröð"
 
@@ -1733,7 +1733,7 @@ msgstr "Heiti tækis"
 msgid "Device properties..."
 msgstr "Eiginleikar tækis..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Tæki"
 
@@ -1984,7 +1984,7 @@ msgstr "Breytilegt slembið mix"
 msgid "Edit smart playlist..."
 msgstr "Sýsla með snjallan spilunarlista..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Breyta merki \"%1\"..."
@@ -2123,8 +2123,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Samsvarar --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Villa"
 
@@ -2270,7 +2270,7 @@ msgstr "Deyfing"
 msgid "Fading duration"
 msgstr "Tímalengd dofnunar"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Mistókst að lesa CD-drif"
 
@@ -2393,7 +2393,7 @@ msgstr "Tegund skráar"
 msgid "Filename"
 msgstr "Skráarheiti"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Gögn"
 
@@ -2808,7 +2808,7 @@ msgstr "Uppsett"
 msgid "Integrity check"
 msgstr "Athugun á áreiðanleika"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -2996,7 +2996,7 @@ msgstr "Vinstri"
 msgid "Length"
 msgstr "Lengd"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Safn"
@@ -3005,7 +3005,7 @@ msgstr "Safn"
 msgid "Library advanced grouping"
 msgstr "Þróuð flokkun safns"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Tilkynning um skönnun á tónlistarsafni"
 
@@ -3333,7 +3333,7 @@ msgstr "Tengipunktar"
 msgid "Move down"
 msgstr "Færa niður"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Flytja í safn..."
 
@@ -3342,7 +3342,7 @@ msgstr "Flytja í safn..."
 msgid "Move up"
 msgstr "Færa upp"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Tónlist"
 
@@ -3404,7 +3404,7 @@ msgstr "Aldrei hefja spilun"
 msgid "New folder"
 msgstr "Ný mappa"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nýr lagalisti"
 
@@ -3475,7 +3475,7 @@ msgstr "Engar stuttar blokkir"
 msgid "None"
 msgstr "Ekkert"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Ekkert af völdu lögunum henta til að afrita yfir á tæki"
 
@@ -3690,7 +3690,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Skipuleggja skrár"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Skipuleggja skrár..."
 
@@ -3774,7 +3774,7 @@ msgstr "Partý"
 msgid "Password"
 msgstr "Lykilorð"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Í bið"
@@ -3810,8 +3810,8 @@ msgstr "Mynddíll"
 msgid "Plain sidebar"
 msgstr "Einfalt hliðarspjald"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3834,11 +3834,11 @@ msgstr "Spila ef stöðvað, setja í hlé ef spilandi"
 msgid "Play if there is nothing already playing"
 msgstr "Spila ef ekkert er þegar í afspilun"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Spila næsta"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Spila valin lög næst"
 
@@ -3877,7 +3877,7 @@ msgstr "Valkostir spilunarlista"
 msgid "Playlist type"
 msgstr "Gerð spilunarlista"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Lagalisti"
 
@@ -4059,12 +4059,12 @@ msgstr "Skoða tæki..."
 msgid "Queue Manager"
 msgstr "Biðraðastjóri"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Setja valin lög í biðröð"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Setja í biðröð"
 
@@ -4455,7 +4455,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Leita"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Leita"
@@ -4480,7 +4480,7 @@ msgstr "Leita á Subsonic"
 msgid "Search automatically"
 msgstr "Leita sjálfvirkt"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Leita að hljómplötu"
 
@@ -4493,7 +4493,7 @@ msgstr "Leita að plötuumslögum..."
 msgid "Search for anything"
 msgstr "Leita að einhverju"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Leita að flytjanda"
 
@@ -4618,7 +4618,7 @@ msgstr "Nánar um þjón "
 msgid "Service offline"
 msgstr "Þjónusta ekki á neti"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Setja %1 sem \"%2\"..."
@@ -4698,7 +4698,7 @@ msgstr "Birta fegraðan OSD-stjórntexta"
 msgid "Show above status bar"
 msgstr "Birta fyrir ofan stöðustiku"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Birta öll lög"
 
@@ -4718,12 +4718,12 @@ msgstr "Sýna aðgreina"
 msgid "Show fullsize..."
 msgstr "Sýna fulla stærð..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Sýna í skráavafra..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Sýna í safni..."
 
@@ -4735,11 +4735,11 @@ msgstr "Birta undir ýmsum flytjendum"
 msgid "Show moodbar"
 msgstr "Birta skapbrigðastiku"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Aðeins birta tvítekningar"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Aðeins birta ómerkt"
 
@@ -4831,7 +4831,7 @@ msgstr "Sleppa talningu"
 msgid "Skip forwards in playlist"
 msgstr "Fara áfram í spilunarlista"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Sleppa völdum lögum"
 
@@ -4839,7 +4839,7 @@ msgstr "Sleppa völdum lögum"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Sleppa lagi"
 
@@ -4871,7 +4871,7 @@ msgstr "Mjúkt rokk"
 msgid "Song Information"
 msgstr "Upplýsingar um lag"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Um lagið"
 
@@ -4992,7 +4992,7 @@ msgstr "Stoppa eftir hvert lag"
 msgid "Stop after every track"
 msgstr "Stoppa eftir öll lög"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Stoppa eftir þetta lag"
 
@@ -5160,7 +5160,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5202,7 +5202,7 @@ msgid ""
 "continue?"
 msgstr "Þessum skrám verður eytt af tækinu, ertu viss um að þú viljir halda áfram?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5304,7 +5304,7 @@ msgstr "Víxla af/á fegruðum OSD-stjórntexta"
 msgid "Toggle fullscreen"
 msgstr "Víxla heilskjá"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Víxla stöðu biðraðar"
 
@@ -5442,11 +5442,11 @@ msgstr "Óþekkt villa"
 msgid "Unset cover"
 msgstr "Aftengja umslag"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Hætta við að sleppa völdum lögum"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Hætta við að sleppa lagi"
 
@@ -5783,7 +5783,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Viltu láta endurskanna allt safnið núna?"
 

--- a/src/translations/it.po
+++ b/src/translations/it.po
@@ -12,8 +12,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-26 23:47+0000\n"
-"Last-Translator: John Maguire <john.maguire@gmail.com>\n"
+"PO-Revision-Date: 2021-01-27 07:20+0000\n"
+"Last-Translator: Vincenzo Reale <vinx.reale@gmail.com>\n"
 "Language-Team: Italian (http://www.transifex.com/davidsansome/clementine/language/it/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -514,7 +514,7 @@ msgstr "Aggiungi un altro flusso..."
 msgid "Add directory..."
 msgstr "Aggiungi cartella..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Aggiungi file"
 
@@ -534,7 +534,7 @@ msgstr "Aggiungi file..."
 msgid "Add files to transcode"
 msgstr "Aggiungi file da transcodificare"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Aggiungi cartella"
@@ -639,7 +639,7 @@ msgstr "Aggiungi alle scalette di Spotify"
 msgid "Add to Spotify starred"
 msgstr "Aggiungi ai preferiti di Spotify"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Aggiungi a un'altra scaletta"
 
@@ -861,7 +861,7 @@ msgstr "Sei sicuro di voler scrivere le statistiche nei file dei brani della tua
 msgid "Artist"
 msgstr "Artista"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Info artista"
 
@@ -1124,7 +1124,7 @@ msgstr "Verifica la presenza di nuove puntate"
 msgid "Check for updates"
 msgstr "Controllo aggiornamenti"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Controlla aggiornamenti..."
 
@@ -1364,7 +1364,7 @@ msgstr "Configura Subsonic..."
 msgid "Configure global search..."
 msgstr "Configura la ricerca globale..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Configura raccolta..."
 
@@ -1436,11 +1436,11 @@ msgid "Copy to clipboard"
 msgstr "Copia negli appunti"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Copia su dispositivo..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Copia nella raccolta..."
@@ -1658,7 +1658,7 @@ msgid "Delete downloaded data"
 msgstr "Elimina i dati scaricati"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Elimina i file"
 
@@ -1666,7 +1666,7 @@ msgstr "Elimina i file"
 msgid "Delete from device..."
 msgstr "Elimina da dispositivo..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Elimina dal disco..."
@@ -1699,11 +1699,11 @@ msgstr "Eliminazione dei file"
 msgid "Depth"
 msgstr "Profondità"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Rimuovi le tracce selezionate dalla coda"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Rimuovi tracce dalla coda"
 
@@ -1732,7 +1732,7 @@ msgstr "Nome del dispositivo"
 msgid "Device properties..."
 msgstr "Proprietà del dispositivo..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Dispositivi"
 
@@ -1983,7 +1983,7 @@ msgstr "Misto casuale dinamico"
 msgid "Edit smart playlist..."
 msgstr "Modifica la scaletta veloce..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Modifica tag \"%1\"..."
@@ -2122,8 +2122,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Equivalente a --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Errore"
 
@@ -2243,7 +2243,7 @@ msgstr "Esportate %1 copertine di %2 (%3 saltate)"
 
 #: ../bin/src/ui_mainwindow.h:790
 msgid "F9"
-msgstr ""
+msgstr "F9"
 
 #: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
@@ -2269,7 +2269,7 @@ msgstr "Dissolvenza"
 msgid "Fading duration"
 msgstr "Durata della dissolvenza"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Lettura del CD non riuscita"
 
@@ -2392,7 +2392,7 @@ msgstr "Tipo file"
 msgid "Filename"
 msgstr "Nome file"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "File"
 
@@ -2807,7 +2807,7 @@ msgstr "Installati"
 msgid "Integrity check"
 msgstr "Controllo d'integrità"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -2995,7 +2995,7 @@ msgstr "Sinistra"
 msgid "Length"
 msgstr "Durata"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Raccolta"
@@ -3004,7 +3004,7 @@ msgstr "Raccolta"
 msgid "Library advanced grouping"
 msgstr "Raggruppamento avanzato della raccolta"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Notifica nuova scansione della raccolta"
 
@@ -3332,7 +3332,7 @@ msgstr "Punti di mount"
 msgid "Move down"
 msgstr "Sposta in basso"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Sposta nella raccolta..."
 
@@ -3341,7 +3341,7 @@ msgstr "Sposta nella raccolta..."
 msgid "Move up"
 msgstr "Sposta in alto"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Musica"
 
@@ -3403,7 +3403,7 @@ msgstr "Non iniziare mai la riproduzione"
 msgid "New folder"
 msgstr "Nuova cartella"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nuova scaletta"
 
@@ -3433,7 +3433,7 @@ msgstr "Successivo"
 
 #: ../bin/src/ui_mainwindow.h:785
 msgid "Next album"
-msgstr ""
+msgstr "Album successivo"
 
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
 #: ../bin/src/ui_mainwindow.h:727
@@ -3474,7 +3474,7 @@ msgstr "Nessun blocco corto"
 msgid "None"
 msgstr "Nessuna"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Nessuna delle canzoni selezionate era adatta alla copia su un dispositivo"
 
@@ -3689,7 +3689,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organizza file"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Organizza file..."
 
@@ -3773,7 +3773,7 @@ msgstr "Festa"
 msgid "Password"
 msgstr "Password"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pausa"
@@ -3809,8 +3809,8 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Barra laterale semplice"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3833,11 +3833,11 @@ msgstr "Riproduci se fermata, sospendi se in riproduzione"
 msgid "Play if there is nothing already playing"
 msgstr "Riproduci se non c'è altro in riproduzione"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Riproduci successivo"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Riproduci successivamente le tracce riprodotte"
 
@@ -3876,7 +3876,7 @@ msgstr "Opzioni della scaletta"
 msgid "Playlist type"
 msgstr "Tipo di scaletta"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Scalette"
 
@@ -4058,12 +4058,12 @@ msgstr "Interrogazione dispositivo..."
 msgid "Queue Manager"
 msgstr "Gestore della coda"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Accoda le tracce selezionate"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Accoda la traccia"
 
@@ -4454,7 +4454,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Cerca"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Cerca"
@@ -4479,7 +4479,7 @@ msgstr "Cerca su Subsonic"
 msgid "Search automatically"
 msgstr "Cerca automaticamente"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Cerca album"
 
@@ -4492,7 +4492,7 @@ msgstr "Cerca copertine degli album..."
 msgid "Search for anything"
 msgstr "Cerca qualsiasi cosa"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Cerca artista"
 
@@ -4617,7 +4617,7 @@ msgstr "Dettagli del server"
 msgid "Service offline"
 msgstr "Servizio non in linea"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Imposta %1 a \"%2\"..."
@@ -4697,7 +4697,7 @@ msgstr "Mostra un OSD gradevole"
 msgid "Show above status bar"
 msgstr "Mostra la barra di stato superiore"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Mostra tutti i brani"
 
@@ -4717,12 +4717,12 @@ msgstr "Mostra separatori"
 msgid "Show fullsize..."
 msgstr "Mostra a dimensioni originali..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Mostra nel navigatore file..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Mostra nella raccolta..."
 
@@ -4734,11 +4734,11 @@ msgstr "Mostra in artisti vari"
 msgid "Show moodbar"
 msgstr "Mostra la barra dell'atmosfera"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Mostra solo i duplicati"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Mostra solo i brani senza tag"
 
@@ -4830,15 +4830,15 @@ msgstr "Salta il conteggio"
 msgid "Skip forwards in playlist"
 msgstr "Salta in avanti nella scaletta"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Salta le tracce selezionate"
 
 #: ../bin/src/ui_mainwindow.h:787
 msgid "Skip to the next album"
-msgstr ""
+msgstr "Passa all'album successivo"
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Salta la traccia"
 
@@ -4870,7 +4870,7 @@ msgstr "Rock leggero"
 msgid "Song Information"
 msgstr "Informazioni brano"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Info brano"
 
@@ -4991,7 +4991,7 @@ msgstr "Ferma dopo ogni traccia"
 msgid "Stop after every track"
 msgstr "Ferma dopo tutte le tracce"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Ferma dopo questa traccia"
 
@@ -5159,7 +5159,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Il periodo di prova per il server Subsonic è scaduto. Effettua una donazione per ottenere una chiave di licenza. Visita subsonic.org per i dettagli."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5201,7 +5201,7 @@ msgid ""
 "continue?"
 msgstr "Questi file saranno eliminati dal dispositivo, sei sicuro di voler continuare?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5303,7 +5303,7 @@ msgstr "Commuta Pretty OSD"
 msgid "Toggle fullscreen"
 msgstr "Attiva la modalità a schermo intero"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Cambia lo stato della coda"
 
@@ -5441,11 +5441,11 @@ msgstr "Errore sconosciuto"
 msgid "Unset cover"
 msgstr "Rimuovi copertina"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Ripristina le tracce selezionate"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Ripristina la traccia"
 
@@ -5782,7 +5782,7 @@ msgid ""
 "well?"
 msgstr "Vuoi spostare anche gli altri brani di questo album in Artisti vari?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Vuoi eseguire subito una nuova scansione completa?"
 

--- a/src/translations/it.po
+++ b/src/translations/it.po
@@ -12,8 +12,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-13 07:42+0000\n"
-"Last-Translator: Vincenzo Reale <vinx.reale@gmail.com>\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
+"Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Italian (http://www.transifex.com/davidsansome/clementine/language/it/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -166,19 +166,19 @@ msgstr "%L1 tracce"
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n non riusciti"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n completati"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -196,7 +196,7 @@ msgstr "&Centrato"
 msgid "&Custom"
 msgstr "&Personalizzata"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Extra"
 
@@ -204,7 +204,7 @@ msgstr "&Extra"
 msgid "&Grouping"
 msgstr "Ra&ggruppamento"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "Aiuto"
 
@@ -229,7 +229,7 @@ msgstr "B&locca valutazione"
 msgid "&Lyrics"
 msgstr "&Testi"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Musica"
 
@@ -237,15 +237,15 @@ msgstr "&Musica"
 msgid "&None"
 msgstr "&Nessuna"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "Scale&tta"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Esci"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "Modalità di &ripetizione"
 
@@ -253,7 +253,7 @@ msgstr "Modalità di &ripetizione"
 msgid "&Right"
 msgstr "A dest&ra"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Modalità di me&scolamento"
 
@@ -261,7 +261,7 @@ msgstr "Modalità di me&scolamento"
 msgid "&Stretch columns to fit window"
 msgstr "Allunga le colonne per adattarle alla fines&tra"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "S&trumenti"
 
@@ -450,11 +450,11 @@ msgstr "Interrompi"
 msgid "About %1"
 msgstr "Informazioni su %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Informazioni su Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Informazioni su Qt..."
 
@@ -514,32 +514,32 @@ msgstr "Aggiungi un altro flusso..."
 msgid "Add directory..."
 msgstr "Aggiungi cartella..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Aggiungi file"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Aggiungi file al transcodificatore"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Aggiungi file al transcodificatore"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Aggiungi file..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Aggiungi file da transcodificare"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Aggiungi cartella"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Aggiungi cartella..."
 
@@ -551,7 +551,7 @@ msgstr "Aggiungi nuova cartella..."
 msgid "Add podcast"
 msgstr "Aggiungi podcast"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Aggiungi podcast..."
 
@@ -627,7 +627,7 @@ msgstr "Aggiungi il tag traccia al brano"
 msgid "Add song year tag"
 msgstr "Aggiungi il tag anno al brano"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Aggiungi flusso..."
 
@@ -639,7 +639,7 @@ msgstr "Aggiungi alle scalette di Spotify"
 msgid "Add to Spotify starred"
 msgstr "Aggiungi ai preferiti di Spotify"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Aggiungi a un'altra scaletta"
 
@@ -733,7 +733,7 @@ msgstr "Tutto"
 msgid "All Files (*)"
 msgstr "Tutti i file (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Gloria, gloria all'ipnorospo!"
@@ -1124,7 +1124,7 @@ msgstr "Verifica la presenza di nuove puntate"
 msgid "Check for updates"
 msgstr "Controllo aggiornamenti"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Controlla aggiornamenti..."
 
@@ -1173,18 +1173,18 @@ msgstr "Classica"
 msgid "Cleaning up"
 msgstr "Svuota"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Svuota"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Svuota la scaletta"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1329,7 +1329,7 @@ msgstr "Commento"
 msgid "Complete tags automatically"
 msgstr "Completa automaticamente i tag"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Completa automaticamente i tag..."
 
@@ -1364,7 +1364,7 @@ msgstr "Configura Subsonic..."
 msgid "Configure global search..."
 msgstr "Configura la ricerca globale..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Configura raccolta..."
 
@@ -1407,7 +1407,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Connessione scaduta, controlla l'URL del server. Esempio: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Console"
 
@@ -1436,11 +1436,11 @@ msgid "Copy to clipboard"
 msgstr "Copia negli appunti"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Copia su dispositivo..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Copia nella raccolta..."
@@ -1483,14 +1483,14 @@ msgstr "Impossibile accedere a Last.fm. Prova ancora."
 msgid "Couldn't create playlist"
 msgstr "Impossibile creare la scaletta"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Impossibile trovare un multiplatore per %1, verifica l'installazione del plugin GStreamer corretto"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1505,7 +1505,7 @@ msgstr "Impossibile aprire il file di uscita %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Gestore delle copertine"
 
@@ -1658,7 +1658,7 @@ msgid "Delete downloaded data"
 msgstr "Elimina i dati scaricati"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Elimina i file"
 
@@ -1666,7 +1666,7 @@ msgstr "Elimina i file"
 msgid "Delete from device..."
 msgstr "Elimina da dispositivo..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Elimina dal disco..."
@@ -1699,11 +1699,11 @@ msgstr "Eliminazione dei file"
 msgid "Depth"
 msgstr "Profondità"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Rimuovi le tracce selezionate dalla coda"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Rimuovi tracce dalla coda"
 
@@ -1804,7 +1804,7 @@ msgstr "Opzioni di visualizzazione"
 msgid "Display the on-screen-display"
 msgstr "Visualizza l'on-screen-display"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Esegui una nuova scansione completa della raccolta"
 
@@ -1983,12 +1983,12 @@ msgstr "Misto casuale dinamico"
 msgid "Edit smart playlist..."
 msgstr "Modifica la scaletta veloce..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Modifica tag \"%1\"..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Modifica tag..."
 
@@ -2001,7 +2001,7 @@ msgid "Edit track information"
 msgstr "Modifica informazioni della traccia"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Modifica informazioni sulla traccia..."
 
@@ -2109,7 +2109,7 @@ msgstr "Collezione completa"
 msgid "Episode information"
 msgstr "Informazioni episodio"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Equalizzatore"
 
@@ -2122,8 +2122,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Equivalente a --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Errore"
 
@@ -2158,7 +2158,7 @@ msgstr "Errore durante il caricamento di %1"
 msgid "Error loading di.fm playlist"
 msgstr "Errore durante il caricamento della scaletta di.fm"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Errore durante l'elaborazione di %1: %2"
@@ -2241,7 +2241,11 @@ msgstr "Esporta completate"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "Esportate %1 copertine di %2 (%3 saltate)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2265,7 +2269,7 @@ msgstr "Dissolvenza"
 msgid "Fading duration"
 msgstr "Durata della dissolvenza"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Lettura del CD non riuscita"
 
@@ -2547,11 +2551,11 @@ msgstr "Dagli un nome:"
 msgid "Go"
 msgstr "Vai"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Vai alla scheda della scaletta successiva"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Vai alla scheda della scaletta precedente"
 
@@ -2884,7 +2888,7 @@ msgstr "Database di Jamendo"
 msgid "Jump to previous song right away"
 msgstr "Salta subito al brano precedente"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Salta alla traccia in riproduzione"
 
@@ -2908,7 +2912,7 @@ msgstr "Mantieni l'esecuzione sullo sfondo quando la finestra è chiusa"
 msgid "Keep the original files"
 msgstr "Mantieni i file originali"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Gattini"
@@ -3000,7 +3004,7 @@ msgstr "Raccolta"
 msgid "Library advanced grouping"
 msgstr "Raggruppamento avanzato della raccolta"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Notifica nuova scansione della raccolta"
 
@@ -3040,7 +3044,7 @@ msgstr "Carica copertina da disco..."
 msgid "Load playlist"
 msgstr "Carica la scaletta"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Carica la scaletta..."
 
@@ -3101,11 +3105,15 @@ msgstr "Accedi"
 msgid "Login failed"
 msgstr "Accesso non riuscito"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr "Log"
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Profilo con predizione di lungo termine (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Mi piace"
 
@@ -3140,11 +3148,11 @@ msgstr "Testi da %1"
 msgid "Lyrics from the tag"
 msgstr "Testi dal tag"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3186,7 +3194,7 @@ msgstr "Profilo principale (MAIN)"
 msgid "Make it so!"
 msgstr "Procedi"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Procedi"
@@ -3324,7 +3332,7 @@ msgstr "Punti di mount"
 msgid "Move down"
 msgstr "Sposta in basso"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Sposta nella raccolta..."
 
@@ -3333,7 +3341,7 @@ msgstr "Sposta nella raccolta..."
 msgid "Move up"
 msgstr "Sposta in alto"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Musica"
 
@@ -3346,7 +3354,7 @@ msgid "Music extensions remotely visible"
 msgstr "Estensioni musicali visibili da remoto"
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Silenzia"
 
@@ -3395,7 +3403,7 @@ msgstr "Non iniziare mai la riproduzione"
 msgid "New folder"
 msgstr "Nuova cartella"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nuova scaletta"
 
@@ -3423,8 +3431,12 @@ msgstr "Tracce più recenti"
 msgid "Next"
 msgstr "Successivo"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Traccia successiva"
 
@@ -3462,7 +3474,7 @@ msgstr "Nessun blocco corto"
 msgid "None"
 msgstr "Nessuna"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Nessuna delle canzoni selezionate era adatta alla copia su un dispositivo"
 
@@ -3547,19 +3559,19 @@ msgstr "Spento"
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3603,7 +3615,7 @@ msgstr "Opacità"
 msgid "Open %1 in browser"
 msgstr "Apri %1 nel browser"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Apri CD &audio..."
 
@@ -3615,7 +3627,7 @@ msgstr "Apri file OPML"
 msgid "Open OPML file..."
 msgstr "Apri file OPML..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Apri una cartella da cui importare la musica"
 
@@ -3623,7 +3635,7 @@ msgstr "Apri una cartella da cui importare la musica"
 msgid "Open device"
 msgstr "Apri dispositivo"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Apri file..."
 
@@ -3677,7 +3689,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organizza file"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Organizza file..."
 
@@ -3761,7 +3773,7 @@ msgstr "Festa"
 msgid "Password"
 msgstr "Password"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pausa"
@@ -3785,6 +3797,10 @@ msgstr "Musicista"
 msgid "Pipeline"
 msgstr "Pipeline"
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr "Pipeline"
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Pixel"
@@ -3793,10 +3809,10 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Barra laterale semplice"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Riproduci"
 
@@ -3817,11 +3833,11 @@ msgstr "Riproduci se fermata, sospendi se in riproduzione"
 msgid "Play if there is nothing already playing"
 msgstr "Riproduci se non c'è altro in riproduzione"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Riproduci successivo"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Riproduci successivamente le tracce riprodotte"
 
@@ -3920,7 +3936,7 @@ msgstr "Preferenza"
 msgid "Preferences"
 msgstr "Preferenze"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Preferenze..."
 
@@ -3980,7 +3996,7 @@ msgid "Previous"
 msgstr "Precedente"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Traccia precedente"
 
@@ -4038,16 +4054,16 @@ msgstr "Qualità"
 msgid "Querying device..."
 msgstr "Interrogazione dispositivo..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Gestore della coda"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Accoda le tracce selezionate"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Accoda la traccia"
 
@@ -4063,7 +4079,7 @@ msgstr "Radio (volume uguale per tutte le tracce)"
 msgid "Rain"
 msgstr "Pioggia"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Pioggia"
@@ -4175,7 +4191,7 @@ msgstr "Rimuovi azione"
 msgid "Remove current song from playlist"
 msgstr "Rimuovi il brano attuale dalla scaletta"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Rimuovi duplicati dalla scaletta"
 
@@ -4183,7 +4199,7 @@ msgstr "Rimuovi duplicati dalla scaletta"
 msgid "Remove folder"
 msgstr "Rimuovi cartella"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Rimuovi dalla scaletta"
 
@@ -4195,7 +4211,7 @@ msgstr "Rimuovi la scaletta"
 msgid "Remove playlists"
 msgstr "Rimuovi scalette"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Rimuovi tracce non disponibili dalla scaletta"
 
@@ -4207,7 +4223,7 @@ msgstr "Rinomina la scaletta"
 msgid "Rename playlist..."
 msgstr "Rinomina la scaletta..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Ricorda l'ordine delle tracce..."
 
@@ -4298,7 +4314,7 @@ msgstr "Estrai"
 msgid "Rip CD"
 msgstr "Estrai CD"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Estrai CD audio"
 
@@ -4376,7 +4392,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Salva la scaletta"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Salva la scaletta..."
 
@@ -4463,7 +4479,7 @@ msgstr "Cerca su Subsonic"
 msgid "Search automatically"
 msgstr "Cerca automaticamente"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Cerca album"
 
@@ -4476,7 +4492,7 @@ msgstr "Cerca copertine degli album..."
 msgid "Search for anything"
 msgstr "Cerca qualsiasi cosa"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Cerca artista"
 
@@ -4601,7 +4617,7 @@ msgstr "Dettagli del server"
 msgid "Service offline"
 msgstr "Servizio non in linea"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Imposta %1 a \"%2\"..."
@@ -4610,7 +4626,7 @@ msgstr "Imposta %1 a \"%2\"..."
 msgid "Set the volume to <value> percent"
 msgstr "Imposta il volume al <value> percento"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Imposta valore per tutte le tracce selezionate..."
 
@@ -4681,7 +4697,7 @@ msgstr "Mostra un OSD gradevole"
 msgid "Show above status bar"
 msgstr "Mostra la barra di stato superiore"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Mostra tutti i brani"
 
@@ -4701,12 +4717,12 @@ msgstr "Mostra separatori"
 msgid "Show fullsize..."
 msgstr "Mostra a dimensioni originali..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Mostra nel navigatore file..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Mostra nella raccolta..."
 
@@ -4718,15 +4734,15 @@ msgstr "Mostra in artisti vari"
 msgid "Show moodbar"
 msgstr "Mostra la barra dell'atmosfera"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Mostra solo i duplicati"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Mostra solo i brani senza tag"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Mostra o nascondi la barra laterale"
 
@@ -4734,7 +4750,7 @@ msgstr "Mostra o nascondi la barra laterale"
 msgid "Show search suggestions"
 msgstr "Mostra i suggerimenti di ricerca"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Mostra la barra laterale"
 
@@ -4770,7 +4786,7 @@ msgstr "Mescola gli album"
 msgid "Shuffle all"
 msgstr "Mescola tutto"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Mescola la scaletta"
 
@@ -4814,11 +4830,15 @@ msgstr "Salta il conteggio"
 msgid "Skip forwards in playlist"
 msgstr "Salta in avanti nella scaletta"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Salta le tracce selezionate"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Salta la traccia"
 
@@ -4935,7 +4955,7 @@ msgstr "Avvia l'estrazione"
 msgid "Start the playlist currently playing"
 msgstr "Avvia la scaletta attualmente in riproduzione"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Avvia transcodifica"
 
@@ -4945,7 +4965,7 @@ msgid ""
 "list"
 msgstr "Inizia a scrivere qualcosa nella casella di ricerca per riempire l'elenco dei risultati di ricerca."
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Avvio di %1"
@@ -4955,7 +4975,7 @@ msgid "Starting..."
 msgstr "Avvio in corso..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Ferma"
 
@@ -4971,7 +4991,7 @@ msgstr "Ferma dopo ogni traccia"
 msgid "Stop after every track"
 msgstr "Ferma dopo tutte le tracce"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Ferma dopo questa traccia"
 
@@ -5139,7 +5159,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Il periodo di prova per il server Subsonic è scaduto. Effettua una donazione per ottenere una chiave di licenza. Visita subsonic.org per i dettagli."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5181,7 +5201,7 @@ msgid ""
 "continue?"
 msgstr "Questi file saranno eliminati dal dispositivo, sei sicuro di voler continuare?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5283,11 +5303,11 @@ msgstr "Commuta Pretty OSD"
 msgid "Toggle fullscreen"
 msgstr "Attiva la modalità a schermo intero"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Cambia lo stato della coda"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Commuta lo scrobbling"
 
@@ -5332,19 +5352,19 @@ msgstr "Trac&cia"
 msgid "Track"
 msgstr "Traccia"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Transcodifica musica"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Log di transcodifica"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr "Dettagli del transcodificatore"
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Transcodifica"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Transcodifica di %1 file utilizzando %2 thread"
@@ -5421,11 +5441,11 @@ msgstr "Errore sconosciuto"
 msgid "Unset cover"
 msgstr "Rimuovi copertina"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Ripristina le tracce selezionate"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Ripristina la traccia"
 
@@ -5442,7 +5462,7 @@ msgstr "Prossimi concerti"
 msgid "Update all podcasts"
 msgstr "Aggiorna tutti i podcast"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Aggiorna le cartelle modificate della raccolta"
 
@@ -5603,7 +5623,7 @@ msgstr "Versione %1"
 msgid "View"
 msgstr "Visualizza"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Visualizza dettagli flusso"
 
@@ -5611,7 +5631,7 @@ msgstr "Visualizza dettagli flusso"
 msgid "Visualization mode"
 msgstr "Modalità di visualizzazione"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Visualizzazioni"
 
@@ -5652,7 +5672,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr "Avviso: questo livello di compressione non rientra nel sottoinsieme di trasmissione. Ciò significa che un decodificatore potrebbe non essere in grado di iniziare a riprodurlo a metà del flusso. Potrebbe anche influire sulle prestazioni dei decodificatori hardware."
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5748,7 +5768,7 @@ msgstr "Windows media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media audio"
 
@@ -5762,7 +5782,7 @@ msgid ""
 "well?"
 msgstr "Vuoi spostare anche gli altri brani di questo album in Artisti vari?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Vuoi eseguire subito una nuova scansione completa?"
 

--- a/src/translations/ja.po
+++ b/src/translations/ja.po
@@ -523,7 +523,7 @@ msgstr "別のストリームを追加..."
 msgid "Add directory..."
 msgstr "ディレクトリを追加..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "ファイルを追加"
 
@@ -543,7 +543,7 @@ msgstr "ファイルを追加..."
 msgid "Add files to transcode"
 msgstr "変換するファイルを追加"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "フォルダーを追加"
@@ -648,7 +648,7 @@ msgstr "Spotify のプレイリストに追加する"
 msgid "Add to Spotify starred"
 msgstr "Spotify の星付きトラックを追加する"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "別のプレイリストに追加する"
 
@@ -870,7 +870,7 @@ msgstr "ライブラリーのすべての曲の統計情報を曲ファイルに
 msgid "Artist"
 msgstr "アーティスト"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "アーティストの情報"
 
@@ -1133,7 +1133,7 @@ msgstr "新しいエピソードのチェック"
 msgid "Check for updates"
 msgstr "更新の確認"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "更新のチェック..."
 
@@ -1373,7 +1373,7 @@ msgstr "Subsonic を設定..."
 msgid "Configure global search..."
 msgstr "全体検索の設定..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "ライブラリの設定..."
 
@@ -1445,11 +1445,11 @@ msgid "Copy to clipboard"
 msgstr "クリップボードにコピー"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "デバイスへコピー..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "ライブラリへコピー..."
@@ -1667,7 +1667,7 @@ msgid "Delete downloaded data"
 msgstr "ダウンロード済みデータを削除"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "ファイルの削除"
 
@@ -1675,7 +1675,7 @@ msgstr "ファイルの削除"
 msgid "Delete from device..."
 msgstr "デバイスから削除..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "ディスクから削除..."
@@ -1708,11 +1708,11 @@ msgstr "ファイルの削除中"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "選択されたトラックをキューから削除する"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "トラックをキューから削除"
 
@@ -1741,7 +1741,7 @@ msgstr "デバイス名"
 msgid "Device properties..."
 msgstr "デバイスのプロパティ..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "デバイス"
 
@@ -1992,7 +1992,7 @@ msgstr "ダイナミックランダムミックス"
 msgid "Edit smart playlist..."
 msgstr "スマートプレイリストの編集..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "タグ「%1」を編集..."
@@ -2131,8 +2131,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "--log-levels *:3 と同じ"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "エラー"
 
@@ -2278,7 +2278,7 @@ msgstr "フェード"
 msgid "Fading duration"
 msgstr "フェードの長さ"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "CD ドライブの読み込みが失敗しました"
 
@@ -2401,7 +2401,7 @@ msgstr "ファイルの種類"
 msgid "Filename"
 msgstr "ファイル名"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "ファイル"
 
@@ -2816,7 +2816,7 @@ msgstr "インストール済み"
 msgid "Integrity check"
 msgstr "整合性の検査"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "インターネット"
 
@@ -3004,7 +3004,7 @@ msgstr "左"
 msgid "Length"
 msgstr "長さ"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "ライブラリ"
@@ -3013,7 +3013,7 @@ msgstr "ライブラリ"
 msgid "Library advanced grouping"
 msgstr "ライブラリの高度なグループ化"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "ライブラリー再スキャン通知"
 
@@ -3341,7 +3341,7 @@ msgstr "マウントポイント"
 msgid "Move down"
 msgstr "下へ移動"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "ライブラリへ移動..."
 
@@ -3350,7 +3350,7 @@ msgstr "ライブラリへ移動..."
 msgid "Move up"
 msgstr "上へ移動"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "ミュージック"
 
@@ -3412,7 +3412,7 @@ msgstr "再生を開始しない"
 msgid "New folder"
 msgstr "新しいフォルダー"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "新しいプレイリスト"
 
@@ -3483,7 +3483,7 @@ msgstr "短いブロックなし"
 msgid "None"
 msgstr "なし"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "デバイスへのコピーに適切な曲が選択されていません"
 
@@ -3698,7 +3698,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "ファイルの整理"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "ファイルの整理..."
 
@@ -3782,7 +3782,7 @@ msgstr "パーティー"
 msgid "Password"
 msgstr "パスワード"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "一時停止"
@@ -3818,8 +3818,8 @@ msgstr "ピクセル"
 msgid "Plain sidebar"
 msgstr "プレーンサイドバー"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3842,11 +3842,11 @@ msgstr "停止中は再生し、再生中は一時停止します"
 msgid "Play if there is nothing already playing"
 msgstr "再生中の曲がない場合は再生する"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3885,7 +3885,7 @@ msgstr "プレイリストのオプション"
 msgid "Playlist type"
 msgstr "プレイリストの種類"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "プレイリスト"
 
@@ -4067,12 +4067,12 @@ msgstr "デバイスを照会しています..."
 msgid "Queue Manager"
 msgstr "キューマネージャー"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "選択されたトラックをキューに追加"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "トラックをキューに追加"
 
@@ -4463,7 +4463,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "検索"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "検索"
@@ -4488,7 +4488,7 @@ msgstr "Subsonic を検索する"
 msgid "Search automatically"
 msgstr "自動的に検索する"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4501,7 +4501,7 @@ msgstr "アルバムカバーの検索..."
 msgid "Search for anything"
 msgstr "何かを検索"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4626,7 +4626,7 @@ msgstr "サーバーの詳細"
 msgid "Service offline"
 msgstr "サービスがオフラインです"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "%1 を「%2」に設定します..."
@@ -4706,7 +4706,7 @@ msgstr "Pretty OSD を表示する"
 msgid "Show above status bar"
 msgstr "ステータスバーの上に表示"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "すべての曲を表示する"
 
@@ -4726,12 +4726,12 @@ msgstr "区切りを表示する"
 msgid "Show fullsize..."
 msgstr "原寸表示..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "ファイルブラウザーで表示..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "ライブラリーに表示..."
 
@@ -4743,11 +4743,11 @@ msgstr "さまざまなアーティストに表示"
 msgid "Show moodbar"
 msgstr "ムードバーを表示する"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "重複するものだけ表示"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "タグのないものだけ表示"
 
@@ -4839,7 +4839,7 @@ msgstr "スキップ回数"
 msgid "Skip forwards in playlist"
 msgstr "プレイリストで前にスキップ"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "選択したトラックをスキップする"
 
@@ -4847,7 +4847,7 @@ msgstr "選択したトラックをスキップする"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "トラックをスキップする"
 
@@ -4879,7 +4879,7 @@ msgstr "Soft Rock"
 msgid "Song Information"
 msgstr "曲の情報"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "曲の情報"
 
@@ -5000,7 +5000,7 @@ msgstr "各トラック後に停止"
 msgid "Stop after every track"
 msgstr "各トラック後に停止"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "このトラック後に停止"
 
@@ -5168,7 +5168,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Subsonic サーバーのお試し期間は終了しました。寄付してライセンスキーを取得してください。詳細は subsonic.org を参照してください。"
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5210,7 +5210,7 @@ msgid ""
 "continue?"
 msgstr "これらのファイルはデバイスから削除されます。続行してもよろしいですか?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5312,7 +5312,7 @@ msgstr "Pretty OSD の切り替え"
 msgid "Toggle fullscreen"
 msgstr "全画面表示の切り替え"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "キュー状態の切り替え"
 
@@ -5450,11 +5450,11 @@ msgstr "不明なエラー"
 msgid "Unset cover"
 msgstr "カバーを未設定にする"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "選択したトラックをスキップしない"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "トラックをスキップしない"
 
@@ -5791,7 +5791,7 @@ msgid ""
 "well?"
 msgstr "このアルバムにある他の曲も さまざまなアーティスト に移動しますか?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "全体の再スキャンを今すぐ実行しますか?"
 

--- a/src/translations/ja.po
+++ b/src/translations/ja.po
@@ -21,7 +21,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Japanese (http://www.transifex.com/davidsansome/clementine/language/ja/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -175,19 +175,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n 曲失敗しました"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n が完了しました"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -205,7 +205,7 @@ msgstr "中央揃え(&C)"
 msgid "&Custom"
 msgstr "カスタム(&C)"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "おまけ(&E)"
 
@@ -213,7 +213,7 @@ msgstr "おまけ(&E)"
 msgid "&Grouping"
 msgstr "&グループ化"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "ヘルプ(&H)"
 
@@ -238,7 +238,7 @@ msgstr "評価をロック(&L)"
 msgid "&Lyrics"
 msgstr "&歌詞"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "ミュージック(&M)"
 
@@ -246,15 +246,15 @@ msgstr "ミュージック(&M)"
 msgid "&None"
 msgstr "なし(&N)"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "プレイリスト(&P)"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "終了(&Q)"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "リピートモード(&R)"
 
@@ -262,7 +262,7 @@ msgstr "リピートモード(&R)"
 msgid "&Right"
 msgstr "右揃え(&R)"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "シャッフルモード(&S)"
 
@@ -270,7 +270,7 @@ msgstr "シャッフルモード(&S)"
 msgid "&Stretch columns to fit window"
 msgstr "列の幅をウィンドウに合わせる(&S)"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "ツール(&T)"
 
@@ -459,11 +459,11 @@ msgstr "中止"
 msgid "About %1"
 msgstr "%1 について"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Clementine について..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Qt について..."
 
@@ -523,32 +523,32 @@ msgstr "別のストリームを追加..."
 msgid "Add directory..."
 msgstr "ディレクトリを追加..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "ファイルを追加"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "ファイルをトランスコーダーに追加する"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "ファイルをトランスコーダーに追加する"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "ファイルを追加..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "変換するファイルを追加"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "フォルダーを追加"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "フォルダーを追加..."
 
@@ -560,7 +560,7 @@ msgstr "新しいフォルダーを追加..."
 msgid "Add podcast"
 msgstr "ポッドキャストを追加"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "ポッドキャストを追加..."
 
@@ -636,7 +636,7 @@ msgstr "曲のトラックタグを追加"
 msgid "Add song year tag"
 msgstr "曲の年タグを追加"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "ストリームを追加..."
 
@@ -648,7 +648,7 @@ msgstr "Spotify のプレイリストに追加する"
 msgid "Add to Spotify starred"
 msgstr "Spotify の星付きトラックを追加する"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "別のプレイリストに追加する"
 
@@ -742,7 +742,7 @@ msgstr "全て"
 msgid "All Files (*)"
 msgstr "すべてのファイル (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr ""
@@ -1133,7 +1133,7 @@ msgstr "新しいエピソードのチェック"
 msgid "Check for updates"
 msgstr "更新の確認"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "更新のチェック..."
 
@@ -1182,18 +1182,18 @@ msgstr "クラシック"
 msgid "Cleaning up"
 msgstr "整理"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "クリア"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "プレイリストをクリア"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1338,7 +1338,7 @@ msgstr "コメント"
 msgid "Complete tags automatically"
 msgstr "タグの自動補完"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "タグを自動補完..."
 
@@ -1373,7 +1373,7 @@ msgstr "Subsonic を設定..."
 msgid "Configure global search..."
 msgstr "全体検索の設定..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "ライブラリの設定..."
 
@@ -1416,7 +1416,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "接続がタイムアウトしました。サーバーの URL を確認してください。例: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "コンソール"
 
@@ -1445,11 +1445,11 @@ msgid "Copy to clipboard"
 msgstr "クリップボードにコピー"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "デバイスへコピー..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "ライブラリへコピー..."
@@ -1492,14 +1492,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr "プレイリストを作成できません"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "%1 のミュクサーを見つけることができませんでした。正しい GStreamer プラグインがインストールされていることをチェックしてください"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1514,7 +1514,7 @@ msgstr "出力ファイル %1 を開けませんでした"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "カバーマネージャー"
 
@@ -1667,7 +1667,7 @@ msgid "Delete downloaded data"
 msgstr "ダウンロード済みデータを削除"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "ファイルの削除"
 
@@ -1675,7 +1675,7 @@ msgstr "ファイルの削除"
 msgid "Delete from device..."
 msgstr "デバイスから削除..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "ディスクから削除..."
@@ -1708,11 +1708,11 @@ msgstr "ファイルの削除中"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "選択されたトラックをキューから削除する"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "トラックをキューから削除"
 
@@ -1813,7 +1813,7 @@ msgstr "画面のオプション"
 msgid "Display the on-screen-display"
 msgstr "OSD を表示する"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "ライブラリ全体を再スキャン"
 
@@ -1992,12 +1992,12 @@ msgstr "ダイナミックランダムミックス"
 msgid "Edit smart playlist..."
 msgstr "スマートプレイリストの編集..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "タグ「%1」を編集..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "タグの編集..."
 
@@ -2010,7 +2010,7 @@ msgid "Edit track information"
 msgstr "トラック情報の編集"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "トラック情報の編集..."
 
@@ -2118,7 +2118,7 @@ msgstr "コレクション全体"
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "イコライザー"
 
@@ -2131,8 +2131,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "--log-levels *:3 と同じ"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "エラー"
 
@@ -2167,7 +2167,7 @@ msgstr "%1 の読み込みエラー"
 msgid "Error loading di.fm playlist"
 msgstr "di.fm プレイリストの読み込みエラー"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "%1 の処理エラー: %2"
@@ -2250,7 +2250,11 @@ msgstr "エクスポートが完了しました"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "%2 個中 %1 個のカバーをエクスポートしました (%3 個スキップしました)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2274,7 +2278,7 @@ msgstr "フェード"
 msgid "Fading duration"
 msgstr "フェードの長さ"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "CD ドライブの読み込みが失敗しました"
 
@@ -2556,11 +2560,11 @@ msgstr "名前を入力してください:"
 msgid "Go"
 msgstr "進む"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "次のプレイリストタブへ"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "前のプレイリストタブへ"
 
@@ -2893,7 +2897,7 @@ msgstr "Jamendo のデータベース"
 msgid "Jump to previous song right away"
 msgstr "すぐに、前の曲にジャンプする"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "現在再生中のトラックへジャンプ"
 
@@ -2917,7 +2921,7 @@ msgstr "ウィンドウを閉じたときバックグラウンドで起動し続
 msgid "Keep the original files"
 msgstr "元のファイルを保持する"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Kittens"
@@ -3009,7 +3013,7 @@ msgstr "ライブラリ"
 msgid "Library advanced grouping"
 msgstr "ライブラリの高度なグループ化"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "ライブラリー再スキャン通知"
 
@@ -3049,7 +3053,7 @@ msgstr "ディスクからカバーの読み込み..."
 msgid "Load playlist"
 msgstr "プレイリストの読み込み"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "プレイリストの読み込み..."
 
@@ -3110,11 +3114,15 @@ msgstr "ログイン"
 msgid "Login failed"
 msgstr "ログインは失敗しました"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Long Term Prediction プロファイル (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Love"
 
@@ -3149,11 +3157,11 @@ msgstr "%1 からの歌詞"
 msgid "Lyrics from the tag"
 msgstr "タグからの歌詞"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3195,7 +3203,7 @@ msgstr "Main プロファイル (MAIN)"
 msgid "Make it so!"
 msgstr "Make it so!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Make it so!"
@@ -3333,7 +3341,7 @@ msgstr "マウントポイント"
 msgid "Move down"
 msgstr "下へ移動"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "ライブラリへ移動..."
 
@@ -3342,7 +3350,7 @@ msgstr "ライブラリへ移動..."
 msgid "Move up"
 msgstr "上へ移動"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "ミュージック"
 
@@ -3355,7 +3363,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "ミュート"
 
@@ -3404,7 +3412,7 @@ msgstr "再生を開始しない"
 msgid "New folder"
 msgstr "新しいフォルダー"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "新しいプレイリスト"
 
@@ -3432,8 +3440,12 @@ msgstr "最新のトラック"
 msgid "Next"
 msgstr "次へ"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "次のトラック"
 
@@ -3471,7 +3483,7 @@ msgstr "短いブロックなし"
 msgid "None"
 msgstr "なし"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "デバイスへのコピーに適切な曲が選択されていません"
 
@@ -3556,19 +3568,19 @@ msgstr "オフ"
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3612,7 +3624,7 @@ msgstr "不透明度"
 msgid "Open %1 in browser"
 msgstr "%1 をブラウザーで開く"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "オーディオ CD を開く(&A)..."
 
@@ -3624,7 +3636,7 @@ msgstr "OPML ファイルを開く"
 msgid "Open OPML file..."
 msgstr "OPML ファイルを開く..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "音楽を取り込むディレクトリを開く"
 
@@ -3632,7 +3644,7 @@ msgstr "音楽を取り込むディレクトリを開く"
 msgid "Open device"
 msgstr "デバイスを開く"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "ファイルを開く..."
 
@@ -3686,7 +3698,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "ファイルの整理"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "ファイルの整理..."
 
@@ -3770,7 +3782,7 @@ msgstr "パーティー"
 msgid "Password"
 msgstr "パスワード"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "一時停止"
@@ -3794,6 +3806,10 @@ msgstr "出演者"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "ピクセル"
@@ -3802,10 +3818,10 @@ msgstr "ピクセル"
 msgid "Plain sidebar"
 msgstr "プレーンサイドバー"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "再生"
 
@@ -3826,11 +3842,11 @@ msgstr "停止中は再生し、再生中は一時停止します"
 msgid "Play if there is nothing already playing"
 msgstr "再生中の曲がない場合は再生する"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3929,7 +3945,7 @@ msgstr "設定"
 msgid "Preferences"
 msgstr "設定"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "設定..."
 
@@ -3989,7 +4005,7 @@ msgid "Previous"
 msgstr "前へ"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "前のトラック"
 
@@ -4047,16 +4063,16 @@ msgstr "品質"
 msgid "Querying device..."
 msgstr "デバイスを照会しています..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "キューマネージャー"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "選択されたトラックをキューに追加"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "トラックをキューに追加"
 
@@ -4072,7 +4088,7 @@ msgstr "ラジオ (すべてのトラックで均一の音量)"
 msgid "Rain"
 msgstr "Rain"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Rain"
@@ -4184,7 +4200,7 @@ msgstr "アクションの削除"
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "重複するものをプレイリストから削除"
 
@@ -4192,7 +4208,7 @@ msgstr "重複するものをプレイリストから削除"
 msgid "Remove folder"
 msgstr "フォルダーの削除"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "プレイリストから削除"
 
@@ -4204,7 +4220,7 @@ msgstr "プレイリストを削除する"
 msgid "Remove playlists"
 msgstr "プレイリストを削除する"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "無効なトラックをプレイリストから削除"
 
@@ -4216,7 +4232,7 @@ msgstr "プレイリストの名前の変更"
 msgid "Rename playlist..."
 msgstr "プレイリストの名前の変更..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "この順序でトラック番号を振る..."
 
@@ -4307,7 +4323,7 @@ msgstr "リッピングする"
 msgid "Rip CD"
 msgstr "CD をリッピングする"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "オーディオ CD をリッピングする"
 
@@ -4385,7 +4401,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "プレイリストを保存する"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "プレイリストの保存..."
 
@@ -4472,7 +4488,7 @@ msgstr "Subsonic を検索する"
 msgid "Search automatically"
 msgstr "自動的に検索する"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4485,7 +4501,7 @@ msgstr "アルバムカバーの検索..."
 msgid "Search for anything"
 msgstr "何かを検索"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4610,7 +4626,7 @@ msgstr "サーバーの詳細"
 msgid "Service offline"
 msgstr "サービスがオフラインです"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "%1 を「%2」に設定します..."
@@ -4619,7 +4635,7 @@ msgstr "%1 を「%2」に設定します..."
 msgid "Set the volume to <value> percent"
 msgstr "音量を <value> パーセントへ設定しました"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "すべての選択されたトラックの音量を設定しました..."
 
@@ -4690,7 +4706,7 @@ msgstr "Pretty OSD を表示する"
 msgid "Show above status bar"
 msgstr "ステータスバーの上に表示"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "すべての曲を表示する"
 
@@ -4710,12 +4726,12 @@ msgstr "区切りを表示する"
 msgid "Show fullsize..."
 msgstr "原寸表示..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "ファイルブラウザーで表示..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "ライブラリーに表示..."
 
@@ -4727,15 +4743,15 @@ msgstr "さまざまなアーティストに表示"
 msgid "Show moodbar"
 msgstr "ムードバーを表示する"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "重複するものだけ表示"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "タグのないものだけ表示"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "ムードバーを表示/非表示"
 
@@ -4743,7 +4759,7 @@ msgstr "ムードバーを表示/非表示"
 msgid "Show search suggestions"
 msgstr "検索のおすすめを表示する"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "ムードバーを表示する"
 
@@ -4779,7 +4795,7 @@ msgstr "アルバムをシャッフル"
 msgid "Shuffle all"
 msgstr "すべてシャッフル"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "プレイリストをシャッフル"
 
@@ -4823,11 +4839,15 @@ msgstr "スキップ回数"
 msgid "Skip forwards in playlist"
 msgstr "プレイリストで前にスキップ"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "選択したトラックをスキップする"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "トラックをスキップする"
 
@@ -4944,7 +4964,7 @@ msgstr "リッピングを開始する"
 msgid "Start the playlist currently playing"
 msgstr "現在再生中のプレイリストを開始する"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "トランスコードの開始"
 
@@ -4954,7 +4974,7 @@ msgid ""
 "list"
 msgstr "この検索結果のリストを補完するには、上の検索ボックスに何か入力してください。"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "%1 の開始中"
@@ -4964,7 +4984,7 @@ msgid "Starting..."
 msgstr "開始しています..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "停止"
 
@@ -4980,7 +5000,7 @@ msgstr "各トラック後に停止"
 msgid "Stop after every track"
 msgstr "各トラック後に停止"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "このトラック後に停止"
 
@@ -5148,7 +5168,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Subsonic サーバーのお試し期間は終了しました。寄付してライセンスキーを取得してください。詳細は subsonic.org を参照してください。"
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5190,7 +5210,7 @@ msgid ""
 "continue?"
 msgstr "これらのファイルはデバイスから削除されます。続行してもよろしいですか?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5292,11 +5312,11 @@ msgstr "Pretty OSD の切り替え"
 msgid "Toggle fullscreen"
 msgstr "全画面表示の切り替え"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "キュー状態の切り替え"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "scrobbling の切り替え"
 
@@ -5341,19 +5361,19 @@ msgstr ""
 msgid "Track"
 msgstr "トラック"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "音楽のトランスコード"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "トランスコーダーのログ"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "トランスコード"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "%2 個のスレッドを使用して %1 個のファイルをトランスコードしています"
@@ -5430,11 +5450,11 @@ msgstr "不明なエラー"
 msgid "Unset cover"
 msgstr "カバーを未設定にする"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "選択したトラックをスキップしない"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "トラックをスキップしない"
 
@@ -5451,7 +5471,7 @@ msgstr "次のコンサート"
 msgid "Update all podcasts"
 msgstr "すべてのポッドキャストを更新"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "変更されたライブラリフォルダーを更新"
 
@@ -5612,7 +5632,7 @@ msgstr "バージョン %1"
 msgid "View"
 msgstr "表示"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5620,7 +5640,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr "ビジュアライゼーションモード"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "ビジュアライゼーション"
 
@@ -5661,7 +5681,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5757,7 +5777,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media オーディオ"
 
@@ -5771,7 +5791,7 @@ msgid ""
 "well?"
 msgstr "このアルバムにある他の曲も さまざまなアーティスト に移動しますか?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "全体の再スキャンを今すぐ実行しますか?"
 

--- a/src/translations/ka.po
+++ b/src/translations/ka.po
@@ -9,7 +9,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Georgian (http://www.transifex.com/davidsansome/clementine/language/ka/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -163,19 +163,19 @@ msgstr ""
 msgid "%filename%"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -193,7 +193,7 @@ msgstr "&ცენტრირება"
 msgid "&Custom"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "დამა&ტებითი"
 
@@ -201,7 +201,7 @@ msgstr "დამა&ტებითი"
 msgid "&Grouping"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&დახმარება"
 
@@ -226,7 +226,7 @@ msgstr "&შეფასების ჩაკეტვა"
 msgid "&Lyrics"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&მუსიკა"
 
@@ -234,15 +234,15 @@ msgstr "&მუსიკა"
 msgid "&None"
 msgstr "&არცერთი"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&დასაკრავი სია"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&გამოსვლა"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "&გამეორების რეჟიმი"
 
@@ -250,7 +250,7 @@ msgstr "&გამეორების რეჟიმი"
 msgid "&Right"
 msgstr "&მარჯვენა"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "&არევის რეჟიმი"
 
@@ -258,7 +258,7 @@ msgstr "&არევის რეჟიმი"
 msgid "&Stretch columns to fit window"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&ხელსაწყოები"
 
@@ -447,11 +447,11 @@ msgstr ""
 msgid "About %1"
 msgstr "%1-ის შესახებ"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Clementine-ის შესახებ..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Qt-ის შესახებ..."
 
@@ -511,32 +511,32 @@ msgstr "სხვა ნაკადის დამატება..."
 msgid "Add directory..."
 msgstr "დირექტორიის დამატება..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "ფაილის დამატება..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "გადასაკოდირებელი ფაილების დამატება"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "დასტის დამატება"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "დასტის დამატება..."
 
@@ -548,7 +548,7 @@ msgstr "ახალი დასტის დამატება..."
 msgid "Add podcast"
 msgstr "პოდკასტის დამატება"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "პოდკასტის დამატება..."
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Add song year tag"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "ნაკადის დამატება..."
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "სხვა რეპერტუარში დამატება"
 
@@ -730,7 +730,7 @@ msgstr ""
 msgid "All Files (*)"
 msgstr "ყველა ფაილი (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr ""
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "განახლებებზე შემოწმება..."
 
@@ -1170,18 +1170,18 @@ msgstr "კლასიკური"
 msgid "Cleaning up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "გასუფთავება"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "რეპერტუარის გასუფთავება"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1326,7 +1326,7 @@ msgstr "კომენტარი"
 msgid "Complete tags automatically"
 msgstr "ჭდეების ავტომატური შევსება"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "ჭდეების ავტომატური შევსება..."
 
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "ბიბლიოთეკის გამართვა..."
 
@@ -1404,7 +1404,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr ""
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr ""
 
@@ -1433,11 +1433,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1480,14 +1480,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr ""
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1502,7 +1502,7 @@ msgstr ""
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr ""
 
@@ -1655,7 +1655,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "ფაილების წაშლა"
 
@@ -1663,7 +1663,7 @@ msgstr "ფაილების წაშლა"
 msgid "Delete from device..."
 msgstr "მოწყობილობიდან წაშლა..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "დისკიდან წაშლა..."
@@ -1696,11 +1696,11 @@ msgstr "ფაილების წაშლა"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr ""
 
@@ -1801,7 +1801,7 @@ msgstr "პარამეტრების ჩვენება"
 msgid "Display the on-screen-display"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr ""
 
@@ -1980,12 +1980,12 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "ჭდის რედაქტირება..."
 
@@ -1998,7 +1998,7 @@ msgid "Edit track information"
 msgstr ""
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr ""
 
@@ -2106,7 +2106,7 @@ msgstr "მთელი კოლექცია"
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "ეკვალაიზერი"
 
@@ -2119,8 +2119,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "შეცდომა"
 
@@ -2155,7 +2155,7 @@ msgstr ""
 msgid "Error loading di.fm playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr ""
@@ -2238,7 +2238,11 @@ msgstr ""
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr ""
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2262,7 +2266,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2544,11 +2548,11 @@ msgstr ""
 msgid "Go"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr ""
 
@@ -2881,7 +2885,7 @@ msgstr ""
 msgid "Jump to previous song right away"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr ""
 
@@ -2905,7 +2909,7 @@ msgstr ""
 msgid "Keep the original files"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr ""
@@ -2997,7 +3001,7 @@ msgstr "ბიბლიოთეკა"
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3037,7 +3041,7 @@ msgstr ""
 msgid "Load playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr ""
 
@@ -3098,11 +3102,15 @@ msgstr ""
 msgid "Login failed"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "შეყვარება"
 
@@ -3137,11 +3145,11 @@ msgstr ""
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr ""
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr ""
@@ -3183,7 +3191,7 @@ msgstr ""
 msgid "Make it so!"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr ""
@@ -3321,7 +3329,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3330,7 +3338,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "მუსიკა"
 
@@ -3343,7 +3351,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "გაჩუმება"
 
@@ -3392,7 +3400,7 @@ msgstr ""
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3420,8 +3428,12 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "შემდეგი ჩანაწერი"
 
@@ -3459,7 +3471,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3544,19 +3556,19 @@ msgstr ""
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr ""
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr ""
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr ""
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3600,7 +3612,7 @@ msgstr ""
 msgid "Open %1 in browser"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "&აუდიო CD-ის გახსნა..."
 
@@ -3612,7 +3624,7 @@ msgstr ""
 msgid "Open OPML file..."
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr ""
 
@@ -3620,7 +3632,7 @@ msgstr ""
 msgid "Open device"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "ფაილის გახსნა..."
 
@@ -3674,7 +3686,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr "ფაილების ორგანიზება"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "ფაილების ორგანიზება..."
 
@@ -3758,7 +3770,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr ""
@@ -3782,6 +3794,10 @@ msgstr ""
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr ""
@@ -3790,10 +3806,10 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "დაკვრა"
 
@@ -3814,11 +3830,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3917,7 +3933,7 @@ msgstr ""
 msgid "Preferences"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr ""
 
@@ -3977,7 +3993,7 @@ msgid "Previous"
 msgstr ""
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "წინა ჩანაწერი"
 
@@ -4035,16 +4051,16 @@ msgstr ""
 msgid "Querying device..."
 msgstr ""
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr ""
 
@@ -4060,7 +4076,7 @@ msgstr ""
 msgid "Rain"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr ""
@@ -4172,7 +4188,7 @@ msgstr ""
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr ""
 
@@ -4180,7 +4196,7 @@ msgstr ""
 msgid "Remove folder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr ""
 
@@ -4192,7 +4208,7 @@ msgstr ""
 msgid "Remove playlists"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr ""
 
@@ -4204,7 +4220,7 @@ msgstr ""
 msgid "Rename playlist..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr ""
 
@@ -4295,7 +4311,7 @@ msgstr ""
 msgid "Rip CD"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr ""
 
@@ -4373,7 +4389,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr ""
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr ""
 
@@ -4460,7 +4476,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4473,7 +4489,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4598,7 +4614,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4607,7 +4623,7 @@ msgstr ""
 msgid "Set the volume to <value> percent"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr ""
 
@@ -4678,7 +4694,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr ""
 
@@ -4698,12 +4714,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr ""
 
@@ -4715,15 +4731,15 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4731,7 +4747,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4767,7 +4783,7 @@ msgstr ""
 msgid "Shuffle all"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr ""
 
@@ -4811,11 +4827,15 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr ""
 
@@ -4932,7 +4952,7 @@ msgstr ""
 msgid "Start the playlist currently playing"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr ""
 
@@ -4942,7 +4962,7 @@ msgid ""
 "list"
 msgstr ""
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr ""
@@ -4952,7 +4972,7 @@ msgid "Starting..."
 msgstr ""
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "გაჩერება"
 
@@ -4968,7 +4988,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5136,7 +5156,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5178,7 +5198,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5280,11 +5300,11 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr ""
 
@@ -5329,19 +5349,19 @@ msgstr ""
 msgid "Track"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr ""
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
 msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr ""
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr ""
@@ -5418,11 +5438,11 @@ msgstr ""
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr ""
 
@@ -5439,7 +5459,7 @@ msgstr ""
 msgid "Update all podcasts"
 msgstr "ყველა პოდკასტის განახლება"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr ""
 
@@ -5600,7 +5620,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5608,7 +5628,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr ""
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr ""
 
@@ -5649,7 +5669,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr ""
 
@@ -5745,7 +5765,7 @@ msgstr ""
 msgid "Windows Media 64k"
 msgstr ""
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr ""
 
@@ -5759,7 +5779,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/ka.po
+++ b/src/translations/ka.po
@@ -511,7 +511,7 @@ msgstr "სხვა ნაკადის დამატება..."
 msgid "Add directory..."
 msgstr "დირექტორიის დამატება..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr ""
 
@@ -531,7 +531,7 @@ msgstr "ფაილის დამატება..."
 msgid "Add files to transcode"
 msgstr "გადასაკოდირებელი ფაილების დამატება"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "დასტის დამატება"
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "სხვა რეპერტუარში დამატება"
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Artist"
 msgstr "შემსრულებელი"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "შემსრულებლის ინფო"
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "განახლებებზე შემოწმება..."
 
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "ბიბლიოთეკის გამართვა..."
 
@@ -1433,11 +1433,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1655,7 +1655,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "ფაილების წაშლა"
 
@@ -1663,7 +1663,7 @@ msgstr "ფაილების წაშლა"
 msgid "Delete from device..."
 msgstr "მოწყობილობიდან წაშლა..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "დისკიდან წაშლა..."
@@ -1696,11 +1696,11 @@ msgstr "ფაილების წაშლა"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr ""
 
@@ -1729,7 +1729,7 @@ msgstr "მოწყობილობის სახელი"
 msgid "Device properties..."
 msgstr "მოწყობილობის პარამეტრები..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "მოწყობილობები"
 
@@ -1980,7 +1980,7 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
@@ -2119,8 +2119,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "შეცდომა"
 
@@ -2266,7 +2266,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2389,7 +2389,7 @@ msgstr ""
 msgid "Filename"
 msgstr ""
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "ფაილები"
 
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "Integrity check"
 msgstr ""
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "ინტერნეტი"
 
@@ -2992,7 +2992,7 @@ msgstr ""
 msgid "Length"
 msgstr ""
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "ბიბლიოთეკა"
@@ -3001,7 +3001,7 @@ msgstr "ბიბლიოთეკა"
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3329,7 +3329,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3338,7 +3338,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "მუსიკა"
 
@@ -3400,7 +3400,7 @@ msgstr ""
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3471,7 +3471,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3686,7 +3686,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr "ფაილების ორგანიზება"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "ფაილების ორგანიზება..."
 
@@ -3770,7 +3770,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr ""
@@ -3806,8 +3806,8 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3830,11 +3830,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3873,7 +3873,7 @@ msgstr ""
 msgid "Playlist type"
 msgstr ""
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr ""
 
@@ -4055,12 +4055,12 @@ msgstr ""
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr ""
 
@@ -4451,7 +4451,7 @@ msgstr ""
 msgid "Search"
 msgstr "ძებნა"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr ""
@@ -4476,7 +4476,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4489,7 +4489,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4614,7 +4614,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4694,7 +4694,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr ""
 
@@ -4714,12 +4714,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr ""
 
@@ -4731,11 +4731,11 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr ""
 
@@ -4835,7 +4835,7 @@ msgstr ""
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr ""
 
@@ -4867,7 +4867,7 @@ msgstr ""
 msgid "Song Information"
 msgstr "ინფორმაცია სიმღერაზე"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "ინფორმაცია"
 
@@ -4988,7 +4988,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5156,7 +5156,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5198,7 +5198,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5300,7 +5300,7 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr ""
 
@@ -5438,11 +5438,11 @@ msgstr ""
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr ""
 
@@ -5779,7 +5779,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/kk.po
+++ b/src/translations/kk.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Kazakh (http://www.transifex.com/davidsansome/clementine/language/kk/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -161,19 +161,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n сәтсіз"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n аяқталған"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -191,7 +191,7 @@ msgstr "Ор&тасы"
 msgid "&Custom"
 msgstr "Таң&дауыңызша"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr ""
 
@@ -199,7 +199,7 @@ msgstr ""
 msgid "&Grouping"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Көмек"
 
@@ -224,7 +224,7 @@ msgstr ""
 msgid "&Lyrics"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "Му&зыка"
 
@@ -232,15 +232,15 @@ msgstr "Му&зыка"
 msgid "&None"
 msgstr "&Ешнәрсе"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Шығу"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr ""
 
@@ -248,7 +248,7 @@ msgstr ""
 msgid "&Right"
 msgstr "&Оң жақ"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr ""
 
@@ -256,7 +256,7 @@ msgstr ""
 msgid "&Stretch columns to fit window"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "Са&ймандар"
 
@@ -445,11 +445,11 @@ msgstr ""
 msgid "About %1"
 msgstr "%1 туралы"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Qt туралы..."
 
@@ -509,32 +509,32 @@ msgstr ""
 msgid "Add directory..."
 msgstr ""
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Файлды қосу"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Файлды қосу..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Буманы қосу"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Буманы қосу..."
 
@@ -546,7 +546,7 @@ msgstr ""
 msgid "Add podcast"
 msgstr ""
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr ""
 
@@ -622,7 +622,7 @@ msgstr ""
 msgid "Add song year tag"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr ""
 
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr ""
 
@@ -728,7 +728,7 @@ msgstr ""
 msgid "All Files (*)"
 msgstr "Барлық файлдар (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr ""
@@ -1119,7 +1119,7 @@ msgstr "Жаңа эпизодтарға тексеру"
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Жаңартуларға тексеру..."
 
@@ -1168,18 +1168,18 @@ msgstr "Классикалық"
 msgid "Cleaning up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Тазарту"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr ""
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr ""
 
@@ -1324,7 +1324,7 @@ msgstr "Түсіндірме"
 msgid "Complete tags automatically"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr ""
 
@@ -1359,7 +1359,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr ""
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr ""
 
@@ -1431,11 +1431,11 @@ msgid "Copy to clipboard"
 msgstr "Алмасу буферіне көшіру"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1478,14 +1478,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr ""
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1500,7 +1500,7 @@ msgstr ""
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr ""
 
@@ -1653,7 +1653,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Файлдарды өшіру"
 
@@ -1661,7 +1661,7 @@ msgstr "Файлдарды өшіру"
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1694,11 +1694,11 @@ msgstr "Файлдарды өшіру"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr ""
 
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "Display the on-screen-display"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr ""
 
@@ -1978,12 +1978,12 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr ""
 
@@ -1996,7 +1996,7 @@ msgid "Edit track information"
 msgstr ""
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr ""
 
@@ -2104,7 +2104,7 @@ msgstr ""
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Эквалайзер"
 
@@ -2117,8 +2117,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Қате"
 
@@ -2153,7 +2153,7 @@ msgstr ""
 msgid "Error loading di.fm playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr ""
@@ -2236,7 +2236,11 @@ msgstr ""
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr ""
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2260,7 +2264,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2542,11 +2546,11 @@ msgstr ""
 msgid "Go"
 msgstr "Өту"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr ""
 
@@ -2879,7 +2883,7 @@ msgstr ""
 msgid "Jump to previous song right away"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr ""
 
@@ -2903,7 +2907,7 @@ msgstr ""
 msgid "Keep the original files"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr ""
@@ -2995,7 +2999,7 @@ msgstr "Жинақ"
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3035,7 +3039,7 @@ msgstr ""
 msgid "Load playlist"
 msgstr "Ойнату тізімін жүктеу"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Ойнату тізімін жүктеу..."
 
@@ -3096,11 +3100,15 @@ msgstr "Кіру"
 msgid "Login failed"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr ""
 
@@ -3135,11 +3143,11 @@ msgstr ""
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr ""
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3181,7 +3189,7 @@ msgstr ""
 msgid "Make it so!"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr ""
@@ -3319,7 +3327,7 @@ msgstr ""
 msgid "Move down"
 msgstr "Төмен жылжыту"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3328,7 +3336,7 @@ msgstr ""
 msgid "Move up"
 msgstr "Жоғары жылжыту"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Музыка"
 
@@ -3341,7 +3349,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Дыбысын басу"
 
@@ -3390,7 +3398,7 @@ msgstr ""
 msgid "New folder"
 msgstr "Жаңа бума"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Жаңа ойнату тізімі"
 
@@ -3418,8 +3426,12 @@ msgstr ""
 msgid "Next"
 msgstr "Келесі"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr ""
 
@@ -3457,7 +3469,7 @@ msgstr ""
 msgid "None"
 msgstr "Жоқ"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3542,19 +3554,19 @@ msgstr ""
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3598,7 +3610,7 @@ msgstr "Мөлдірсіздік"
 msgid "Open %1 in browser"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr ""
 
@@ -3610,7 +3622,7 @@ msgstr ""
 msgid "Open OPML file..."
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr ""
 
@@ -3618,7 +3630,7 @@ msgstr ""
 msgid "Open device"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Файлды ашу..."
 
@@ -3672,7 +3684,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr ""
 
@@ -3756,7 +3768,7 @@ msgstr ""
 msgid "Password"
 msgstr "Пароль"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Аялдату"
@@ -3780,6 +3792,10 @@ msgstr "Орындайтын"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr ""
@@ -3788,10 +3804,10 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Ойнату"
 
@@ -3812,11 +3828,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3915,7 +3931,7 @@ msgstr ""
 msgid "Preferences"
 msgstr "Баптаулар"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Баптаулар..."
 
@@ -3975,7 +3991,7 @@ msgid "Previous"
 msgstr "Алдыңғы"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr ""
 
@@ -4033,16 +4049,16 @@ msgstr ""
 msgid "Querying device..."
 msgstr ""
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr ""
 
@@ -4058,7 +4074,7 @@ msgstr ""
 msgid "Rain"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr ""
@@ -4170,7 +4186,7 @@ msgstr ""
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr ""
 
@@ -4178,7 +4194,7 @@ msgstr ""
 msgid "Remove folder"
 msgstr "Буманы өшіру"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr ""
 
@@ -4190,7 +4206,7 @@ msgstr ""
 msgid "Remove playlists"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr ""
 
@@ -4202,7 +4218,7 @@ msgstr "Ойнату тізімінің атын ауыстыру"
 msgid "Rename playlist..."
 msgstr "Ойнату тізімінің атын ауыстыру..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr ""
 
@@ -4293,7 +4309,7 @@ msgstr ""
 msgid "Rip CD"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr ""
 
@@ -4371,7 +4387,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr ""
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Ойнату тізімін сақтау..."
 
@@ -4458,7 +4474,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4471,7 +4487,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4596,7 +4612,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4605,7 +4621,7 @@ msgstr ""
 msgid "Set the volume to <value> percent"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr ""
 
@@ -4676,7 +4692,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr ""
 
@@ -4696,12 +4712,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr ""
 
@@ -4713,15 +4729,15 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4729,7 +4745,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4765,7 +4781,7 @@ msgstr "Альбомдарды араластыру"
 msgid "Shuffle all"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr ""
 
@@ -4809,11 +4825,15 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr ""
 
@@ -4930,7 +4950,7 @@ msgstr ""
 msgid "Start the playlist currently playing"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr ""
 
@@ -4940,7 +4960,7 @@ msgid ""
 "list"
 msgstr ""
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "%1 іске қосылу"
@@ -4950,7 +4970,7 @@ msgid "Starting..."
 msgstr "Іске қосылу..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Тоқтату"
 
@@ -4966,7 +4986,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5134,7 +5154,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5176,7 +5196,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5278,11 +5298,11 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr "Толық экранға өту/шығу"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr ""
 
@@ -5327,19 +5347,19 @@ msgstr ""
 msgid "Track"
 msgstr "Трек"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr ""
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
 msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr ""
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr ""
@@ -5416,11 +5436,11 @@ msgstr "Белгісіз қате"
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr ""
 
@@ -5437,7 +5457,7 @@ msgstr ""
 msgid "Update all podcasts"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr ""
 
@@ -5598,7 +5618,7 @@ msgstr "%1 нұсқасы"
 msgid "View"
 msgstr "Түрі"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5606,7 +5626,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr ""
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr ""
 
@@ -5647,7 +5667,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr ""
 
@@ -5743,7 +5763,7 @@ msgstr ""
 msgid "Windows Media 64k"
 msgstr ""
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr ""
 
@@ -5757,7 +5777,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/kk.po
+++ b/src/translations/kk.po
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add directory..."
 msgstr ""
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Файлды қосу"
 
@@ -529,7 +529,7 @@ msgstr "Файлды қосу..."
 msgid "Add files to transcode"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Буманы қосу"
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr ""
 
@@ -856,7 +856,7 @@ msgstr ""
 msgid "Artist"
 msgstr "Орындайтын"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr ""
 
@@ -1119,7 +1119,7 @@ msgstr "Жаңа эпизодтарға тексеру"
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Жаңартуларға тексеру..."
 
@@ -1359,7 +1359,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr ""
 
@@ -1431,11 +1431,11 @@ msgid "Copy to clipboard"
 msgstr "Алмасу буферіне көшіру"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1653,7 +1653,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Файлдарды өшіру"
 
@@ -1661,7 +1661,7 @@ msgstr "Файлдарды өшіру"
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1694,11 +1694,11 @@ msgstr "Файлдарды өшіру"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr ""
 
@@ -1727,7 +1727,7 @@ msgstr "Құрылғы аты"
 msgid "Device properties..."
 msgstr ""
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Құрылғылар"
 
@@ -1978,7 +1978,7 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
@@ -2117,8 +2117,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Қате"
 
@@ -2264,7 +2264,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2387,7 +2387,7 @@ msgstr "Файл түрі"
 msgid "Filename"
 msgstr "Файл аты"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Файлдар"
 
@@ -2802,7 +2802,7 @@ msgstr "Орнатылған"
 msgid "Integrity check"
 msgstr ""
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Интернет"
 
@@ -2990,7 +2990,7 @@ msgstr ""
 msgid "Length"
 msgstr "Ұзындығы"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Жинақ"
@@ -2999,7 +2999,7 @@ msgstr "Жинақ"
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3327,7 +3327,7 @@ msgstr ""
 msgid "Move down"
 msgstr "Төмен жылжыту"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3336,7 +3336,7 @@ msgstr ""
 msgid "Move up"
 msgstr "Жоғары жылжыту"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Музыка"
 
@@ -3398,7 +3398,7 @@ msgstr ""
 msgid "New folder"
 msgstr "Жаңа бума"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Жаңа ойнату тізімі"
 
@@ -3469,7 +3469,7 @@ msgstr ""
 msgid "None"
 msgstr "Жоқ"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3684,7 +3684,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr ""
 
@@ -3768,7 +3768,7 @@ msgstr ""
 msgid "Password"
 msgstr "Пароль"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Аялдату"
@@ -3804,8 +3804,8 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3828,11 +3828,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Playlist type"
 msgstr ""
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr ""
 
@@ -4053,12 +4053,12 @@ msgstr ""
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr ""
 
@@ -4449,7 +4449,7 @@ msgstr ""
 msgid "Search"
 msgstr "Іздеу"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr ""
@@ -4474,7 +4474,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4487,7 +4487,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4692,7 +4692,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr ""
 
@@ -4712,12 +4712,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr ""
 
@@ -4729,11 +4729,11 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr ""
 
@@ -4825,7 +4825,7 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr ""
 
@@ -4833,7 +4833,7 @@ msgstr ""
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr ""
 
@@ -4865,7 +4865,7 @@ msgstr ""
 msgid "Song Information"
 msgstr ""
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr ""
 
@@ -4986,7 +4986,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5154,7 +5154,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5196,7 +5196,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5298,7 +5298,7 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr "Толық экранға өту/шығу"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr ""
 
@@ -5436,11 +5436,11 @@ msgstr "Белгісіз қате"
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr ""
 
@@ -5777,7 +5777,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/ko.po
+++ b/src/translations/ko.po
@@ -526,7 +526,7 @@ msgstr "다른 스트림 추가..."
 msgid "Add directory..."
 msgstr "디렉토리 추가..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "파일 추가"
 
@@ -546,7 +546,7 @@ msgstr "파일 추가..."
 msgid "Add files to transcode"
 msgstr "변환할 파일 추가"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "폴더 추가"
@@ -651,7 +651,7 @@ msgstr "Spotify 재색목록에 추가"
 msgid "Add to Spotify starred"
 msgstr "Spotify 별점에 추가"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "다른 재생목록에 추가"
 
@@ -873,7 +873,7 @@ msgstr "라이브러리의 모든 음악에 대해 음악의 통계를 음악 �
 msgid "Artist"
 msgstr "음악가"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "음악가 정보"
 
@@ -1136,7 +1136,7 @@ msgstr "새로운 에피소드 확인"
 msgid "Check for updates"
 msgstr "업데이트 확인"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "업데이트 확인..."
 
@@ -1376,7 +1376,7 @@ msgstr "Subsonic 설정"
 msgid "Configure global search..."
 msgstr "글로벌 검색 설정..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "라이브러리 설정..."
 
@@ -1448,11 +1448,11 @@ msgid "Copy to clipboard"
 msgstr "클립보드로 복사"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "장치에 복사..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "라이브러리에 복사..."
@@ -1670,7 +1670,7 @@ msgid "Delete downloaded data"
 msgstr "다운로드된 데이터 삭제"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "파일 삭제"
 
@@ -1678,7 +1678,7 @@ msgstr "파일 삭제"
 msgid "Delete from device..."
 msgstr "장치에서 삭제..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "디스크에서 삭제..."
@@ -1711,11 +1711,11 @@ msgstr "파일 삭제 중"
 msgid "Depth"
 msgstr "깊이"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "선택한 곡을 대기열에서 해제"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "곡을 대기열에서 해제"
 
@@ -1744,7 +1744,7 @@ msgstr "장치 이름"
 msgid "Device properties..."
 msgstr "장치 속성..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "장치"
 
@@ -1995,7 +1995,7 @@ msgstr "동적 무작위 조합"
 msgid "Edit smart playlist..."
 msgstr "스마트 재생목록 편집..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "태그 수정 \"%1\"..."
@@ -2134,8 +2134,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "동등한 --log-level *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "오류"
 
@@ -2281,7 +2281,7 @@ msgstr "페이드 아웃"
 msgid "Fading duration"
 msgstr "페이드 아웃 시간"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "CD 드라이브 읽기 실패"
 
@@ -2404,7 +2404,7 @@ msgstr "파일 형태"
 msgid "Filename"
 msgstr "파일이름"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "파일"
 
@@ -2819,7 +2819,7 @@ msgstr "설치 됨"
 msgid "Integrity check"
 msgstr "무결성 검사"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "인터넷"
 
@@ -3007,7 +3007,7 @@ msgstr "왼쪽"
 msgid "Length"
 msgstr "길이"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "라이브러리 "
@@ -3016,7 +3016,7 @@ msgstr "라이브러리 "
 msgid "Library advanced grouping"
 msgstr "향상된 그룹 "
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "라이브러리 재탐색 알림"
 
@@ -3344,7 +3344,7 @@ msgstr "마운트 지점"
 msgid "Move down"
 msgstr "아래로 이동"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "라이브러리로 이동..."
 
@@ -3353,7 +3353,7 @@ msgstr "라이브러리로 이동..."
 msgid "Move up"
 msgstr "위로 이동"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "음악"
 
@@ -3415,7 +3415,7 @@ msgstr "재생을 시작하지 않음"
 msgid "New folder"
 msgstr "새 폴더"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "새로운 재생목록"
 
@@ -3486,7 +3486,7 @@ msgstr "짧은 블록 "
 msgid "None"
 msgstr "없음"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "선택한 곡 중 장치에 복사하기에 적합한 곡이 없음"
 
@@ -3701,7 +3701,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "파일 정리"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "파일 정리..."
 
@@ -3785,7 +3785,7 @@ msgstr "파티"
 msgid "Password"
 msgstr "암호"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "일시중지"
@@ -3821,8 +3821,8 @@ msgstr "픽셀"
 msgid "Plain sidebar"
 msgstr "일반 사이드바"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3845,11 +3845,11 @@ msgstr "중지중일때 재생, 재생중일때 중지"
 msgid "Play if there is nothing already playing"
 msgstr "이미 재생되는 곡이 없다면 재생"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "다음 곡 재생"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "선택한 곡을 다음에 재생하기"
 
@@ -3888,7 +3888,7 @@ msgstr "재생목록 옵션"
 msgid "Playlist type"
 msgstr "재생목록 종류"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "재생목록"
 
@@ -4070,12 +4070,12 @@ msgstr "장치 질의..."
 msgid "Queue Manager"
 msgstr "대기열 관리자"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "선택한 곡을 대기열에 추가"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "곡 대기열"
 
@@ -4466,7 +4466,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "검색"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "검색"
@@ -4491,7 +4491,7 @@ msgstr "Subsonic 검색"
 msgid "Search automatically"
 msgstr "자동적으로 찾기"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "앨범 검색"
 
@@ -4504,7 +4504,7 @@ msgstr "앨범 표지 검색..."
 msgid "Search for anything"
 msgstr "검색"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "음악가 검색"
 
@@ -4629,7 +4629,7 @@ msgstr "서버 자세히"
 msgid "Service offline"
 msgstr "서비스 오프라인"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "%1을 \"%2\"로 설정..."
@@ -4709,7 +4709,7 @@ msgstr "예쁜 OSD 보기"
 msgid "Show above status bar"
 msgstr "상태 표시 줄 위에 보기"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "모든 음악 표시"
 
@@ -4729,12 +4729,12 @@ msgstr "분할 표시"
 msgid "Show fullsize..."
 msgstr "전체화면 보기..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "파일 브라우져에서 보기..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "라이브러리에서 보기..."
 
@@ -4746,11 +4746,11 @@ msgstr "다양한 음악가에서 보기"
 msgid "Show moodbar"
 msgstr "분위기 막대 보여주기"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "복사본만 보기"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "태그되지 않은 것만 보기"
 
@@ -4842,7 +4842,7 @@ msgstr "건너뛰기 횟수"
 msgid "Skip forwards in playlist"
 msgstr "재생목록에서 앞으로 건너뛰기"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "선택한 곡 건너뛰기"
 
@@ -4850,7 +4850,7 @@ msgstr "선택한 곡 건너뛰기"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "곡 건너뛰기"
 
@@ -4882,7 +4882,7 @@ msgstr "소프트 록"
 msgid "Song Information"
 msgstr "음악 정보"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "음악 정보"
 
@@ -5003,7 +5003,7 @@ msgstr "곡 재생 후 정지"
 msgid "Stop after every track"
 msgstr "모든 곡 재생 후 정지"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "이 곡 재생 후 정지"
 
@@ -5171,7 +5171,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Subsonic의 시험 기간이 끝났습니다. 라이센스 키를 얻기위한 기부를 해주세요. 자세한 사항은 subsonic.org 에서 확인하세요."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5213,7 +5213,7 @@ msgid ""
 "continue?"
 msgstr "파일들이 장치로 부터 삭제될 것 입니다. 계속 진행 하시겠습니까?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5315,7 +5315,7 @@ msgstr "예쁜 OSD 토글"
 msgid "Toggle fullscreen"
 msgstr "전체화면 토글"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "대기열 상황 토글"
 
@@ -5453,11 +5453,11 @@ msgstr "알 수 없는 오류"
 msgid "Unset cover"
 msgstr "커버 해제"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "선택한 곡 건너뛰기 해제"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "곡 건너뛰기 해제"
 
@@ -5794,7 +5794,7 @@ msgid ""
 "well?"
 msgstr "이번 앨범에 수록된 다른 곡들도 다양한 아티스트로 이동하시겠습니까?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "지금 전부 다시 검색해도 좋습니까?"
 

--- a/src/translations/ko.po
+++ b/src/translations/ko.po
@@ -24,7 +24,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Korean (http://www.transifex.com/davidsansome/clementine/language/ko/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -178,19 +178,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n 실패"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n 끝냄"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -208,7 +208,7 @@ msgstr "가운데(&C)"
 msgid "&Custom"
 msgstr "사용자 정의(&C)"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "효과음(&E)"
 
@@ -216,7 +216,7 @@ msgstr "효과음(&E)"
 msgid "&Grouping"
 msgstr "그룹화(&G)"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "도움말(&H)"
 
@@ -241,7 +241,7 @@ msgstr "평가 잠금"
 msgid "&Lyrics"
 msgstr "가사(&L)"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "음악(&M)"
 
@@ -249,15 +249,15 @@ msgstr "음악(&M)"
 msgid "&None"
 msgstr "없음(&N)"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "재생목록(&P)"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "종료(&Q)"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "반복 모드(&R)"
 
@@ -265,7 +265,7 @@ msgstr "반복 모드(&R)"
 msgid "&Right"
 msgstr "오른쪽(&R)"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "순서섞기 모드(&S)"
 
@@ -273,7 +273,7 @@ msgstr "순서섞기 모드(&S)"
 msgid "&Stretch columns to fit window"
 msgstr "창 크기에 맞게 글자열 넓히기(&S)"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "도구(&T)"
 
@@ -462,11 +462,11 @@ msgstr "중단"
 msgid "About %1"
 msgstr "%1 정보"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "클레멘타인 정보..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Qt 정보"
 
@@ -526,32 +526,32 @@ msgstr "다른 스트림 추가..."
 msgid "Add directory..."
 msgstr "디렉토리 추가..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "파일 추가"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "변환기에 파일 추가"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "변환기에 파일(들) 추가"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "파일 추가..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "변환할 파일 추가"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "폴더 추가"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "폴더 추가..."
 
@@ -563,7 +563,7 @@ msgstr "새로운 폴더 추가..."
 msgid "Add podcast"
 msgstr "팟케스트 추가"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "팟케스트 추가..."
 
@@ -639,7 +639,7 @@ msgstr "음악 곡 태그 추가"
 msgid "Add song year tag"
 msgstr "음악 연도 태그 추가"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "스트림 추가..."
 
@@ -651,7 +651,7 @@ msgstr "Spotify 재색목록에 추가"
 msgid "Add to Spotify starred"
 msgstr "Spotify 별점에 추가"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "다른 재생목록에 추가"
 
@@ -745,7 +745,7 @@ msgstr "전체"
 msgid "All Files (*)"
 msgstr "모든 파일 (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "최면두꺼비에게 모든 영광을!"
@@ -1136,7 +1136,7 @@ msgstr "새로운 에피소드 확인"
 msgid "Check for updates"
 msgstr "업데이트 확인"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "업데이트 확인..."
 
@@ -1185,18 +1185,18 @@ msgstr "클래식"
 msgid "Cleaning up"
 msgstr "자동 정리"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "비우기"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "재생목록 비우기"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "클레멘타인"
 
@@ -1341,7 +1341,7 @@ msgstr "설명"
 msgid "Complete tags automatically"
 msgstr "자동으로 태그 저장"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "자동으로 태그 저장..."
 
@@ -1376,7 +1376,7 @@ msgstr "Subsonic 설정"
 msgid "Configure global search..."
 msgstr "글로벌 검색 설정..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "라이브러리 설정..."
 
@@ -1419,7 +1419,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "연결 시간이 초과되었습니다. 서버의 주소를 확인하세요. 예)http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "콘솔"
 
@@ -1448,11 +1448,11 @@ msgid "Copy to clipboard"
 msgstr "클립보드로 복사"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "장치에 복사..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "라이브러리에 복사..."
@@ -1495,14 +1495,14 @@ msgstr "Last.fm에 로그인 할 수 없습니다. 다시 시도하세요."
 msgid "Couldn't create playlist"
 msgstr "재생목록을 생성할수 없습니다."
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "%1 먹서를 찾을 수 없습니다, GStreamer 플러그인이 올바르게 설치되어 있는지 확인하세요"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1517,7 +1517,7 @@ msgstr "출력 파일 %1를 열 수 없습니다"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "커버 관리자"
 
@@ -1670,7 +1670,7 @@ msgid "Delete downloaded data"
 msgstr "다운로드된 데이터 삭제"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "파일 삭제"
 
@@ -1678,7 +1678,7 @@ msgstr "파일 삭제"
 msgid "Delete from device..."
 msgstr "장치에서 삭제..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "디스크에서 삭제..."
@@ -1711,11 +1711,11 @@ msgstr "파일 삭제 중"
 msgid "Depth"
 msgstr "깊이"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "선택한 곡을 대기열에서 해제"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "곡을 대기열에서 해제"
 
@@ -1816,7 +1816,7 @@ msgstr "옵션 표시"
 msgid "Display the on-screen-display"
 msgstr "OSD 표시"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "전체 라이브러리 다시 읽기"
 
@@ -1995,12 +1995,12 @@ msgstr "동적 무작위 조합"
 msgid "Edit smart playlist..."
 msgstr "스마트 재생목록 편집..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "태그 수정 \"%1\"..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "태그 편집..."
 
@@ -2013,7 +2013,7 @@ msgid "Edit track information"
 msgstr "곡 정보 편집"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "곡 정보 편집..."
 
@@ -2121,7 +2121,7 @@ msgstr "전체 선택"
 msgid "Episode information"
 msgstr "에피소드 정보"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "이퀄라이저"
 
@@ -2134,8 +2134,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "동등한 --log-level *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "오류"
 
@@ -2170,7 +2170,7 @@ msgstr "%1 불러오기 오류"
 msgid "Error loading di.fm playlist"
 msgstr "dl.fm 재생목록 불러오기 오류"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "%1: %2 처리 오류"
@@ -2253,7 +2253,11 @@ msgstr "내보내기 완료"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "%2개의 앨범 표지중 %1개 내보냄. (%3개 건너뜀)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2277,7 +2281,7 @@ msgstr "페이드 아웃"
 msgid "Fading duration"
 msgstr "페이드 아웃 시간"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "CD 드라이브 읽기 실패"
 
@@ -2559,11 +2563,11 @@ msgstr "이름 지정:"
 msgid "Go"
 msgstr "Go"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "다음 재생목록 탭으로 가기"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "이전 재생목록 탭으로 가기"
 
@@ -2896,7 +2900,7 @@ msgstr "Jamendo 데이터베이스"
 msgid "Jump to previous song right away"
 msgstr "바로 이전 곡으로 이동"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "현재 재생 중인 곡 건너뛰기"
 
@@ -2920,7 +2924,7 @@ msgstr "창을 닫을 때 백그라운드에서 계속 실행"
 msgid "Keep the original files"
 msgstr "원본 파일들 "
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "새끼 고양이"
@@ -3012,7 +3016,7 @@ msgstr "라이브러리 "
 msgid "Library advanced grouping"
 msgstr "향상된 그룹 "
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "라이브러리 재탐색 알림"
 
@@ -3052,7 +3056,7 @@ msgstr "디스크로부터 커버열기..."
 msgid "Load playlist"
 msgstr "재생목록 불러오기"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "재생목록 불러오기..."
 
@@ -3113,11 +3117,15 @@ msgstr "로그인"
 msgid "Login failed"
 msgstr "로그인 실패"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "장기 예측 프로파일(LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "좋아요"
 
@@ -3152,11 +3160,11 @@ msgstr "%1 의 가사"
 msgid "Lyrics from the tag"
 msgstr "태그로부터의 가사"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "MP4 AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3198,7 +3206,7 @@ msgstr "메인 프로필 (MAIN)"
 msgid "Make it so!"
 msgstr "정각에 종치기!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "정각에 종치기!"
@@ -3336,7 +3344,7 @@ msgstr "마운트 지점"
 msgid "Move down"
 msgstr "아래로 이동"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "라이브러리로 이동..."
 
@@ -3345,7 +3353,7 @@ msgstr "라이브러리로 이동..."
 msgid "Move up"
 msgstr "위로 이동"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "음악"
 
@@ -3358,7 +3366,7 @@ msgid "Music extensions remotely visible"
 msgstr "음악 확장 기능을 원격으로 표시"
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "음소거"
 
@@ -3407,7 +3415,7 @@ msgstr "재생을 시작하지 않음"
 msgid "New folder"
 msgstr "새 폴더"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "새로운 재생목록"
 
@@ -3435,8 +3443,12 @@ msgstr "최신 곡"
 msgid "Next"
 msgstr "다음"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "다음 곡"
 
@@ -3474,7 +3486,7 @@ msgstr "짧은 블록 "
 msgid "None"
 msgstr "없음"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "선택한 곡 중 장치에 복사하기에 적합한 곡이 없음"
 
@@ -3559,19 +3571,19 @@ msgstr "꺼짐"
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "OGG Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3615,7 +3627,7 @@ msgstr "투명도"
 msgid "Open %1 in browser"
 msgstr "브라우저에서 %1 열기"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "오디오 CD 열기(&a)..."
 
@@ -3627,7 +3639,7 @@ msgstr "OPML 파일 열기"
 msgid "Open OPML file..."
 msgstr "OPML 파일 열기"
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "음악을 가져올 디렉토리 열기"
 
@@ -3635,7 +3647,7 @@ msgstr "음악을 가져올 디렉토리 열기"
 msgid "Open device"
 msgstr "장치 열기"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "파일 열기..."
 
@@ -3689,7 +3701,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "파일 정리"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "파일 정리..."
 
@@ -3773,7 +3785,7 @@ msgstr "파티"
 msgid "Password"
 msgstr "암호"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "일시중지"
@@ -3797,6 +3809,10 @@ msgstr "연주가"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "픽셀"
@@ -3805,10 +3821,10 @@ msgstr "픽셀"
 msgid "Plain sidebar"
 msgstr "일반 사이드바"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "재생"
 
@@ -3829,11 +3845,11 @@ msgstr "중지중일때 재생, 재생중일때 중지"
 msgid "Play if there is nothing already playing"
 msgstr "이미 재생되는 곡이 없다면 재생"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "다음 곡 재생"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "선택한 곡을 다음에 재생하기"
 
@@ -3932,7 +3948,7 @@ msgstr "설정"
 msgid "Preferences"
 msgstr "환경설정"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "환경설정..."
 
@@ -3992,7 +4008,7 @@ msgid "Previous"
 msgstr "이전"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "이전 곡"
 
@@ -4050,16 +4066,16 @@ msgstr "해상도"
 msgid "Querying device..."
 msgstr "장치 질의..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "대기열 관리자"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "선택한 곡을 대기열에 추가"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "곡 대기열"
 
@@ -4075,7 +4091,7 @@ msgstr "라디오 (모든 곡을 같은 볼륨으로)"
 msgid "Rain"
 msgstr "빗소리"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "빗소리"
@@ -4187,7 +4203,7 @@ msgstr "작업 제거"
 msgid "Remove current song from playlist"
 msgstr "재생 목록에서 현재 음악 제거"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "재생목록에서 중복 제거"
 
@@ -4195,7 +4211,7 @@ msgstr "재생목록에서 중복 제거"
 msgid "Remove folder"
 msgstr "폴더 제거"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "재생목록에서 제거"
 
@@ -4207,7 +4223,7 @@ msgstr "재생목록 제거"
 msgid "Remove playlists"
 msgstr "재생목록 제거"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "재생목록에서 재생 불가능한 곡 제거"
 
@@ -4219,7 +4235,7 @@ msgstr "재생목록 이름 바꾸기"
 msgid "Rename playlist..."
 msgstr "재생목록 이름 바꾸기..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "이 순서에서 곡 번호를 다시 부여..."
 
@@ -4310,7 +4326,7 @@ msgstr "추출"
 msgid "Rip CD"
 msgstr "CD 추출"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "오디오 CD 추출"
 
@@ -4388,7 +4404,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "재생목록 저장"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "재생목록 저장..."
 
@@ -4475,7 +4491,7 @@ msgstr "Subsonic 검색"
 msgid "Search automatically"
 msgstr "자동적으로 찾기"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "앨범 검색"
 
@@ -4488,7 +4504,7 @@ msgstr "앨범 표지 검색..."
 msgid "Search for anything"
 msgstr "검색"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "음악가 검색"
 
@@ -4613,7 +4629,7 @@ msgstr "서버 자세히"
 msgid "Service offline"
 msgstr "서비스 오프라인"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "%1을 \"%2\"로 설정..."
@@ -4622,7 +4638,7 @@ msgstr "%1을 \"%2\"로 설정..."
 msgid "Set the volume to <value> percent"
 msgstr "음량을 <value> 퍼센트로 설정"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "모든 선택된 곡의 값 지정..."
 
@@ -4693,7 +4709,7 @@ msgstr "예쁜 OSD 보기"
 msgid "Show above status bar"
 msgstr "상태 표시 줄 위에 보기"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "모든 음악 표시"
 
@@ -4713,12 +4729,12 @@ msgstr "분할 표시"
 msgid "Show fullsize..."
 msgstr "전체화면 보기..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "파일 브라우져에서 보기..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "라이브러리에서 보기..."
 
@@ -4730,15 +4746,15 @@ msgstr "다양한 음악가에서 보기"
 msgid "Show moodbar"
 msgstr "분위기 막대 보여주기"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "복사본만 보기"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "태그되지 않은 것만 보기"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "사이드바 보기/숨기기"
 
@@ -4746,7 +4762,7 @@ msgstr "사이드바 보기/숨기기"
 msgid "Show search suggestions"
 msgstr "검색 제안 표시"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "사이드바 보기"
 
@@ -4782,7 +4798,7 @@ msgstr "앨범 순서섞기"
 msgid "Shuffle all"
 msgstr "모두 순서섞기"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "재생목록 순서섞기"
 
@@ -4826,11 +4842,15 @@ msgstr "건너뛰기 횟수"
 msgid "Skip forwards in playlist"
 msgstr "재생목록에서 앞으로 건너뛰기"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "선택한 곡 건너뛰기"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "곡 건너뛰기"
 
@@ -4947,7 +4967,7 @@ msgstr "추출 시작"
 msgid "Start the playlist currently playing"
 msgstr "현재 재생중인 재생목록 시작"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "변환 시작"
 
@@ -4957,7 +4977,7 @@ msgid ""
 "list"
 msgstr "이 검색 결과 목록을 채우기 위해 위의 검색 창에 무언가를 입력하십시오."
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "%1 시작중"
@@ -4967,7 +4987,7 @@ msgid "Starting..."
 msgstr "시작중..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "중지"
 
@@ -4983,7 +5003,7 @@ msgstr "곡 재생 후 정지"
 msgid "Stop after every track"
 msgstr "모든 곡 재생 후 정지"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "이 곡 재생 후 정지"
 
@@ -5151,7 +5171,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Subsonic의 시험 기간이 끝났습니다. 라이센스 키를 얻기위한 기부를 해주세요. 자세한 사항은 subsonic.org 에서 확인하세요."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5193,7 +5213,7 @@ msgid ""
 "continue?"
 msgstr "파일들이 장치로 부터 삭제될 것 입니다. 계속 진행 하시겠습니까?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5295,11 +5315,11 @@ msgstr "예쁜 OSD 토글"
 msgid "Toggle fullscreen"
 msgstr "전체화면 토글"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "대기열 상황 토글"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "청취 기록 토글"
 
@@ -5344,19 +5364,19 @@ msgstr "곡(&K)"
 msgid "Track"
 msgstr "곡"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "음악 변환"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "변환기 기록"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "변환"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "%2개의 쓰레드를 이용하여 %1 파일을 변환 중"
@@ -5433,11 +5453,11 @@ msgstr "알 수 없는 오류"
 msgid "Unset cover"
 msgstr "커버 해제"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "선택한 곡 건너뛰기 해제"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "곡 건너뛰기 해제"
 
@@ -5454,7 +5474,7 @@ msgstr "다가오는 콘서트"
 msgid "Update all podcasts"
 msgstr "모든 팟케스트 업데이트"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "변경된 라이브러리 폴더 업데이트"
 
@@ -5615,7 +5635,7 @@ msgstr "버전 %1"
 msgid "View"
 msgstr "보기"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "스트림 상세정보 보기"
 
@@ -5623,7 +5643,7 @@ msgstr "스트림 상세정보 보기"
 msgid "Visualization mode"
 msgstr "시각화 모드"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "시각화"
 
@@ -5664,7 +5684,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5760,7 +5780,7 @@ msgstr "윈도우 미디어 40k"
 msgid "Windows Media 64k"
 msgstr "윈도우 미디어 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "윈도우 미디어 오디오"
 
@@ -5774,7 +5794,7 @@ msgid ""
 "well?"
 msgstr "이번 앨범에 수록된 다른 곡들도 다양한 아티스트로 이동하시겠습니까?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "지금 전부 다시 검색해도 좋습니까?"
 

--- a/src/translations/lt.po
+++ b/src/translations/lt.po
@@ -12,7 +12,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Lithuanian (http://www.transifex.com/davidsansome/clementine/language/lt/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -166,19 +166,19 @@ msgstr "%L1 takeliai"
 msgid "%filename%"
 msgstr "%failovardas%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n nepavyko"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n baigta"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -196,7 +196,7 @@ msgstr "&Centras"
 msgid "&Custom"
 msgstr "&Pasirinktinas"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "P&apildomai"
 
@@ -204,7 +204,7 @@ msgstr "P&apildomai"
 msgid "&Grouping"
 msgstr "&Grupavimas"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Pagalba"
 
@@ -229,7 +229,7 @@ msgstr "&Užrakinti įvertinimą"
 msgid "&Lyrics"
 msgstr "&Dainų žodžiai"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Muzika"
 
@@ -237,15 +237,15 @@ msgstr "&Muzika"
 msgid "&None"
 msgstr "&Nieko"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&Grojaraštis"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Baigti"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "&Kartojimo režimas"
 
@@ -253,7 +253,7 @@ msgstr "&Kartojimo režimas"
 msgid "&Right"
 msgstr "&Dešinė"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "&Maišymo veiksena"
 
@@ -261,7 +261,7 @@ msgstr "&Maišymo veiksena"
 msgid "&Stretch columns to fit window"
 msgstr "&Ištempti stulpelius, kad užpildytų langą"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "Į&rankiai"
 
@@ -450,11 +450,11 @@ msgstr "Nutraukti"
 msgid "About %1"
 msgstr "Apie %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Apie Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Apie Qt..."
 
@@ -514,32 +514,32 @@ msgstr "Pridėti kitą srautą..."
 msgid "Add directory..."
 msgstr "Pridėti nuorodą..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Pridėti  failą"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Pridėti failą perkodavimui"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Pridėti failus perkodavimui"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Pridėti failą..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Pridėti failus perkodavimui"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Pridėti aplanką"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Pridėti aplanką..."
 
@@ -551,7 +551,7 @@ msgstr "Pridėti naują aplanką..."
 msgid "Add podcast"
 msgstr "Pridėti tinklalaidę"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Pridėti tinklalaidę..."
 
@@ -627,7 +627,7 @@ msgstr "Pridėti žymę kūrinio numeriui"
 msgid "Add song year tag"
 msgstr "Pridėti žymę kūrionio metams"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Pridėti srautą..."
 
@@ -639,7 +639,7 @@ msgstr "Pridėti į Spotify grojaraščius"
 msgid "Add to Spotify starred"
 msgstr "Pridėti į Spotify pažymėtus"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Pridėti prie kito grojaraščio"
 
@@ -733,7 +733,7 @@ msgstr "Visi"
 msgid "All Files (*)"
 msgstr "Visi Failai (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Visa šlovė Hypnotoad'ui!"
@@ -1124,7 +1124,7 @@ msgstr "Tikrinti, ar nėra naujų epizodų"
 msgid "Check for updates"
 msgstr "Tikrinti ar yra atnaujinimų"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Atnaujinimų tikrinimas..."
 
@@ -1173,18 +1173,18 @@ msgstr "Klasika"
 msgid "Cleaning up"
 msgstr "Valoma"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Išvalyti"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Išvalyti grojaraštį"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "„Clementine“"
 
@@ -1329,7 +1329,7 @@ msgstr "Komentaras"
 msgid "Complete tags automatically"
 msgstr "Užbaigti žymes automatiškai"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Pabaigti žymes automatiškai..."
 
@@ -1364,7 +1364,7 @@ msgstr "Konfigūruoti subsonix"
 msgid "Configure global search..."
 msgstr "Nustatyti visuotinę paiešką..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Konfigūruoti fonoteką..."
 
@@ -1407,7 +1407,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Baigėsi prisijungimo laikas, patikrinkite serverio URL. Pavyzdys: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Pultas"
 
@@ -1436,11 +1436,11 @@ msgid "Copy to clipboard"
 msgstr "Kopijuoti į atmintinę"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopijuoti į įrenginį..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kopijuoti į fonoteką..."
@@ -1483,14 +1483,14 @@ msgstr "Nepavyko prisijungti prie Last.fm. Bandykite dar kartą."
 msgid "Couldn't create playlist"
 msgstr "Nepavyko sukurti grojaraščio"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Nepavyko rasti maišytuvo %1, įsitikinkite ar įdiegti visi reikalingi „GStreamer“ plėtiniai"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1505,7 +1505,7 @@ msgstr "Nepavyko atverti išvesties failo %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Viršelių tvarkytuvė"
 
@@ -1658,7 +1658,7 @@ msgid "Delete downloaded data"
 msgstr "Naikinti atsiųstus duomenis"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Ištrinti failus"
 
@@ -1666,7 +1666,7 @@ msgstr "Ištrinti failus"
 msgid "Delete from device..."
 msgstr "Ištrinti iš įrenginio..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Ištrinti iš disko..."
@@ -1699,11 +1699,11 @@ msgstr "Trinami failai"
 msgid "Depth"
 msgstr "Gylis"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Iš eilės pažymėtus takelius"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Iš eilės takelį"
 
@@ -1804,7 +1804,7 @@ msgstr "Rodymo parinktys"
 msgid "Display the on-screen-display"
 msgstr "Rodyti OSD"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Pilnai perskenuoti fonoteką"
 
@@ -1983,12 +1983,12 @@ msgstr "Dinaminis atsitiktinis maišymas"
 msgid "Edit smart playlist..."
 msgstr "Taisyti išmanųjį grojaraštį..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Redaguoti žymę \"%1\"..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Taisyti žymę..."
 
@@ -2001,7 +2001,7 @@ msgid "Edit track information"
 msgstr "Taisyti takelio informaciją"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Taisyti takelio informaciją..."
 
@@ -2109,7 +2109,7 @@ msgstr "Visa kolekcija"
 msgid "Episode information"
 msgstr "Epizodo informacija"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Glodintuvas"
 
@@ -2122,8 +2122,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Tai atitinka --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Klaida"
 
@@ -2158,7 +2158,7 @@ msgstr "Klaida įkeliant %1"
 msgid "Error loading di.fm playlist"
 msgstr "Klaida įkeliant di.fm grojaraštį"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Klaida apdorojant %1: %2"
@@ -2241,7 +2241,11 @@ msgstr "Eksportavimas baigtas"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "Eksportuota %1 viršelių iš %2 (%3 praleista)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2265,7 +2269,7 @@ msgstr "Pradingimas"
 msgid "Fading duration"
 msgstr "Suliejimo trukmė"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Nepavyko perskaityti CD disko"
 
@@ -2547,11 +2551,11 @@ msgstr "Suteikti pavadinimą"
 msgid "Go"
 msgstr "Eiti"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Eiti į sekančią grojaraščių kortelę"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Eiti į praeitą grojarasčių kortelę"
 
@@ -2884,7 +2888,7 @@ msgstr "Jamendo duomenų bazė"
 msgid "Jump to previous song right away"
 msgstr "Iš karto perjungiama į ankstesnį takelį"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Peršokti prie dabar grojamo takelio"
 
@@ -2908,7 +2912,7 @@ msgstr "Veikti fone kai langas užveriamas"
 msgid "Keep the original files"
 msgstr "Palikti originialius failus"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Kačiukai"
@@ -3000,7 +3004,7 @@ msgstr "Fonoteka"
 msgid "Library advanced grouping"
 msgstr "Sudėtingesnis fonotekos grupavimas"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Fonotekos perskenavimo žinutė"
 
@@ -3040,7 +3044,7 @@ msgstr "Įkelti viršelį iš disko..."
 msgid "Load playlist"
 msgstr "Įkelti grojaraštį"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Įkelti grojaraštį..."
 
@@ -3101,11 +3105,15 @@ msgstr "Prisijungti"
 msgid "Login failed"
 msgstr "Prisijungimas nepavyko"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Ilgalaikio nuspėjimo profilis (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Patinka"
 
@@ -3140,11 +3148,11 @@ msgstr "Žodžiai iš %1"
 msgid "Lyrics from the tag"
 msgstr "Dainos žodžiai iš žymės"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3186,7 +3194,7 @@ msgstr "Pagrindinis profilis"
 msgid "Make it so!"
 msgstr "Padaryti tai taip!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Padaryti tai taip!"
@@ -3324,7 +3332,7 @@ msgstr "Prijungimo vietos"
 msgid "Move down"
 msgstr "Perkelti žemyn"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Perkelti į fonoteką"
 
@@ -3333,7 +3341,7 @@ msgstr "Perkelti į fonoteką"
 msgid "Move up"
 msgstr "Perkelti aukštyn"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Muzika"
 
@@ -3346,7 +3354,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Nutildyti"
 
@@ -3395,7 +3403,7 @@ msgstr "Niekada nepradėti groti"
 msgid "New folder"
 msgstr "Naujas aplankas"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Naujas grojaraštis"
 
@@ -3423,8 +3431,12 @@ msgstr "Naujausi takeliai"
 msgid "Next"
 msgstr "Toliau"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Kitas takelis"
 
@@ -3462,7 +3474,7 @@ msgstr "Jokių trumpų blokų"
 msgid "None"
 msgstr "Nėra"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Nei viena iš pažymėtų dainų netinka kopijavimui į įrenginį"
 
@@ -3547,19 +3559,19 @@ msgstr "Išjungta"
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3603,7 +3615,7 @@ msgstr "Permatomumas"
 msgid "Open %1 in browser"
 msgstr "Atverti %1 naršyklėje"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Atverti &garso CD..."
 
@@ -3615,7 +3627,7 @@ msgstr "Atverti OPML failą"
 msgid "Open OPML file..."
 msgstr "Atverti OPML failą..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Atverti katalogą, iš kurio importuoti muziką"
 
@@ -3623,7 +3635,7 @@ msgstr "Atverti katalogą, iš kurio importuoti muziką"
 msgid "Open device"
 msgstr "Atverti įrenginį"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Atverti failą..."
 
@@ -3677,7 +3689,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Tvarkyti failus"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Tvarkyti failus..."
 
@@ -3761,7 +3773,7 @@ msgstr "Vakarėlis"
 msgid "Password"
 msgstr "Slaptažodis"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pristabdyti"
@@ -3785,6 +3797,10 @@ msgstr "Atlikėjas"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Pikselis"
@@ -3793,10 +3809,10 @@ msgstr "Pikselis"
 msgid "Plain sidebar"
 msgstr "Paprasta šoninė juosta"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Groti"
 
@@ -3817,11 +3833,11 @@ msgstr "Groti jei sustabdyta, Pristabdyti jei grojama"
 msgid "Play if there is nothing already playing"
 msgstr "Groti jei jau kas nors negroja"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Groti kitą"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Toliau groti pasirinktus takelius"
 
@@ -3920,7 +3936,7 @@ msgstr "Nuostata"
 msgid "Preferences"
 msgstr "Nuostatos"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Nuostatos..."
 
@@ -3980,7 +3996,7 @@ msgid "Previous"
 msgstr "Atgal"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Ankstesnis takelis"
 
@@ -4038,16 +4054,16 @@ msgstr "Kokybė"
 msgid "Querying device..."
 msgstr "Pateikiama užklausa įrenginiui..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Eilės tvarkytuvė"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "į eilę pažymėtus takelius"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "į eilę takelį"
 
@@ -4063,7 +4079,7 @@ msgstr "Radijas (vienodas garsumas visiems takeliams)"
 msgid "Rain"
 msgstr "Lietus"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Lietus"
@@ -4175,7 +4191,7 @@ msgstr "Pašalinti veiksmą"
 msgid "Remove current song from playlist"
 msgstr "Šalinti esamą dainą iš grojaraščio"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Pašalinti dublikatus iš grojaraščio"
 
@@ -4183,7 +4199,7 @@ msgstr "Pašalinti dublikatus iš grojaraščio"
 msgid "Remove folder"
 msgstr "Pašalinti aplanką"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Ištrinti iš grojaraščio"
 
@@ -4195,7 +4211,7 @@ msgstr "Pašalinti grojaraštį"
 msgid "Remove playlists"
 msgstr "Pašalinti grojaraščius"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Pašalinti neprieinamus takelius iš grojaraščio"
 
@@ -4207,7 +4223,7 @@ msgstr "Pervadinti grojaraštį"
 msgid "Rename playlist..."
 msgstr "Pervadinti grojaraštį..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Pernumeruoti takelius šia tvarka..."
 
@@ -4298,7 +4314,7 @@ msgstr "Perrašyti"
 msgid "Rip CD"
 msgstr "Perrašyti CD"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Perrašyti garso įrašų CD"
 
@@ -4376,7 +4392,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Įrašyti grojaraštį"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Įrašyti grojaraštį..."
 
@@ -4463,7 +4479,7 @@ msgstr "Ieškoti subsonic"
 msgid "Search automatically"
 msgstr "Ieškoti automatiškai"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Ieškoti albumo"
 
@@ -4476,7 +4492,7 @@ msgstr "Ieškoti albumo viršelių..."
 msgid "Search for anything"
 msgstr "Ieškoti bet ko"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Ieškoti atlikėjo"
 
@@ -4601,7 +4617,7 @@ msgstr "Serverio detalės"
 msgid "Service offline"
 msgstr "Servisas nepasiekiamas"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Nustatyti %1 į \"%2\"..."
@@ -4610,7 +4626,7 @@ msgstr "Nustatyti %1 į \"%2\"..."
 msgid "Set the volume to <value> percent"
 msgstr "Nustatyti garsumą iki <value> procentų"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Nustatyti vertę visiems pažymėtiems takeliams..."
 
@@ -4681,7 +4697,7 @@ msgstr "Rodyti gražų OSD"
 msgid "Show above status bar"
 msgstr "Rodyti virš būsenos juostos"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Rodyti visas dainas"
 
@@ -4701,12 +4717,12 @@ msgstr "Rodyti skirtukus"
 msgid "Show fullsize..."
 msgstr "Rodyti viso dydžio..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Rodyti failų naršyklėje..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Rodyti fonotekoje..."
 
@@ -4718,15 +4734,15 @@ msgstr "Rodyti įvairiuose atlikėjuose"
 msgid "Show moodbar"
 msgstr "Rodyti nuotaikos juostą"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Rodyti tik duplikatus"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Rodyti tik be žymių"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Rodyti ar slėpti šoninę juostą"
 
@@ -4734,7 +4750,7 @@ msgstr "Rodyti ar slėpti šoninę juostą"
 msgid "Show search suggestions"
 msgstr "Rodyti paieškos pasiūlymus"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Rodyti šoninę juostą"
 
@@ -4770,7 +4786,7 @@ msgstr "Maišyti albumus"
 msgid "Shuffle all"
 msgstr "Maišyti viską"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Maišyti grojaraštį"
 
@@ -4814,11 +4830,15 @@ msgstr "Praleisti skaičiavimą"
 msgid "Skip forwards in playlist"
 msgstr "Kitas grojaraščio kūrinys"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Praleisti pasirinktus takelius"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Praleisti takelį"
 
@@ -4935,7 +4955,7 @@ msgstr "Pradėti perrašymą"
 msgid "Start the playlist currently playing"
 msgstr "Pradėti grajaraštį nuo dabar grojančio"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Perkoduoti"
 
@@ -4945,7 +4965,7 @@ msgid ""
 "list"
 msgstr "Pradėkite rašyti paieškos laukelyje žemiau, kad užpildyti šį paieškos rezultatų sąrašą"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Paleidžiama %1"
@@ -4955,7 +4975,7 @@ msgid "Starting..."
 msgstr "Pradedama..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Stabdyti"
 
@@ -4971,7 +4991,7 @@ msgstr "Stabdyti po kiekvieno takelio"
 msgid "Stop after every track"
 msgstr "Stabdyti po kiekvieno takelio"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Stabdyti po šio takelio"
 
@@ -5139,7 +5159,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Bandomasis subsonic laikotarpis baigėsi. Paaukokite ir gaukite licenciją. Norėdami sužinoti daugiau aplankykite subsonic.org."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5181,7 +5201,7 @@ msgid ""
 "continue?"
 msgstr "Šie failai bus ištrinti iš įrenginio, ar tikrai norite tęsti?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5283,11 +5303,11 @@ msgstr "Išjungti gražų OSD"
 msgid "Toggle fullscreen"
 msgstr "Visame ekrane"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Perjungti eilės statusą"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Perjungti „scrobbling“ būseną"
 
@@ -5332,19 +5352,19 @@ msgstr "Ta&kelis"
 msgid "Track"
 msgstr "Takelis"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Perkoduoti muziką"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Perkodavimo logas"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Perkoduojama"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Perkoduojami %1 failai naudojant %2 gijų"
@@ -5421,11 +5441,11 @@ msgstr "Nežinoma klaida"
 msgid "Unset cover"
 msgstr "Pašalinti viršelį"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Nepraleisti pasirinktų takelių"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Nepraleisti takelio"
 
@@ -5442,7 +5462,7 @@ msgstr "Artėjantys koncertai"
 msgid "Update all podcasts"
 msgstr "Atnaujinti visas tinklalaides"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Atnaujinti pakeistus fonotekos katalogus"
 
@@ -5603,7 +5623,7 @@ msgstr "Versija %1"
 msgid "View"
 msgstr "Rodymas"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Rodyti išsamesnę srauto informaciją"
 
@@ -5611,7 +5631,7 @@ msgstr "Rodyti išsamesnę srauto informaciją"
 msgid "Visualization mode"
 msgstr "Vaizdinio veiksena"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Vaizdiniai"
 
@@ -5652,7 +5672,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5748,7 +5768,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media Audio"
 
@@ -5762,7 +5782,7 @@ msgid ""
 "well?"
 msgstr "Ar norėtumėte perkelti kitas dainas į šio atlikėjo albumą?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Ar norite paleisti pilną perskenavimą dabar?"
 

--- a/src/translations/lt.po
+++ b/src/translations/lt.po
@@ -12,8 +12,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-26 23:47+0000\n"
-"Last-Translator: John Maguire <john.maguire@gmail.com>\n"
+"PO-Revision-Date: 2021-01-27 09:21+0000\n"
+"Last-Translator: Moo\n"
 "Language-Team: Lithuanian (http://www.transifex.com/davidsansome/clementine/language/lt/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -514,7 +514,7 @@ msgstr "Pridėti kitą srautą..."
 msgid "Add directory..."
 msgstr "Pridėti nuorodą..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Pridėti  failą"
 
@@ -534,7 +534,7 @@ msgstr "Pridėti failą..."
 msgid "Add files to transcode"
 msgstr "Pridėti failus perkodavimui"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Pridėti aplanką"
@@ -639,7 +639,7 @@ msgstr "Pridėti į Spotify grojaraščius"
 msgid "Add to Spotify starred"
 msgstr "Pridėti į Spotify pažymėtus"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Pridėti prie kito grojaraščio"
 
@@ -861,7 +861,7 @@ msgstr "Ar tikrai norite įrašyti dainos statistiką į dainos failą visoms da
 msgid "Artist"
 msgstr "Atlikėjas"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Atlikėjo info"
 
@@ -1124,7 +1124,7 @@ msgstr "Tikrinti, ar nėra naujų epizodų"
 msgid "Check for updates"
 msgstr "Tikrinti ar yra atnaujinimų"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Atnaujinimų tikrinimas..."
 
@@ -1364,7 +1364,7 @@ msgstr "Konfigūruoti subsonix"
 msgid "Configure global search..."
 msgstr "Nustatyti visuotinę paiešką..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Konfigūruoti fonoteką..."
 
@@ -1436,11 +1436,11 @@ msgid "Copy to clipboard"
 msgstr "Kopijuoti į atmintinę"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopijuoti į įrenginį..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kopijuoti į fonoteką..."
@@ -1658,7 +1658,7 @@ msgid "Delete downloaded data"
 msgstr "Naikinti atsiųstus duomenis"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Ištrinti failus"
 
@@ -1666,7 +1666,7 @@ msgstr "Ištrinti failus"
 msgid "Delete from device..."
 msgstr "Ištrinti iš įrenginio..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Ištrinti iš disko..."
@@ -1699,11 +1699,11 @@ msgstr "Trinami failai"
 msgid "Depth"
 msgstr "Gylis"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Iš eilės pažymėtus takelius"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Iš eilės takelį"
 
@@ -1732,7 +1732,7 @@ msgstr "Įrenginio pavadinimas"
 msgid "Device properties..."
 msgstr "Įrenginio savybės..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Įrenginiai"
 
@@ -1983,7 +1983,7 @@ msgstr "Dinaminis atsitiktinis maišymas"
 msgid "Edit smart playlist..."
 msgstr "Taisyti išmanųjį grojaraštį..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Redaguoti žymę \"%1\"..."
@@ -2122,8 +2122,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Tai atitinka --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Klaida"
 
@@ -2243,7 +2243,7 @@ msgstr "Eksportuota %1 viršelių iš %2 (%3 praleista)"
 
 #: ../bin/src/ui_mainwindow.h:790
 msgid "F9"
-msgstr ""
+msgstr "F9"
 
 #: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
@@ -2269,7 +2269,7 @@ msgstr "Pradingimas"
 msgid "Fading duration"
 msgstr "Suliejimo trukmė"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Nepavyko perskaityti CD disko"
 
@@ -2392,13 +2392,13 @@ msgstr "Failo tipas"
 msgid "Filename"
 msgstr "Failopavadinimas"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Failai"
 
 #: ../bin/src/ui_networkremotesettingspage.h:376
 msgid "Files root folder"
-msgstr ""
+msgstr "Failų šakninis aplankas"
 
 #: ../bin/src/ui_transcodedialog.h:214
 msgid "Files to transcode"
@@ -2807,7 +2807,7 @@ msgstr "Įdiegta"
 msgid "Integrity check"
 msgstr "Vientisumo tikrinimas"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internetas"
 
@@ -2995,7 +2995,7 @@ msgstr "Kairė"
 msgid "Length"
 msgstr "Trukmė"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Fonoteka"
@@ -3004,7 +3004,7 @@ msgstr "Fonoteka"
 msgid "Library advanced grouping"
 msgstr "Sudėtingesnis fonotekos grupavimas"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Fonotekos perskenavimo žinutė"
 
@@ -3107,7 +3107,7 @@ msgstr "Prisijungimas nepavyko"
 
 #: ../bin/src/ui_transcodelogdialog.h:107
 msgid "Logs"
-msgstr ""
+msgstr "Žurnalai"
 
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
@@ -3332,7 +3332,7 @@ msgstr "Prijungimo vietos"
 msgid "Move down"
 msgstr "Perkelti žemyn"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Perkelti į fonoteką"
 
@@ -3341,7 +3341,7 @@ msgstr "Perkelti į fonoteką"
 msgid "Move up"
 msgstr "Perkelti aukštyn"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Muzika"
 
@@ -3403,7 +3403,7 @@ msgstr "Niekada nepradėti groti"
 msgid "New folder"
 msgstr "Naujas aplankas"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Naujas grojaraštis"
 
@@ -3433,7 +3433,7 @@ msgstr "Toliau"
 
 #: ../bin/src/ui_mainwindow.h:785
 msgid "Next album"
-msgstr ""
+msgstr "Kitas albumas"
 
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
 #: ../bin/src/ui_mainwindow.h:727
@@ -3474,7 +3474,7 @@ msgstr "Jokių trumpų blokų"
 msgid "None"
 msgstr "Nėra"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Nei viena iš pažymėtų dainų netinka kopijavimui į įrenginį"
 
@@ -3689,7 +3689,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Tvarkyti failus"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Tvarkyti failus..."
 
@@ -3773,7 +3773,7 @@ msgstr "Vakarėlis"
 msgid "Password"
 msgstr "Slaptažodis"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pristabdyti"
@@ -3809,8 +3809,8 @@ msgstr "Pikselis"
 msgid "Plain sidebar"
 msgstr "Paprasta šoninė juosta"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3833,11 +3833,11 @@ msgstr "Groti jei sustabdyta, Pristabdyti jei grojama"
 msgid "Play if there is nothing already playing"
 msgstr "Groti jei jau kas nors negroja"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Groti kitą"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Toliau groti pasirinktus takelius"
 
@@ -3876,7 +3876,7 @@ msgstr "Grojaraščio parinktys"
 msgid "Playlist type"
 msgstr "Grojaraščio tipas"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Grojaraščiai"
 
@@ -4058,12 +4058,12 @@ msgstr "Pateikiama užklausa įrenginiui..."
 msgid "Queue Manager"
 msgstr "Eilės tvarkytuvė"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "į eilę pažymėtus takelius"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "į eilę takelį"
 
@@ -4454,7 +4454,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Ieškoti"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Paieška"
@@ -4479,7 +4479,7 @@ msgstr "Ieškoti subsonic"
 msgid "Search automatically"
 msgstr "Ieškoti automatiškai"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Ieškoti albumo"
 
@@ -4492,7 +4492,7 @@ msgstr "Ieškoti albumo viršelių..."
 msgid "Search for anything"
 msgstr "Ieškoti bet ko"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Ieškoti atlikėjo"
 
@@ -4617,7 +4617,7 @@ msgstr "Serverio detalės"
 msgid "Service offline"
 msgstr "Servisas nepasiekiamas"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Nustatyti %1 į \"%2\"..."
@@ -4697,7 +4697,7 @@ msgstr "Rodyti gražų OSD"
 msgid "Show above status bar"
 msgstr "Rodyti virš būsenos juostos"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Rodyti visas dainas"
 
@@ -4717,12 +4717,12 @@ msgstr "Rodyti skirtukus"
 msgid "Show fullsize..."
 msgstr "Rodyti viso dydžio..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Rodyti failų naršyklėje..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Rodyti fonotekoje..."
 
@@ -4734,11 +4734,11 @@ msgstr "Rodyti įvairiuose atlikėjuose"
 msgid "Show moodbar"
 msgstr "Rodyti nuotaikos juostą"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Rodyti tik duplikatus"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Rodyti tik be žymių"
 
@@ -4830,7 +4830,7 @@ msgstr "Praleisti skaičiavimą"
 msgid "Skip forwards in playlist"
 msgstr "Kitas grojaraščio kūrinys"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Praleisti pasirinktus takelius"
 
@@ -4838,7 +4838,7 @@ msgstr "Praleisti pasirinktus takelius"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Praleisti takelį"
 
@@ -4870,7 +4870,7 @@ msgstr "Ramus rokas"
 msgid "Song Information"
 msgstr "Dainos informacija"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Dainos info"
 
@@ -4991,7 +4991,7 @@ msgstr "Stabdyti po kiekvieno takelio"
 msgid "Stop after every track"
 msgstr "Stabdyti po kiekvieno takelio"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Stabdyti po šio takelio"
 
@@ -5159,7 +5159,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Bandomasis subsonic laikotarpis baigėsi. Paaukokite ir gaukite licenciją. Norėdami sužinoti daugiau aplankykite subsonic.org."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5201,7 +5201,7 @@ msgid ""
 "continue?"
 msgstr "Šie failai bus ištrinti iš įrenginio, ar tikrai norite tęsti?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5303,7 +5303,7 @@ msgstr "Išjungti gražų OSD"
 msgid "Toggle fullscreen"
 msgstr "Visame ekrane"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Perjungti eilės statusą"
 
@@ -5441,11 +5441,11 @@ msgstr "Nežinoma klaida"
 msgid "Unset cover"
 msgstr "Pašalinti viršelį"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Nepraleisti pasirinktų takelių"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Nepraleisti takelio"
 
@@ -5782,7 +5782,7 @@ msgid ""
 "well?"
 msgstr "Ar norėtumėte perkelti kitas dainas į šio atlikėjo albumą?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Ar norite paleisti pilną perskenavimą dabar?"
 

--- a/src/translations/lv.po
+++ b/src/translations/lv.po
@@ -514,7 +514,7 @@ msgstr "Pievienot citu straumi..."
 msgid "Add directory..."
 msgstr "Pievienot mapi..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Pievienot failu"
 
@@ -534,7 +534,7 @@ msgstr "Pievienot failu..."
 msgid "Add files to transcode"
 msgstr "Pievienot failus pārkodēšanai"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Pievienot mapi"
@@ -639,7 +639,7 @@ msgstr "Pievienot Spotify atskaņošanas sarakstiem"
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Pievienot citam atskaņošanas sarakstam"
 
@@ -861,7 +861,7 @@ msgstr ""
 msgid "Artist"
 msgstr "Izpildītājs"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Informācija par izpildītāju"
 
@@ -1124,7 +1124,7 @@ msgstr "BBC podraides"
 msgid "Check for updates"
 msgstr "Pārbaudīt atjauninājumu"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Pārbaudīt atjauninājumus..."
 
@@ -1364,7 +1364,7 @@ msgstr "Konfigurēju Subsonic..."
 msgid "Configure global search..."
 msgstr "Konfigurēt globālo meklēšanu..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Konfigurēt bibliotēku..."
 
@@ -1436,11 +1436,11 @@ msgid "Copy to clipboard"
 msgstr "Kopēt starpliktuvē"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopēt uz ierīci..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kopēt uz bibliotēku..."
@@ -1658,7 +1658,7 @@ msgid "Delete downloaded data"
 msgstr "Dzēst lejuplādētos datus"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Dzēst failus"
 
@@ -1666,7 +1666,7 @@ msgstr "Dzēst failus"
 msgid "Delete from device..."
 msgstr "Dzēst no ierīces..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Dzēst no diska..."
@@ -1699,11 +1699,11 @@ msgstr "Dzēš failus"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Izņemt dziesmas no rindas"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Izņemt dziesmu no rindas"
 
@@ -1732,7 +1732,7 @@ msgstr "Ierīces nosaukums"
 msgid "Device properties..."
 msgstr "Ierīces īpašības..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Ierīces"
 
@@ -1983,7 +1983,7 @@ msgstr "Dinamisks nejaušs mikss"
 msgid "Edit smart playlist..."
 msgstr "Rediģēt gudro dziesmu listi..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Rediģēt birku \"%1\"..."
@@ -2122,8 +2122,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Vienāds ar --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Kļūda"
 
@@ -2269,7 +2269,7 @@ msgstr "Pāreja"
 msgid "Fading duration"
 msgstr "Pārejas garums"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2392,7 +2392,7 @@ msgstr "Faila tips"
 msgid "Filename"
 msgstr "Faila nosaukums"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Faili"
 
@@ -2807,7 +2807,7 @@ msgstr "Uzstādīts"
 msgid "Integrity check"
 msgstr ""
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internets"
 
@@ -2995,7 +2995,7 @@ msgstr "Pa kreisi"
 msgid "Length"
 msgstr "Ilgums"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Bibliotēka"
@@ -3004,7 +3004,7 @@ msgstr "Bibliotēka"
 msgid "Library advanced grouping"
 msgstr "Advancēta Bibliotēkas grupēšana"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Bibliotēkās skenēšanas paziņojums"
 
@@ -3332,7 +3332,7 @@ msgstr "Montēšanas punkti"
 msgid "Move down"
 msgstr "Pārvietot uz leju"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Pārvietot uz bibliotēku..."
 
@@ -3341,7 +3341,7 @@ msgstr "Pārvietot uz bibliotēku..."
 msgid "Move up"
 msgstr "Pārvietot uz augšu"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Mūzika"
 
@@ -3403,7 +3403,7 @@ msgstr "Nekad Nesākt atskaņot"
 msgid "New folder"
 msgstr "Jauna mape"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Jauna dziesmu liste"
 
@@ -3474,7 +3474,7 @@ msgstr "Bez īsiem blokiem"
 msgid "None"
 msgstr "Nekas"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Neviena no izvēlētajām dziesmām nav piemērota kopēšanai uz ierīci"
 
@@ -3689,7 +3689,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr "Organizēt Failus"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Organizēt failus..."
 
@@ -3773,7 +3773,7 @@ msgstr "Ballīte"
 msgid "Password"
 msgstr "Parole"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pauze"
@@ -3809,8 +3809,8 @@ msgstr "Pikselis"
 msgid "Plain sidebar"
 msgstr "Parasta sānjosla"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3833,11 +3833,11 @@ msgstr "Atskaņot, ja apturēts, pauzēt, ja atskaņo"
 msgid "Play if there is nothing already playing"
 msgstr "Atskaņot, ja nekas netiek atskaņots"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3876,7 +3876,7 @@ msgstr "Dziesmu listes opcijas"
 msgid "Playlist type"
 msgstr "Dziesmu listes tips"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Atskaņošanas saraksti"
 
@@ -4058,12 +4058,12 @@ msgstr "Ierindoju ierīci..."
 msgid "Queue Manager"
 msgstr "Rindas pārvaldnieks"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Ierindot izvēlētās dziesmas"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Ierindot dziesmu"
 
@@ -4454,7 +4454,7 @@ msgstr ""
 msgid "Search"
 msgstr "Meklēt"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Meklēt"
@@ -4479,7 +4479,7 @@ msgstr "Meklēt Subsonic"
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4492,7 +4492,7 @@ msgstr "Meklēt albumu vāciņus..."
 msgid "Search for anything"
 msgstr "Meklējiet jebko"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4617,7 +4617,7 @@ msgstr ""
 msgid "Service offline"
 msgstr "Serviss atslēgts"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Uzstādīt %1 uz \"%2\"..."
@@ -4697,7 +4697,7 @@ msgstr "Rādīt skaistu paziņojumu logu"
 msgid "Show above status bar"
 msgstr "Rādīt virs statusa joslas"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Rādīt visas dziesmas"
 
@@ -4717,12 +4717,12 @@ msgstr "Rādīt atdalītājus"
 msgid "Show fullsize..."
 msgstr "Radīt pa visu ekrānu..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Rādīt failu pārlūkā..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Rādīt bibliotēkā..."
 
@@ -4734,11 +4734,11 @@ msgstr "Rādīt pie dažādiem izpildītājiem"
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Rādīt tikai dublikātus"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Rādīt tikai bez birkām"
 
@@ -4830,7 +4830,7 @@ msgstr "Izlaista"
 msgid "Skip forwards in playlist"
 msgstr "Izlaist turpinot dziesmu listē"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr ""
 
@@ -4838,7 +4838,7 @@ msgstr ""
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr ""
 
@@ -4870,7 +4870,7 @@ msgstr "Vieglais roks"
 msgid "Song Information"
 msgstr "Dziesmas informācija"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Dziesmas info"
 
@@ -4991,7 +4991,7 @@ msgstr "Apstāties pēc katras dziesmas"
 msgid "Stop after every track"
 msgstr "Apstāties pēc katras dziesmas"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Apturēt pēc šīs dziesmas"
 
@@ -5159,7 +5159,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5201,7 +5201,7 @@ msgid ""
 "continue?"
 msgstr "Šie faili tiks dzēsti no ierīces. Vai jūs tiešām vēlaties turpināt?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5303,7 +5303,7 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr "Ieslēgt pilnu ekrānu"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Ieslēgt rindas statusu"
 
@@ -5441,11 +5441,11 @@ msgstr "Nezināma kļūda"
 msgid "Unset cover"
 msgstr "Noņemt vāka attēlu"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr ""
 
@@ -5782,7 +5782,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Vai jūs vēlaties palaist pilnu skenēšanu?"
 

--- a/src/translations/lv.po
+++ b/src/translations/lv.po
@@ -12,7 +12,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Latvian (http://www.transifex.com/davidsansome/clementine/language/lv/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -166,19 +166,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n neizdevās"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n pabeigti"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -196,7 +196,7 @@ msgstr "&Centrs"
 msgid "&Custom"
 msgstr "&Pielāgots"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "Ekstras"
 
@@ -204,7 +204,7 @@ msgstr "Ekstras"
 msgid "&Grouping"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Palīdzība"
 
@@ -229,7 +229,7 @@ msgstr ""
 msgid "&Lyrics"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "Mūzika"
 
@@ -237,15 +237,15 @@ msgstr "Mūzika"
 msgid "&None"
 msgstr "&Nav"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "Atskaņošanas saraksts"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Iziet"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "Atkārtošanas režīms"
 
@@ -253,7 +253,7 @@ msgstr "Atkārtošanas režīms"
 msgid "&Right"
 msgstr "&Pa labi"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Jaukšanas režīms"
 
@@ -261,7 +261,7 @@ msgstr "Jaukšanas režīms"
 msgid "&Stretch columns to fit window"
 msgstr "&izstiept kolonnas, lai pielāgotu loga izmēram"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Rīki"
 
@@ -450,11 +450,11 @@ msgstr "Atcelt"
 msgid "About %1"
 msgstr "Par %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Par Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Par Qt..."
 
@@ -514,32 +514,32 @@ msgstr "Pievienot citu straumi..."
 msgid "Add directory..."
 msgstr "Pievienot mapi..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Pievienot failu"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Pievienot failu pārkodētājam"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Pievienot failu(s) pārkodētājam"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Pievienot failu..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Pievienot failus pārkodēšanai"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Pievienot mapi"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Pievienot mapi..."
 
@@ -551,7 +551,7 @@ msgstr "Pievienot jaunu mapi..."
 msgid "Add podcast"
 msgstr "Pievienot podraidi"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Pievienot podraidi..."
 
@@ -627,7 +627,7 @@ msgstr "Pievienot dziesmas numura birku"
 msgid "Add song year tag"
 msgstr "Pievienot dziesmas gada birku"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Pievienot straumi..."
 
@@ -639,7 +639,7 @@ msgstr "Pievienot Spotify atskaņošanas sarakstiem"
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Pievienot citam atskaņošanas sarakstam"
 
@@ -733,7 +733,7 @@ msgstr "Visi"
 msgid "All Files (*)"
 msgstr "Visi faili (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr ""
@@ -1124,7 +1124,7 @@ msgstr "BBC podraides"
 msgid "Check for updates"
 msgstr "Pārbaudīt atjauninājumu"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Pārbaudīt atjauninājumus..."
 
@@ -1173,18 +1173,18 @@ msgstr "Klasisks"
 msgid "Cleaning up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Notīrīt"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Notīrīt atskaņošanas sarakstu"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1329,7 +1329,7 @@ msgstr "Piezīmes"
 msgid "Complete tags automatically"
 msgstr "Noformēt tagus automātiski"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Noformēt tagus automātiski..."
 
@@ -1364,7 +1364,7 @@ msgstr "Konfigurēju Subsonic..."
 msgid "Configure global search..."
 msgstr "Konfigurēt globālo meklēšanu..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Konfigurēt bibliotēku..."
 
@@ -1407,7 +1407,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr ""
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Konsole"
 
@@ -1436,11 +1436,11 @@ msgid "Copy to clipboard"
 msgstr "Kopēt starpliktuvē"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopēt uz ierīci..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kopēt uz bibliotēku..."
@@ -1483,14 +1483,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr "Nevar izveidot atskaņošanas sarakstu"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Nevar atrast jaucēju priekš %1, pārbaudiet vai jums ir uzstādīti pareizi GStreamer spraudņi"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1505,7 +1505,7 @@ msgstr "Nevar atvērt izejas failu %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Vāka attēlu pārvaldnieks"
 
@@ -1658,7 +1658,7 @@ msgid "Delete downloaded data"
 msgstr "Dzēst lejuplādētos datus"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Dzēst failus"
 
@@ -1666,7 +1666,7 @@ msgstr "Dzēst failus"
 msgid "Delete from device..."
 msgstr "Dzēst no ierīces..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Dzēst no diska..."
@@ -1699,11 +1699,11 @@ msgstr "Dzēš failus"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Izņemt dziesmas no rindas"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Izņemt dziesmu no rindas"
 
@@ -1804,7 +1804,7 @@ msgstr "Displeja opcijas"
 msgid "Display the on-screen-display"
 msgstr "Rādīt displeju-uz-ekrāna"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Veikt pilnu bibliotēkas skenēšanu"
 
@@ -1983,12 +1983,12 @@ msgstr "Dinamisks nejaušs mikss"
 msgid "Edit smart playlist..."
 msgstr "Rediģēt gudro dziesmu listi..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Rediģēt birku \"%1\"..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Rediģēt birku"
 
@@ -2001,7 +2001,7 @@ msgid "Edit track information"
 msgstr "Rediģēt dziesmas informāciju"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Rediģēt dziesmas informāciju..."
 
@@ -2109,7 +2109,7 @@ msgstr "Visa kolekcija"
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Ekvalaizers"
 
@@ -2122,8 +2122,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Vienāds ar --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Kļūda"
 
@@ -2158,7 +2158,7 @@ msgstr "Kļūda ielādējot %1"
 msgid "Error loading di.fm playlist"
 msgstr "Kļūda ielādējot di.fm atskaņošanas sarakstu"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Kļūda apstrādājot %1: %2"
@@ -2241,7 +2241,11 @@ msgstr "Eksportēšana pabeigta"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr ""
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2265,7 +2269,7 @@ msgstr "Pāreja"
 msgid "Fading duration"
 msgstr "Pārejas garums"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2547,11 +2551,11 @@ msgstr "Dodiet tam vārdu:"
 msgid "Go"
 msgstr "Aiziet"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Iet uz nākamās dziesmu listes cilni"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Iet uz iepriekšējās dziesmu listes cilni"
 
@@ -2884,7 +2888,7 @@ msgstr "Jamendo datubāze"
 msgid "Jump to previous song right away"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Pārslēgties uz šobrīd skanošo dziesmu"
 
@@ -2908,7 +2912,7 @@ msgstr "Darboties fonā, kad logs ir aizvērts"
 msgid "Keep the original files"
 msgstr "Atstāt oriģinālos failus"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Kaķīši"
@@ -3000,7 +3004,7 @@ msgstr "Bibliotēka"
 msgid "Library advanced grouping"
 msgstr "Advancēta Bibliotēkas grupēšana"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Bibliotēkās skenēšanas paziņojums"
 
@@ -3040,7 +3044,7 @@ msgstr "Ielādēt vāka attēlu no diska..."
 msgid "Load playlist"
 msgstr "Ielādēt dziesmu listi"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Ielādēt dziesmu listi..."
 
@@ -3101,11 +3105,15 @@ msgstr "Pieslēgties"
 msgid "Login failed"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Ilga termiņa paredzēšanas profils (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Patīk"
 
@@ -3140,11 +3148,11 @@ msgstr "Dziesmas vārdi no %1"
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr ""
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3186,7 +3194,7 @@ msgstr "Galvenais profils (MAIN)"
 msgid "Make it so!"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr ""
@@ -3324,7 +3332,7 @@ msgstr "Montēšanas punkti"
 msgid "Move down"
 msgstr "Pārvietot uz leju"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Pārvietot uz bibliotēku..."
 
@@ -3333,7 +3341,7 @@ msgstr "Pārvietot uz bibliotēku..."
 msgid "Move up"
 msgstr "Pārvietot uz augšu"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Mūzika"
 
@@ -3346,7 +3354,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Klusums"
 
@@ -3395,7 +3403,7 @@ msgstr "Nekad Nesākt atskaņot"
 msgid "New folder"
 msgstr "Jauna mape"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Jauna dziesmu liste"
 
@@ -3423,8 +3431,12 @@ msgstr "Jaunākās dziesmas"
 msgid "Next"
 msgstr "Uz priekšu"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Nākamā"
 
@@ -3462,7 +3474,7 @@ msgstr "Bez īsiem blokiem"
 msgid "None"
 msgstr "Nekas"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Neviena no izvēlētajām dziesmām nav piemērota kopēšanai uz ierīci"
 
@@ -3547,19 +3559,19 @@ msgstr ""
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr ""
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3603,7 +3615,7 @@ msgstr ""
 msgid "Open %1 in browser"
 msgstr "Atvērt %1 pārlūkā"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Atvērt &audio CD..."
 
@@ -3615,7 +3627,7 @@ msgstr "Atvērt OPML failu"
 msgid "Open OPML file..."
 msgstr "Atvērt OPML failu..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr ""
 
@@ -3623,7 +3635,7 @@ msgstr ""
 msgid "Open device"
 msgstr "Atvērt ierīci"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Atvērt datni..."
 
@@ -3677,7 +3689,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr "Organizēt Failus"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Organizēt failus..."
 
@@ -3761,7 +3773,7 @@ msgstr "Ballīte"
 msgid "Password"
 msgstr "Parole"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pauze"
@@ -3785,6 +3797,10 @@ msgstr ""
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Pikselis"
@@ -3793,10 +3809,10 @@ msgstr "Pikselis"
 msgid "Plain sidebar"
 msgstr "Parasta sānjosla"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Atskaņot"
 
@@ -3817,11 +3833,11 @@ msgstr "Atskaņot, ja apturēts, pauzēt, ja atskaņo"
 msgid "Play if there is nothing already playing"
 msgstr "Atskaņot, ja nekas netiek atskaņots"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3920,7 +3936,7 @@ msgstr ""
 msgid "Preferences"
 msgstr "Uzstādījumi"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Iestatījumi..."
 
@@ -3980,7 +3996,7 @@ msgid "Previous"
 msgstr "Iepriekšējais"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Iepriekšējā"
 
@@ -4038,16 +4054,16 @@ msgstr "Kvalitāte"
 msgid "Querying device..."
 msgstr "Ierindoju ierīci..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Rindas pārvaldnieks"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Ierindot izvēlētās dziesmas"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Ierindot dziesmu"
 
@@ -4063,7 +4079,7 @@ msgstr "Radio (ekvivalents skaļums visiem celiņiem)"
 msgid "Rain"
 msgstr "Lietus"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Lietus"
@@ -4175,7 +4191,7 @@ msgstr "Noņemt darbību"
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr ""
 
@@ -4183,7 +4199,7 @@ msgstr ""
 msgid "Remove folder"
 msgstr "Aizvākt mapi"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Azivākt no dziesmu listes"
 
@@ -4195,7 +4211,7 @@ msgstr "Dzēst atskaņošanas sarakstu"
 msgid "Remove playlists"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr ""
 
@@ -4207,7 +4223,7 @@ msgstr "Pārdēvēt dziesmu listi"
 msgid "Rename playlist..."
 msgstr "Pārdēvēt dziesmu listi..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Pārkārtot šādā secībā..."
 
@@ -4298,7 +4314,7 @@ msgstr ""
 msgid "Rip CD"
 msgstr "Noripot CD"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Noripot audio CD"
 
@@ -4376,7 +4392,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Saglabāt dziesmu listi"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Saglabāt dziesmu listi..."
 
@@ -4463,7 +4479,7 @@ msgstr "Meklēt Subsonic"
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4476,7 +4492,7 @@ msgstr "Meklēt albumu vāciņus..."
 msgid "Search for anything"
 msgstr "Meklējiet jebko"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4601,7 +4617,7 @@ msgstr ""
 msgid "Service offline"
 msgstr "Serviss atslēgts"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Uzstādīt %1 uz \"%2\"..."
@@ -4610,7 +4626,7 @@ msgstr "Uzstādīt %1 uz \"%2\"..."
 msgid "Set the volume to <value> percent"
 msgstr "Uzstādīt skaļumu uz <value> procentiem"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Saglabāt vērtību izvēlētajām dziesmām..."
 
@@ -4681,7 +4697,7 @@ msgstr "Rādīt skaistu paziņojumu logu"
 msgid "Show above status bar"
 msgstr "Rādīt virs statusa joslas"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Rādīt visas dziesmas"
 
@@ -4701,12 +4717,12 @@ msgstr "Rādīt atdalītājus"
 msgid "Show fullsize..."
 msgstr "Radīt pa visu ekrānu..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Rādīt failu pārlūkā..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Rādīt bibliotēkā..."
 
@@ -4718,15 +4734,15 @@ msgstr "Rādīt pie dažādiem izpildītājiem"
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Rādīt tikai dublikātus"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Rādīt tikai bez birkām"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4734,7 +4750,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4770,7 +4786,7 @@ msgstr "Jaukt albumus"
 msgid "Shuffle all"
 msgstr "Jaukt visu"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Jaukt dziesmu listi"
 
@@ -4814,11 +4830,15 @@ msgstr "Izlaista"
 msgid "Skip forwards in playlist"
 msgstr "Izlaist turpinot dziesmu listē"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr ""
 
@@ -4935,7 +4955,7 @@ msgstr "Sākt ripošanu"
 msgid "Start the playlist currently playing"
 msgstr "Sākt pašreiz atskaņoto dziesmu listi"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Sākt kodēšanu"
 
@@ -4945,7 +4965,7 @@ msgid ""
 "list"
 msgstr ""
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Palaiž %1"
@@ -4955,7 +4975,7 @@ msgid "Starting..."
 msgstr "Palaiž..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Apturēt"
 
@@ -4971,7 +4991,7 @@ msgstr "Apstāties pēc katras dziesmas"
 msgid "Stop after every track"
 msgstr "Apstāties pēc katras dziesmas"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Apturēt pēc šīs dziesmas"
 
@@ -5139,7 +5159,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5181,7 +5201,7 @@ msgid ""
 "continue?"
 msgstr "Šie faili tiks dzēsti no ierīces. Vai jūs tiešām vēlaties turpināt?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5283,11 +5303,11 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr "Ieslēgt pilnu ekrānu"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Ieslēgt rindas statusu"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Ieslēgt skroblēšanu"
 
@@ -5332,19 +5352,19 @@ msgstr ""
 msgid "Track"
 msgstr "Dziesma"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Kodēt Mūziku"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Kodēšanas piezīmes"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Pārkodēšana"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr ""
@@ -5421,11 +5441,11 @@ msgstr "Nezināma kļūda"
 msgid "Unset cover"
 msgstr "Noņemt vāka attēlu"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr ""
 
@@ -5442,7 +5462,7 @@ msgstr "Tuvākie koncerti"
 msgid "Update all podcasts"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Atjaunot mainītās bibliotēkas mapes"
 
@@ -5603,7 +5623,7 @@ msgstr "Versija %1"
 msgid "View"
 msgstr "Skats"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5611,7 +5631,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr "Vizualizāciju režīms"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Vizualizācijas"
 
@@ -5652,7 +5672,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5748,7 +5768,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media audio"
 
@@ -5762,7 +5782,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Vai jūs vēlaties palaist pilnu skenēšanu?"
 

--- a/src/translations/mk_MK.po
+++ b/src/translations/mk_MK.po
@@ -10,7 +10,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Macedonian (Macedonia) (http://www.transifex.com/davidsansome/clementine/language/mk_MK/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -164,19 +164,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n неуспешно"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n завршено"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -194,7 +194,7 @@ msgstr "%Центрирај"
 msgid "&Custom"
 msgstr "&Прилагодено"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Додатоци"
 
@@ -202,7 +202,7 @@ msgstr "&Додатоци"
 msgid "&Grouping"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Помош"
 
@@ -227,7 +227,7 @@ msgstr "&Заклучи Рејтинг"
 msgid "&Lyrics"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Музика"
 
@@ -235,15 +235,15 @@ msgstr "&Музика"
 msgid "&None"
 msgstr "&Без"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&Плејлиста"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Излези"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "&Повторувај мод"
 
@@ -251,7 +251,7 @@ msgstr "&Повторувај мод"
 msgid "&Right"
 msgstr "&Десно"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "&Размешај мод"
 
@@ -259,7 +259,7 @@ msgstr "&Размешај мод"
 msgid "&Stretch columns to fit window"
 msgstr "&Истегни ги колоните за да го пополнат прозорецот"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Алатки"
 
@@ -448,11 +448,11 @@ msgstr "Откажи"
 msgid "About %1"
 msgstr "Околу %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "За Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "За Qt..."
 
@@ -512,32 +512,32 @@ msgstr "Додади уште еден извор..."
 msgid "Add directory..."
 msgstr "Додади директориум..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Додади датотека"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Додади датотека на транскодерот"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Додади датотека(и) на транскодерот"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Додади датотека..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Додади датотеки за транскодирање"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Додади папка"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Додади папка..."
 
@@ -549,7 +549,7 @@ msgstr "Додади нова папка..."
 msgid "Add podcast"
 msgstr "Додади podcast"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Додади podcast..."
 
@@ -625,7 +625,7 @@ msgstr "Додади ознака за нумера на песна"
 msgid "Add song year tag"
 msgstr "Додади ознака за песна на годината"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Додади извор..."
 
@@ -637,7 +637,7 @@ msgstr "Додади во Spotify плејлисти"
 msgid "Add to Spotify starred"
 msgstr "Додади во Spotify означени со ѕвездичка"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Додади на друга плејлиста"
 
@@ -731,7 +731,7 @@ msgstr "Сите"
 msgid "All Files (*)"
 msgstr "Сите Датотеки (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Слава и на Хипножабата"
@@ -1122,7 +1122,7 @@ msgstr "Провери за нови епизоди"
 msgid "Check for updates"
 msgstr "Провери за ажурирања"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Провери за ажурирања..."
 
@@ -1171,18 +1171,18 @@ msgstr "Класичен"
 msgid "Cleaning up"
 msgstr "Чистење"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Исчисти"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Исчисти плејлиста"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr ""
 
@@ -1327,7 +1327,7 @@ msgstr "Коментар"
 msgid "Complete tags automatically"
 msgstr "Автоматско комплетирање на тагови"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Автоматско комплетирање на тагови..."
 
@@ -1362,7 +1362,7 @@ msgstr "Конфигурирај го "
 msgid "Configure global search..."
 msgstr "Конфигурирај глобално пребарување..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Конфигурирај ја библиотеката..."
 
@@ -1405,7 +1405,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Времето за конектирање истече, провери го URL-то на серверот. Пример: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Конзола"
 
@@ -1434,11 +1434,11 @@ msgid "Copy to clipboard"
 msgstr "Копирај на клипбордот"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Копирај на уред..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Копирај во библиотека..."
@@ -1481,14 +1481,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr "Не може да се креира плејлиста"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Не може да се најде миксер за %1, провери дали точните GStreamer plugin-и се инсталирани"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1503,7 +1503,7 @@ msgstr "Не може да се отвори излезен фајл %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Омот менаџер"
 
@@ -1656,7 +1656,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr ""
 
@@ -1664,7 +1664,7 @@ msgstr ""
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1697,11 +1697,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr ""
 
@@ -1802,7 +1802,7 @@ msgstr ""
 msgid "Display the on-screen-display"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr ""
 
@@ -1981,12 +1981,12 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr ""
 
@@ -1999,7 +1999,7 @@ msgid "Edit track information"
 msgstr ""
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr ""
 
@@ -2107,7 +2107,7 @@ msgstr ""
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr ""
 
@@ -2120,8 +2120,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr ""
 
@@ -2156,7 +2156,7 @@ msgstr ""
 msgid "Error loading di.fm playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr ""
@@ -2239,7 +2239,11 @@ msgstr ""
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr ""
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2263,7 +2267,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2545,11 +2549,11 @@ msgstr ""
 msgid "Go"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr ""
 
@@ -2882,7 +2886,7 @@ msgstr ""
 msgid "Jump to previous song right away"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr ""
 
@@ -2906,7 +2910,7 @@ msgstr ""
 msgid "Keep the original files"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr ""
@@ -2998,7 +3002,7 @@ msgstr ""
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3038,7 +3042,7 @@ msgstr ""
 msgid "Load playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr ""
 
@@ -3099,11 +3103,15 @@ msgstr ""
 msgid "Login failed"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr ""
 
@@ -3138,11 +3146,11 @@ msgstr ""
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr ""
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr ""
@@ -3184,7 +3192,7 @@ msgstr ""
 msgid "Make it so!"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr ""
@@ -3322,7 +3330,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3331,7 +3339,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr ""
 
@@ -3344,7 +3352,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr ""
 
@@ -3393,7 +3401,7 @@ msgstr ""
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3421,8 +3429,12 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr ""
 
@@ -3460,7 +3472,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3545,19 +3557,19 @@ msgstr ""
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr ""
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr ""
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr ""
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3601,7 +3613,7 @@ msgstr ""
 msgid "Open %1 in browser"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr ""
 
@@ -3613,7 +3625,7 @@ msgstr ""
 msgid "Open OPML file..."
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr ""
 
@@ -3621,7 +3633,7 @@ msgstr ""
 msgid "Open device"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr ""
 
@@ -3675,7 +3687,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr ""
 
@@ -3759,7 +3771,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr ""
@@ -3783,6 +3795,10 @@ msgstr ""
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr ""
@@ -3791,10 +3807,10 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr ""
 
@@ -3815,11 +3831,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3918,7 +3934,7 @@ msgstr ""
 msgid "Preferences"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr ""
 
@@ -3978,7 +3994,7 @@ msgid "Previous"
 msgstr ""
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr ""
 
@@ -4036,16 +4052,16 @@ msgstr ""
 msgid "Querying device..."
 msgstr ""
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr ""
 
@@ -4061,7 +4077,7 @@ msgstr ""
 msgid "Rain"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr ""
@@ -4173,7 +4189,7 @@ msgstr ""
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr ""
 
@@ -4181,7 +4197,7 @@ msgstr ""
 msgid "Remove folder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr ""
 
@@ -4193,7 +4209,7 @@ msgstr ""
 msgid "Remove playlists"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr ""
 
@@ -4205,7 +4221,7 @@ msgstr ""
 msgid "Rename playlist..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr ""
 
@@ -4296,7 +4312,7 @@ msgstr ""
 msgid "Rip CD"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr ""
 
@@ -4374,7 +4390,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr ""
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr ""
 
@@ -4461,7 +4477,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4474,7 +4490,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4599,7 +4615,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4608,7 +4624,7 @@ msgstr ""
 msgid "Set the volume to <value> percent"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr ""
 
@@ -4679,7 +4695,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr ""
 
@@ -4699,12 +4715,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr ""
 
@@ -4716,15 +4732,15 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4732,7 +4748,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4768,7 +4784,7 @@ msgstr ""
 msgid "Shuffle all"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr ""
 
@@ -4812,11 +4828,15 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr ""
 
@@ -4933,7 +4953,7 @@ msgstr ""
 msgid "Start the playlist currently playing"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr ""
 
@@ -4943,7 +4963,7 @@ msgid ""
 "list"
 msgstr ""
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr ""
@@ -4953,7 +4973,7 @@ msgid "Starting..."
 msgstr ""
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr ""
 
@@ -4969,7 +4989,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5137,7 +5157,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5179,7 +5199,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5281,11 +5301,11 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr ""
 
@@ -5330,19 +5350,19 @@ msgstr ""
 msgid "Track"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr ""
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
 msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr ""
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr ""
@@ -5419,11 +5439,11 @@ msgstr ""
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr ""
 
@@ -5440,7 +5460,7 @@ msgstr ""
 msgid "Update all podcasts"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr ""
 
@@ -5601,7 +5621,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5609,7 +5629,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr ""
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr ""
 
@@ -5650,7 +5670,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr ""
 
@@ -5746,7 +5766,7 @@ msgstr ""
 msgid "Windows Media 64k"
 msgstr ""
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr ""
 
@@ -5760,7 +5780,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/mk_MK.po
+++ b/src/translations/mk_MK.po
@@ -512,7 +512,7 @@ msgstr "Додади уште еден извор..."
 msgid "Add directory..."
 msgstr "Додади директориум..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Додади датотека"
 
@@ -532,7 +532,7 @@ msgstr "Додади датотека..."
 msgid "Add files to transcode"
 msgstr "Додади датотеки за транскодирање"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Додади папка"
@@ -637,7 +637,7 @@ msgstr "Додади во Spotify плејлисти"
 msgid "Add to Spotify starred"
 msgstr "Додади во Spotify означени со ѕвездичка"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Додади на друга плејлиста"
 
@@ -859,7 +859,7 @@ msgstr "Дали сте сигурни дека сакате да ги запи�
 msgid "Artist"
 msgstr "Изведувач"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Податоци за изведувач"
 
@@ -1122,7 +1122,7 @@ msgstr "Провери за нови епизоди"
 msgid "Check for updates"
 msgstr "Провери за ажурирања"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Провери за ажурирања..."
 
@@ -1362,7 +1362,7 @@ msgstr "Конфигурирај го "
 msgid "Configure global search..."
 msgstr "Конфигурирај глобално пребарување..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Конфигурирај ја библиотеката..."
 
@@ -1434,11 +1434,11 @@ msgid "Copy to clipboard"
 msgstr "Копирај на клипбордот"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Копирај на уред..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Копирај во библиотека..."
@@ -1656,7 +1656,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr ""
 
@@ -1664,7 +1664,7 @@ msgstr ""
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1697,11 +1697,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr ""
 
@@ -1730,7 +1730,7 @@ msgstr ""
 msgid "Device properties..."
 msgstr ""
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr ""
 
@@ -1981,7 +1981,7 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
@@ -2120,8 +2120,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr ""
 
@@ -2267,7 +2267,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2390,7 +2390,7 @@ msgstr ""
 msgid "Filename"
 msgstr ""
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr ""
 
@@ -2805,7 +2805,7 @@ msgstr ""
 msgid "Integrity check"
 msgstr ""
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr ""
 
@@ -2993,7 +2993,7 @@ msgstr "Лево"
 msgid "Length"
 msgstr ""
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr ""
@@ -3002,7 +3002,7 @@ msgstr ""
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3330,7 +3330,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3339,7 +3339,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr ""
 
@@ -3401,7 +3401,7 @@ msgstr ""
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3472,7 +3472,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3687,7 +3687,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr ""
 
@@ -3771,7 +3771,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr ""
@@ -3807,8 +3807,8 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3831,11 +3831,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3874,7 +3874,7 @@ msgstr ""
 msgid "Playlist type"
 msgstr ""
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr ""
 
@@ -4056,12 +4056,12 @@ msgstr ""
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr ""
 
@@ -4452,7 +4452,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr ""
@@ -4477,7 +4477,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4490,7 +4490,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4615,7 +4615,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4695,7 +4695,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr ""
 
@@ -4715,12 +4715,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr ""
 
@@ -4732,11 +4732,11 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr ""
 
@@ -4828,7 +4828,7 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr ""
 
@@ -4836,7 +4836,7 @@ msgstr ""
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr ""
 
@@ -4868,7 +4868,7 @@ msgstr ""
 msgid "Song Information"
 msgstr ""
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr ""
 
@@ -4989,7 +4989,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5157,7 +5157,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5199,7 +5199,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5301,7 +5301,7 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr ""
 
@@ -5439,11 +5439,11 @@ msgstr ""
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr ""
 
@@ -5780,7 +5780,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/mr.po
+++ b/src/translations/mr.po
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add directory..."
 msgstr ""
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgstr ""
 msgid "Add files to transcode"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr ""
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr ""
 
@@ -856,7 +856,7 @@ msgstr ""
 msgid "Artist"
 msgstr ""
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr ""
 
@@ -1119,7 +1119,7 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr ""
 
@@ -1359,7 +1359,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr ""
 
@@ -1431,11 +1431,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1653,7 +1653,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr ""
 
@@ -1661,7 +1661,7 @@ msgstr ""
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1694,11 +1694,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr ""
 
@@ -1727,7 +1727,7 @@ msgstr ""
 msgid "Device properties..."
 msgstr ""
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr ""
 
@@ -1978,7 +1978,7 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
@@ -2117,8 +2117,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr ""
 
@@ -2264,7 +2264,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2387,7 +2387,7 @@ msgstr ""
 msgid "Filename"
 msgstr ""
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr ""
 
@@ -2802,7 +2802,7 @@ msgstr ""
 msgid "Integrity check"
 msgstr ""
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr ""
 
@@ -2990,7 +2990,7 @@ msgstr ""
 msgid "Length"
 msgstr ""
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr ""
@@ -2999,7 +2999,7 @@ msgstr ""
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3327,7 +3327,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3336,7 +3336,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr ""
 
@@ -3398,7 +3398,7 @@ msgstr ""
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3469,7 +3469,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3684,7 +3684,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr ""
 
@@ -3768,7 +3768,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr ""
@@ -3804,8 +3804,8 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3828,11 +3828,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Playlist type"
 msgstr ""
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr ""
 
@@ -4053,12 +4053,12 @@ msgstr ""
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr ""
 
@@ -4449,7 +4449,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr ""
@@ -4474,7 +4474,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4487,7 +4487,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4692,7 +4692,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr ""
 
@@ -4712,12 +4712,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr ""
 
@@ -4729,11 +4729,11 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr ""
 
@@ -4825,7 +4825,7 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr ""
 
@@ -4833,7 +4833,7 @@ msgstr ""
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr ""
 
@@ -4865,7 +4865,7 @@ msgstr ""
 msgid "Song Information"
 msgstr ""
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr ""
 
@@ -4986,7 +4986,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5154,7 +5154,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5196,7 +5196,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5298,7 +5298,7 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr ""
 
@@ -5436,11 +5436,11 @@ msgstr ""
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr ""
 
@@ -5777,7 +5777,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/mr.po
+++ b/src/translations/mr.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Marathi (http://www.transifex.com/davidsansome/clementine/language/mr/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -161,19 +161,19 @@ msgstr ""
 msgid "%filename%"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -191,7 +191,7 @@ msgstr ""
 msgid "&Custom"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr ""
 
@@ -199,7 +199,7 @@ msgstr ""
 msgid "&Grouping"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr ""
 
@@ -224,7 +224,7 @@ msgstr ""
 msgid "&Lyrics"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr ""
 
@@ -232,15 +232,15 @@ msgstr ""
 msgid "&None"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr ""
 
@@ -248,7 +248,7 @@ msgstr ""
 msgid "&Right"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr ""
 
@@ -256,7 +256,7 @@ msgstr ""
 msgid "&Stretch columns to fit window"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr ""
 
@@ -445,11 +445,11 @@ msgstr ""
 msgid "About %1"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr ""
 
@@ -509,32 +509,32 @@ msgstr ""
 msgid "Add directory..."
 msgstr ""
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr ""
 
@@ -546,7 +546,7 @@ msgstr ""
 msgid "Add podcast"
 msgstr ""
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr ""
 
@@ -622,7 +622,7 @@ msgstr ""
 msgid "Add song year tag"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr ""
 
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr ""
 
@@ -728,7 +728,7 @@ msgstr ""
 msgid "All Files (*)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr ""
@@ -1119,7 +1119,7 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr ""
 
@@ -1168,18 +1168,18 @@ msgstr ""
 msgid "Cleaning up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr ""
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr ""
 
@@ -1324,7 +1324,7 @@ msgstr ""
 msgid "Complete tags automatically"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr ""
 
@@ -1359,7 +1359,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr ""
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr ""
 
@@ -1431,11 +1431,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1478,14 +1478,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr ""
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1500,7 +1500,7 @@ msgstr ""
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr ""
 
@@ -1653,7 +1653,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr ""
 
@@ -1661,7 +1661,7 @@ msgstr ""
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1694,11 +1694,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr ""
 
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "Display the on-screen-display"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr ""
 
@@ -1978,12 +1978,12 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr ""
 
@@ -1996,7 +1996,7 @@ msgid "Edit track information"
 msgstr ""
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr ""
 
@@ -2104,7 +2104,7 @@ msgstr ""
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr ""
 
@@ -2117,8 +2117,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr ""
 
@@ -2153,7 +2153,7 @@ msgstr ""
 msgid "Error loading di.fm playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr ""
@@ -2236,7 +2236,11 @@ msgstr ""
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr ""
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2260,7 +2264,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2542,11 +2546,11 @@ msgstr ""
 msgid "Go"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr ""
 
@@ -2879,7 +2883,7 @@ msgstr ""
 msgid "Jump to previous song right away"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr ""
 
@@ -2903,7 +2907,7 @@ msgstr ""
 msgid "Keep the original files"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr ""
@@ -2995,7 +2999,7 @@ msgstr ""
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3035,7 +3039,7 @@ msgstr ""
 msgid "Load playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr ""
 
@@ -3096,11 +3100,15 @@ msgstr ""
 msgid "Login failed"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr ""
 
@@ -3135,11 +3143,11 @@ msgstr ""
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr ""
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr ""
@@ -3181,7 +3189,7 @@ msgstr ""
 msgid "Make it so!"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr ""
@@ -3319,7 +3327,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3328,7 +3336,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr ""
 
@@ -3341,7 +3349,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr ""
 
@@ -3390,7 +3398,7 @@ msgstr ""
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3418,8 +3426,12 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr ""
 
@@ -3457,7 +3469,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3542,19 +3554,19 @@ msgstr ""
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr ""
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr ""
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr ""
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3598,7 +3610,7 @@ msgstr ""
 msgid "Open %1 in browser"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr ""
 
@@ -3610,7 +3622,7 @@ msgstr ""
 msgid "Open OPML file..."
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr ""
 
@@ -3618,7 +3630,7 @@ msgstr ""
 msgid "Open device"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr ""
 
@@ -3672,7 +3684,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr ""
 
@@ -3756,7 +3768,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr ""
@@ -3780,6 +3792,10 @@ msgstr ""
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr ""
@@ -3788,10 +3804,10 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr ""
 
@@ -3812,11 +3828,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3915,7 +3931,7 @@ msgstr ""
 msgid "Preferences"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr ""
 
@@ -3975,7 +3991,7 @@ msgid "Previous"
 msgstr ""
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr ""
 
@@ -4033,16 +4049,16 @@ msgstr ""
 msgid "Querying device..."
 msgstr ""
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr ""
 
@@ -4058,7 +4074,7 @@ msgstr ""
 msgid "Rain"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr ""
@@ -4170,7 +4186,7 @@ msgstr ""
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr ""
 
@@ -4178,7 +4194,7 @@ msgstr ""
 msgid "Remove folder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr ""
 
@@ -4190,7 +4206,7 @@ msgstr ""
 msgid "Remove playlists"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr ""
 
@@ -4202,7 +4218,7 @@ msgstr ""
 msgid "Rename playlist..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr ""
 
@@ -4293,7 +4309,7 @@ msgstr ""
 msgid "Rip CD"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr ""
 
@@ -4371,7 +4387,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr ""
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr ""
 
@@ -4458,7 +4474,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4471,7 +4487,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4596,7 +4612,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4605,7 +4621,7 @@ msgstr ""
 msgid "Set the volume to <value> percent"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr ""
 
@@ -4676,7 +4692,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr ""
 
@@ -4696,12 +4712,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr ""
 
@@ -4713,15 +4729,15 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4729,7 +4745,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4765,7 +4781,7 @@ msgstr ""
 msgid "Shuffle all"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr ""
 
@@ -4809,11 +4825,15 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr ""
 
@@ -4930,7 +4950,7 @@ msgstr ""
 msgid "Start the playlist currently playing"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr ""
 
@@ -4940,7 +4960,7 @@ msgid ""
 "list"
 msgstr ""
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr ""
@@ -4950,7 +4970,7 @@ msgid "Starting..."
 msgstr ""
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr ""
 
@@ -4966,7 +4986,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5134,7 +5154,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5176,7 +5196,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5278,11 +5298,11 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr ""
 
@@ -5327,19 +5347,19 @@ msgstr ""
 msgid "Track"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr ""
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
 msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr ""
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr ""
@@ -5416,11 +5436,11 @@ msgstr ""
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr ""
 
@@ -5437,7 +5457,7 @@ msgstr ""
 msgid "Update all podcasts"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr ""
 
@@ -5598,7 +5618,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5606,7 +5626,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr ""
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr ""
 
@@ -5647,7 +5667,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr ""
 
@@ -5743,7 +5763,7 @@ msgstr ""
 msgid "Windows Media 64k"
 msgstr ""
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr ""
 
@@ -5757,7 +5777,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/ms.po
+++ b/src/translations/ms.po
@@ -10,7 +10,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Malay (http://www.transifex.com/davidsansome/clementine/language/ms/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -164,19 +164,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n gagal"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n telah selesai"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -194,7 +194,7 @@ msgstr "&Tengah"
 msgid "&Custom"
 msgstr "&Tersuai"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "Tambahan"
 
@@ -202,7 +202,7 @@ msgstr "Tambahan"
 msgid "&Grouping"
 msgstr "&Pengelompokan"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Bantuan"
 
@@ -227,7 +227,7 @@ msgstr "&Pengadaran Kunci"
 msgid "&Lyrics"
 msgstr "&Lirik"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Muzik"
 
@@ -235,15 +235,15 @@ msgstr "&Muzik"
 msgid "&None"
 msgstr "&Tiada"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "Senarai main"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Keluar"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "Mod ulang"
 
@@ -251,7 +251,7 @@ msgstr "Mod ulang"
 msgid "&Right"
 msgstr "&Kanan"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Mod kocok"
 
@@ -259,7 +259,7 @@ msgstr "Mod kocok"
 msgid "&Stretch columns to fit window"
 msgstr "&Tarik kolum untuk disesuaikan dengan tetingkap"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Alatan"
 
@@ -448,11 +448,11 @@ msgstr "Henti Paksa"
 msgid "About %1"
 msgstr "Perihal %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Perihal Clementine"
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Perihal Qt..."
 
@@ -512,32 +512,32 @@ msgstr "Tambah strim lain..."
 msgid "Add directory..."
 msgstr "Tambah direktori..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Tambah fail"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Tambah fail ke transkoder"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Tambah fail ke transkoder"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Tambah fail..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Tambah fail-fail untuk transkod"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Tambah folder"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Tambah folder..."
 
@@ -549,7 +549,7 @@ msgstr "Tambah folder baharu..."
 msgid "Add podcast"
 msgstr "Tambah podcast"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Tambah podcast..."
 
@@ -625,7 +625,7 @@ msgstr "Tambah tag trek lagu"
 msgid "Add song year tag"
 msgstr "Tambah tag tahun lagu"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Tambah stream..."
 
@@ -637,7 +637,7 @@ msgstr "Tambah ke senarai main Spotify"
 msgid "Add to Spotify starred"
 msgstr "Tambah ke Spotify dibintangi"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Tambahkan ke senarai main lain"
 
@@ -731,7 +731,7 @@ msgstr "Semua"
 msgid "All Files (*)"
 msgstr "Semua Fail (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "All Glory to the Hypnotoad!"
@@ -1122,7 +1122,7 @@ msgstr "Periksa episod baharu"
 msgid "Check for updates"
 msgstr "Periksa kemaskini"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Periksa kemaskini..."
 
@@ -1171,18 +1171,18 @@ msgstr "Klasik"
 msgid "Cleaning up"
 msgstr "Membersihkan"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Kosongkan"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Kosongkan senarai main"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1327,7 +1327,7 @@ msgstr "Komen"
 msgid "Complete tags automatically"
 msgstr "Lengkapkan tag secara automatik"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Lengkapkan tag secara automatik..."
 
@@ -1362,7 +1362,7 @@ msgstr "Konfigur Subsonic..."
 msgid "Configure global search..."
 msgstr "Konfigure gelintar sejagat..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Konfigur pustaka..."
 
@@ -1405,7 +1405,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Sambungan tamat masa, periksa URL pelayan. Contoh: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Konsol"
 
@@ -1434,11 +1434,11 @@ msgid "Copy to clipboard"
 msgstr "Salin ke papan keratan"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Salin ke peranti..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Salin ke pustaka..."
@@ -1481,14 +1481,14 @@ msgstr "Tidak dapat mendaftar masuk ke Last.fm. Cuba sekali lagi."
 msgid "Couldn't create playlist"
 msgstr "Tidak dapat cipta senarai main"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Tidak dapat cari muxer untuk %1. Periksa sama ada anda mempunyai pemalam GStreamer yang betul dipasang"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1503,7 +1503,7 @@ msgstr "Tidak dapat buka fail output %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Pengurus Kulit Muka"
 
@@ -1656,7 +1656,7 @@ msgid "Delete downloaded data"
 msgstr "Padam data dimuat turun"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Padam fail"
 
@@ -1664,7 +1664,7 @@ msgstr "Padam fail"
 msgid "Delete from device..."
 msgstr "Padam dari peranti..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Padam dari cakera..."
@@ -1697,11 +1697,11 @@ msgstr "Memadam fail-fail"
 msgid "Depth"
 msgstr "Kedalaman"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Nyahbaris gilir trek terpilih"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Nyahbaris gilir trek"
 
@@ -1802,7 +1802,7 @@ msgstr "Pilihan paparan"
 msgid "Display the on-screen-display"
 msgstr "Papar paparan-atas-skrin"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Buat imbas semula pustaka penuh"
 
@@ -1981,12 +1981,12 @@ msgstr "Campuran rawak dinamik"
 msgid "Edit smart playlist..."
 msgstr "Sunting senarai main pintar..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Sunting tag \"%1\"..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Sunting tag..."
 
@@ -1999,7 +1999,7 @@ msgid "Edit track information"
 msgstr "Sunting maklumat trek"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Sunting maklumat trek..."
 
@@ -2107,7 +2107,7 @@ msgstr "Kesemua koleksi"
 msgid "Episode information"
 msgstr "Maklumat episod"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Penyama"
 
@@ -2120,8 +2120,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Sama dengan --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Ralat"
 
@@ -2156,7 +2156,7 @@ msgstr "Ralat memuatkan %1"
 msgid "Error loading di.fm playlist"
 msgstr "Ralat memuatkan senarai main di.fm"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Ralat memproses %1: %2"
@@ -2239,7 +2239,11 @@ msgstr "Eksport selesai"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "%1 kulit muka dieksport dari %2 (%3 dilangkau)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2263,7 +2267,7 @@ msgstr "Peresapan"
 msgid "Fading duration"
 msgstr "Jangkamasa peresapan"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Gagal membaca pemacu CD"
 
@@ -2545,11 +2549,11 @@ msgstr "Berikan ia nama"
 msgid "Go"
 msgstr "Pergi"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Pergi ke tab senarai main berikutnya"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Pergi ke tab senarai main sebelumnya"
 
@@ -2882,7 +2886,7 @@ msgstr "Pangkalan data Jamendo"
 msgid "Jump to previous song right away"
 msgstr "Lompat ke lagu terdahulu sekarang jua"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Lompat ke trek semasa dimainkan"
 
@@ -2906,7 +2910,7 @@ msgstr "Kekal berjalan di balik tabir bila tetingkap ditutup"
 msgid "Keep the original files"
 msgstr "Kekalkan fail asal"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Kittens"
@@ -2998,7 +3002,7 @@ msgstr "Pustaka"
 msgid "Library advanced grouping"
 msgstr "Pengelompokan lanjutan pustaka"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Notis imbas semula pustaka"
 
@@ -3038,7 +3042,7 @@ msgstr "Muat kulit muka dari cakera..."
 msgid "Load playlist"
 msgstr "Muat senarai main"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Muat senarai main..."
 
@@ -3099,11 +3103,15 @@ msgstr "Daftar masuk"
 msgid "Login failed"
 msgstr "Daftar masuk gagal"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Profil jangkaan jangka panjang (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Suka"
 
@@ -3138,11 +3146,11 @@ msgstr "Lirik dari %1"
 msgid "Lyrics from the tag"
 msgstr "Lirik dari tag"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3184,7 +3192,7 @@ msgstr "Profil utama (MAIN)"
 msgid "Make it so!"
 msgstr "Make it so!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Make it so!"
@@ -3322,7 +3330,7 @@ msgstr "Titik lekap"
 msgid "Move down"
 msgstr "Alih ke bawah"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Alih ke pustaka..."
 
@@ -3331,7 +3339,7 @@ msgstr "Alih ke pustaka..."
 msgid "Move up"
 msgstr "Alih ke atas"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Muzik"
 
@@ -3344,7 +3352,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Senyap"
 
@@ -3393,7 +3401,7 @@ msgstr "Tidak sesekali mula dimainkan"
 msgid "New folder"
 msgstr "Folder baharu"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Senarai main baharu"
 
@@ -3421,8 +3429,12 @@ msgstr "Trek terbaharu"
 msgid "Next"
 msgstr "Seterusnya"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Trek seterusnya"
 
@@ -3460,7 +3472,7 @@ msgstr "Tiada blok pendek"
 msgid "None"
 msgstr "Tiada"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Tiada satupun lagu yang dipilih sesuai untuk disalin ke peranti"
 
@@ -3545,19 +3557,19 @@ msgstr "Mati"
 msgid "Ogg FLAC"
 msgstr "Flac Ogg"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Flac Ogg"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Speex Ogg"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3601,7 +3613,7 @@ msgstr "Kelegapan"
 msgid "Open %1 in browser"
 msgstr "Buka %1 dalam pelayar"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Buka CD &audio..."
 
@@ -3613,7 +3625,7 @@ msgstr "Buka fail OPML"
 msgid "Open OPML file..."
 msgstr "Buka fail OPML..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Buka satu direktori untuk mengimport muzik darinya"
 
@@ -3621,7 +3633,7 @@ msgstr "Buka satu direktori untuk mengimport muzik darinya"
 msgid "Open device"
 msgstr "Buka peranti"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Buka fail..."
 
@@ -3675,7 +3687,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Aturkan Fail"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Urus fail..."
 
@@ -3759,7 +3771,7 @@ msgstr "Parti"
 msgid "Password"
 msgstr "Kata laluan"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Jeda"
@@ -3783,6 +3795,10 @@ msgstr "Penyampai"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Piksel"
@@ -3791,10 +3807,10 @@ msgstr "Piksel"
 msgid "Plain sidebar"
 msgstr "Palang sisi biasa"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Main"
 
@@ -3815,11 +3831,11 @@ msgstr "Main sekiranya telah dihenti, jeda sekiranya dimainkan"
 msgid "Play if there is nothing already playing"
 msgstr "Main sekiranya tiada apa yang tersedia dimainkan"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Main berikutnya"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Main trek terpilih berikutnya"
 
@@ -3918,7 +3934,7 @@ msgstr "Keutamaan"
 msgid "Preferences"
 msgstr "Keutamaan"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Keutamaan..."
 
@@ -3978,7 +3994,7 @@ msgid "Previous"
 msgstr "Sebelum"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Trek sebelumnya"
 
@@ -4036,16 +4052,16 @@ msgstr "Kualiti"
 msgid "Querying device..."
 msgstr "Menanya peranti..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Pengurus Baris Gilir"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Baris gilir trek terpilih"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Baris gilir trek"
 
@@ -4061,7 +4077,7 @@ msgstr "Radio (sama kelantangan untuk semua trek)"
 msgid "Rain"
 msgstr "Rain"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Rain"
@@ -4173,7 +4189,7 @@ msgstr "Buang tindakan"
 msgid "Remove current song from playlist"
 msgstr "Buang lagu semasa dari senarai main"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Buang pendua dari senarai main"
 
@@ -4181,7 +4197,7 @@ msgstr "Buang pendua dari senarai main"
 msgid "Remove folder"
 msgstr "Buang folder"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Buang dari senarai main"
 
@@ -4193,7 +4209,7 @@ msgstr "Buang senarai main"
 msgid "Remove playlists"
 msgstr "Buang senarai main"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Buang trek tidak tersedia dari senarai main"
 
@@ -4205,7 +4221,7 @@ msgstr "Namakan semula senarai main"
 msgid "Rename playlist..."
 msgstr "Namakan semula senarai main..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Nomborkan semula trek mengikut tertib ini..."
 
@@ -4296,7 +4312,7 @@ msgstr "Retas"
 msgid "Rip CD"
 msgstr "Retas CD"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Retas CD audio"
 
@@ -4374,7 +4390,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Simpan senarai main"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Simpan senarai main..."
 
@@ -4461,7 +4477,7 @@ msgstr "Gelintar Subsonic"
 msgid "Search automatically"
 msgstr "Gelintar secara automatik"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Gelintar album"
 
@@ -4474,7 +4490,7 @@ msgstr "Gelintar kulit album..."
 msgid "Search for anything"
 msgstr "Gelintar apa saja"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Gelintar artis"
 
@@ -4599,7 +4615,7 @@ msgstr "Perincian pelayan"
 msgid "Service offline"
 msgstr "Perkhidmatan di luar talian"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Tetapkan %1 ke \"%2\"..."
@@ -4608,7 +4624,7 @@ msgstr "Tetapkan %1 ke \"%2\"..."
 msgid "Set the volume to <value> percent"
 msgstr "Tetapkan volum ke <value> peratus"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Tetapkan nilai untuk semua trek terpilih..."
 
@@ -4679,7 +4695,7 @@ msgstr "Tunjuk OSD menarik"
 msgid "Show above status bar"
 msgstr "Tunjuk di atas palang status"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Tunjuk semua lagu"
 
@@ -4699,12 +4715,12 @@ msgstr "Tunjuk pembahagi"
 msgid "Show fullsize..."
 msgstr "Tunjuk saiz penuh..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Tunjuk dalam pelayar fail..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Tunjuk dalam pustaka...."
 
@@ -4716,15 +4732,15 @@ msgstr "Tunjuk dalam artis pelbagai"
 msgid "Show moodbar"
 msgstr "Tunjuk palang suasana"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Hanya tunjuk pendua"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Tunjuk hanya tidak ditag"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Tunjuk atau sembunyi palang sisi"
 
@@ -4732,7 +4748,7 @@ msgstr "Tunjuk atau sembunyi palang sisi"
 msgid "Show search suggestions"
 msgstr "Tunjuk cadangan gelintar"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Tunjuk palang sisi"
 
@@ -4768,7 +4784,7 @@ msgstr "Kocok album"
 msgid "Shuffle all"
 msgstr "Kocok semua"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Kocok senarai main"
 
@@ -4812,11 +4828,15 @@ msgstr "Kiraan langkau"
 msgid "Skip forwards in playlist"
 msgstr "Langkau maju dalam senarai main"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Langkau trek terpilih"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Langkau trek"
 
@@ -4933,7 +4953,7 @@ msgstr "Mula meretas"
 msgid "Start the playlist currently playing"
 msgstr "Mulakan senarai main semasa dimainkan"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Mulakan transkod"
 
@@ -4943,7 +4963,7 @@ msgid ""
 "list"
 msgstr "Mula menaip sesuatu pada kotak gelintar di ata untuk mengisi senarai keputusan gelintar ini"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Memulakan %1"
@@ -4953,7 +4973,7 @@ msgid "Starting..."
 msgstr "Memulakan..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Henti"
 
@@ -4969,7 +4989,7 @@ msgstr "Henti selepas setiap trek"
 msgid "Stop after every track"
 msgstr "Henti selepas setiap trek"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Henti selepas trek ini"
 
@@ -5137,7 +5157,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Tempoh percubaan pelayan Subsonic telah tamat. Sila beri derma untuk dapatkan kunci lesen. Lawati subsonic untuk perincian."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5179,7 +5199,7 @@ msgid ""
 "continue?"
 msgstr "Fail ini akan dipadam dari peranti, anda pasti untuk meneruskan?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5281,11 +5301,11 @@ msgstr "Togol OSD Menarik"
 msgid "Toggle fullscreen"
 msgstr "Togol skrin penuh"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Togol status baris gilir"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Togol scrobble"
 
@@ -5330,19 +5350,19 @@ msgstr "Tre&k"
 msgid "Track"
 msgstr "Trek"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Transkod Muzik"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Log Transkoder"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Membuat transkod"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Membuat transkod %1 fail menggunakan bebenang %2"
@@ -5419,11 +5439,11 @@ msgstr "Ralat tidak diketahui"
 msgid "Unset cover"
 msgstr "Nyahtetap kulit muka"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Jangan langkau trek terpilih"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Jangan langkau trek"
 
@@ -5440,7 +5460,7 @@ msgstr "Konsert Akan Datang"
 msgid "Update all podcasts"
 msgstr "Kemaskini semua podcast"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Kemaskini folder pustaka yang berubah"
 
@@ -5601,7 +5621,7 @@ msgstr "Versi %1"
 msgid "View"
 msgstr "Lihat"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Lihat Perincian Strim"
 
@@ -5609,7 +5629,7 @@ msgstr "Lihat Perincian Strim"
 msgid "Visualization mode"
 msgstr "Mod pengvisualan"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Pengvisualan"
 
@@ -5650,7 +5670,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5746,7 +5766,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Audio Windows Media"
 
@@ -5760,7 +5780,7 @@ msgid ""
 "well?"
 msgstr "Anda mahu alih lagu lain dalam album ini ke Artis Pelbagai juga?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Anda mahu jalankan imbas semula penuh sekarang?"
 

--- a/src/translations/ms.po
+++ b/src/translations/ms.po
@@ -512,7 +512,7 @@ msgstr "Tambah strim lain..."
 msgid "Add directory..."
 msgstr "Tambah direktori..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Tambah fail"
 
@@ -532,7 +532,7 @@ msgstr "Tambah fail..."
 msgid "Add files to transcode"
 msgstr "Tambah fail-fail untuk transkod"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Tambah folder"
@@ -637,7 +637,7 @@ msgstr "Tambah ke senarai main Spotify"
 msgid "Add to Spotify starred"
 msgstr "Tambah ke Spotify dibintangi"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Tambahkan ke senarai main lain"
 
@@ -859,7 +859,7 @@ msgstr "Anda pasti mahu menulis statistik lagu ke dalam fail lagu untuk semua la
 msgid "Artist"
 msgstr "Artis"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Info artis"
 
@@ -1122,7 +1122,7 @@ msgstr "Periksa episod baharu"
 msgid "Check for updates"
 msgstr "Periksa kemaskini"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Periksa kemaskini..."
 
@@ -1362,7 +1362,7 @@ msgstr "Konfigur Subsonic..."
 msgid "Configure global search..."
 msgstr "Konfigure gelintar sejagat..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Konfigur pustaka..."
 
@@ -1434,11 +1434,11 @@ msgid "Copy to clipboard"
 msgstr "Salin ke papan keratan"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Salin ke peranti..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Salin ke pustaka..."
@@ -1656,7 +1656,7 @@ msgid "Delete downloaded data"
 msgstr "Padam data dimuat turun"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Padam fail"
 
@@ -1664,7 +1664,7 @@ msgstr "Padam fail"
 msgid "Delete from device..."
 msgstr "Padam dari peranti..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Padam dari cakera..."
@@ -1697,11 +1697,11 @@ msgstr "Memadam fail-fail"
 msgid "Depth"
 msgstr "Kedalaman"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Nyahbaris gilir trek terpilih"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Nyahbaris gilir trek"
 
@@ -1730,7 +1730,7 @@ msgstr "Nama peranti"
 msgid "Device properties..."
 msgstr "Ciri-ciri peranti..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Peranti-peranti"
 
@@ -1981,7 +1981,7 @@ msgstr "Campuran rawak dinamik"
 msgid "Edit smart playlist..."
 msgstr "Sunting senarai main pintar..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Sunting tag \"%1\"..."
@@ -2120,8 +2120,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Sama dengan --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Ralat"
 
@@ -2267,7 +2267,7 @@ msgstr "Peresapan"
 msgid "Fading duration"
 msgstr "Jangkamasa peresapan"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Gagal membaca pemacu CD"
 
@@ -2390,7 +2390,7 @@ msgstr "Jenis fail"
 msgid "Filename"
 msgstr "Namafail"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Fail"
 
@@ -2805,7 +2805,7 @@ msgstr "Terpasang"
 msgid "Integrity check"
 msgstr "Semakan integriti"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -2993,7 +2993,7 @@ msgstr "Kiri"
 msgid "Length"
 msgstr "Jangkamasa"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Pustaka"
@@ -3002,7 +3002,7 @@ msgstr "Pustaka"
 msgid "Library advanced grouping"
 msgstr "Pengelompokan lanjutan pustaka"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Notis imbas semula pustaka"
 
@@ -3330,7 +3330,7 @@ msgstr "Titik lekap"
 msgid "Move down"
 msgstr "Alih ke bawah"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Alih ke pustaka..."
 
@@ -3339,7 +3339,7 @@ msgstr "Alih ke pustaka..."
 msgid "Move up"
 msgstr "Alih ke atas"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Muzik"
 
@@ -3401,7 +3401,7 @@ msgstr "Tidak sesekali mula dimainkan"
 msgid "New folder"
 msgstr "Folder baharu"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Senarai main baharu"
 
@@ -3472,7 +3472,7 @@ msgstr "Tiada blok pendek"
 msgid "None"
 msgstr "Tiada"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Tiada satupun lagu yang dipilih sesuai untuk disalin ke peranti"
 
@@ -3687,7 +3687,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Aturkan Fail"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Urus fail..."
 
@@ -3771,7 +3771,7 @@ msgstr "Parti"
 msgid "Password"
 msgstr "Kata laluan"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Jeda"
@@ -3807,8 +3807,8 @@ msgstr "Piksel"
 msgid "Plain sidebar"
 msgstr "Palang sisi biasa"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3831,11 +3831,11 @@ msgstr "Main sekiranya telah dihenti, jeda sekiranya dimainkan"
 msgid "Play if there is nothing already playing"
 msgstr "Main sekiranya tiada apa yang tersedia dimainkan"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Main berikutnya"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Main trek terpilih berikutnya"
 
@@ -3874,7 +3874,7 @@ msgstr "Pilihan senarai main"
 msgid "Playlist type"
 msgstr "Jenis senarai main"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Senarai main"
 
@@ -4056,12 +4056,12 @@ msgstr "Menanya peranti..."
 msgid "Queue Manager"
 msgstr "Pengurus Baris Gilir"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Baris gilir trek terpilih"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Baris gilir trek"
 
@@ -4452,7 +4452,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Gelintar"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Gelintar"
@@ -4477,7 +4477,7 @@ msgstr "Gelintar Subsonic"
 msgid "Search automatically"
 msgstr "Gelintar secara automatik"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Gelintar album"
 
@@ -4490,7 +4490,7 @@ msgstr "Gelintar kulit album..."
 msgid "Search for anything"
 msgstr "Gelintar apa saja"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Gelintar artis"
 
@@ -4615,7 +4615,7 @@ msgstr "Perincian pelayan"
 msgid "Service offline"
 msgstr "Perkhidmatan di luar talian"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Tetapkan %1 ke \"%2\"..."
@@ -4695,7 +4695,7 @@ msgstr "Tunjuk OSD menarik"
 msgid "Show above status bar"
 msgstr "Tunjuk di atas palang status"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Tunjuk semua lagu"
 
@@ -4715,12 +4715,12 @@ msgstr "Tunjuk pembahagi"
 msgid "Show fullsize..."
 msgstr "Tunjuk saiz penuh..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Tunjuk dalam pelayar fail..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Tunjuk dalam pustaka...."
 
@@ -4732,11 +4732,11 @@ msgstr "Tunjuk dalam artis pelbagai"
 msgid "Show moodbar"
 msgstr "Tunjuk palang suasana"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Hanya tunjuk pendua"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Tunjuk hanya tidak ditag"
 
@@ -4828,7 +4828,7 @@ msgstr "Kiraan langkau"
 msgid "Skip forwards in playlist"
 msgstr "Langkau maju dalam senarai main"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Langkau trek terpilih"
 
@@ -4836,7 +4836,7 @@ msgstr "Langkau trek terpilih"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Langkau trek"
 
@@ -4868,7 +4868,7 @@ msgstr "Soft Rock"
 msgid "Song Information"
 msgstr "Maklumat Lagu"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Maklumat lagu"
 
@@ -4989,7 +4989,7 @@ msgstr "Henti selepas setiap trek"
 msgid "Stop after every track"
 msgstr "Henti selepas setiap trek"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Henti selepas trek ini"
 
@@ -5157,7 +5157,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Tempoh percubaan pelayan Subsonic telah tamat. Sila beri derma untuk dapatkan kunci lesen. Lawati subsonic untuk perincian."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5199,7 +5199,7 @@ msgid ""
 "continue?"
 msgstr "Fail ini akan dipadam dari peranti, anda pasti untuk meneruskan?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5301,7 +5301,7 @@ msgstr "Togol OSD Menarik"
 msgid "Toggle fullscreen"
 msgstr "Togol skrin penuh"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Togol status baris gilir"
 
@@ -5439,11 +5439,11 @@ msgstr "Ralat tidak diketahui"
 msgid "Unset cover"
 msgstr "Nyahtetap kulit muka"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Jangan langkau trek terpilih"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Jangan langkau trek"
 
@@ -5780,7 +5780,7 @@ msgid ""
 "well?"
 msgstr "Anda mahu alih lagu lain dalam album ini ke Artis Pelbagai juga?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Anda mahu jalankan imbas semula penuh sekarang?"
 

--- a/src/translations/my.po
+++ b/src/translations/my.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Burmese (http://www.transifex.com/davidsansome/clementine/language/my/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -161,19 +161,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n ဖွင့်မရ"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n ပြီးဆံုး"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -191,7 +191,7 @@ msgstr "အလယ်(&C)"
 msgid "&Custom"
 msgstr "စိတ်ကြိုက်(&C)"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "အပိုများ(&E)"
 
@@ -199,7 +199,7 @@ msgstr "အပိုများ(&E)"
 msgid "&Grouping"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "အကူအညီ(&H)"
 
@@ -224,7 +224,7 @@ msgstr ""
 msgid "&Lyrics"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "ဂီတ(&M)"
 
@@ -232,15 +232,15 @@ msgstr "ဂီတ(&M)"
 msgid "&None"
 msgstr "တစ်ခုမျှ(&N)"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "သီချင်းစာရင်း(&P)"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "ထွက်(&Q)"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "စနစ်ပြန်ဆို(&R)"
 
@@ -248,7 +248,7 @@ msgstr "စနစ်ပြန်ဆို(&R)"
 msgid "&Right"
 msgstr "ညာ(&R)"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "ကုလားဖန်ထိုးစနစ်(&S)"
 
@@ -256,7 +256,7 @@ msgstr "ကုလားဖန်ထိုးစနစ်(&S)"
 msgid "&Stretch columns to fit window"
 msgstr "ဝင်းဒိုးနဲ့အံကိုက်ကော်လံများကိုဆွဲဆန့်(&S)"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "ကိရိယာများ(&T)"
 
@@ -445,11 +445,11 @@ msgstr "ဖျက်သိမ်း"
 msgid "About %1"
 msgstr "ခန့် %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "ကလီမန်တိုင်းအကြောင်း"
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "ကျူတီအကြောင်း..."
 
@@ -509,32 +509,32 @@ msgstr "သီချင်းစီးကြောင်းနောက်တစ
 msgid "Add directory..."
 msgstr "ဖိုင်လမ်းညွှန်ထည့်..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "ဖိုင်ထည့်"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "ဖိုင်များကိုပံုစံပြောင်းလဲသူသို့ထည့်ပါ"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "ဖိုင်(များ)ကိုပံုစံပြောင်းလဲသူသို့ထည့်ပါ"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "ဖိုင်ထည့်..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "ဖိုင်များကိုပံုစံပြောင်းလဲရန်ထည့်ပါ"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "ဖိုင်တွဲထည့်"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "ဖိုင်တွဲထည့်..."
 
@@ -546,7 +546,7 @@ msgstr "ဖိုင်တွဲအသစ်ထည့်..."
 msgid "Add podcast"
 msgstr "ပို့စ်ကဒ်ထည့်"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "ပို့စ်ကဒ်ထည့်..."
 
@@ -622,7 +622,7 @@ msgstr "သီချင်းတေးသံလမ်းကြောအမည်
 msgid "Add song year tag"
 msgstr "သီချင်းနှစ်အမည်ထည့်"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "သီချင်းစီးကြောင်းထည့်..."
 
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "သီချင်းစာရင်းနောက်တစ်ခုသို့ထည့်"
 
@@ -728,7 +728,7 @@ msgstr ""
 msgid "All Files (*)"
 msgstr "ဖိုင်များအားလံုး(*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "အံ့မခန်းဖွယ်အားလံုးကိုဟိုက်ဖ်နိုဖားသို့!"
@@ -1119,7 +1119,7 @@ msgstr "တွဲအသစ်များစစ်ဆေးခြင်း"
 msgid "Check for updates"
 msgstr "မွမ်းမံများစစ်ဆေးခြင်း"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "မွမ်းမံများစစ်ဆေးခြင်း..."
 
@@ -1168,18 +1168,18 @@ msgstr "ဂန္တဝင်"
 msgid "Cleaning up"
 msgstr "ရှင်းထုတ်ဖြစ်"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "ဖယ်ထုတ်"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "သီချင်းစာရင်းဖယ်ထုတ်"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "ကလီမန်တိုင်း"
 
@@ -1324,7 +1324,7 @@ msgstr "ထင်မြင်ချက်"
 msgid "Complete tags automatically"
 msgstr "အမည်များအလိုအလျောက်ဖြည့်"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "အမည်များအလိုအလျောက်ဖြည့်..."
 
@@ -1359,7 +1359,7 @@ msgstr "ဆပ်ဆိုးနစ်ပုံစံပြင်..."
 msgid "Configure global search..."
 msgstr "အနှံ့ရှာဖွေပုံစံပြင်..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "သီချင်းတိုက်ပုံစံပြင်..."
 
@@ -1402,7 +1402,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "ဆက်သွယ်ချိန်ကုန်ဆံုး၊ ဆာဗာယူအာအယ်ပြန်စစ်ဆေးပါ။ ဥပမာ: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "ခလုတ်ခုံ"
 
@@ -1431,11 +1431,11 @@ msgid "Copy to clipboard"
 msgstr "အောက်ခံကတ်ပြားသို့ကူးယူ"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "ပစ္စည်းသို့ကူးယူ"
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "သီချင်းတိုက်သို့ကူးယူ..."
@@ -1478,14 +1478,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "%1 အတွက်မြုစာမရှာဖွေနိင်၊ ဂျီသီချင်းစီးကြောင်းလိုအပ်သောဖြည့်စွက်ပရိုဂရမ်များသွင်းပြီးမပြီးစစ်ဆေး"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1500,7 +1500,7 @@ msgstr "ပေးပို့ဖိုင်ဖွင့်မရ %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "အဖုံးမန်နေဂျာ"
 
@@ -1653,7 +1653,7 @@ msgid "Delete downloaded data"
 msgstr "ကူးဆွဲပြီးအချက်အလက်ပယ်ဖျက်"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "ဖိုင်များပယ်ဖျက်"
 
@@ -1661,7 +1661,7 @@ msgstr "ဖိုင်များပယ်ဖျက်"
 msgid "Delete from device..."
 msgstr "ပစ္စည်းမှပယ်ဖျက်..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "ဓာတ်ပြားမှပယ်ဖျက်..."
@@ -1694,11 +1694,11 @@ msgstr "ဖိုင်များပယ်ဖျက်နေ"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "ရွေးချယ်တေးသံလမ်းကြောများမစီတန်း"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "တေးသံလမ်းကြောမစီတန်း"
 
@@ -1799,7 +1799,7 @@ msgstr "ပြသခြင်းရွေးပိုင်ခွင့်မျ
 msgid "Display the on-screen-display"
 msgstr "ဖန်သားပြင်ပေါ်ပံုရိပ်ပြသခြင်း"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "သီချင်းတိုက်အပြည့်ပြန်လည်ဖတ်ရှု"
 
@@ -1978,12 +1978,12 @@ msgstr "ကျပန်းရောသမမွှေအရှင်"
 msgid "Edit smart playlist..."
 msgstr "ချက်ချာသီချင်းစာရင်းပြင်ဆင်..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "အမည်ပြင်ဆင် \"%1\"..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "အမည်ပြင်ဆင်..."
 
@@ -1996,7 +1996,7 @@ msgid "Edit track information"
 msgstr "တေးသံလမ်းကြောအချက်အလက်ပြင်ဆင်"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "တေးသံလမ်းကြောအချက်အလက်ပြင်ဆင်..."
 
@@ -2104,7 +2104,7 @@ msgstr "စုပေါင်းမှုတစ်ခုလုံး"
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "အသံထိန်းညှိသူ"
 
@@ -2117,8 +2117,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Equivalent to --log-levels *:3တူညီ"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "အမှားပြ"
 
@@ -2153,7 +2153,7 @@ msgstr "ထည့်သွင်းခြင်းအမှားပြ %1"
 msgid "Error loading di.fm playlist"
 msgstr "ဒီအိုင်.အက်ဖ်အမ်သီချင်းစာရင်းထည့်သွင်းအမှားပြ"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "ဆောင်ရွက်ခြင်းအမှားပြ %1: %2"
@@ -2236,7 +2236,11 @@ msgstr "တင်ပို့ခြင်းပြီးဆံုး"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "တင်ပို့ပြီး %1 အဖံုးများရရှိ %2 မှ (%3 ခုန်ကျော်)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2260,7 +2264,7 @@ msgstr "အရောင်မှိန်"
 msgid "Fading duration"
 msgstr "အရောင်မှိန်ကြာချိန်"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2542,11 +2546,11 @@ msgstr "ဒီဟာကိုနာမည်ပေး:"
 msgid "Go"
 msgstr "သွား"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "နောက်သီချင်းစာရင်းမျက်နှာစာသို့သွား"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "ယခင်သီချင်းစာရင်းမျက်နှာစာသို့သွား"
 
@@ -2879,7 +2883,7 @@ msgstr "ဂျမန်တိုအချက်အလက်အစု"
 msgid "Jump to previous song right away"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "လက်ရှိဖွင့်ဆဲတေးသံလမ်းကြောသို့"
 
@@ -2903,7 +2907,7 @@ msgstr "ဝင်းဒိုးပိတ်နေစဉ်နောက်ခံ
 msgid "Keep the original files"
 msgstr "မူရင်းဖိုင်များထိန်းထား"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "ကြောင်ပေါက်စများ"
@@ -2995,7 +2999,7 @@ msgstr "သီချင်းတိုက်"
 msgid "Library advanced grouping"
 msgstr "သီချင်းတိုက်အဆင့်မြင့်အုပ်စုဖွဲ့ခြင်း"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "သီချင်းတိုက်ပြန်လည်ဖတ်ရှုအကြောင်းကြားစာ"
 
@@ -3035,7 +3039,7 @@ msgstr "ဓာတ်ပြားမှအဖုံးထည့်သွင်း
 msgid "Load playlist"
 msgstr "သီချင်းစာရင်းထည့်သွင်း"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "သီချင်းစာရင်းထည့်သွင်း..."
 
@@ -3096,11 +3100,15 @@ msgstr "ဖွင့်ဝင်"
 msgid "Login failed"
 msgstr "ဖွင့်ဝင်၍မရ"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "ကာလရှည်ခန့်မှန်းအကြောင်း (အယ်တီပီ)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "နှစ်သက်"
 
@@ -3135,11 +3143,11 @@ msgstr "%1 မှသီချင်းစာသားများ"
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "MP4 AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "အမ်ပီသရီး"
@@ -3181,7 +3189,7 @@ msgstr "အဓိကအကြောင်း(အဓိက)"
 msgid "Make it so!"
 msgstr "အဲဒီကဲ့သို့လုပ်"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "အဲဒီကဲ့သို့လုပ်"
@@ -3319,7 +3327,7 @@ msgstr "အမှတ်များစီစဉ်"
 msgid "Move down"
 msgstr "အောက်သို့ရွှေ့"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "သီချင်းတိုက်သို့ရွှေ့..."
 
@@ -3328,7 +3336,7 @@ msgstr "သီချင်းတိုက်သို့ရွှေ့..."
 msgid "Move up"
 msgstr "အပေါ်သို့ရွှေ့"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "ဂီတ"
 
@@ -3341,7 +3349,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "အသံအုပ်"
 
@@ -3390,7 +3398,7 @@ msgstr "သီချင်းလုံးဝစတင်မဖွင့်"
 msgid "New folder"
 msgstr "ဖိုင်တွဲအသစ်"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "သီချင်းစာရင်းအသစ်"
 
@@ -3418,8 +3426,12 @@ msgstr "တေးသံလမ်းကြောအသစ်ဆုံးမျာ
 msgid "Next"
 msgstr "နောက်တစ်ခု"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "နောက်တေးသံလမ်းကြော"
 
@@ -3457,7 +3469,7 @@ msgstr "ဘလောက်တိုများမရှိ"
 msgid "None"
 msgstr "ဘယ်တစ်ခုမျှ"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "ရွေးချယ်ပြီးသီချင်းများတစ်ခုမှပစ္စည်းသို့ကူးယူရန်မသင့်တော်"
 
@@ -3542,19 +3554,19 @@ msgstr "ပိတ်"
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "အောဖ့်အက်ဖ်အယ်အေစီ"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "အောဖ့်တေး"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "အောဖ့်စဖိစ်"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3598,7 +3610,7 @@ msgstr "အလင်းပိတ်မှု"
 msgid "Open %1 in browser"
 msgstr "ဘရောက်ဇာထဲတွင် %1 ဖွင့်"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "အသံဓာတ်ပြားဖွင့်(&a)..."
 
@@ -3610,7 +3622,7 @@ msgstr "အိုပီအမ်အယ်ဖိုင်ဖွင့်"
 msgid "Open OPML file..."
 msgstr "အိုပီအမ်အယ်ဖိုင်ဖွင့်..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr ""
 
@@ -3618,7 +3630,7 @@ msgstr ""
 msgid "Open device"
 msgstr "ပစ္စည်းဖွင့်"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "ဖိုင်ဖွင့်..."
 
@@ -3672,7 +3684,7 @@ msgstr "တေး"
 msgid "Organise Files"
 msgstr "ဖိုင်များစုစည်း"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "ဖိုင်များစုစည်း..."
 
@@ -3756,7 +3768,7 @@ msgstr "အဖွဲ့"
 msgid "Password"
 msgstr "စကားဝှက်"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "ရပ်တန့်"
@@ -3780,6 +3792,10 @@ msgstr "တင်ဆင်သူ"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "အစက်အပြောက်"
@@ -3788,10 +3804,10 @@ msgstr "အစက်အပြောက်"
 msgid "Plain sidebar"
 msgstr "ဘေးတိုင်ရိုးရိုး"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "ဖွင့်"
 
@@ -3812,11 +3828,11 @@ msgstr "ရပ်တန့်ပြီးလျှင်ဖွင့်၊ ဖ�
 msgid "Play if there is nothing already playing"
 msgstr "ဘယ်သီချင်းမှဖွင့်မနေလျှင်စတင်ဖွင့်"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3915,7 +3931,7 @@ msgstr "လိုလားချက်"
 msgid "Preferences"
 msgstr "လိုလားချက်များ"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "လိုလားချက်များ..."
 
@@ -3975,7 +3991,7 @@ msgid "Previous"
 msgstr "ယခင်"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "ယခင်တေးသံလမ်းကြော"
 
@@ -4033,16 +4049,16 @@ msgstr "အရည်အသွေး"
 msgid "Querying device..."
 msgstr "ပစ္စည်းမေးမြန်းခြင်း..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "စီတန်းမန်နေဂျာ"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "ရွေးချယ်တေးသံလမ်းကြောများစီတန်း"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "တေးသံလမ်းကြောစီတန်း"
 
@@ -4058,7 +4074,7 @@ msgstr "ရေဒီယို (တေးသံလမ်းကြောမျာ�
 msgid "Rain"
 msgstr "မိုး"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "မိုး"
@@ -4170,7 +4186,7 @@ msgstr "လုပ်ဆောင်ချက်ဖယ်ရှား"
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "သီချင်းစာရင်းမှပုံတူများဖယ်ရှား"
 
@@ -4178,7 +4194,7 @@ msgstr "သီချင်းစာရင်းမှပုံတူများ
 msgid "Remove folder"
 msgstr "ဖိုင်တွဲဖယ်ရှား"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "သီချင်းစာရင်းမှဖယ်ရှား"
 
@@ -4190,7 +4206,7 @@ msgstr "သီချင်းစာရင်းဖယ်ရှား"
 msgid "Remove playlists"
 msgstr "သီချင်းစာရင်းများဖယ်ရှား"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr ""
 
@@ -4202,7 +4218,7 @@ msgstr "သီချင်းစာရင်းနာမည်ပြန်ရွ
 msgid "Rename playlist..."
 msgstr "သီချင်းစာရင်းနာမည်ပြန်ရွေး..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "တေးသံလမ်းကြောများယခုအစဉ်အလိုက်နံပါတ်ပြန်ပြောင်းပါ..."
 
@@ -4293,7 +4309,7 @@ msgstr "တင်သွင်း"
 msgid "Rip CD"
 msgstr "စီဒီတင်သွင်း"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr ""
 
@@ -4371,7 +4387,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "သီချင်းစာရင်းမှတ်သား"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "သီချင်းစာရင်းမှတ်သား..."
 
@@ -4458,7 +4474,7 @@ msgstr "ဆပ်ဆိုးနစ်ရှာဖွေ"
 msgid "Search automatically"
 msgstr "အလိုအလျောက်ရှာဖွေ"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4471,7 +4487,7 @@ msgstr "အယ်လဘမ်အဖုံးများအားရှာဖွ
 msgid "Search for anything"
 msgstr "တစ်စုံတစ်ရာဖြစ်ဖြစ်ရှာဖွေ"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4596,7 +4612,7 @@ msgstr "ဆာဗာအသေးစိတ်အကြောင်းအရာမ
 msgid "Service offline"
 msgstr "အောဖ့်လိုင်းဝန်ဆောင်မှု"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "%1 မှ \"%2\" ထိန်းညှိ..."
@@ -4605,7 +4621,7 @@ msgstr "%1 မှ \"%2\" ထိန်းညှိ..."
 msgid "Set the volume to <value> percent"
 msgstr "အသံပမာဏ <value> ရာခိုင်နှုန်းခန့်ထိန်းညှိ"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "ရွေးချယ်တေးသံလမ်းကြောများအားလံုးအတွက်တန်ဖိုးထိန်းညှိ..."
 
@@ -4676,7 +4692,7 @@ msgstr "ဖန်သားပြင်ပေါ်ပံုရိပ်လှလ
 msgid "Show above status bar"
 msgstr "အခြေအနေပြတိုင်အပေါ်မှာပြသ"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "သီချင်းများအားလံုးပြသ"
 
@@ -4696,12 +4712,12 @@ msgstr "ခွဲခြားမှုများပြသ"
 msgid "Show fullsize..."
 msgstr "အရွယ်အပြည့်ပြသ..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "ဖိုင်ဘရောက်ဇာထဲမှာပြသ..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr ""
 
@@ -4713,15 +4729,15 @@ msgstr "အနုပညာရှင်များအမျိုးမျို
 msgid "Show moodbar"
 msgstr "စိတ်နေစိတ်ထားဘားမျဉ်းပြသ"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "ပုံတူများသာပြသ"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "အမည်မရှိများသာပြသ"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4729,7 +4745,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr "ရှာဖွေအကြံပြုချက်များပြသ"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4765,7 +4781,7 @@ msgstr "အယ်လဘမ်များကုလားဖန်ထိုး"
 msgid "Shuffle all"
 msgstr "ကုလားဖန်အားလံုးထိုး"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "သီချင်းစာရင်းကုလားဖန်ထိုး"
 
@@ -4809,11 +4825,15 @@ msgstr "အရေအတွက်ခုန်ကျော်"
 msgid "Skip forwards in playlist"
 msgstr "စာရင်းရှိရှေ့သို့များခုန်ကျော်"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr ""
 
@@ -4930,7 +4950,7 @@ msgstr ""
 msgid "Start the playlist currently playing"
 msgstr "လက်ရှိဖွင့်ဆဲသီချင်းစာရင်းစတင်"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "ပံုစံပြောင်းလဲခြင်းစတင်"
 
@@ -4940,7 +4960,7 @@ msgid ""
 "list"
 msgstr "ရှာဖွေရလဒ်များစာရင်းများကိုဖြည့်ရန်ရှာဖွေနေရာတွင်တစ်ခုခုရိုက်ထည့်ပါ"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "%1 စတင်နေ"
@@ -4950,7 +4970,7 @@ msgid "Starting..."
 msgstr "စတင်နေ..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "ရပ်"
 
@@ -4966,7 +4986,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "ဒီတေးသံလမ်းကြောပြီးနောက်ရပ်"
 
@@ -5134,7 +5154,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "ဆပ်ဆိုးနစ်ဆာဗာအစမ်းသံုးကာလပြီးဆံုး။ လိုင်စင်ကီးရယူရန်ငွေလှုပါ။ အသေးစိတ်အကြောင်းအရာများအတွက် subsonic.org သို့လည်ပတ်ပါ။"
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5176,7 +5196,7 @@ msgid ""
 "continue?"
 msgstr "ပစ္စည်းမှယခုဖို်င်များအားလံုးပယ်ဖျက်မည်၊ လုပ်ဆောင်မည်လား?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5278,11 +5298,11 @@ msgstr "ဖန်သားပြင်ပေါ်ပံုရိပ်လှလ
 msgid "Toggle fullscreen"
 msgstr "ဖန်သားပြင်အပြည့်ဖွင့်ပိတ်လုပ်"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "စီတန်းအခြေအနေဖွင့်ပိတ်လုပ်"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "သီချင်းနာမည်ပေးပို့ခြင်းဖွင့်ပိတ်လုပ်"
 
@@ -5327,19 +5347,19 @@ msgstr ""
 msgid "Track"
 msgstr "တေးသံလမ်းကြော"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "ဂီတပံုစံပြောင်းလဲခြင်း"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "ပံုစံပြောင်းလဲခြင်းမှတ်တမ်း"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "ပံုစံပြောင်းလဲခြင်း"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "%2 ပရိုဂရမ်များအသံုးပြုပြီး %1 ဖိုင်များပြောင်းလဲခြင်း"
@@ -5416,11 +5436,11 @@ msgstr "အမည်မသိအမှားပြ"
 msgid "Unset cover"
 msgstr "အဖုံးမသတ်မှတ်"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr ""
 
@@ -5437,7 +5457,7 @@ msgstr "လာမည့်ဂီတဖြေဖျော်ပွဲများ
 msgid "Update all podcasts"
 msgstr "ပို့စ်ကဒ်များစစ်ဆေးခြင်း"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "ပြောင်းလဲပြီးသီချင်းတိုက်ဖိုင်တွဲများမွမ်းမံ"
 
@@ -5598,7 +5618,7 @@ msgstr "ပုံစံ %1"
 msgid "View"
 msgstr "ကြည့်ရှု"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5606,7 +5626,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr "ပုံဖော်ကြည့်ခြင်းစနစ်"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "ပုံဖော်ကြည့်ခြင်းများ"
 
@@ -5647,7 +5667,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "တပလူအေဗီ"
 
@@ -5743,7 +5763,7 @@ msgstr "ဝင်းဒိုးမီဒီယာ၄၀ကီလို"
 msgid "Windows Media 64k"
 msgstr "ဝင်းဒိုးမီဒီယာ၆၄ကီလို"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "ဝင်းဒိုးမီဒီယာအသံ"
 
@@ -5757,7 +5777,7 @@ msgid ""
 "well?"
 msgstr "အနုပညာရှင်များအမျိုးမျိုးသို့ယခုအယ်လဘမ်မှတစ်ခြားသီချင်းများကိုရွှေ့"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "ယခုနောက်တစ်ချိန်အပြည့်ပြန်လည်ဖတ်ရှု?"
 

--- a/src/translations/my.po
+++ b/src/translations/my.po
@@ -509,7 +509,7 @@ msgstr "သီချင်းစီးကြောင်းနောက်တစ
 msgid "Add directory..."
 msgstr "ဖိုင်လမ်းညွှန်ထည့်..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "ဖိုင်ထည့်"
 
@@ -529,7 +529,7 @@ msgstr "ဖိုင်ထည့်..."
 msgid "Add files to transcode"
 msgstr "ဖိုင်များကိုပံုစံပြောင်းလဲရန်ထည့်ပါ"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "ဖိုင်တွဲထည့်"
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "သီချင်းစာရင်းနောက်တစ်ခုသို့ထည့်"
 
@@ -856,7 +856,7 @@ msgstr "သီချင်းတိုက်သီချင်းများအ
 msgid "Artist"
 msgstr "အနုပညာရှင်"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "အနုပညာရှင်အချက်အလက်"
 
@@ -1119,7 +1119,7 @@ msgstr "တွဲအသစ်များစစ်ဆေးခြင်း"
 msgid "Check for updates"
 msgstr "မွမ်းမံများစစ်ဆေးခြင်း"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "မွမ်းမံများစစ်ဆေးခြင်း..."
 
@@ -1359,7 +1359,7 @@ msgstr "ဆပ်ဆိုးနစ်ပုံစံပြင်..."
 msgid "Configure global search..."
 msgstr "အနှံ့ရှာဖွေပုံစံပြင်..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "သီချင်းတိုက်ပုံစံပြင်..."
 
@@ -1431,11 +1431,11 @@ msgid "Copy to clipboard"
 msgstr "အောက်ခံကတ်ပြားသို့ကူးယူ"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "ပစ္စည်းသို့ကူးယူ"
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "သီချင်းတိုက်သို့ကူးယူ..."
@@ -1653,7 +1653,7 @@ msgid "Delete downloaded data"
 msgstr "ကူးဆွဲပြီးအချက်အလက်ပယ်ဖျက်"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "ဖိုင်များပယ်ဖျက်"
 
@@ -1661,7 +1661,7 @@ msgstr "ဖိုင်များပယ်ဖျက်"
 msgid "Delete from device..."
 msgstr "ပစ္စည်းမှပယ်ဖျက်..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "ဓာတ်ပြားမှပယ်ဖျက်..."
@@ -1694,11 +1694,11 @@ msgstr "ဖိုင်များပယ်ဖျက်နေ"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "ရွေးချယ်တေးသံလမ်းကြောများမစီတန်း"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "တေးသံလမ်းကြောမစီတန်း"
 
@@ -1727,7 +1727,7 @@ msgstr "ပစ္စည်းနာမည်"
 msgid "Device properties..."
 msgstr "ပစ္စည်းဂုဏ်သတ္တိများ..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "ပစ္စည်းများ"
 
@@ -1978,7 +1978,7 @@ msgstr "ကျပန်းရောသမမွှေအရှင်"
 msgid "Edit smart playlist..."
 msgstr "ချက်ချာသီချင်းစာရင်းပြင်ဆင်..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "အမည်ပြင်ဆင် \"%1\"..."
@@ -2117,8 +2117,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Equivalent to --log-levels *:3တူညီ"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "အမှားပြ"
 
@@ -2264,7 +2264,7 @@ msgstr "အရောင်မှိန်"
 msgid "Fading duration"
 msgstr "အရောင်မှိန်ကြာချိန်"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2387,7 +2387,7 @@ msgstr "ဖိုင်အမျိုးအစား"
 msgid "Filename"
 msgstr "ဖိုင်နာမည်"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "ဖိုင်များ"
 
@@ -2802,7 +2802,7 @@ msgstr "သွင်းပြီး"
 msgid "Integrity check"
 msgstr "ခိုင်မြဲမှုစစ်ဆေး"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "အင်တာနက်"
 
@@ -2990,7 +2990,7 @@ msgstr "ဘယ်"
 msgid "Length"
 msgstr "အလျား"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "သီချင်းတိုက်"
@@ -2999,7 +2999,7 @@ msgstr "သီချင်းတိုက်"
 msgid "Library advanced grouping"
 msgstr "သီချင်းတိုက်အဆင့်မြင့်အုပ်စုဖွဲ့ခြင်း"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "သီချင်းတိုက်ပြန်လည်ဖတ်ရှုအကြောင်းကြားစာ"
 
@@ -3327,7 +3327,7 @@ msgstr "အမှတ်များစီစဉ်"
 msgid "Move down"
 msgstr "အောက်သို့ရွှေ့"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "သီချင်းတိုက်သို့ရွှေ့..."
 
@@ -3336,7 +3336,7 @@ msgstr "သီချင်းတိုက်သို့ရွှေ့..."
 msgid "Move up"
 msgstr "အပေါ်သို့ရွှေ့"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "ဂီတ"
 
@@ -3398,7 +3398,7 @@ msgstr "သီချင်းလုံးဝစတင်မဖွင့်"
 msgid "New folder"
 msgstr "ဖိုင်တွဲအသစ်"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "သီချင်းစာရင်းအသစ်"
 
@@ -3469,7 +3469,7 @@ msgstr "ဘလောက်တိုများမရှိ"
 msgid "None"
 msgstr "ဘယ်တစ်ခုမျှ"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "ရွေးချယ်ပြီးသီချင်းများတစ်ခုမှပစ္စည်းသို့ကူးယူရန်မသင့်တော်"
 
@@ -3684,7 +3684,7 @@ msgstr "တေး"
 msgid "Organise Files"
 msgstr "ဖိုင်များစုစည်း"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "ဖိုင်များစုစည်း..."
 
@@ -3768,7 +3768,7 @@ msgstr "အဖွဲ့"
 msgid "Password"
 msgstr "စကားဝှက်"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "ရပ်တန့်"
@@ -3804,8 +3804,8 @@ msgstr "အစက်အပြောက်"
 msgid "Plain sidebar"
 msgstr "ဘေးတိုင်ရိုးရိုး"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3828,11 +3828,11 @@ msgstr "ရပ်တန့်ပြီးလျှင်ဖွင့်၊ ဖ�
 msgid "Play if there is nothing already playing"
 msgstr "ဘယ်သီချင်းမှဖွင့်မနေလျှင်စတင်ဖွင့်"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3871,7 +3871,7 @@ msgstr "သီချင်းစာရင်းရွေးပိုင်ခွ
 msgid "Playlist type"
 msgstr "သီချင်းစာရင်းအမျိုးအစား"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "သီချင်းစာရင်းများ"
 
@@ -4053,12 +4053,12 @@ msgstr "ပစ္စည်းမေးမြန်းခြင်း..."
 msgid "Queue Manager"
 msgstr "စီတန်းမန်နေဂျာ"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "ရွေးချယ်တေးသံလမ်းကြောများစီတန်း"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "တေးသံလမ်းကြောစီတန်း"
 
@@ -4449,7 +4449,7 @@ msgstr ""
 msgid "Search"
 msgstr "ရှာဖွေ"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "ရှာဖွေ"
@@ -4474,7 +4474,7 @@ msgstr "ဆပ်ဆိုးနစ်ရှာဖွေ"
 msgid "Search automatically"
 msgstr "အလိုအလျောက်ရှာဖွေ"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4487,7 +4487,7 @@ msgstr "အယ်လဘမ်အဖုံးများအားရှာဖွ
 msgid "Search for anything"
 msgstr "တစ်စုံတစ်ရာဖြစ်ဖြစ်ရှာဖွေ"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4612,7 +4612,7 @@ msgstr "ဆာဗာအသေးစိတ်အကြောင်းအရာမ
 msgid "Service offline"
 msgstr "အောဖ့်လိုင်းဝန်ဆောင်မှု"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "%1 မှ \"%2\" ထိန်းညှိ..."
@@ -4692,7 +4692,7 @@ msgstr "ဖန်သားပြင်ပေါ်ပံုရိပ်လှလ
 msgid "Show above status bar"
 msgstr "အခြေအနေပြတိုင်အပေါ်မှာပြသ"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "သီချင်းများအားလံုးပြသ"
 
@@ -4712,12 +4712,12 @@ msgstr "ခွဲခြားမှုများပြသ"
 msgid "Show fullsize..."
 msgstr "အရွယ်အပြည့်ပြသ..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "ဖိုင်ဘရောက်ဇာထဲမှာပြသ..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr ""
 
@@ -4729,11 +4729,11 @@ msgstr "အနုပညာရှင်များအမျိုးမျို
 msgid "Show moodbar"
 msgstr "စိတ်နေစိတ်ထားဘားမျဉ်းပြသ"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "ပုံတူများသာပြသ"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "အမည်မရှိများသာပြသ"
 
@@ -4825,7 +4825,7 @@ msgstr "အရေအတွက်ခုန်ကျော်"
 msgid "Skip forwards in playlist"
 msgstr "စာရင်းရှိရှေ့သို့များခုန်ကျော်"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr ""
 
@@ -4833,7 +4833,7 @@ msgstr ""
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr ""
 
@@ -4865,7 +4865,7 @@ msgstr "ပျော့ရော့ခ်ဂီတ"
 msgid "Song Information"
 msgstr "သီချင်းအချက်အလက်"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "သီချင်းအချက်အလက်"
 
@@ -4986,7 +4986,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "ဒီတေးသံလမ်းကြောပြီးနောက်ရပ်"
 
@@ -5154,7 +5154,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "ဆပ်ဆိုးနစ်ဆာဗာအစမ်းသံုးကာလပြီးဆံုး။ လိုင်စင်ကီးရယူရန်ငွေလှုပါ။ အသေးစိတ်အကြောင်းအရာများအတွက် subsonic.org သို့လည်ပတ်ပါ။"
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5196,7 +5196,7 @@ msgid ""
 "continue?"
 msgstr "ပစ္စည်းမှယခုဖို်င်များအားလံုးပယ်ဖျက်မည်၊ လုပ်ဆောင်မည်လား?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5298,7 +5298,7 @@ msgstr "ဖန်သားပြင်ပေါ်ပံုရိပ်လှလ
 msgid "Toggle fullscreen"
 msgstr "ဖန်သားပြင်အပြည့်ဖွင့်ပိတ်လုပ်"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "စီတန်းအခြေအနေဖွင့်ပိတ်လုပ်"
 
@@ -5436,11 +5436,11 @@ msgstr "အမည်မသိအမှားပြ"
 msgid "Unset cover"
 msgstr "အဖုံးမသတ်မှတ်"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr ""
 
@@ -5777,7 +5777,7 @@ msgid ""
 "well?"
 msgstr "အနုပညာရှင်များအမျိုးမျိုးသို့ယခုအယ်လဘမ်မှတစ်ခြားသီချင်းများကိုရွှေ့"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "ယခုနောက်တစ်ချိန်အပြည့်ပြန်လည်ဖတ်ရှု?"
 

--- a/src/translations/nb.po
+++ b/src/translations/nb.po
@@ -12,7 +12,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Norwegian Bokmål (http://www.transifex.com/davidsansome/clementine/language/nb/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -166,19 +166,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filnavn%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "kunne ikke: %n"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n ferdige"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -196,7 +196,7 @@ msgstr "Sentr&er"
 msgid "&Custom"
 msgstr "&Egendefinert"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Ekstra"
 
@@ -204,7 +204,7 @@ msgstr "&Ekstra"
 msgid "&Grouping"
 msgstr "&Gruppering"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "Hjelp"
 
@@ -229,7 +229,7 @@ msgstr "&Lås poenggivning"
 msgid "&Lyrics"
 msgstr "&Sangtekster"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "Musikk"
 
@@ -237,15 +237,15 @@ msgstr "Musikk"
 msgid "&None"
 msgstr "&Ingen"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&Spilleliste"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Avslutt"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "&Gjentagelsesmodus"
 
@@ -253,7 +253,7 @@ msgstr "&Gjentagelsesmodus"
 msgid "&Right"
 msgstr "&Høyre"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "&Stokkemodus"
 
@@ -261,7 +261,7 @@ msgstr "&Stokkemodus"
 msgid "&Stretch columns to fit window"
 msgstr "Fyll &kolonner i vinduet"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Verktøy"
 
@@ -450,11 +450,11 @@ msgstr "Avbryt"
 msgid "About %1"
 msgstr "Om %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Om Clementine…"
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Om Qt…"
 
@@ -514,32 +514,32 @@ msgstr "Legg til enda en strøm…"
 msgid "Add directory..."
 msgstr "Legg til mappe…"
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Legg til fil"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Legg fil til omkoder"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Legg fil(er) til omkoder"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Legg til fil…"
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Legg filer til for omkoding"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Legg til mappe"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Legg til mappe…"
 
@@ -551,7 +551,7 @@ msgstr "Legg til mappe…"
 msgid "Add podcast"
 msgstr "Legg til nettradioopptak"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Legg til nettradioopptak…"
 
@@ -627,7 +627,7 @@ msgstr "Fest etikett for låtnummer til sporet"
 msgid "Add song year tag"
 msgstr "Fest etikett for utgivelsesår på sporet"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Legg til strøm…"
 
@@ -639,7 +639,7 @@ msgstr "Legg til Spotify-spilleliste"
 msgid "Add to Spotify starred"
 msgstr "Legg til stjernemerkede på Spotify"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Legg til i annen spilleliste"
 
@@ -733,7 +733,7 @@ msgstr "Alle"
 msgid "All Files (*)"
 msgstr "Alle filer (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Ære være Hypnotoad!"
@@ -1124,7 +1124,7 @@ msgstr "Se etter nye episoder"
 msgid "Check for updates"
 msgstr "Se etter oppdateringer"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Se etter oppdateringer…"
 
@@ -1173,18 +1173,18 @@ msgstr "Klassisk"
 msgid "Cleaning up"
 msgstr "Rydder"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Tøm"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Tøm spillelisten"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1329,7 +1329,7 @@ msgstr "Kommentar"
 msgid "Complete tags automatically"
 msgstr "Fyll ut etiketter automatisk"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Full ut etiketter automatisk…"
 
@@ -1364,7 +1364,7 @@ msgstr "Sett opp Subsonic…"
 msgid "Configure global search..."
 msgstr "Sett opp globalt søk…"
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Sett opp bibliotek…"
 
@@ -1407,7 +1407,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Tidsavbrudd i tilkoblingen; sjekk tjener-URL. For eksempel: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Konsoll"
 
@@ -1436,11 +1436,11 @@ msgid "Copy to clipboard"
 msgstr "Kopier til utklippstavla"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopier til enhet…"
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kopier til bibliotek…"
@@ -1483,14 +1483,14 @@ msgstr "Klarte ikke å logge inn på Last.fm. Prøv igjen."
 msgid "Couldn't create playlist"
 msgstr "Kunne ikke opprette spilleliste"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Kunne ikke finne multiplekser for %1, sjekk at du har de riktige GStreamer-programutvidelsene installert"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1505,7 +1505,7 @@ msgstr "Kunne ikke åpne output fil %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Behandling av plateomslag"
 
@@ -1658,7 +1658,7 @@ msgid "Delete downloaded data"
 msgstr "Slett nedlastet data"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Slett filer"
 
@@ -1666,7 +1666,7 @@ msgstr "Slett filer"
 msgid "Delete from device..."
 msgstr "Slett fra enhet…"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Slett fra disk…"
@@ -1699,11 +1699,11 @@ msgstr "Sletter filer"
 msgid "Depth"
 msgstr "Dybde"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Fjern valgte spor fra avspillingskøen"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Fjern sporet fra avspillingskøen"
 
@@ -1804,7 +1804,7 @@ msgstr "Visningsalternativ"
 msgid "Display the on-screen-display"
 msgstr "Overleggsvisning"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Søk gjennom hele biblioteket"
 
@@ -1983,12 +1983,12 @@ msgstr "Dynamisk tilfeldig miks"
 msgid "Edit smart playlist..."
 msgstr "Rediger smart spilleliste…"
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Rediger etiketten \"%1\"…"
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Rediger etikett…"
 
@@ -2001,7 +2001,7 @@ msgid "Edit track information"
 msgstr "Rediger sporinfo"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Rediger sporinfo…"
 
@@ -2109,7 +2109,7 @@ msgstr "Hele samlingen"
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Tonekontroll"
 
@@ -2122,8 +2122,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Tilsvarer --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Feil"
 
@@ -2158,7 +2158,7 @@ msgstr "Kunne ikke laste inn %1"
 msgid "Error loading di.fm playlist"
 msgstr "Kunne ikke laste ned spillelista fra di.fm"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Kunne ikke behandle %1: %2"
@@ -2241,7 +2241,11 @@ msgstr "Eksport fullført"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "%1 av %2 omslag eksportert (hoppet over %3)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2265,7 +2269,7 @@ msgstr "Ton inn/ut"
 msgid "Fading duration"
 msgstr "Tonings-varighet"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Kunne ikke lese av CD-ROM-en"
 
@@ -2547,11 +2551,11 @@ msgstr "Gi den et navn:"
 msgid "Go"
 msgstr "Gå"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Gå til neste fane på spillelista"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Gå til forrige fane på spillelista"
 
@@ -2884,7 +2888,7 @@ msgstr "Jamendo-database"
 msgid "Jump to previous song right away"
 msgstr "Gå til forrige sang nå"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Gå til sporet som spilles av nå"
 
@@ -2908,7 +2912,7 @@ msgstr "Fortsett i bakgrunnen selv om vinduet lukkes"
 msgid "Keep the original files"
 msgstr "Behold originalfilene"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Småpuser"
@@ -3000,7 +3004,7 @@ msgstr "Bibliotek"
 msgid "Library advanced grouping"
 msgstr "Avansert biblioteksgruppering"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Melding om gjennomsøk av biblioteket"
 
@@ -3040,7 +3044,7 @@ msgstr "Hent omslag fra disk…"
 msgid "Load playlist"
 msgstr "Åpne spilleliste"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Åpne spilleliste…"
 
@@ -3101,11 +3105,15 @@ msgstr "Innlogging"
 msgid "Login failed"
 msgstr "Innlogging feilet"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Profil for langtidspredikie (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Elsker"
 
@@ -3140,11 +3148,11 @@ msgstr "Sangtekster fra %1"
 msgid "Lyrics from the tag"
 msgstr "Sangtekster fra etiketten"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3186,7 +3194,7 @@ msgstr "Hovedprofil (MAIN)"
 msgid "Make it so!"
 msgstr "Hold munn, Wesley."
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Hold munn, Wesley."
@@ -3324,7 +3332,7 @@ msgstr "Monteringspunkter"
 msgid "Move down"
 msgstr "Flytt nedover"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Flytt til bibliotek…"
 
@@ -3333,7 +3341,7 @@ msgstr "Flytt til bibliotek…"
 msgid "Move up"
 msgstr "Flytt oppover"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Musikk"
 
@@ -3346,7 +3354,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Demp"
 
@@ -3395,7 +3403,7 @@ msgstr "Aldri begynn avspilling"
 msgid "New folder"
 msgstr "Ny mappe"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Ny spilleliste"
 
@@ -3423,8 +3431,12 @@ msgstr "Nyeste spor"
 msgid "Next"
 msgstr "Neste"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Neste spor"
 
@@ -3462,7 +3474,7 @@ msgstr "Ikke korte blokker"
 msgid "None"
 msgstr "Ingen"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Kunne ikke kopiere noen av de valgte sangene til en enhet"
 
@@ -3547,19 +3559,19 @@ msgstr "Av"
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "OGG FLAC"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3603,7 +3615,7 @@ msgstr "Dekkevne"
 msgid "Open %1 in browser"
 msgstr "Åpne %1 i nettleser"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Åpne lyd-&CD"
 
@@ -3615,7 +3627,7 @@ msgstr "Åpne OPML-fil"
 msgid "Open OPML file..."
 msgstr "Åpne OPML-fil…"
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Importer musikk fra ei mappe"
 
@@ -3623,7 +3635,7 @@ msgstr "Importer musikk fra ei mappe"
 msgid "Open device"
 msgstr "Åpne enhet"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Åpne fil…"
 
@@ -3677,7 +3689,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organiser filer"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Organiser filer…"
 
@@ -3761,7 +3773,7 @@ msgstr "Fest"
 msgid "Password"
 msgstr "Passord"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pause"
@@ -3785,6 +3797,10 @@ msgstr "Utøver"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Piksel"
@@ -3793,10 +3809,10 @@ msgstr "Piksel"
 msgid "Plain sidebar"
 msgstr "Enkelt sidefelt"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Spill"
 
@@ -3817,11 +3833,11 @@ msgstr "Hvis stoppet: Spill av. Hvis spiller: pause"
 msgid "Play if there is nothing already playing"
 msgstr "Spill hvis det ikke er noe annet som spilles av for øyeblikket"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3920,7 +3936,7 @@ msgstr "Innstillinger"
 msgid "Preferences"
 msgstr "Innstillinger"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Innstillinger…"
 
@@ -3980,7 +3996,7 @@ msgid "Previous"
 msgstr "Forrige"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Forrige spor"
 
@@ -4038,16 +4054,16 @@ msgstr "Kvalitet"
 msgid "Querying device..."
 msgstr "Spør enhet…"
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Købehandler"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Legg valgte spor i kø"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Legg spor i kø"
 
@@ -4063,7 +4079,7 @@ msgstr "Radio (lik lydstyrkeutgjevning for alle spor)"
 msgid "Rain"
 msgstr "Regn"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Regn"
@@ -4175,7 +4191,7 @@ msgstr "Fjern handling"
 msgid "Remove current song from playlist"
 msgstr "Fjern gjeldene sang fra spillelisten"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Fjern duplikater fra spillelisten"
 
@@ -4183,7 +4199,7 @@ msgstr "Fjern duplikater fra spillelisten"
 msgid "Remove folder"
 msgstr "Fjern mappe"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Fjern fra spillelisten"
 
@@ -4195,7 +4211,7 @@ msgstr "Fjern spilleliste"
 msgid "Remove playlists"
 msgstr "Fjern spillelister"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Fjern utilgjengelige spor fra spilleliste"
 
@@ -4207,7 +4223,7 @@ msgstr "Gi nytt navn til spillelista"
 msgid "Rename playlist..."
 msgstr "Gi nytt navn til spillelista…"
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Renummerer sporene i denne rekkefølgen…"
 
@@ -4298,7 +4314,7 @@ msgstr "Ripp"
 msgid "Rip CD"
 msgstr "Ripp CD"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Kopier lyd-CD"
 
@@ -4376,7 +4392,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Lagre spilleliste"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Lagre spilleliste…"
 
@@ -4463,7 +4479,7 @@ msgstr "Søk i Subsonic"
 msgid "Search automatically"
 msgstr "Automatisk søk"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Søk etter album"
 
@@ -4476,7 +4492,7 @@ msgstr "Søk etter albumomslag…"
 msgid "Search for anything"
 msgstr "Søk etter hva som helst"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Søk etter artist"
 
@@ -4601,7 +4617,7 @@ msgstr "Tjenerdetaljer"
 msgid "Service offline"
 msgstr "Tjenesten er utilgjengelig"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Sett %1 til \"%2\"…"
@@ -4610,7 +4626,7 @@ msgstr "Sett %1 til \"%2\"…"
 msgid "Set the volume to <value> percent"
 msgstr "Sett lydstyrken til <verdi> prosent"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Sett verdi for alle valgte spor…"
 
@@ -4681,7 +4697,7 @@ msgstr "Vis et pent skjermbildeoverlegg"
 msgid "Show above status bar"
 msgstr "Vis over statuslinja"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Vis alle sanger"
 
@@ -4701,12 +4717,12 @@ msgstr "Vis adskillere"
 msgid "Show fullsize..."
 msgstr "Fullskjermsvisning…"
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Vis i filbehandler…"
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Vis i bibliotek…"
 
@@ -4718,15 +4734,15 @@ msgstr "Vis under Diverse Artister"
 msgid "Show moodbar"
 msgstr "Vis stemningsstolpe"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Bare vis duplikater"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Bare vis filer uten etiketter"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Vis eller gjem sidefeltet"
 
@@ -4734,7 +4750,7 @@ msgstr "Vis eller gjem sidefeltet"
 msgid "Show search suggestions"
 msgstr "Vis søkeforslag"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Vis sidefelt"
 
@@ -4770,7 +4786,7 @@ msgstr "Stokk om album"
 msgid "Shuffle all"
 msgstr "Stokk alle"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Stokk om spillelista"
 
@@ -4814,11 +4830,15 @@ msgstr "Antall ganger hoppet over"
 msgid "Skip forwards in playlist"
 msgstr "Gå fremover i spillelista"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Hopp over valgte spor"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Hopp over spor"
 
@@ -4935,7 +4955,7 @@ msgstr "Start ripping"
 msgid "Start the playlist currently playing"
 msgstr "Begynn på spillelista som spilles nå"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Start omkoding"
 
@@ -4945,7 +4965,7 @@ msgid ""
 "list"
 msgstr "Skriv noe i søkeboksen ovenfor for å fylle denne resultatlisten"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Starter %1"
@@ -4955,7 +4975,7 @@ msgid "Starting..."
 msgstr "Starter…"
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Stopp"
 
@@ -4971,7 +4991,7 @@ msgstr "Stopp etter hvert spor"
 msgid "Stop after every track"
 msgstr "Stopp etter hvert spor"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Stopp etter denne sangen"
 
@@ -5139,7 +5159,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Prøveperioden for Subsonic er over. Gi en donasjon for å få en lisensnøkkel. Besøk subsonic.org for mer informasjon."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5181,7 +5201,7 @@ msgid ""
 "continue?"
 msgstr "Filene vil bli slettet fra enheten. Er du sikker?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5283,11 +5303,11 @@ msgstr "Slå av/på pent skjermbildeoverlegg"
 msgid "Toggle fullscreen"
 msgstr "Slå av/på fullskjermsmodus"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Slå av/på køstatus"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Slå av/på deling av lyttevaner"
 
@@ -5332,19 +5352,19 @@ msgstr "&Spor"
 msgid "Track"
 msgstr "Spor"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Omkod musikk"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Logg for omkoder"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Omkoding"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Omkoder %1 filer i %2 tråder"
@@ -5421,11 +5441,11 @@ msgstr "Ukjent feil"
 msgid "Unset cover"
 msgstr "Fjern omslagsvalg"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Ikke hopp over de valgte sporene"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Ikke hopp over sporet"
 
@@ -5442,7 +5462,7 @@ msgstr "Fremtidige konserter"
 msgid "Update all podcasts"
 msgstr "Oppdater alle nettradioopptak"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Oppdater endrede bibliotekmapper"
 
@@ -5603,7 +5623,7 @@ msgstr "Versjon %1"
 msgid "View"
 msgstr "Vis"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Vis strømnings-detaljer"
 
@@ -5611,7 +5631,7 @@ msgstr "Vis strømnings-detaljer"
 msgid "Visualization mode"
 msgstr "Visualiseringsmodus"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Visualiseringer"
 
@@ -5652,7 +5672,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "WAV"
 
@@ -5748,7 +5768,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media audio"
 
@@ -5762,7 +5782,7 @@ msgid ""
 "well?"
 msgstr "Ønsker du å også flytte resten av sangene fra albumet til Diverse artister?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Vil du søke gjennom hele biblioteket på ny nå?"
 

--- a/src/translations/nb.po
+++ b/src/translations/nb.po
@@ -514,7 +514,7 @@ msgstr "Legg til enda en strøm…"
 msgid "Add directory..."
 msgstr "Legg til mappe…"
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Legg til fil"
 
@@ -534,7 +534,7 @@ msgstr "Legg til fil…"
 msgid "Add files to transcode"
 msgstr "Legg filer til for omkoding"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Legg til mappe"
@@ -639,7 +639,7 @@ msgstr "Legg til Spotify-spilleliste"
 msgid "Add to Spotify starred"
 msgstr "Legg til stjernemerkede på Spotify"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Legg til i annen spilleliste"
 
@@ -861,7 +861,7 @@ msgstr "Er du sikker på at du ønsker å skrive sangstatistikk inn i alle filen
 msgid "Artist"
 msgstr "Artist"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Artistinfo"
 
@@ -1124,7 +1124,7 @@ msgstr "Se etter nye episoder"
 msgid "Check for updates"
 msgstr "Se etter oppdateringer"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Se etter oppdateringer…"
 
@@ -1364,7 +1364,7 @@ msgstr "Sett opp Subsonic…"
 msgid "Configure global search..."
 msgstr "Sett opp globalt søk…"
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Sett opp bibliotek…"
 
@@ -1436,11 +1436,11 @@ msgid "Copy to clipboard"
 msgstr "Kopier til utklippstavla"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopier til enhet…"
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kopier til bibliotek…"
@@ -1658,7 +1658,7 @@ msgid "Delete downloaded data"
 msgstr "Slett nedlastet data"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Slett filer"
 
@@ -1666,7 +1666,7 @@ msgstr "Slett filer"
 msgid "Delete from device..."
 msgstr "Slett fra enhet…"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Slett fra disk…"
@@ -1699,11 +1699,11 @@ msgstr "Sletter filer"
 msgid "Depth"
 msgstr "Dybde"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Fjern valgte spor fra avspillingskøen"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Fjern sporet fra avspillingskøen"
 
@@ -1732,7 +1732,7 @@ msgstr "Enhetsnavn"
 msgid "Device properties..."
 msgstr "Egenskaper for enhet…"
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Enheter"
 
@@ -1983,7 +1983,7 @@ msgstr "Dynamisk tilfeldig miks"
 msgid "Edit smart playlist..."
 msgstr "Rediger smart spilleliste…"
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Rediger etiketten \"%1\"…"
@@ -2122,8 +2122,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Tilsvarer --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Feil"
 
@@ -2269,7 +2269,7 @@ msgstr "Ton inn/ut"
 msgid "Fading duration"
 msgstr "Tonings-varighet"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Kunne ikke lese av CD-ROM-en"
 
@@ -2392,7 +2392,7 @@ msgstr "Filtype"
 msgid "Filename"
 msgstr "Filnavn"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Filer"
 
@@ -2807,7 +2807,7 @@ msgstr "Installert"
 msgid "Integrity check"
 msgstr "Integritetskontrol"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internett"
 
@@ -2995,7 +2995,7 @@ msgstr "Venstre"
 msgid "Length"
 msgstr "Lengde"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Bibliotek"
@@ -3004,7 +3004,7 @@ msgstr "Bibliotek"
 msgid "Library advanced grouping"
 msgstr "Avansert biblioteksgruppering"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Melding om gjennomsøk av biblioteket"
 
@@ -3332,7 +3332,7 @@ msgstr "Monteringspunkter"
 msgid "Move down"
 msgstr "Flytt nedover"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Flytt til bibliotek…"
 
@@ -3341,7 +3341,7 @@ msgstr "Flytt til bibliotek…"
 msgid "Move up"
 msgstr "Flytt oppover"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Musikk"
 
@@ -3403,7 +3403,7 @@ msgstr "Aldri begynn avspilling"
 msgid "New folder"
 msgstr "Ny mappe"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Ny spilleliste"
 
@@ -3474,7 +3474,7 @@ msgstr "Ikke korte blokker"
 msgid "None"
 msgstr "Ingen"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Kunne ikke kopiere noen av de valgte sangene til en enhet"
 
@@ -3689,7 +3689,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organiser filer"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Organiser filer…"
 
@@ -3773,7 +3773,7 @@ msgstr "Fest"
 msgid "Password"
 msgstr "Passord"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pause"
@@ -3809,8 +3809,8 @@ msgstr "Piksel"
 msgid "Plain sidebar"
 msgstr "Enkelt sidefelt"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3833,11 +3833,11 @@ msgstr "Hvis stoppet: Spill av. Hvis spiller: pause"
 msgid "Play if there is nothing already playing"
 msgstr "Spill hvis det ikke er noe annet som spilles av for øyeblikket"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3876,7 +3876,7 @@ msgstr "Innstillinger for spilleliste"
 msgid "Playlist type"
 msgstr "Type spilleliste"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Spillelister"
 
@@ -4058,12 +4058,12 @@ msgstr "Spør enhet…"
 msgid "Queue Manager"
 msgstr "Købehandler"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Legg valgte spor i kø"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Legg spor i kø"
 
@@ -4454,7 +4454,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Søk"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Søk"
@@ -4479,7 +4479,7 @@ msgstr "Søk i Subsonic"
 msgid "Search automatically"
 msgstr "Automatisk søk"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Søk etter album"
 
@@ -4492,7 +4492,7 @@ msgstr "Søk etter albumomslag…"
 msgid "Search for anything"
 msgstr "Søk etter hva som helst"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Søk etter artist"
 
@@ -4617,7 +4617,7 @@ msgstr "Tjenerdetaljer"
 msgid "Service offline"
 msgstr "Tjenesten er utilgjengelig"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Sett %1 til \"%2\"…"
@@ -4697,7 +4697,7 @@ msgstr "Vis et pent skjermbildeoverlegg"
 msgid "Show above status bar"
 msgstr "Vis over statuslinja"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Vis alle sanger"
 
@@ -4717,12 +4717,12 @@ msgstr "Vis adskillere"
 msgid "Show fullsize..."
 msgstr "Fullskjermsvisning…"
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Vis i filbehandler…"
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Vis i bibliotek…"
 
@@ -4734,11 +4734,11 @@ msgstr "Vis under Diverse Artister"
 msgid "Show moodbar"
 msgstr "Vis stemningsstolpe"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Bare vis duplikater"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Bare vis filer uten etiketter"
 
@@ -4830,7 +4830,7 @@ msgstr "Antall ganger hoppet over"
 msgid "Skip forwards in playlist"
 msgstr "Gå fremover i spillelista"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Hopp over valgte spor"
 
@@ -4838,7 +4838,7 @@ msgstr "Hopp over valgte spor"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Hopp over spor"
 
@@ -4870,7 +4870,7 @@ msgstr "Soft rock"
 msgid "Song Information"
 msgstr "Sanginformasjon"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Info om sangen"
 
@@ -4991,7 +4991,7 @@ msgstr "Stopp etter hvert spor"
 msgid "Stop after every track"
 msgstr "Stopp etter hvert spor"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Stopp etter denne sangen"
 
@@ -5159,7 +5159,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Prøveperioden for Subsonic er over. Gi en donasjon for å få en lisensnøkkel. Besøk subsonic.org for mer informasjon."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5201,7 +5201,7 @@ msgid ""
 "continue?"
 msgstr "Filene vil bli slettet fra enheten. Er du sikker?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5303,7 +5303,7 @@ msgstr "Slå av/på pent skjermbildeoverlegg"
 msgid "Toggle fullscreen"
 msgstr "Slå av/på fullskjermsmodus"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Slå av/på køstatus"
 
@@ -5441,11 +5441,11 @@ msgstr "Ukjent feil"
 msgid "Unset cover"
 msgstr "Fjern omslagsvalg"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Ikke hopp over de valgte sporene"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Ikke hopp over sporet"
 
@@ -5782,7 +5782,7 @@ msgid ""
 "well?"
 msgstr "Ønsker du å også flytte resten av sangene fra albumet til Diverse artister?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Vil du søke gjennom hele biblioteket på ny nå?"
 

--- a/src/translations/nl.po
+++ b/src/translations/nl.po
@@ -18,7 +18,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Dutch (http://www.transifex.com/davidsansome/clementine/language/nl/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -172,19 +172,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n mislukt"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n voltooid"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -202,7 +202,7 @@ msgstr "&Centreren"
 msgid "&Custom"
 msgstr "Aan&gepast"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Extra’s"
 
@@ -210,7 +210,7 @@ msgstr "&Extra’s"
 msgid "&Grouping"
 msgstr "&Groepering"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Hulp"
 
@@ -235,7 +235,7 @@ msgstr "Waardering vergrendelen"
 msgid "&Lyrics"
 msgstr "Songteksten"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Muziek"
 
@@ -243,15 +243,15 @@ msgstr "&Muziek"
 msgid "&None"
 msgstr "Gee&n"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&Afspeellijst"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Afsluiten"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "&Herhaalmodus"
 
@@ -259,7 +259,7 @@ msgstr "&Herhaalmodus"
 msgid "&Right"
 msgstr "&Rechts"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "&Willekeurige modus"
 
@@ -267,7 +267,7 @@ msgstr "&Willekeurige modus"
 msgid "&Stretch columns to fit window"
 msgstr "Kolommen &uitstrekken totdat ze het venster vullen"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Hulpmiddelen"
 
@@ -456,11 +456,11 @@ msgstr "Afbreken"
 msgid "About %1"
 msgstr "Over %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Over Clementine…"
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Over Qt…"
 
@@ -520,32 +520,32 @@ msgstr "Nog een radiostream toevoegen…"
 msgid "Add directory..."
 msgstr "Map toevoegen…"
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Bestand toevoegen"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Bestand toevoegen voor conversie."
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Bestand(en) toevoegen voor conversie."
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Bestand toevoegen…"
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Te converteren bestanden toevoegen"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Map toevoegen"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Map toevoegen…"
 
@@ -557,7 +557,7 @@ msgstr "Nieuwe map toevoegen…"
 msgid "Add podcast"
 msgstr "Voeg podcast toe"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Podcast toevoegen…"
 
@@ -633,7 +633,7 @@ msgstr "Nummer-label toevoegen"
 msgid "Add song year tag"
 msgstr "Jaar-label toevoegen"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Radiostream toevoegen…"
 
@@ -645,7 +645,7 @@ msgstr "Aan Spotify afspeellijsten toevoegen"
 msgid "Add to Spotify starred"
 msgstr "Aan favoriete Spotify-nummers toevoegen"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Aan een andere afspeellijst toevoegen"
 
@@ -739,7 +739,7 @@ msgstr "Alle"
 msgid "All Files (*)"
 msgstr "Alle bestanden (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "All Glory to the Hypnotoad!"
@@ -1130,7 +1130,7 @@ msgstr "Zoek naar nieuwe afleveringen"
 msgid "Check for updates"
 msgstr "Zoek naar updates"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Naar updates zoeken…"
 
@@ -1179,18 +1179,18 @@ msgstr "Klassiek"
 msgid "Cleaning up"
 msgstr "Bezig met opschonen"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Wissen"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Afspeellijst wissen"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1335,7 +1335,7 @@ msgstr "Opmerking"
 msgid "Complete tags automatically"
 msgstr "Labels automatisch voltooien"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Labels automatisch voltooien…"
 
@@ -1370,7 +1370,7 @@ msgstr "Subsonic configureren…"
 msgid "Configure global search..."
 msgstr "Globaal zoeken instellen…"
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Bibliotheek configureren…"
 
@@ -1413,7 +1413,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Time-out van verbinding, controleer de URL van de server. Bijvoorbeeld: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Console"
 
@@ -1442,11 +1442,11 @@ msgid "Copy to clipboard"
 msgstr "Kopieer naar klembord"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Naar apparaat kopiëren…"
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Naar bibliotheek kopiëren…"
@@ -1489,14 +1489,14 @@ msgstr "Kon niet inloggen bij last.fm. Probeer het nog eens."
 msgid "Couldn't create playlist"
 msgstr "Kon afspeellijst niet maken"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Kan muxer voor %1 niet vinden, controleer of u de juiste GStreamer plug-ins geïnstalleerd heeft"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1511,7 +1511,7 @@ msgstr "Kan uitvoerbestand %1 niet openen"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Albumhoesbeheerder"
 
@@ -1664,7 +1664,7 @@ msgid "Delete downloaded data"
 msgstr "Verwijder gedownloadde gegevens"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Bestanden verwijderen"
 
@@ -1672,7 +1672,7 @@ msgstr "Bestanden verwijderen"
 msgid "Delete from device..."
 msgstr "Van apparaat verwijderen…"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Van schijf verwijderen…"
@@ -1705,11 +1705,11 @@ msgstr "Bestanden worden verwijderd"
 msgid "Depth"
 msgstr "Diepte"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Geselecteerde nummers uit wachtrij verwijderen"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Nummer uit wachtrij verwijderen"
 
@@ -1810,7 +1810,7 @@ msgstr "Weergaveopties"
 msgid "Display the on-screen-display"
 msgstr "Infoschermvenster weergeven"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "De volledige database opnieuw scannen"
 
@@ -1989,12 +1989,12 @@ msgstr "Dynamische random mix"
 msgid "Edit smart playlist..."
 msgstr "Slimme-afspeellijst bewerken…"
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Label ‘%1’ bewerken…"
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Label bewerken…"
 
@@ -2007,7 +2007,7 @@ msgid "Edit track information"
 msgstr "Nummerinformatie bewerken"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Nummerinformatie bewerken…"
 
@@ -2115,7 +2115,7 @@ msgstr "Gehele verzameling"
 msgid "Episode information"
 msgstr "Aflevering informatie"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Equalizer"
 
@@ -2128,8 +2128,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Gelijkwaardig aan --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Fout"
 
@@ -2164,7 +2164,7 @@ msgstr "Fout bij laden van %1"
 msgid "Error loading di.fm playlist"
 msgstr "Fout bij laden di.fm afspeellijst"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Fout bij verwerken van %1: %2"
@@ -2247,7 +2247,11 @@ msgstr "Klaar me exporteren"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "%1 van %2 albumhoezen geëxporteerd (%3 overgeslagen)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2271,7 +2275,7 @@ msgstr "Uitvagen"
 msgid "Fading duration"
 msgstr "Uitvaagduur"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "CD-station lezen mislukt"
 
@@ -2553,11 +2557,11 @@ msgstr "Geef het een naam:"
 msgid "Go"
 msgstr "Ga"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Ga naar het volgende afspeellijst-tabblad"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Ga naar het vorige afspeellijst-tabblad"
 
@@ -2890,7 +2894,7 @@ msgstr "Jamendo database"
 msgid "Jump to previous song right away"
 msgstr "Meteen naar vorige nummer springen"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Spring naar het huidige nummer"
 
@@ -2914,7 +2918,7 @@ msgstr "In de achtergrond laten draaien als het venster gesloten wordt"
 msgid "Keep the original files"
 msgstr "De originele bestanden behouden"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Poesjes"
@@ -3006,7 +3010,7 @@ msgstr "Bibliotheek"
 msgid "Library advanced grouping"
 msgstr "Bibliotheek geavanceerd groeperen"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Database herscan-melding"
 
@@ -3046,7 +3050,7 @@ msgstr "Albumhoes van schijf laden…"
 msgid "Load playlist"
 msgstr "Afspeellijst laden"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Afspeellijst laden…"
 
@@ -3107,11 +3111,15 @@ msgstr "Inloggen"
 msgid "Login failed"
 msgstr "Inloggen mislukt"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Lange termijn voorspellingsprofiel (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Mooi"
 
@@ -3146,11 +3154,11 @@ msgstr "Songtekst van %1"
 msgid "Lyrics from the tag"
 msgstr "Songteksten van de tag"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3192,7 +3200,7 @@ msgstr "Normaal profiel (MAIN)"
 msgid "Make it so!"
 msgstr "Voer uit!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Voer uit!"
@@ -3330,7 +3338,7 @@ msgstr "Koppelpunten"
 msgid "Move down"
 msgstr "Omlaag verplaatsen"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Naar bibliotheek verplaatsen…"
 
@@ -3339,7 +3347,7 @@ msgstr "Naar bibliotheek verplaatsen…"
 msgid "Move up"
 msgstr "Omhoog verplaatsen"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Muziek"
 
@@ -3352,7 +3360,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Dempen"
 
@@ -3401,7 +3409,7 @@ msgstr "Nooit afspelen"
 msgid "New folder"
 msgstr "Nieuwe map"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nieuwe afspeellijst"
 
@@ -3429,8 +3437,12 @@ msgstr "Nieuwste nummers"
 msgid "Next"
 msgstr "Volgende"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Volgend nummer"
 
@@ -3468,7 +3480,7 @@ msgstr "Geen korte blokken"
 msgid "None"
 msgstr "Geen"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Geen van de geselecteerde nummers waren geschikt voor het kopiëren naar een apparaat"
 
@@ -3553,19 +3565,19 @@ msgstr "Uit"
 msgid "Ogg FLAC"
 msgstr "Ogg Flac"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3609,7 +3621,7 @@ msgstr "Doorzichtigheid"
 msgid "Open %1 in browser"
 msgstr "%1 in de browser openen"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "&Audio-CD openen…"
 
@@ -3621,7 +3633,7 @@ msgstr "OML bestand openen"
 msgid "Open OPML file..."
 msgstr "OML-bestand openen…"
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Open een pad om muziek uit te importeren"
 
@@ -3629,7 +3641,7 @@ msgstr "Open een pad om muziek uit te importeren"
 msgid "Open device"
 msgstr "Apparaat openen"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Bestand openen…"
 
@@ -3683,7 +3695,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Bestanden sorteren"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Bestanden sorteren…"
 
@@ -3767,7 +3779,7 @@ msgstr "Party"
 msgid "Password"
 msgstr "Wachtwoord"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pauze"
@@ -3791,6 +3803,10 @@ msgstr "Uitvoerend artiest"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Pixel"
@@ -3799,10 +3815,10 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Normale zijbalk"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Afspelen"
 
@@ -3823,11 +3839,11 @@ msgstr "Afspelen indien gestopt, pauzeren indien afgespeeld"
 msgid "Play if there is nothing already playing"
 msgstr "Afspelen wanneer niets aan het afspelen is"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Speel vervolgens"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Speel geselecteerde nummers vervolgens af"
 
@@ -3926,7 +3942,7 @@ msgstr "Voorkeur"
 msgid "Preferences"
 msgstr "Voorkeuren"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Voorkeuren…"
 
@@ -3986,7 +4002,7 @@ msgid "Previous"
 msgstr "Vorige"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Vorig nummer"
 
@@ -4044,16 +4060,16 @@ msgstr "Kwaliteit"
 msgid "Querying device..."
 msgstr "Apparaat afzoeken…"
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Wachtrijbeheer"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Geselecteerde nummers in de wachtrij plaatsen"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Nummer in de wachtrij plaatsen"
 
@@ -4069,7 +4085,7 @@ msgstr "Radio (gelijk volume voor alle nummers)"
 msgid "Rain"
 msgstr "Regen"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Regen"
@@ -4181,7 +4197,7 @@ msgstr "Actie verwijderen"
 msgid "Remove current song from playlist"
 msgstr "Verwijder huidig nummer van de afspeellijst"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Verwijder dubbelen uit afspeellijst"
 
@@ -4189,7 +4205,7 @@ msgstr "Verwijder dubbelen uit afspeellijst"
 msgid "Remove folder"
 msgstr "Map verwijderen"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Uit afspeellijst verwijderen"
 
@@ -4201,7 +4217,7 @@ msgstr "Afspeellijst verwijderen"
 msgid "Remove playlists"
 msgstr "Afspeellijsten verwijderen"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Verwijder niet beschikbare nummers van de afspeellijst"
 
@@ -4213,7 +4229,7 @@ msgstr "Afspeellijst hernoemen"
 msgid "Rename playlist..."
 msgstr "Afspeellijst hernoemen…"
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Nummers in deze volgorde een nieuw nummer geven…"
 
@@ -4304,7 +4320,7 @@ msgstr "Rip"
 msgid "Rip CD"
 msgstr "Rip CD"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Rip audio CD"
 
@@ -4382,7 +4398,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Afspeellijst opslaan"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Afspeellijst opslaan…"
 
@@ -4469,7 +4485,7 @@ msgstr "Subsonic doorzoeken"
 msgid "Search automatically"
 msgstr "Automatisch zoeken"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Zoek naar album"
 
@@ -4482,7 +4498,7 @@ msgstr "Naar albumhoezen zoeken…"
 msgid "Search for anything"
 msgstr "Naar iets zoeken"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Zoek naar artiest"
 
@@ -4607,7 +4623,7 @@ msgstr "Server gegevens"
 msgid "Service offline"
 msgstr "Service offline"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Stel %1 in op “%2”…"
@@ -4616,7 +4632,7 @@ msgstr "Stel %1 in op “%2”…"
 msgid "Set the volume to <value> percent"
 msgstr "Zet het volume op <value> procent"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Waarde voor alle geselecteerde nummers instellen…"
 
@@ -4687,7 +4703,7 @@ msgstr "Mooi infoschermvenster weergeven"
 msgid "Show above status bar"
 msgstr "Boven statusbalk weergeven"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Alle nummers weergeven"
 
@@ -4707,12 +4723,12 @@ msgstr "Verdelers tonen"
 msgid "Show fullsize..."
 msgstr "Volledig weergeven…"
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "In bestandsbeheer tonen…"
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "In bibliotheek tonen…"
 
@@ -4724,15 +4740,15 @@ msgstr "In diverse artiesten weergeven"
 msgid "Show moodbar"
 msgstr "Toon stemmingsbalk"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Alleen dubbelen tonen"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Nummers zonder labels tonen"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Toon of verberg de zijbalk"
 
@@ -4740,7 +4756,7 @@ msgstr "Toon of verberg de zijbalk"
 msgid "Show search suggestions"
 msgstr "Toon zoeksuggesties"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Toon zijbalk"
 
@@ -4776,7 +4792,7 @@ msgstr "Albums willekeurig afspelen"
 msgid "Shuffle all"
 msgstr "Alles willekeurig"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Afspeellijst schudden"
 
@@ -4820,11 +4836,15 @@ msgstr "Aantal maal overgeslagen"
 msgid "Skip forwards in playlist"
 msgstr "Vooruit in afspeellijst"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Geselecteerde nummers overslaan"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Nummer overslaan"
 
@@ -4941,7 +4961,7 @@ msgstr "Begin met rippen"
 msgid "Start the playlist currently playing"
 msgstr "Momenteel spelende afspeellijst starten"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Converteren starten"
 
@@ -4951,7 +4971,7 @@ msgid ""
 "list"
 msgstr "Typ iets in de bovenstaande zoekbalk om de lijst met zoekresultaten te zien"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "%1 wordt gestart"
@@ -4961,7 +4981,7 @@ msgid "Starting..."
 msgstr "Starten…"
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Stoppen"
 
@@ -4977,7 +4997,7 @@ msgstr "Na ieder nummer stoppen"
 msgid "Stop after every track"
 msgstr "Na ieder nummer stoppen"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Na dit nummer stoppen"
 
@@ -5145,7 +5165,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "De proefperiode voor de Subsonic server is afgelopen. Doneer om een licentie sleutel te krijgen. Ga naar subsonic.org voor details."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5187,7 +5207,7 @@ msgid ""
 "continue?"
 msgstr "Deze bestanden zullen definitief van het apparaat verwijderd worden. Weet u zeker dat u door wilt gaan?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5289,11 +5309,11 @@ msgstr "Mooi infoschermvenster aan/uit"
 msgid "Toggle fullscreen"
 msgstr "Volledig scherm aan/uit"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Wachtrijstatus aan/uit"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Zet scrobbling aan/uit"
 
@@ -5338,19 +5358,19 @@ msgstr "Nummer"
 msgid "Track"
 msgstr "Nummer"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Muziek converteren"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Conversielog"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Converteren"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Converteren van %1 bestanden m.b.v. %2 threads"
@@ -5427,11 +5447,11 @@ msgstr "Onbekende fout"
 msgid "Unset cover"
 msgstr "Albumhoes wissen"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Geselecteerde nummers niet overslaan"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Nummer niet overslaan"
 
@@ -5448,7 +5468,7 @@ msgstr "Komende concerten"
 msgid "Update all podcasts"
 msgstr "Vernieuw alle podcasts"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Aangepaste databasemappen updaten"
 
@@ -5609,7 +5629,7 @@ msgstr "Versie %1"
 msgid "View"
 msgstr "Weergave"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Bekijk Stream Details"
 
@@ -5617,7 +5637,7 @@ msgstr "Bekijk Stream Details"
 msgid "Visualization mode"
 msgstr "Visualisatiemodus"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Visualisaties"
 
@@ -5658,7 +5678,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5754,7 +5774,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64K"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media-audio"
 
@@ -5768,7 +5788,7 @@ msgid ""
 "well?"
 msgstr "Wilt u de andere nummers van dit album ook verplaatsen naar Diverse Artiesten?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Wilt u op dit moment een volledige herscan laten uitvoeren?"
 

--- a/src/translations/nl.po
+++ b/src/translations/nl.po
@@ -520,7 +520,7 @@ msgstr "Nog een radiostream toevoegen…"
 msgid "Add directory..."
 msgstr "Map toevoegen…"
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Bestand toevoegen"
 
@@ -540,7 +540,7 @@ msgstr "Bestand toevoegen…"
 msgid "Add files to transcode"
 msgstr "Te converteren bestanden toevoegen"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Map toevoegen"
@@ -645,7 +645,7 @@ msgstr "Aan Spotify afspeellijsten toevoegen"
 msgid "Add to Spotify starred"
 msgstr "Aan favoriete Spotify-nummers toevoegen"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Aan een andere afspeellijst toevoegen"
 
@@ -867,7 +867,7 @@ msgstr "Weet u zeker dat u de waarderingen en statistieken in alle bestanden van
 msgid "Artist"
 msgstr "Artiest"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Artiestinfo"
 
@@ -1130,7 +1130,7 @@ msgstr "Zoek naar nieuwe afleveringen"
 msgid "Check for updates"
 msgstr "Zoek naar updates"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Naar updates zoeken…"
 
@@ -1370,7 +1370,7 @@ msgstr "Subsonic configureren…"
 msgid "Configure global search..."
 msgstr "Globaal zoeken instellen…"
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Bibliotheek configureren…"
 
@@ -1442,11 +1442,11 @@ msgid "Copy to clipboard"
 msgstr "Kopieer naar klembord"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Naar apparaat kopiëren…"
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Naar bibliotheek kopiëren…"
@@ -1664,7 +1664,7 @@ msgid "Delete downloaded data"
 msgstr "Verwijder gedownloadde gegevens"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Bestanden verwijderen"
 
@@ -1672,7 +1672,7 @@ msgstr "Bestanden verwijderen"
 msgid "Delete from device..."
 msgstr "Van apparaat verwijderen…"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Van schijf verwijderen…"
@@ -1705,11 +1705,11 @@ msgstr "Bestanden worden verwijderd"
 msgid "Depth"
 msgstr "Diepte"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Geselecteerde nummers uit wachtrij verwijderen"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Nummer uit wachtrij verwijderen"
 
@@ -1738,7 +1738,7 @@ msgstr "Apparaatnaam"
 msgid "Device properties..."
 msgstr "Apparaateigenschappen…"
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Apparaten"
 
@@ -1989,7 +1989,7 @@ msgstr "Dynamische random mix"
 msgid "Edit smart playlist..."
 msgstr "Slimme-afspeellijst bewerken…"
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Label ‘%1’ bewerken…"
@@ -2128,8 +2128,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Gelijkwaardig aan --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Fout"
 
@@ -2275,7 +2275,7 @@ msgstr "Uitvagen"
 msgid "Fading duration"
 msgstr "Uitvaagduur"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "CD-station lezen mislukt"
 
@@ -2398,7 +2398,7 @@ msgstr "Bestandstype"
 msgid "Filename"
 msgstr "Bestandsnaam"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Bestanden"
 
@@ -2813,7 +2813,7 @@ msgstr "Geïnstalleerd"
 msgid "Integrity check"
 msgstr "Integriteits check"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -3001,7 +3001,7 @@ msgstr "Links"
 msgid "Length"
 msgstr "Duur"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Bibliotheek"
@@ -3010,7 +3010,7 @@ msgstr "Bibliotheek"
 msgid "Library advanced grouping"
 msgstr "Bibliotheek geavanceerd groeperen"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Database herscan-melding"
 
@@ -3338,7 +3338,7 @@ msgstr "Koppelpunten"
 msgid "Move down"
 msgstr "Omlaag verplaatsen"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Naar bibliotheek verplaatsen…"
 
@@ -3347,7 +3347,7 @@ msgstr "Naar bibliotheek verplaatsen…"
 msgid "Move up"
 msgstr "Omhoog verplaatsen"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Muziek"
 
@@ -3409,7 +3409,7 @@ msgstr "Nooit afspelen"
 msgid "New folder"
 msgstr "Nieuwe map"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nieuwe afspeellijst"
 
@@ -3480,7 +3480,7 @@ msgstr "Geen korte blokken"
 msgid "None"
 msgstr "Geen"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Geen van de geselecteerde nummers waren geschikt voor het kopiëren naar een apparaat"
 
@@ -3695,7 +3695,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Bestanden sorteren"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Bestanden sorteren…"
 
@@ -3779,7 +3779,7 @@ msgstr "Party"
 msgid "Password"
 msgstr "Wachtwoord"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pauze"
@@ -3815,8 +3815,8 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Normale zijbalk"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3839,11 +3839,11 @@ msgstr "Afspelen indien gestopt, pauzeren indien afgespeeld"
 msgid "Play if there is nothing already playing"
 msgstr "Afspelen wanneer niets aan het afspelen is"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Speel vervolgens"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Speel geselecteerde nummers vervolgens af"
 
@@ -3882,7 +3882,7 @@ msgstr "Afspeellijst-opties"
 msgid "Playlist type"
 msgstr "Afspeellijst type"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Afspeellijsten"
 
@@ -4064,12 +4064,12 @@ msgstr "Apparaat afzoeken…"
 msgid "Queue Manager"
 msgstr "Wachtrijbeheer"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Geselecteerde nummers in de wachtrij plaatsen"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Nummer in de wachtrij plaatsen"
 
@@ -4460,7 +4460,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Zoeken"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Zoeken"
@@ -4485,7 +4485,7 @@ msgstr "Subsonic doorzoeken"
 msgid "Search automatically"
 msgstr "Automatisch zoeken"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Zoek naar album"
 
@@ -4498,7 +4498,7 @@ msgstr "Naar albumhoezen zoeken…"
 msgid "Search for anything"
 msgstr "Naar iets zoeken"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Zoek naar artiest"
 
@@ -4623,7 +4623,7 @@ msgstr "Server gegevens"
 msgid "Service offline"
 msgstr "Service offline"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Stel %1 in op “%2”…"
@@ -4703,7 +4703,7 @@ msgstr "Mooi infoschermvenster weergeven"
 msgid "Show above status bar"
 msgstr "Boven statusbalk weergeven"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Alle nummers weergeven"
 
@@ -4723,12 +4723,12 @@ msgstr "Verdelers tonen"
 msgid "Show fullsize..."
 msgstr "Volledig weergeven…"
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "In bestandsbeheer tonen…"
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "In bibliotheek tonen…"
 
@@ -4740,11 +4740,11 @@ msgstr "In diverse artiesten weergeven"
 msgid "Show moodbar"
 msgstr "Toon stemmingsbalk"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Alleen dubbelen tonen"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Nummers zonder labels tonen"
 
@@ -4836,7 +4836,7 @@ msgstr "Aantal maal overgeslagen"
 msgid "Skip forwards in playlist"
 msgstr "Vooruit in afspeellijst"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Geselecteerde nummers overslaan"
 
@@ -4844,7 +4844,7 @@ msgstr "Geselecteerde nummers overslaan"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Nummer overslaan"
 
@@ -4876,7 +4876,7 @@ msgstr "Soft Rock"
 msgid "Song Information"
 msgstr "Nummerinformatie"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Nummerinfo"
 
@@ -4997,7 +4997,7 @@ msgstr "Na ieder nummer stoppen"
 msgid "Stop after every track"
 msgstr "Na ieder nummer stoppen"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Na dit nummer stoppen"
 
@@ -5165,7 +5165,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "De proefperiode voor de Subsonic server is afgelopen. Doneer om een licentie sleutel te krijgen. Ga naar subsonic.org voor details."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5207,7 +5207,7 @@ msgid ""
 "continue?"
 msgstr "Deze bestanden zullen definitief van het apparaat verwijderd worden. Weet u zeker dat u door wilt gaan?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5309,7 +5309,7 @@ msgstr "Mooi infoschermvenster aan/uit"
 msgid "Toggle fullscreen"
 msgstr "Volledig scherm aan/uit"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Wachtrijstatus aan/uit"
 
@@ -5447,11 +5447,11 @@ msgstr "Onbekende fout"
 msgid "Unset cover"
 msgstr "Albumhoes wissen"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Geselecteerde nummers niet overslaan"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Nummer niet overslaan"
 
@@ -5788,7 +5788,7 @@ msgid ""
 "well?"
 msgstr "Wilt u de andere nummers van dit album ook verplaatsen naar Diverse Artiesten?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Wilt u op dit moment een volledige herscan laten uitvoeren?"
 

--- a/src/translations/oc.po
+++ b/src/translations/oc.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Occitan (post 1500) (http://www.transifex.com/davidsansome/clementine/language/oc/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -161,19 +161,19 @@ msgstr ""
 msgid "%filename%"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -191,7 +191,7 @@ msgstr ""
 msgid "&Custom"
 msgstr "&Personalizat"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr ""
 
@@ -199,7 +199,7 @@ msgstr ""
 msgid "&Grouping"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Ajuda"
 
@@ -224,7 +224,7 @@ msgstr ""
 msgid "&Lyrics"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "Musica"
 
@@ -232,15 +232,15 @@ msgstr "Musica"
 msgid "&None"
 msgstr "&Pas cap"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "Lista de lectura"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Quitar"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "Lectura en bocla"
 
@@ -248,7 +248,7 @@ msgstr "Lectura en bocla"
 msgid "&Right"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Mòde aleatòri"
 
@@ -256,7 +256,7 @@ msgstr "Mòde aleatòri"
 msgid "&Stretch columns to fit window"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "Aisinas"
 
@@ -445,11 +445,11 @@ msgstr ""
 msgid "About %1"
 msgstr "A prepaus de « %1 »"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "A prepaus de Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr ""
 
@@ -509,32 +509,32 @@ msgstr ""
 msgid "Add directory..."
 msgstr ""
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Seleccionar un fichièr vidèo..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Apondre un dorsièr"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr ""
 
@@ -546,7 +546,7 @@ msgstr ""
 msgid "Add podcast"
 msgstr ""
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr ""
 
@@ -622,7 +622,7 @@ msgstr ""
 msgid "Add song year tag"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Apondre un flux..."
 
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr ""
 
@@ -728,7 +728,7 @@ msgstr ""
 msgid "All Files (*)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr ""
@@ -1119,7 +1119,7 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr ""
 
@@ -1168,18 +1168,18 @@ msgstr "Classic"
 msgid "Cleaning up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Voidar la lista de lectura"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr ""
 
@@ -1324,7 +1324,7 @@ msgstr "Comentari"
 msgid "Complete tags automatically"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr ""
 
@@ -1359,7 +1359,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr ""
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr ""
 
@@ -1431,11 +1431,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1478,14 +1478,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr ""
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1500,7 +1500,7 @@ msgstr ""
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Gestionari de pochetas"
 
@@ -1653,7 +1653,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr ""
 
@@ -1661,7 +1661,7 @@ msgstr ""
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1694,11 +1694,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr ""
 
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "Display the on-screen-display"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr ""
 
@@ -1978,12 +1978,12 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr ""
 
@@ -1996,7 +1996,7 @@ msgid "Edit track information"
 msgstr ""
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr ""
 
@@ -2104,7 +2104,7 @@ msgstr ""
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Egalizador"
 
@@ -2117,8 +2117,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr ""
 
@@ -2153,7 +2153,7 @@ msgstr ""
 msgid "Error loading di.fm playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr ""
@@ -2236,7 +2236,11 @@ msgstr ""
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr ""
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2260,7 +2264,7 @@ msgstr "Fondut"
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2542,11 +2546,11 @@ msgstr ""
 msgid "Go"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr ""
 
@@ -2879,7 +2883,7 @@ msgstr ""
 msgid "Jump to previous song right away"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr ""
 
@@ -2903,7 +2907,7 @@ msgstr ""
 msgid "Keep the original files"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr ""
@@ -2995,7 +2999,7 @@ msgstr "Bibliotèca"
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3035,7 +3039,7 @@ msgstr ""
 msgid "Load playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr ""
 
@@ -3096,11 +3100,15 @@ msgstr ""
 msgid "Login failed"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "M'agrada fòrça"
 
@@ -3135,11 +3143,11 @@ msgstr ""
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr ""
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3181,7 +3189,7 @@ msgstr ""
 msgid "Make it so!"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr ""
@@ -3319,7 +3327,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3328,7 +3336,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr ""
 
@@ -3341,7 +3349,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Mut"
 
@@ -3390,7 +3398,7 @@ msgstr ""
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3418,8 +3426,12 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Pista seguenta"
 
@@ -3457,7 +3469,7 @@ msgstr ""
 msgid "None"
 msgstr "Pas cap"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3542,19 +3554,19 @@ msgstr ""
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr ""
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr ""
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3598,7 +3610,7 @@ msgstr ""
 msgid "Open %1 in browser"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr ""
 
@@ -3610,7 +3622,7 @@ msgstr ""
 msgid "Open OPML file..."
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr ""
 
@@ -3618,7 +3630,7 @@ msgstr ""
 msgid "Open device"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr ""
 
@@ -3672,7 +3684,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr ""
 
@@ -3756,7 +3768,7 @@ msgstr "Fèsta"
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pausa"
@@ -3780,6 +3792,10 @@ msgstr ""
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr ""
@@ -3788,10 +3804,10 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Lectura"
 
@@ -3812,11 +3828,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3915,7 +3931,7 @@ msgstr ""
 msgid "Preferences"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr ""
 
@@ -3975,7 +3991,7 @@ msgid "Previous"
 msgstr ""
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Pista precedenta"
 
@@ -4033,16 +4049,16 @@ msgstr ""
 msgid "Querying device..."
 msgstr ""
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr ""
 
@@ -4058,7 +4074,7 @@ msgstr ""
 msgid "Rain"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr ""
@@ -4170,7 +4186,7 @@ msgstr ""
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr ""
 
@@ -4178,7 +4194,7 @@ msgstr ""
 msgid "Remove folder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr ""
 
@@ -4190,7 +4206,7 @@ msgstr ""
 msgid "Remove playlists"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr ""
 
@@ -4202,7 +4218,7 @@ msgstr ""
 msgid "Rename playlist..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr ""
 
@@ -4293,7 +4309,7 @@ msgstr ""
 msgid "Rip CD"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr ""
 
@@ -4371,7 +4387,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr ""
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr ""
 
@@ -4458,7 +4474,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4471,7 +4487,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4596,7 +4612,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4605,7 +4621,7 @@ msgstr ""
 msgid "Set the volume to <value> percent"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr ""
 
@@ -4676,7 +4692,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr ""
 
@@ -4696,12 +4712,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr ""
 
@@ -4713,15 +4729,15 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4729,7 +4745,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4765,7 +4781,7 @@ msgstr ""
 msgid "Shuffle all"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr ""
 
@@ -4809,11 +4825,15 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr ""
 
@@ -4930,7 +4950,7 @@ msgstr ""
 msgid "Start the playlist currently playing"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr ""
 
@@ -4940,7 +4960,7 @@ msgid ""
 "list"
 msgstr ""
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr ""
@@ -4950,7 +4970,7 @@ msgid "Starting..."
 msgstr ""
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Arrestar"
 
@@ -4966,7 +4986,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5134,7 +5154,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5176,7 +5196,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5278,11 +5298,11 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr ""
 
@@ -5327,19 +5347,19 @@ msgstr ""
 msgid "Track"
 msgstr "Pista"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr ""
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
 msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr ""
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr ""
@@ -5416,11 +5436,11 @@ msgstr "Error desconeguda"
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr ""
 
@@ -5437,7 +5457,7 @@ msgstr ""
 msgid "Update all podcasts"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr ""
 
@@ -5598,7 +5618,7 @@ msgstr "Version %1"
 msgid "View"
 msgstr "Afichatge"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5606,7 +5626,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr ""
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr ""
 
@@ -5647,7 +5667,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr ""
 
@@ -5743,7 +5763,7 @@ msgstr ""
 msgid "Windows Media 64k"
 msgstr ""
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr ""
 
@@ -5757,7 +5777,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/oc.po
+++ b/src/translations/oc.po
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add directory..."
 msgstr ""
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgstr "Seleccionar un fichièr vidèo..."
 msgid "Add files to transcode"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Apondre un dorsièr"
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr ""
 
@@ -856,7 +856,7 @@ msgstr ""
 msgid "Artist"
 msgstr "Artista"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr ""
 
@@ -1119,7 +1119,7 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr ""
 
@@ -1359,7 +1359,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr ""
 
@@ -1431,11 +1431,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1653,7 +1653,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr ""
 
@@ -1661,7 +1661,7 @@ msgstr ""
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1694,11 +1694,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr ""
 
@@ -1727,7 +1727,7 @@ msgstr ""
 msgid "Device properties..."
 msgstr ""
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr ""
 
@@ -1978,7 +1978,7 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
@@ -2117,8 +2117,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr ""
 
@@ -2264,7 +2264,7 @@ msgstr "Fondut"
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2387,7 +2387,7 @@ msgstr "Tipe de fichièr"
 msgid "Filename"
 msgstr "Nom del fichièr"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Fichièrs"
 
@@ -2802,7 +2802,7 @@ msgstr ""
 msgid "Integrity check"
 msgstr ""
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Sus Internet"
 
@@ -2990,7 +2990,7 @@ msgstr ""
 msgid "Length"
 msgstr "Longor"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Bibliotèca"
@@ -2999,7 +2999,7 @@ msgstr "Bibliotèca"
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3327,7 +3327,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3336,7 +3336,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr ""
 
@@ -3398,7 +3398,7 @@ msgstr ""
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3469,7 +3469,7 @@ msgstr ""
 msgid "None"
 msgstr "Pas cap"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3684,7 +3684,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr ""
 
@@ -3768,7 +3768,7 @@ msgstr "Fèsta"
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pausa"
@@ -3804,8 +3804,8 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3828,11 +3828,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Playlist type"
 msgstr ""
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr ""
 
@@ -4053,12 +4053,12 @@ msgstr ""
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr ""
 
@@ -4449,7 +4449,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr ""
@@ -4474,7 +4474,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4487,7 +4487,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4692,7 +4692,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr ""
 
@@ -4712,12 +4712,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr ""
 
@@ -4729,11 +4729,11 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr ""
 
@@ -4825,7 +4825,7 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr ""
 
@@ -4833,7 +4833,7 @@ msgstr ""
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr ""
 
@@ -4865,7 +4865,7 @@ msgstr "Soft Rock"
 msgid "Song Information"
 msgstr ""
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr ""
 
@@ -4986,7 +4986,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5154,7 +5154,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5196,7 +5196,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5298,7 +5298,7 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr ""
 
@@ -5436,11 +5436,11 @@ msgstr "Error desconeguda"
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr ""
 
@@ -5777,7 +5777,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/pa.po
+++ b/src/translations/pa.po
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add directory..."
 msgstr ""
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgstr ""
 msgid "Add files to transcode"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr ""
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr ""
 
@@ -856,7 +856,7 @@ msgstr ""
 msgid "Artist"
 msgstr ""
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr ""
 
@@ -1119,7 +1119,7 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr ""
 
@@ -1359,7 +1359,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr ""
 
@@ -1431,11 +1431,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1653,7 +1653,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr ""
 
@@ -1661,7 +1661,7 @@ msgstr ""
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1694,11 +1694,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr ""
 
@@ -1727,7 +1727,7 @@ msgstr ""
 msgid "Device properties..."
 msgstr ""
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr ""
 
@@ -1978,7 +1978,7 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
@@ -2117,8 +2117,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr ""
 
@@ -2264,7 +2264,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2387,7 +2387,7 @@ msgstr ""
 msgid "Filename"
 msgstr ""
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr ""
 
@@ -2802,7 +2802,7 @@ msgstr ""
 msgid "Integrity check"
 msgstr ""
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr ""
 
@@ -2990,7 +2990,7 @@ msgstr ""
 msgid "Length"
 msgstr ""
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr ""
@@ -2999,7 +2999,7 @@ msgstr ""
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3327,7 +3327,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3336,7 +3336,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr ""
 
@@ -3398,7 +3398,7 @@ msgstr ""
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3469,7 +3469,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3684,7 +3684,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr ""
 
@@ -3768,7 +3768,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr ""
@@ -3804,8 +3804,8 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3828,11 +3828,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Playlist type"
 msgstr ""
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr ""
 
@@ -4053,12 +4053,12 @@ msgstr ""
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr ""
 
@@ -4449,7 +4449,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr ""
@@ -4474,7 +4474,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4487,7 +4487,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4692,7 +4692,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr ""
 
@@ -4712,12 +4712,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr ""
 
@@ -4729,11 +4729,11 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr ""
 
@@ -4825,7 +4825,7 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr ""
 
@@ -4833,7 +4833,7 @@ msgstr ""
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr ""
 
@@ -4865,7 +4865,7 @@ msgstr ""
 msgid "Song Information"
 msgstr ""
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr ""
 
@@ -4986,7 +4986,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5154,7 +5154,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5196,7 +5196,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5298,7 +5298,7 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr ""
 
@@ -5436,11 +5436,11 @@ msgstr ""
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr ""
 
@@ -5777,7 +5777,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/pa.po
+++ b/src/translations/pa.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Panjabi (Punjabi) (http://www.transifex.com/davidsansome/clementine/language/pa/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -161,19 +161,19 @@ msgstr ""
 msgid "%filename%"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -191,7 +191,7 @@ msgstr ""
 msgid "&Custom"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr ""
 
@@ -199,7 +199,7 @@ msgstr ""
 msgid "&Grouping"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr ""
 
@@ -224,7 +224,7 @@ msgstr ""
 msgid "&Lyrics"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr ""
 
@@ -232,15 +232,15 @@ msgstr ""
 msgid "&None"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr ""
 
@@ -248,7 +248,7 @@ msgstr ""
 msgid "&Right"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr ""
 
@@ -256,7 +256,7 @@ msgstr ""
 msgid "&Stretch columns to fit window"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr ""
 
@@ -445,11 +445,11 @@ msgstr ""
 msgid "About %1"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr ""
 
@@ -509,32 +509,32 @@ msgstr ""
 msgid "Add directory..."
 msgstr ""
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr ""
 
@@ -546,7 +546,7 @@ msgstr ""
 msgid "Add podcast"
 msgstr ""
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr ""
 
@@ -622,7 +622,7 @@ msgstr ""
 msgid "Add song year tag"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr ""
 
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr ""
 
@@ -728,7 +728,7 @@ msgstr ""
 msgid "All Files (*)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr ""
@@ -1119,7 +1119,7 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr ""
 
@@ -1168,18 +1168,18 @@ msgstr ""
 msgid "Cleaning up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr ""
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr ""
 
@@ -1324,7 +1324,7 @@ msgstr ""
 msgid "Complete tags automatically"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr ""
 
@@ -1359,7 +1359,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr ""
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr ""
 
@@ -1431,11 +1431,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1478,14 +1478,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr ""
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1500,7 +1500,7 @@ msgstr ""
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr ""
 
@@ -1653,7 +1653,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr ""
 
@@ -1661,7 +1661,7 @@ msgstr ""
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1694,11 +1694,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr ""
 
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "Display the on-screen-display"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr ""
 
@@ -1978,12 +1978,12 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr ""
 
@@ -1996,7 +1996,7 @@ msgid "Edit track information"
 msgstr ""
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr ""
 
@@ -2104,7 +2104,7 @@ msgstr ""
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr ""
 
@@ -2117,8 +2117,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr ""
 
@@ -2153,7 +2153,7 @@ msgstr ""
 msgid "Error loading di.fm playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr ""
@@ -2236,7 +2236,11 @@ msgstr ""
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr ""
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2260,7 +2264,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2542,11 +2546,11 @@ msgstr ""
 msgid "Go"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr ""
 
@@ -2879,7 +2883,7 @@ msgstr ""
 msgid "Jump to previous song right away"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr ""
 
@@ -2903,7 +2907,7 @@ msgstr ""
 msgid "Keep the original files"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr ""
@@ -2995,7 +2999,7 @@ msgstr ""
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3035,7 +3039,7 @@ msgstr ""
 msgid "Load playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr ""
 
@@ -3096,11 +3100,15 @@ msgstr ""
 msgid "Login failed"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr ""
 
@@ -3135,11 +3143,11 @@ msgstr ""
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr ""
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr ""
@@ -3181,7 +3189,7 @@ msgstr ""
 msgid "Make it so!"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr ""
@@ -3319,7 +3327,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3328,7 +3336,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr ""
 
@@ -3341,7 +3349,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr ""
 
@@ -3390,7 +3398,7 @@ msgstr ""
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3418,8 +3426,12 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr ""
 
@@ -3457,7 +3469,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3542,19 +3554,19 @@ msgstr ""
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr ""
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr ""
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr ""
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3598,7 +3610,7 @@ msgstr ""
 msgid "Open %1 in browser"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr ""
 
@@ -3610,7 +3622,7 @@ msgstr ""
 msgid "Open OPML file..."
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr ""
 
@@ -3618,7 +3630,7 @@ msgstr ""
 msgid "Open device"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr ""
 
@@ -3672,7 +3684,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr ""
 
@@ -3756,7 +3768,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr ""
@@ -3780,6 +3792,10 @@ msgstr ""
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr ""
@@ -3788,10 +3804,10 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr ""
 
@@ -3812,11 +3828,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3915,7 +3931,7 @@ msgstr ""
 msgid "Preferences"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr ""
 
@@ -3975,7 +3991,7 @@ msgid "Previous"
 msgstr ""
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr ""
 
@@ -4033,16 +4049,16 @@ msgstr ""
 msgid "Querying device..."
 msgstr ""
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr ""
 
@@ -4058,7 +4074,7 @@ msgstr ""
 msgid "Rain"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr ""
@@ -4170,7 +4186,7 @@ msgstr ""
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr ""
 
@@ -4178,7 +4194,7 @@ msgstr ""
 msgid "Remove folder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr ""
 
@@ -4190,7 +4206,7 @@ msgstr ""
 msgid "Remove playlists"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr ""
 
@@ -4202,7 +4218,7 @@ msgstr ""
 msgid "Rename playlist..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr ""
 
@@ -4293,7 +4309,7 @@ msgstr ""
 msgid "Rip CD"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr ""
 
@@ -4371,7 +4387,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr ""
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr ""
 
@@ -4458,7 +4474,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4471,7 +4487,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4596,7 +4612,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4605,7 +4621,7 @@ msgstr ""
 msgid "Set the volume to <value> percent"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr ""
 
@@ -4676,7 +4692,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr ""
 
@@ -4696,12 +4712,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr ""
 
@@ -4713,15 +4729,15 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4729,7 +4745,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4765,7 +4781,7 @@ msgstr ""
 msgid "Shuffle all"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr ""
 
@@ -4809,11 +4825,15 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr ""
 
@@ -4930,7 +4950,7 @@ msgstr ""
 msgid "Start the playlist currently playing"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr ""
 
@@ -4940,7 +4960,7 @@ msgid ""
 "list"
 msgstr ""
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr ""
@@ -4950,7 +4970,7 @@ msgid "Starting..."
 msgstr ""
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr ""
 
@@ -4966,7 +4986,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5134,7 +5154,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5176,7 +5196,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5278,11 +5298,11 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr ""
 
@@ -5327,19 +5347,19 @@ msgstr ""
 msgid "Track"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr ""
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
 msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr ""
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr ""
@@ -5416,11 +5436,11 @@ msgstr ""
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr ""
 
@@ -5437,7 +5457,7 @@ msgstr ""
 msgid "Update all podcasts"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr ""
 
@@ -5598,7 +5618,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5606,7 +5626,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr ""
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr ""
 
@@ -5647,7 +5667,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr ""
 
@@ -5743,7 +5763,7 @@ msgstr ""
 msgid "Windows Media 64k"
 msgstr ""
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr ""
 
@@ -5757,7 +5777,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/pl.po
+++ b/src/translations/pl.po
@@ -29,7 +29,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Polish (http://www.transifex.com/davidsansome/clementine/language/pl/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -183,19 +183,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n nieudane"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n zakończone"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -213,7 +213,7 @@ msgstr "Wyśrodkowanie"
 msgid "&Custom"
 msgstr "&Własny"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "Dodatki"
 
@@ -221,7 +221,7 @@ msgstr "Dodatki"
 msgid "&Grouping"
 msgstr "&Grupowanie"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "Pomoc"
 
@@ -246,7 +246,7 @@ msgstr "&Blokuj Ocenę"
 msgid "&Lyrics"
 msgstr "&Tekst utworu"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "Muzyka"
 
@@ -254,15 +254,15 @@ msgstr "Muzyka"
 msgid "&None"
 msgstr "&Brak"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&Playlista"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Zakończ"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "Tryb powtarzania"
 
@@ -270,7 +270,7 @@ msgstr "Tryb powtarzania"
 msgid "&Right"
 msgstr "Do p&rawej"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Tryb losowy"
 
@@ -278,7 +278,7 @@ msgstr "Tryb losowy"
 msgid "&Stretch columns to fit window"
 msgstr "&Rozciągaj kolumny, aby dopasować do okna"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "Narzędzia"
 
@@ -467,11 +467,11 @@ msgstr "Przerwij"
 msgid "About %1"
 msgstr "O programie %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "O Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "O Qt..."
 
@@ -531,32 +531,32 @@ msgstr "Dodaj następny strumień..."
 msgid "Add directory..."
 msgstr "Dodaj katalog..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Dodaj plik"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Dodaj plik do transkodera"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Dodaj plik(i) do transkodera"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Dodaj plik..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Dodaj pliki to transkodowania"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Dodaj katalog"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Dodaj katalog..."
 
@@ -568,7 +568,7 @@ msgstr "Dodaj nowy katalog..."
 msgid "Add podcast"
 msgstr "Dodaj podcast"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Dodaj podcast..."
 
@@ -644,7 +644,7 @@ msgstr "Dodaj tag numeru utworu"
 msgid "Add song year tag"
 msgstr "Dodaj tag roku"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Dodaj strumień..."
 
@@ -656,7 +656,7 @@ msgstr "Dodaj do playlist Spotify"
 msgid "Add to Spotify starred"
 msgstr "Dodaj do śledzonych w Spotify"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Dodaj do innej playlisty"
 
@@ -750,7 +750,7 @@ msgstr "Wszystkie"
 msgid "All Files (*)"
 msgstr "Wszystkie pliki (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Chwała Tobie Hypnoropucho!"
@@ -1141,7 +1141,7 @@ msgstr "Sprawdzaj, czy są nowe audycje"
 msgid "Check for updates"
 msgstr "Sprawdź aktualizacje"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Sprawdź aktualizacje..."
 
@@ -1190,18 +1190,18 @@ msgstr "Muzyka klasyczna"
 msgid "Cleaning up"
 msgstr "Czyszczenie"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Wyczyść"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Wyczyść playlistę"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1346,7 +1346,7 @@ msgstr "Komentarz"
 msgid "Complete tags automatically"
 msgstr "Automatycznie uzupełnij znaczniki"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Automatycznie uzupełnij znaczniki..."
 
@@ -1381,7 +1381,7 @@ msgstr "Skonfiguruj Subsonic..."
 msgid "Configure global search..."
 msgstr "Skonfiguruj globalne wyszukiwanie..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Konfiguruj bibliotekę..."
 
@@ -1424,7 +1424,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Przekroczono limit czasu, sprawdź URL serwera. Przykład: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Konsola"
 
@@ -1453,11 +1453,11 @@ msgid "Copy to clipboard"
 msgstr "Kopiuj do schowka"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Skopiuj na urządzenie..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Skopiuj do biblioteki..."
@@ -1500,14 +1500,14 @@ msgstr "Nie można połączyć się w tej chwili z Last.fm. Proszę spróbować 
 msgid "Couldn't create playlist"
 msgstr "Nie można utworzyć playlisty"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Nie można odnaleźć muxera dla %1. Sprawdź czy posiadasz zainstalowane prawidłowe wtyczki GStreamera"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1522,7 +1522,7 @@ msgstr "Nie można otworzyć pliku %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Menedżer okładek"
 
@@ -1675,7 +1675,7 @@ msgid "Delete downloaded data"
 msgstr "Usuń pobrane dane"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Usuń pliki"
 
@@ -1683,7 +1683,7 @@ msgstr "Usuń pliki"
 msgid "Delete from device..."
 msgstr "Usuń z urządzenia..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Usuń z dysku..."
@@ -1716,11 +1716,11 @@ msgstr "Usuwanie plików"
 msgid "Depth"
 msgstr "Głębokość"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Usuń ścieżki z kolejki odtwarzania"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Usuń ścieżkę z kolejki odtwarzania"
 
@@ -1821,7 +1821,7 @@ msgstr "Opcje wyświetlania"
 msgid "Display the on-screen-display"
 msgstr "Pokaż menu ekranowe"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Przeskanuj całą bibliotekę od nowa"
 
@@ -2000,12 +2000,12 @@ msgstr "Dynamiczny, losowy miks"
 msgid "Edit smart playlist..."
 msgstr "Edytuj inteligentną playlistę..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Edytuj tag \"%1\"..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Edytuj znacznik..."
 
@@ -2018,7 +2018,7 @@ msgid "Edit track information"
 msgstr "Edytuj informacje o utworze"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Edytuj informacje o utworze..."
 
@@ -2126,7 +2126,7 @@ msgstr "Cała kolekcja"
 msgid "Episode information"
 msgstr "Informacje o odcinku"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Korektor dźwięku"
 
@@ -2139,8 +2139,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Rownoważny --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Błąd"
 
@@ -2175,7 +2175,7 @@ msgstr "Błąd wczytywania %1"
 msgid "Error loading di.fm playlist"
 msgstr "Błąd podczas ładowania playlisty di.fm"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Błąd przetwarzania %1: %2"
@@ -2258,7 +2258,11 @@ msgstr "Eksportowanie zakończone"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "Wyodrębniono okładek: %1 / %2 (pominięto: %3)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2282,7 +2286,7 @@ msgstr "Przejście"
 msgid "Fading duration"
 msgstr "Czas przejścia"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Błąd odczytywania napędu CD"
 
@@ -2564,11 +2568,11 @@ msgstr "Nadaj nazwę:"
 msgid "Go"
 msgstr "Idź"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Przejdź do karty kolejnej playlisty"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Przejdź do karty poprzedniej playlisty"
 
@@ -2901,7 +2905,7 @@ msgstr "Baza danych Jamendo"
 msgid "Jump to previous song right away"
 msgstr "Natychmiastowo przeskocz do poprzedniej piosenki"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Przeskocz do aktualnie odtwarzanej ścieżki"
 
@@ -2925,7 +2929,7 @@ msgstr "Pozostań w tle po zamknięciu okna"
 msgid "Keep the original files"
 msgstr "Zachowaj oryginalne pliki"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Kotki"
@@ -3017,7 +3021,7 @@ msgstr "Biblioteka"
 msgid "Library advanced grouping"
 msgstr "Zaawansowanie grupowanie biblioteki"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Konieczność odświeżenia biblioteki"
 
@@ -3057,7 +3061,7 @@ msgstr "Wczytaj okładkę z dysku..."
 msgid "Load playlist"
 msgstr "Wczytaj playlistę"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Wczytaj playlistę..."
 
@@ -3118,11 +3122,15 @@ msgstr "Zaloguj się"
 msgid "Login failed"
 msgstr "Logowanie nieudane"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Profil przewidywania długoterminowego (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Dodaj do ulubionych"
 
@@ -3157,11 +3165,11 @@ msgstr "Tekst z %1"
 msgid "Lyrics from the tag"
 msgstr "Teksty z tagu."
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3203,7 +3211,7 @@ msgstr "Profil główny (MAIN)"
 msgid "Make it so!"
 msgstr "Zrób tak!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Zrób tak!"
@@ -3341,7 +3349,7 @@ msgstr "Punkty montowania"
 msgid "Move down"
 msgstr "Przesuń w dół"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Przenieś do biblioteki..."
 
@@ -3350,7 +3358,7 @@ msgstr "Przenieś do biblioteki..."
 msgid "Move up"
 msgstr "Przesuń w górę"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Muzyka"
 
@@ -3363,7 +3371,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Wycisz"
 
@@ -3412,7 +3420,7 @@ msgstr "Nie odtwarzaj automatycznie"
 msgid "New folder"
 msgstr "Nowy folder"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nowa playlista"
 
@@ -3440,8 +3448,12 @@ msgstr "Najnowsze ścieżki"
 msgid "Next"
 msgstr "Dalej"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Następny utwór"
 
@@ -3479,7 +3491,7 @@ msgstr "Bez krótkich bloków"
 msgid "None"
 msgstr "Brak"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Żaden z zaznaczonych utworów nie był odpowiedni do skopiowania na urządzenie"
 
@@ -3564,19 +3576,19 @@ msgstr "Wył"
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3620,7 +3632,7 @@ msgstr "Krycie"
 msgid "Open %1 in browser"
 msgstr "Otwórz %1 w przeglądarce"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Otwórz audio CD"
 
@@ -3632,7 +3644,7 @@ msgstr "Otwórz plik OPML"
 msgid "Open OPML file..."
 msgstr "Otwórz plik OPML..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Importuj muzykę z"
 
@@ -3640,7 +3652,7 @@ msgstr "Importuj muzykę z"
 msgid "Open device"
 msgstr "Otwórz urządzenie"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Otwórz plik..."
 
@@ -3694,7 +3706,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Uporządkuj pliki"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Uporządkuj pliki..."
 
@@ -3778,7 +3790,7 @@ msgstr "Impreza"
 msgid "Password"
 msgstr "Hasło"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pauza"
@@ -3802,6 +3814,10 @@ msgstr "Wykonawca"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Piksel"
@@ -3810,10 +3826,10 @@ msgstr "Piksel"
 msgid "Plain sidebar"
 msgstr "Zwykły pasek boczny"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Odtwarzaj"
 
@@ -3834,11 +3850,11 @@ msgstr "Odtwarzaj, gdy zatrzymane; zatrzymaj, gdy odtwarzane"
 msgid "Play if there is nothing already playing"
 msgstr "Odtwarzaj jeśli nic nie jest aktualnie odtwarzane"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Odtwórz po bieżącym utworze"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Odtwórz zaznaczone ścieżki po bieżącym utworze"
 
@@ -3937,7 +3953,7 @@ msgstr "Ustawienie"
 msgid "Preferences"
 msgstr "Ustawienia"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Ustawienia..."
 
@@ -3997,7 +4013,7 @@ msgid "Previous"
 msgstr "Wstecz"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Poprzedni utwór"
 
@@ -4055,16 +4071,16 @@ msgstr "Jakość"
 msgid "Querying device..."
 msgstr "Odpytywanie urządzenia..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Menedżer kolejki odtwarzania"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Kolejkuj wybrane ścieżki"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Kolejkuj ścieżkę"
 
@@ -4080,7 +4096,7 @@ msgstr "Radio (równa głośność dla wszystkich ścieżek)"
 msgid "Rain"
 msgstr "Deszcz"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Deszcz"
@@ -4192,7 +4208,7 @@ msgstr "Usuń akcję"
 msgid "Remove current song from playlist"
 msgstr "Usuń bieżącą ścieżkę z playlisty"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Usuń duplikaty z playlisty"
 
@@ -4200,7 +4216,7 @@ msgstr "Usuń duplikaty z playlisty"
 msgid "Remove folder"
 msgstr "Usuń katalog"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Usuń z playlisty"
 
@@ -4212,7 +4228,7 @@ msgstr "Usuń playlistę"
 msgid "Remove playlists"
 msgstr "Usuń playlisty"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Usuń niedostępne ścieżki z playlisty"
 
@@ -4224,7 +4240,7 @@ msgstr "Zmień nazwę playlisty"
 msgid "Rename playlist..."
 msgstr "Zmień nazwę playlisty..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Ponumeruj utwory według tej kolejności..."
 
@@ -4315,7 +4331,7 @@ msgstr "Zgraj"
 msgid "Rip CD"
 msgstr "Zgraj CD"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Zgraj audio CD"
 
@@ -4393,7 +4409,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Zapisz playlistę"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Zapisz playlistę..."
 
@@ -4480,7 +4496,7 @@ msgstr "Przeszukaj Subsonic"
 msgid "Search automatically"
 msgstr "Wyszukaj automatycznie"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Szukaj wydania"
 
@@ -4493,7 +4509,7 @@ msgstr "Szukaj okładek..."
 msgid "Search for anything"
 msgstr "Wpisz dowolną frazę"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Szukaj Wykonawcy"
 
@@ -4618,7 +4634,7 @@ msgstr "Szczegóły serwera"
 msgid "Service offline"
 msgstr "Usługa niedostępna"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Ustaw %1 na \"%2\"..."
@@ -4627,7 +4643,7 @@ msgstr "Ustaw %1 na \"%2\"..."
 msgid "Set the volume to <value> percent"
 msgstr "Ustaw głośność na <value> procent"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Ustaw wartość dla wszystkich zaznaczonych utworów..."
 
@@ -4698,7 +4714,7 @@ msgstr "Pokazuj ładne OSD (menu ekranowe)"
 msgid "Show above status bar"
 msgstr "Pokaż ponad paskiem stanu"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Pokaż wszystkie utwory"
 
@@ -4718,12 +4734,12 @@ msgstr "Pokaż separatory"
 msgid "Show fullsize..."
 msgstr "Pokaż w pełnej wielkości..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Pokaż w menadżerze plików..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Pokaż w bibliotece..."
 
@@ -4735,15 +4751,15 @@ msgstr "Pokaż w różni wykonawcy"
 msgid "Show moodbar"
 msgstr "Pokaż pasek humoru"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Pokaż tylko duplikaty"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Pokaż tylko nieoznaczone"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Pokaż lub schowaj pasek boczny"
 
@@ -4751,7 +4767,7 @@ msgstr "Pokaż lub schowaj pasek boczny"
 msgid "Show search suggestions"
 msgstr "Pokazuj sugestie"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Pokaż pasek boczny"
 
@@ -4787,7 +4803,7 @@ msgstr "Losuj albumy"
 msgid "Shuffle all"
 msgstr "Losuj wszystko"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Wymieszaj playlistę"
 
@@ -4831,11 +4847,15 @@ msgstr "Ilość przeskoczeń utworu"
 msgid "Skip forwards in playlist"
 msgstr "Przeskocz do przodu w playliście"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Pomiń wybrane ścieżki"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Pomiń ścieżkę"
 
@@ -4952,7 +4972,7 @@ msgstr "Zacznij zgrywanie"
 msgid "Start the playlist currently playing"
 msgstr "Rozpocznij aktualnie odtwarzaną playlistę"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Rozpocznij transkodowanie"
 
@@ -4962,7 +4982,7 @@ msgid ""
 "list"
 msgstr "Zacznij wpisywać frazę w polu powyżej, aby rozpocząć wyszukiwanie"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Uruchamianie %1"
@@ -4972,7 +4992,7 @@ msgid "Starting..."
 msgstr "Uruchamianie..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Zatrzymaj"
 
@@ -4988,7 +5008,7 @@ msgstr "Zatrzymaj po każdym utworze"
 msgid "Stop after every track"
 msgstr "Zatrzymaj po każdym utworze"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Zatrzymaj po tym utworze"
 
@@ -5156,7 +5176,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Okres próbny dla serwera Subsonic wygasł. Zapłać, aby otrzymać klucz licencyjny. Szczegóły na subsonic.org."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5198,7 +5218,7 @@ msgid ""
 "continue?"
 msgstr "Te pliki zostaną usunięte z urządzenia. Na pewno chcesz kontynuować?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5300,11 +5320,11 @@ msgstr "Przełącz ładne OSD"
 msgid "Toggle fullscreen"
 msgstr "Przełącz tryb pełnoekranowy"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Przełącz stan kolejki"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Włącz scroblowanie"
 
@@ -5349,19 +5369,19 @@ msgstr "&Utwór"
 msgid "Track"
 msgstr "Utwór"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Transkoduj muzykę"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Dziennik transkodera"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Konwersja"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Transkodowanie %1 plików za pomocą %2 wątków"
@@ -5438,11 +5458,11 @@ msgstr "Nieznany błąd"
 msgid "Unset cover"
 msgstr "Usuń okładkę"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Nie pomijaj wybranych ścieżek"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Nie pomijaj ścieżki"
 
@@ -5459,7 +5479,7 @@ msgstr "Nadchodzące koncerty"
 msgid "Update all podcasts"
 msgstr "Uaktualnij wszystkie podcasty"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Odśwież zmienione katalogi biblioteki"
 
@@ -5620,7 +5640,7 @@ msgstr "Wersja %1"
 msgid "View"
 msgstr "Pokaż"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Pokaż szczegóły strumienia"
 
@@ -5628,7 +5648,7 @@ msgstr "Pokaż szczegóły strumienia"
 msgid "Visualization mode"
 msgstr "Tryb wizualizacji"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Wizualizacje"
 
@@ -5669,7 +5689,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5765,7 +5785,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media audio"
 
@@ -5779,7 +5799,7 @@ msgid ""
 "well?"
 msgstr "Czy chciałbyś przenieść także inny piosenki z tego albumu do Różnych wykonawców?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Czy chcesz teraz rozpocząć odświeżanie biblioteki?"
 

--- a/src/translations/pl.po
+++ b/src/translations/pl.po
@@ -531,7 +531,7 @@ msgstr "Dodaj następny strumień..."
 msgid "Add directory..."
 msgstr "Dodaj katalog..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Dodaj plik"
 
@@ -551,7 +551,7 @@ msgstr "Dodaj plik..."
 msgid "Add files to transcode"
 msgstr "Dodaj pliki to transkodowania"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Dodaj katalog"
@@ -656,7 +656,7 @@ msgstr "Dodaj do playlist Spotify"
 msgid "Add to Spotify starred"
 msgstr "Dodaj do śledzonych w Spotify"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Dodaj do innej playlisty"
 
@@ -878,7 +878,7 @@ msgstr "Czy na pewno chcesz zapisać w plikach wszystkie statystyki każdego utw
 msgid "Artist"
 msgstr "Artysta"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "O artyście"
 
@@ -1141,7 +1141,7 @@ msgstr "Sprawdzaj, czy są nowe audycje"
 msgid "Check for updates"
 msgstr "Sprawdź aktualizacje"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Sprawdź aktualizacje..."
 
@@ -1381,7 +1381,7 @@ msgstr "Skonfiguruj Subsonic..."
 msgid "Configure global search..."
 msgstr "Skonfiguruj globalne wyszukiwanie..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Konfiguruj bibliotekę..."
 
@@ -1453,11 +1453,11 @@ msgid "Copy to clipboard"
 msgstr "Kopiuj do schowka"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Skopiuj na urządzenie..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Skopiuj do biblioteki..."
@@ -1675,7 +1675,7 @@ msgid "Delete downloaded data"
 msgstr "Usuń pobrane dane"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Usuń pliki"
 
@@ -1683,7 +1683,7 @@ msgstr "Usuń pliki"
 msgid "Delete from device..."
 msgstr "Usuń z urządzenia..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Usuń z dysku..."
@@ -1716,11 +1716,11 @@ msgstr "Usuwanie plików"
 msgid "Depth"
 msgstr "Głębokość"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Usuń ścieżki z kolejki odtwarzania"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Usuń ścieżkę z kolejki odtwarzania"
 
@@ -1749,7 +1749,7 @@ msgstr "Nazwa urządzenia"
 msgid "Device properties..."
 msgstr "Ustawienia urządzenia..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Urządzenia"
 
@@ -2000,7 +2000,7 @@ msgstr "Dynamiczny, losowy miks"
 msgid "Edit smart playlist..."
 msgstr "Edytuj inteligentną playlistę..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Edytuj tag \"%1\"..."
@@ -2139,8 +2139,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Rownoważny --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Błąd"
 
@@ -2286,7 +2286,7 @@ msgstr "Przejście"
 msgid "Fading duration"
 msgstr "Czas przejścia"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Błąd odczytywania napędu CD"
 
@@ -2409,7 +2409,7 @@ msgstr "Typ pliku"
 msgid "Filename"
 msgstr "Nazwa pliku"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Pliki"
 
@@ -2824,7 +2824,7 @@ msgstr "Zainstalowano"
 msgid "Integrity check"
 msgstr "Sprawdzanie integralności"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -3012,7 +3012,7 @@ msgstr "Lewy"
 msgid "Length"
 msgstr "Czas"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Biblioteka"
@@ -3021,7 +3021,7 @@ msgstr "Biblioteka"
 msgid "Library advanced grouping"
 msgstr "Zaawansowanie grupowanie biblioteki"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Konieczność odświeżenia biblioteki"
 
@@ -3349,7 +3349,7 @@ msgstr "Punkty montowania"
 msgid "Move down"
 msgstr "Przesuń w dół"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Przenieś do biblioteki..."
 
@@ -3358,7 +3358,7 @@ msgstr "Przenieś do biblioteki..."
 msgid "Move up"
 msgstr "Przesuń w górę"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Muzyka"
 
@@ -3420,7 +3420,7 @@ msgstr "Nie odtwarzaj automatycznie"
 msgid "New folder"
 msgstr "Nowy folder"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nowa playlista"
 
@@ -3491,7 +3491,7 @@ msgstr "Bez krótkich bloków"
 msgid "None"
 msgstr "Brak"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Żaden z zaznaczonych utworów nie był odpowiedni do skopiowania na urządzenie"
 
@@ -3706,7 +3706,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Uporządkuj pliki"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Uporządkuj pliki..."
 
@@ -3790,7 +3790,7 @@ msgstr "Impreza"
 msgid "Password"
 msgstr "Hasło"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pauza"
@@ -3826,8 +3826,8 @@ msgstr "Piksel"
 msgid "Plain sidebar"
 msgstr "Zwykły pasek boczny"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3850,11 +3850,11 @@ msgstr "Odtwarzaj, gdy zatrzymane; zatrzymaj, gdy odtwarzane"
 msgid "Play if there is nothing already playing"
 msgstr "Odtwarzaj jeśli nic nie jest aktualnie odtwarzane"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Odtwórz po bieżącym utworze"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Odtwórz zaznaczone ścieżki po bieżącym utworze"
 
@@ -3893,7 +3893,7 @@ msgstr "Opcje playlisty"
 msgid "Playlist type"
 msgstr "Typ playlisty"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Playlisty"
 
@@ -4075,12 +4075,12 @@ msgstr "Odpytywanie urządzenia..."
 msgid "Queue Manager"
 msgstr "Menedżer kolejki odtwarzania"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Kolejkuj wybrane ścieżki"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Kolejkuj ścieżkę"
 
@@ -4471,7 +4471,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Szukaj"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Szukaj"
@@ -4496,7 +4496,7 @@ msgstr "Przeszukaj Subsonic"
 msgid "Search automatically"
 msgstr "Wyszukaj automatycznie"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Szukaj wydania"
 
@@ -4509,7 +4509,7 @@ msgstr "Szukaj okładek..."
 msgid "Search for anything"
 msgstr "Wpisz dowolną frazę"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Szukaj Wykonawcy"
 
@@ -4634,7 +4634,7 @@ msgstr "Szczegóły serwera"
 msgid "Service offline"
 msgstr "Usługa niedostępna"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Ustaw %1 na \"%2\"..."
@@ -4714,7 +4714,7 @@ msgstr "Pokazuj ładne OSD (menu ekranowe)"
 msgid "Show above status bar"
 msgstr "Pokaż ponad paskiem stanu"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Pokaż wszystkie utwory"
 
@@ -4734,12 +4734,12 @@ msgstr "Pokaż separatory"
 msgid "Show fullsize..."
 msgstr "Pokaż w pełnej wielkości..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Pokaż w menadżerze plików..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Pokaż w bibliotece..."
 
@@ -4751,11 +4751,11 @@ msgstr "Pokaż w różni wykonawcy"
 msgid "Show moodbar"
 msgstr "Pokaż pasek humoru"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Pokaż tylko duplikaty"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Pokaż tylko nieoznaczone"
 
@@ -4847,7 +4847,7 @@ msgstr "Ilość przeskoczeń utworu"
 msgid "Skip forwards in playlist"
 msgstr "Przeskocz do przodu w playliście"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Pomiń wybrane ścieżki"
 
@@ -4855,7 +4855,7 @@ msgstr "Pomiń wybrane ścieżki"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Pomiń ścieżkę"
 
@@ -4887,7 +4887,7 @@ msgstr "Soft Rock"
 msgid "Song Information"
 msgstr "Informacje o utworze"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "O utworze"
 
@@ -5008,7 +5008,7 @@ msgstr "Zatrzymaj po każdym utworze"
 msgid "Stop after every track"
 msgstr "Zatrzymaj po każdym utworze"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Zatrzymaj po tym utworze"
 
@@ -5176,7 +5176,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Okres próbny dla serwera Subsonic wygasł. Zapłać, aby otrzymać klucz licencyjny. Szczegóły na subsonic.org."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5218,7 +5218,7 @@ msgid ""
 "continue?"
 msgstr "Te pliki zostaną usunięte z urządzenia. Na pewno chcesz kontynuować?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5320,7 +5320,7 @@ msgstr "Przełącz ładne OSD"
 msgid "Toggle fullscreen"
 msgstr "Przełącz tryb pełnoekranowy"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Przełącz stan kolejki"
 
@@ -5458,11 +5458,11 @@ msgstr "Nieznany błąd"
 msgid "Unset cover"
 msgstr "Usuń okładkę"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Nie pomijaj wybranych ścieżek"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Nie pomijaj ścieżki"
 
@@ -5799,7 +5799,7 @@ msgid ""
 "well?"
 msgstr "Czy chciałbyś przenieść także inny piosenki z tego albumu do Różnych wykonawców?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Czy chcesz teraz rozpocząć odświeżanie biblioteki?"
 

--- a/src/translations/pt.po
+++ b/src/translations/pt.po
@@ -15,8 +15,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-26 23:47+0000\n"
-"Last-Translator: John Maguire <john.maguire@gmail.com>\n"
+"PO-Revision-Date: 2021-01-27 22:19+0000\n"
+"Last-Translator: Hugo Carvalho <hugokarvalho@hotmail.com>\n"
 "Language-Team: Portuguese (http://www.transifex.com/davidsansome/clementine/language/pt/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -517,7 +517,7 @@ msgstr "Adicionar outra emissão..."
 msgid "Add directory..."
 msgstr "Adicionar diretório..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Adicionar ficheiro"
 
@@ -537,7 +537,7 @@ msgstr "Adicionar ficheiro..."
 msgid "Add files to transcode"
 msgstr "Adicionar ficheiros a converter"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Adicionar diretório"
@@ -642,7 +642,7 @@ msgstr "Adicionar às listas do Spotify"
 msgid "Add to Spotify starred"
 msgstr "Adicionar ao Spotify com estrela"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Adicionar noutra lista de reprodução"
 
@@ -864,7 +864,7 @@ msgstr "Tem a certeza que pretende gravar as estatísticas e avaliações para t
 msgid "Artist"
 msgstr "Artista"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Info do artista"
 
@@ -1127,7 +1127,7 @@ msgstr "Procurar novos episódios"
 msgid "Check for updates"
 msgstr "Procurar atualizações"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Procurar atualizações..."
 
@@ -1367,7 +1367,7 @@ msgstr "Configurar Subsonic..."
 msgid "Configure global search..."
 msgstr "Configurar pesquisa global..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Configurar coleção..."
 
@@ -1439,11 +1439,11 @@ msgid "Copy to clipboard"
 msgstr "Copiar para a área de transferência"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Copiar para o dispositivo..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Copiar para a coleção..."
@@ -1661,7 +1661,7 @@ msgid "Delete downloaded data"
 msgstr "Apagar dados descarregados"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Apagar ficheiros"
 
@@ -1669,7 +1669,7 @@ msgstr "Apagar ficheiros"
 msgid "Delete from device..."
 msgstr "Apagar do dispositivo..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Apagar do disco..."
@@ -1702,11 +1702,11 @@ msgstr "A eliminar ficheiros"
 msgid "Depth"
 msgstr "Extensão"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Retirar da fila as faixas selecionadas"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Retirar esta faixa da fila"
 
@@ -1735,7 +1735,7 @@ msgstr "Nome do dispositivo"
 msgid "Device properties..."
 msgstr "Propriedades do dispositivo..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Dispositivos"
 
@@ -1986,7 +1986,7 @@ msgstr "Combinação aleatória dinâmica"
 msgid "Edit smart playlist..."
 msgstr "Editar lista de reprodução inteligente..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Editar \"%1\"..."
@@ -2125,8 +2125,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Equivalente a --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Erro"
 
@@ -2246,7 +2246,7 @@ msgstr "Exportada(s) %1 de %2 capa(s) (%3 ignoradas)"
 
 #: ../bin/src/ui_mainwindow.h:790
 msgid "F9"
-msgstr ""
+msgstr "F9"
 
 #: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
@@ -2272,7 +2272,7 @@ msgstr "Desvanecimento"
 msgid "Fading duration"
 msgstr "Duração"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Falha ao ler a unidade de CD"
 
@@ -2395,7 +2395,7 @@ msgstr "Tipo de ficheiro"
 msgid "Filename"
 msgstr "Nome do ficheiro"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Ficheiros"
 
@@ -2810,7 +2810,7 @@ msgstr "Instalado"
 msgid "Integrity check"
 msgstr "Verificação de integridade"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -2998,7 +2998,7 @@ msgstr "Esquerda"
 msgid "Length"
 msgstr "Duração"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Coleção"
@@ -3007,7 +3007,7 @@ msgstr "Coleção"
 msgid "Library advanced grouping"
 msgstr "Agrupamento avançado da coleção"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Aviso de análise da coleção"
 
@@ -3110,7 +3110,7 @@ msgstr "Falha ao iniciar sessão"
 
 #: ../bin/src/ui_transcodelogdialog.h:107
 msgid "Logs"
-msgstr ""
+msgstr "Registos"
 
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
@@ -3335,7 +3335,7 @@ msgstr "Pontos de montagem"
 msgid "Move down"
 msgstr "Mover para baixo"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Mover para a coleção..."
 
@@ -3344,7 +3344,7 @@ msgstr "Mover para a coleção..."
 msgid "Move up"
 msgstr "Mover para cima"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Música"
 
@@ -3406,7 +3406,7 @@ msgstr "Nunca iniciar a reprodução"
 msgid "New folder"
 msgstr "Novo diretório"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nova lista de reprodução"
 
@@ -3436,7 +3436,7 @@ msgstr "Seguinte"
 
 #: ../bin/src/ui_mainwindow.h:785
 msgid "Next album"
-msgstr ""
+msgstr "Álbum seguinte"
 
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
 #: ../bin/src/ui_mainwindow.h:727
@@ -3477,7 +3477,7 @@ msgstr "Sem blocos curtos"
 msgid "None"
 msgstr "Nenhum"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Nenhuma das faixas selecionadas eram adequadas à cópia para o dispositivo"
 
@@ -3692,7 +3692,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organizar ficheiros"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Organizar ficheiros..."
 
@@ -3776,7 +3776,7 @@ msgstr "Festa"
 msgid "Password"
 msgstr "Palavra-passe"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pausa"
@@ -3802,7 +3802,7 @@ msgstr "Pipeline"
 
 #: ../bin/src/ui_transcodelogdialog.h:106
 msgid "Pipelines"
-msgstr ""
+msgstr "Pipelines"
 
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
@@ -3812,8 +3812,8 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Barra lateral simples"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3836,11 +3836,11 @@ msgstr "Reproduzir se parado, pausa se em reprodução"
 msgid "Play if there is nothing already playing"
 msgstr "Reproduzir se não existir nada em reprodução"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Reproduzir seguinte"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Reproduzir faixas selecionadas de seguida"
 
@@ -3879,7 +3879,7 @@ msgstr "Opções da lista de reprodução"
 msgid "Playlist type"
 msgstr "Tipo de lista de reprodução"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Listas de reprodução"
 
@@ -4061,12 +4061,12 @@ msgstr "A consultar dispositivo..."
 msgid "Queue Manager"
 msgstr "Gestor da fila"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Colocar em fila as faixas selecionadas"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Colocar esta faixa na fila"
 
@@ -4457,7 +4457,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Pesquisar"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Pesquisar"
@@ -4482,7 +4482,7 @@ msgstr "Pesquisar no Subsconic"
 msgid "Search automatically"
 msgstr "Pesquisar automaticamente"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Pesquisar por álbum"
 
@@ -4495,7 +4495,7 @@ msgstr "Pesquisar capas de álbuns..."
 msgid "Search for anything"
 msgstr "Pesquisar algo"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Pesquisar por artista"
 
@@ -4620,7 +4620,7 @@ msgstr "Detalhes do servidor"
 msgid "Service offline"
 msgstr "Serviço desligado"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Definir %1 para \"%2\"..."
@@ -4700,7 +4700,7 @@ msgstr "Mostrar notificação personalizada"
 msgid "Show above status bar"
 msgstr "Mostrar acima da barra de estado"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Mostrar todas as faixas"
 
@@ -4720,12 +4720,12 @@ msgstr "Mostrar separadores"
 msgid "Show fullsize..."
 msgstr "Mostrar em ecrã completo..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Mostrar no gestor de ficheiros..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Mostrar na coleção..."
 
@@ -4737,11 +4737,11 @@ msgstr "Mostrar em vários artistas"
 msgid "Show moodbar"
 msgstr "Mostrar barra de estado de espírito"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Mostrar apenas as repetidas"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Mostrar apenas faixas sem etiquetas"
 
@@ -4833,15 +4833,15 @@ msgstr "Reproduções ignoradas"
 msgid "Skip forwards in playlist"
 msgstr "Avançar na lista de reprodução"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Ignorar faixas selecionadas"
 
 #: ../bin/src/ui_mainwindow.h:787
 msgid "Skip to the next album"
-msgstr ""
+msgstr "Saltar para o próximo álbum"
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Ignorar faixa"
 
@@ -4873,7 +4873,7 @@ msgstr "Rock suave"
 msgid "Song Information"
 msgstr "Informações da faixa"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Info da faixa"
 
@@ -4994,7 +4994,7 @@ msgstr "Parar após cada faixa"
 msgid "Stop after every track"
 msgstr "Parar após cada faixa"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Parar após esta faixa"
 
@@ -5162,7 +5162,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "O período de testes do Subsonic terminou. Efetue um donativo para obter uma licença. Consulte subsonic.org para mais detalhes."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5204,7 +5204,7 @@ msgid ""
 "continue?"
 msgstr "Estes ficheiros serão removidos do dispositivo. Tem a certeza de que deseja continuar?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5306,7 +5306,7 @@ msgstr "Alternar notificação"
 msgid "Toggle fullscreen"
 msgstr "Trocar para ecrã completo"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Trocar estado da fila"
 
@@ -5361,7 +5361,7 @@ msgstr "Conversão de ficheiros"
 
 #: ../bin/src/ui_transcodelogdialog.h:105
 msgid "Transcoder Details"
-msgstr ""
+msgstr "Detalhes do conversor"
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
@@ -5444,11 +5444,11 @@ msgstr "Erro desconhecido"
 msgid "Unset cover"
 msgstr "Sem capa"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Não ignorar faixas selecionadas"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Não ignorar faixa"
 
@@ -5785,7 +5785,7 @@ msgid ""
 "well?"
 msgstr "Pretende mover as outras faixas deste álbum para Vários artistas?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Pretende executar uma nova análise?"
 

--- a/src/translations/pt.po
+++ b/src/translations/pt.po
@@ -15,8 +15,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 15:21+0000\n"
-"Last-Translator: Hugo Carvalho <hugokarvalho@hotmail.com>\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
+"Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Portuguese (http://www.transifex.com/davidsansome/clementine/language/pt/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -169,19 +169,19 @@ msgstr "%L1 faixas"
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n falha(s)"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n concluída(s)"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -199,7 +199,7 @@ msgstr "&Centro"
 msgid "&Custom"
 msgstr "&Personalizado"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Extras"
 
@@ -207,7 +207,7 @@ msgstr "&Extras"
 msgid "&Grouping"
 msgstr "A&grupamento"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Ajuda"
 
@@ -232,7 +232,7 @@ msgstr "B&loquear avaliação"
 msgid "&Lyrics"
 msgstr "&Letra das músicas"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Música"
 
@@ -240,15 +240,15 @@ msgstr "&Música"
 msgid "&None"
 msgstr "&Nenhum"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "Lista de re&produção"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Sair"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "Modo de &repetição"
 
@@ -256,7 +256,7 @@ msgstr "Modo de &repetição"
 msgid "&Right"
 msgstr "Di&reita"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Modo de de&sordenação"
 
@@ -264,7 +264,7 @@ msgstr "Modo de de&sordenação"
 msgid "&Stretch columns to fit window"
 msgstr "Ajustar coluna&s à janela"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "Ferramen&tas"
 
@@ -453,11 +453,11 @@ msgstr "Abortar"
 msgid "About %1"
 msgstr "Acerca de %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Acerca de Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Acerca de Qt..."
 
@@ -517,32 +517,32 @@ msgstr "Adicionar outra emissão..."
 msgid "Add directory..."
 msgstr "Adicionar diretório..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Adicionar ficheiro"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Adicionar ficheiro ao conversor"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Adicionar ficheiro(s) ao conversor"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Adicionar ficheiro..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Adicionar ficheiros a converter"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Adicionar diretório"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Adicionar diretório..."
 
@@ -554,7 +554,7 @@ msgstr "Adicionar novo diretório..."
 msgid "Add podcast"
 msgstr "Adicionar podcast"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Adicionar podcast..."
 
@@ -630,7 +630,7 @@ msgstr "Adicionar número da faixa"
 msgid "Add song year tag"
 msgstr "Adicionar ano"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Adicionar emissão..."
 
@@ -642,7 +642,7 @@ msgstr "Adicionar às listas do Spotify"
 msgid "Add to Spotify starred"
 msgstr "Adicionar ao Spotify com estrela"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Adicionar noutra lista de reprodução"
 
@@ -736,7 +736,7 @@ msgstr "Todos"
 msgid "All Files (*)"
 msgstr "Todos os ficheiros (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "All Glory to the Hypnotoad!"
@@ -1127,7 +1127,7 @@ msgstr "Procurar novos episódios"
 msgid "Check for updates"
 msgstr "Procurar atualizações"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Procurar atualizações..."
 
@@ -1176,18 +1176,18 @@ msgstr "Clássica"
 msgid "Cleaning up"
 msgstr "Eliminação"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Limpar"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Limpar lista de reprodução"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1332,7 +1332,7 @@ msgstr "Comentário"
 msgid "Complete tags automatically"
 msgstr "Preencher etiquetas automaticamente"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Preencher etiquetas automaticamente..."
 
@@ -1367,7 +1367,7 @@ msgstr "Configurar Subsonic..."
 msgid "Configure global search..."
 msgstr "Configurar pesquisa global..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Configurar coleção..."
 
@@ -1410,7 +1410,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Ligação expirada. Verifique o URL. Por exemplo: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Consola"
 
@@ -1439,11 +1439,11 @@ msgid "Copy to clipboard"
 msgstr "Copiar para a área de transferência"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Copiar para o dispositivo..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Copiar para a coleção..."
@@ -1486,14 +1486,14 @@ msgstr "Falha ao iniciar sessão na Last.fm. Por favor tente novamente."
 msgid "Couldn't create playlist"
 msgstr "Não foi possível criar a lista de reprodução"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Incapaz de encontrar o recurso para %1, verifique se instalou os suplementos GStreamer corretos"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1508,7 +1508,7 @@ msgstr "Não foi possível abrir o ficheiro %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Gestor de capas"
 
@@ -1661,7 +1661,7 @@ msgid "Delete downloaded data"
 msgstr "Apagar dados descarregados"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Apagar ficheiros"
 
@@ -1669,7 +1669,7 @@ msgstr "Apagar ficheiros"
 msgid "Delete from device..."
 msgstr "Apagar do dispositivo..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Apagar do disco..."
@@ -1702,11 +1702,11 @@ msgstr "A eliminar ficheiros"
 msgid "Depth"
 msgstr "Extensão"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Retirar da fila as faixas selecionadas"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Retirar esta faixa da fila"
 
@@ -1807,7 +1807,7 @@ msgstr "Opções de exibição"
 msgid "Display the on-screen-display"
 msgstr "Mostrar notificação"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Reanalisar coleção"
 
@@ -1986,12 +1986,12 @@ msgstr "Combinação aleatória dinâmica"
 msgid "Edit smart playlist..."
 msgstr "Editar lista de reprodução inteligente..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Editar \"%1\"..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Editar etiqueta..."
 
@@ -2004,7 +2004,7 @@ msgid "Edit track information"
 msgstr "Editar informações da faixa"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Editar informações da faixa..."
 
@@ -2112,7 +2112,7 @@ msgstr "Toda a coleção"
 msgid "Episode information"
 msgstr "Informações do episódio"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Equalizador"
 
@@ -2125,8 +2125,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Equivalente a --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Erro"
 
@@ -2161,7 +2161,7 @@ msgstr "Erro ao carregar %1"
 msgid "Error loading di.fm playlist"
 msgstr "Erro ao carregar a lista de reprodução di.fm"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Erro ao processar %1: %2"
@@ -2244,7 +2244,11 @@ msgstr "Exportação terminada"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "Exportada(s) %1 de %2 capa(s) (%3 ignoradas)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2268,7 +2272,7 @@ msgstr "Desvanecimento"
 msgid "Fading duration"
 msgstr "Duração"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Falha ao ler a unidade de CD"
 
@@ -2550,11 +2554,11 @@ msgstr "Nome:"
 msgid "Go"
 msgstr "Procurar"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Ir para o separador seguinte"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Ir para o separador anterior"
 
@@ -2887,7 +2891,7 @@ msgstr "Base de dados Jamendo"
 msgid "Jump to previous song right away"
 msgstr "Ir para a faixa anterior"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Ir para a faixa em reprodução"
 
@@ -2911,7 +2915,7 @@ msgstr "Executar em segundo plano ao fechar a janela principal"
 msgid "Keep the original files"
 msgstr "Manter ficheiros originais"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Gatinhos"
@@ -3003,7 +3007,7 @@ msgstr "Coleção"
 msgid "Library advanced grouping"
 msgstr "Agrupamento avançado da coleção"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Aviso de análise da coleção"
 
@@ -3043,7 +3047,7 @@ msgstr "Carregar capa de álbum no disco..."
 msgid "Load playlist"
 msgstr "Carregar lista de reprodução"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Carregar lista de reprodução..."
 
@@ -3104,11 +3108,15 @@ msgstr "Iniciar sessão"
 msgid "Login failed"
 msgstr "Falha ao iniciar sessão"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Perfil para predição (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Gosto"
 
@@ -3143,11 +3151,11 @@ msgstr "Letras musicais de %1"
 msgid "Lyrics from the tag"
 msgstr "Letra existente nas etiquetas"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3189,7 +3197,7 @@ msgstr "Perfil principal (MAIN)"
 msgid "Make it so!"
 msgstr "Make it so!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Make it so!"
@@ -3327,7 +3335,7 @@ msgstr "Pontos de montagem"
 msgid "Move down"
 msgstr "Mover para baixo"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Mover para a coleção..."
 
@@ -3336,7 +3344,7 @@ msgstr "Mover para a coleção..."
 msgid "Move up"
 msgstr "Mover para cima"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Música"
 
@@ -3349,7 +3357,7 @@ msgid "Music extensions remotely visible"
 msgstr "Extensões musicais remotamente visíveis"
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Sem som"
 
@@ -3398,7 +3406,7 @@ msgstr "Nunca iniciar a reprodução"
 msgid "New folder"
 msgstr "Novo diretório"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nova lista de reprodução"
 
@@ -3426,8 +3434,12 @@ msgstr "Faixas recentes"
 msgid "Next"
 msgstr "Seguinte"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Faixa seguinte"
 
@@ -3465,7 +3477,7 @@ msgstr "Sem blocos curtos"
 msgid "None"
 msgstr "Nenhum"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Nenhuma das faixas selecionadas eram adequadas à cópia para o dispositivo"
 
@@ -3550,19 +3562,19 @@ msgstr "Desligado"
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3606,7 +3618,7 @@ msgstr "Opacidade"
 msgid "Open %1 in browser"
 msgstr "Abrir %1 no navegador"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "&Abrir CD áudio..."
 
@@ -3618,7 +3630,7 @@ msgstr "Abrir um ficheiro OPML"
 msgid "Open OPML file..."
 msgstr "Abrir um ficheiro OPML..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Abrir um diretório para efetuar a importação"
 
@@ -3626,7 +3638,7 @@ msgstr "Abrir um diretório para efetuar a importação"
 msgid "Open device"
 msgstr "Abrir dispositivo"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Abrir ficheiro..."
 
@@ -3680,7 +3692,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organizar ficheiros"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Organizar ficheiros..."
 
@@ -3764,7 +3776,7 @@ msgstr "Festa"
 msgid "Password"
 msgstr "Palavra-passe"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pausa"
@@ -3788,6 +3800,10 @@ msgstr "Intérprete"
 msgid "Pipeline"
 msgstr "Pipeline"
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Pixel"
@@ -3796,10 +3812,10 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Barra lateral simples"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Reproduzir"
 
@@ -3820,11 +3836,11 @@ msgstr "Reproduzir se parado, pausa se em reprodução"
 msgid "Play if there is nothing already playing"
 msgstr "Reproduzir se não existir nada em reprodução"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Reproduzir seguinte"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Reproduzir faixas selecionadas de seguida"
 
@@ -3923,7 +3939,7 @@ msgstr "Preferências"
 msgid "Preferences"
 msgstr "Preferências"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Preferências..."
 
@@ -3983,7 +3999,7 @@ msgid "Previous"
 msgstr "Anterior"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Faixa anterior"
 
@@ -4041,16 +4057,16 @@ msgstr "Qualidade"
 msgid "Querying device..."
 msgstr "A consultar dispositivo..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Gestor da fila"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Colocar em fila as faixas selecionadas"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Colocar esta faixa na fila"
 
@@ -4066,7 +4082,7 @@ msgstr "Faixa (volume igual para todas as faixas)"
 msgid "Rain"
 msgstr "Chuva"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Chuva"
@@ -4178,7 +4194,7 @@ msgstr "Remover ação"
 msgid "Remove current song from playlist"
 msgstr "Remover faixa atual da lista de reprodução"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Remover duplicados da lista de reprodução"
 
@@ -4186,7 +4202,7 @@ msgstr "Remover duplicados da lista de reprodução"
 msgid "Remove folder"
 msgstr "Remover diretório"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Remover da lista de reprodução"
 
@@ -4198,7 +4214,7 @@ msgstr "Remover lista de reprodução"
 msgid "Remove playlists"
 msgstr "Remover listas de reprodução"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Remover da lista de reprodução as faixas indisponíveis"
 
@@ -4210,7 +4226,7 @@ msgstr "Mudar nome da lista de reprodução"
 msgid "Rename playlist..."
 msgstr "Mudar nome da lista de reprodução..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Renumerar faixas por esta ordem..."
 
@@ -4301,7 +4317,7 @@ msgstr "Extrair"
 msgid "Rip CD"
 msgstr "Extrair CD"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Extrair CD áudio"
 
@@ -4379,7 +4395,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Guardar lista de reprodução"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Guardar lista de reprodução..."
 
@@ -4466,7 +4482,7 @@ msgstr "Pesquisar no Subsconic"
 msgid "Search automatically"
 msgstr "Pesquisar automaticamente"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Pesquisar por álbum"
 
@@ -4479,7 +4495,7 @@ msgstr "Pesquisar capas de álbuns..."
 msgid "Search for anything"
 msgstr "Pesquisar algo"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Pesquisar por artista"
 
@@ -4604,7 +4620,7 @@ msgstr "Detalhes do servidor"
 msgid "Service offline"
 msgstr "Serviço desligado"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Definir %1 para \"%2\"..."
@@ -4613,7 +4629,7 @@ msgstr "Definir %1 para \"%2\"..."
 msgid "Set the volume to <value> percent"
 msgstr "Ajustar volume para <value> por cento"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Utilizar valor para todas as faixas selecionadas..."
 
@@ -4684,7 +4700,7 @@ msgstr "Mostrar notificação personalizada"
 msgid "Show above status bar"
 msgstr "Mostrar acima da barra de estado"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Mostrar todas as faixas"
 
@@ -4704,12 +4720,12 @@ msgstr "Mostrar separadores"
 msgid "Show fullsize..."
 msgstr "Mostrar em ecrã completo..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Mostrar no gestor de ficheiros..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Mostrar na coleção..."
 
@@ -4721,15 +4737,15 @@ msgstr "Mostrar em vários artistas"
 msgid "Show moodbar"
 msgstr "Mostrar barra de estado de espírito"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Mostrar apenas as repetidas"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Mostrar apenas faixas sem etiquetas"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Mostrar ou ocultar a barra lateral"
 
@@ -4737,7 +4753,7 @@ msgstr "Mostrar ou ocultar a barra lateral"
 msgid "Show search suggestions"
 msgstr "Mostrar sugestões de pesquisa"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Mostrar barra lateral"
 
@@ -4773,7 +4789,7 @@ msgstr "Desordenar álbuns"
 msgid "Shuffle all"
 msgstr "Desordenar tudo"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Desordenar lista de reprodução"
 
@@ -4817,11 +4833,15 @@ msgstr "Reproduções ignoradas"
 msgid "Skip forwards in playlist"
 msgstr "Avançar na lista de reprodução"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Ignorar faixas selecionadas"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Ignorar faixa"
 
@@ -4938,7 +4958,7 @@ msgstr "Iniciar extração"
 msgid "Start the playlist currently playing"
 msgstr "Iniciar lista de reprodução atual"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Iniciar conversão"
 
@@ -4948,7 +4968,7 @@ msgid ""
 "list"
 msgstr "Escreva algo na caixa de pesquisa para preencher a lista de resultados"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "A iniciar %1"
@@ -4958,7 +4978,7 @@ msgid "Starting..."
 msgstr "A iniciar..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Parar"
 
@@ -4974,7 +4994,7 @@ msgstr "Parar após cada faixa"
 msgid "Stop after every track"
 msgstr "Parar após cada faixa"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Parar após esta faixa"
 
@@ -5142,7 +5162,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "O período de testes do Subsonic terminou. Efetue um donativo para obter uma licença. Consulte subsonic.org para mais detalhes."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5184,7 +5204,7 @@ msgid ""
 "continue?"
 msgstr "Estes ficheiros serão removidos do dispositivo. Tem a certeza de que deseja continuar?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5286,11 +5306,11 @@ msgstr "Alternar notificação"
 msgid "Toggle fullscreen"
 msgstr "Trocar para ecrã completo"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Trocar estado da fila"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Alternar envio"
 
@@ -5335,19 +5355,19 @@ msgstr "Fai&xa"
 msgid "Track"
 msgstr "Faixa"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Conversão de ficheiros"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Registo do conversor"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Conversão"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "A converter %1 ficheiros com %2 processos"
@@ -5424,11 +5444,11 @@ msgstr "Erro desconhecido"
 msgid "Unset cover"
 msgstr "Sem capa"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Não ignorar faixas selecionadas"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Não ignorar faixa"
 
@@ -5445,7 +5465,7 @@ msgstr "Próximos eventos"
 msgid "Update all podcasts"
 msgstr "Atualizar todos os podcasts"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Atualizar diretórios lterados"
 
@@ -5606,7 +5626,7 @@ msgstr "Versão %1"
 msgid "View"
 msgstr "Ver"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Ver detalhes da emissão"
 
@@ -5614,7 +5634,7 @@ msgstr "Ver detalhes da emissão"
 msgid "Visualization mode"
 msgstr "Modo de visualização"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Visualizações"
 
@@ -5655,7 +5675,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr "Aviso: Este nível de compressão está fora do subconjunto transmissível. Isto significa que um descodificador pode não ser capaz de começar a tocá-lo a meio do fluxo. Pode também afetar o desempenho dos descodificadores de hardware."
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5751,7 +5771,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media Áudio"
 
@@ -5765,7 +5785,7 @@ msgid ""
 "well?"
 msgstr "Pretende mover as outras faixas deste álbum para Vários artistas?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Pretende executar uma nova análise?"
 

--- a/src/translations/pt_BR.po
+++ b/src/translations/pt_BR.po
@@ -19,8 +19,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-17 17:37+0000\n"
-"Last-Translator: carlo giusepe tadei valente sasaki <carlo.gt.valente@gmail.com>\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
+"Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) (http://www.transifex.com/davidsansome/clementine/language/pt_BR/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -173,19 +173,19 @@ msgstr "%L1 faixas"
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n falhou"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n finalizado"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -203,7 +203,7 @@ msgstr "&Centro"
 msgid "&Custom"
 msgstr "&Personalizado"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "Extras"
 
@@ -211,7 +211,7 @@ msgstr "Extras"
 msgid "&Grouping"
 msgstr "A&grupamento"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Ajuda"
 
@@ -236,7 +236,7 @@ msgstr "Travar ava&liação"
 msgid "&Lyrics"
 msgstr "&Letras"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "Música"
 
@@ -244,15 +244,15 @@ msgstr "Música"
 msgid "&None"
 msgstr "&Nenhum"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "Lista de Reprodução"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Sair"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "&Mode de Repetição"
 
@@ -260,7 +260,7 @@ msgstr "&Mode de Repetição"
 msgid "&Right"
 msgstr "&Direita"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Modo aleatório"
 
@@ -268,7 +268,7 @@ msgstr "Modo aleatório"
 msgid "&Stretch columns to fit window"
 msgstr "&Esticar colunas para ajustar a janela"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Ferramentas"
 
@@ -457,11 +457,11 @@ msgstr "Abortar"
 msgid "About %1"
 msgstr "Sobre %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Sobre o Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Sobre o Qt..."
 
@@ -521,32 +521,32 @@ msgstr "Adicionar outro canal..."
 msgid "Add directory..."
 msgstr "Adicionar diretório..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Adicionar arquivo"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Adicionar arquivo para conversor"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Adicionar arquivo(s) para conversor"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Adicionar arquivo..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Adicionar arquivos para converter"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Adicionar pasta"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Adicionar pasta..."
 
@@ -558,7 +558,7 @@ msgstr "Adicionar nova pasta..."
 msgid "Add podcast"
 msgstr "Adicionar podcast"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Adicionar podcast..."
 
@@ -634,7 +634,7 @@ msgstr "Adicionar a tag faixa da música"
 msgid "Add song year tag"
 msgstr "Adicionar a tag ano da música"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Adicionar transmissão..."
 
@@ -646,7 +646,7 @@ msgstr "Adicionar às listas de reprodução do Spotify"
 msgid "Add to Spotify starred"
 msgstr "Adicionar ao Spotify com estrela"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Adicionar a outra lista de reprodução"
 
@@ -740,7 +740,7 @@ msgstr "Tudo"
 msgid "All Files (*)"
 msgstr "Todos os arquivos (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Toda a Glória para o Hypnotoad!"
@@ -1131,7 +1131,7 @@ msgstr "Procurar por novos episódios"
 msgid "Check for updates"
 msgstr "Verificar se há atualizações"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Procurar por atualizações..."
 
@@ -1180,18 +1180,18 @@ msgstr "Clássica"
 msgid "Cleaning up"
 msgstr "Limpando"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Limpar"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Limpar lista de reprodução"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1336,7 +1336,7 @@ msgstr "Comentário"
 msgid "Complete tags automatically"
 msgstr "Completar tags automaticamente"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Preencher tags automaticamente..."
 
@@ -1371,7 +1371,7 @@ msgstr "Configurar Subsonic..."
 msgid "Configure global search..."
 msgstr "Configurar busca global..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Configurar biblioteca..."
 
@@ -1414,7 +1414,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Conexão expirou, verifique a URL do servidor. Exemplo: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Painel"
 
@@ -1443,11 +1443,11 @@ msgid "Copy to clipboard"
 msgstr "Copiar para a área de transferência"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Copiar para o dispositivo..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Copiar para biblioteca..."
@@ -1490,14 +1490,14 @@ msgstr "Não foi possível logar no last.fm. Por favor tente novamente."
 msgid "Couldn't create playlist"
 msgstr "Não foi possível criar a lista de reprodução"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Não foi possível encontrar um multiplexador para %1, verifique se você tem os plugins corretos do GStreamer instalados"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1512,7 +1512,7 @@ msgstr "Não foi possível abrir o arquivo de saída %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Gerenciador de capas"
 
@@ -1665,7 +1665,7 @@ msgid "Delete downloaded data"
 msgstr "Apagar dados baixados"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Excluir arquivos"
 
@@ -1673,7 +1673,7 @@ msgstr "Excluir arquivos"
 msgid "Delete from device..."
 msgstr "Apagar do dispositivo..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Apagar do disco..."
@@ -1706,11 +1706,11 @@ msgstr "Apagando arquivos"
 msgid "Depth"
 msgstr "Profundidade"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Retirar faixas selecionadas da fila"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Retirar faixa da fila"
 
@@ -1811,7 +1811,7 @@ msgstr "Opções de exibição"
 msgid "Display the on-screen-display"
 msgstr "Mostrar na tela"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Reescanear por completo a biblioteca"
 
@@ -1990,12 +1990,12 @@ msgstr "Mix aleatório dinâmico"
 msgid "Edit smart playlist..."
 msgstr "Editar lista de reprodução inteligente..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Editar tag \"%1\"..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Editar tag..."
 
@@ -2008,7 +2008,7 @@ msgid "Edit track information"
 msgstr "Editar informações da faixa"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Editar informações da faixa..."
 
@@ -2116,7 +2116,7 @@ msgstr "Toda a coletânia"
 msgid "Episode information"
 msgstr "Informações sobre o episódio"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Equalizador"
 
@@ -2129,8 +2129,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Equivalente ao --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Erro"
 
@@ -2165,7 +2165,7 @@ msgstr "Erro carregando %1"
 msgid "Error loading di.fm playlist"
 msgstr "Erro carregando a lista de reprodução: di.fm"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Erro processando %1:%2"
@@ -2248,7 +2248,11 @@ msgstr "Exportação terminou"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "Exportado %1 capa(s) de %2 (%3 pulado)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2272,7 +2276,7 @@ msgstr "Diminuindo"
 msgid "Fading duration"
 msgstr "Duração da dimunuição"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Falha ao ler o CD"
 
@@ -2554,11 +2558,11 @@ msgstr "Nome da transmissão:"
 msgid "Go"
 msgstr "Ir"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Ir até a aba do próximo playlist"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Ir até a aba lista de reprodução anterior"
 
@@ -2891,7 +2895,7 @@ msgstr "Banco de dados Jamendo"
 msgid "Jump to previous song right away"
 msgstr "Pular imediatamente para a faixa anterior"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Pular para a faixa em execução"
 
@@ -2915,7 +2919,7 @@ msgstr "Continuar executando quando a janela é fechada"
 msgid "Keep the original files"
 msgstr "Manter arquivos originais"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Gatinhos"
@@ -3007,7 +3011,7 @@ msgstr "Biblioteca"
 msgid "Library advanced grouping"
 msgstr "Organização avançada de biblioteca"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Aviso de reescaneamento da biblioteca"
 
@@ -3047,7 +3051,7 @@ msgstr "Carregar capa do disco..."
 msgid "Load playlist"
 msgstr "Carregar lista de reprodução"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Carregar lista de reprodução..."
 
@@ -3108,11 +3112,15 @@ msgstr "Login"
 msgid "Login failed"
 msgstr "Falha ao conectar"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr "Logs"
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Perfil de previsão a longo prazo (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Curtir"
 
@@ -3147,11 +3155,11 @@ msgstr "Letras de %1"
 msgid "Lyrics from the tag"
 msgstr "Letras da etiqueta"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3193,7 +3201,7 @@ msgstr "Menu perfil (PRINCIPAL)"
 msgid "Make it so!"
 msgstr "Agora!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Faça isso!"
@@ -3331,7 +3339,7 @@ msgstr "Pontos de montagem"
 msgid "Move down"
 msgstr "Para baixo"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Mover para biblioteca..."
 
@@ -3340,7 +3348,7 @@ msgstr "Mover para biblioteca..."
 msgid "Move up"
 msgstr "Para cima"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Música"
 
@@ -3353,7 +3361,7 @@ msgid "Music extensions remotely visible"
 msgstr "Extensões das músicas visíveis remotamente"
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Mudo"
 
@@ -3402,7 +3410,7 @@ msgstr "Nunca iniciar tocando"
 msgid "New folder"
 msgstr "Nova pasta"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nova lista de reprodução"
 
@@ -3430,8 +3438,12 @@ msgstr "Faixas mais recentes"
 msgid "Next"
 msgstr "Próximo"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Próxima faixa"
 
@@ -3469,7 +3481,7 @@ msgstr "Sem blocos curtos"
 msgid "None"
 msgstr "Nenhum"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Nenhuma das músicas selecionadas estão adequadas para copiar para um dispositivo"
 
@@ -3554,19 +3566,19 @@ msgstr "Desligado"
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3610,7 +3622,7 @@ msgstr "Opacidade"
 msgid "Open %1 in browser"
 msgstr "Abrir %1 no browser"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Abrir CD de &áudio..."
 
@@ -3622,7 +3634,7 @@ msgstr "Abrir arquivo OPML"
 msgid "Open OPML file..."
 msgstr "Abrir arquivo OPML..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Abrir uma pasta para importar músicas"
 
@@ -3630,7 +3642,7 @@ msgstr "Abrir uma pasta para importar músicas"
 msgid "Open device"
 msgstr "Abrir dispositivo"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Abrir arquivo..."
 
@@ -3684,7 +3696,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organizar Arquivos"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Organizar arquivos..."
 
@@ -3768,7 +3780,7 @@ msgstr "Festa"
 msgid "Password"
 msgstr "Senha"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pausar"
@@ -3792,6 +3804,10 @@ msgstr "Artista"
 msgid "Pipeline"
 msgstr "Canalizador"
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr "Canalizadores"
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Pixel"
@@ -3800,10 +3816,10 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Barra lateral simples"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Reproduzir"
 
@@ -3824,11 +3840,11 @@ msgstr "Reproduzir se estiver parado, pausar se estiver tocando"
 msgid "Play if there is nothing already playing"
 msgstr "Tocar se não houver nada tocando"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Reproduzir próxima"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Reproduzir as faixas selecionadas depois"
 
@@ -3927,7 +3943,7 @@ msgstr "Preferência"
 msgid "Preferences"
 msgstr "Preferências"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Preferências..."
 
@@ -3987,7 +4003,7 @@ msgid "Previous"
 msgstr "Anterior"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Faixa anterior"
 
@@ -4045,16 +4061,16 @@ msgstr "Qualidade"
 msgid "Querying device..."
 msgstr "Consultando dispositivo..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Gerenciador de Fila"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Colocar as faixas selecionadas na fila"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Colocar a faixa na fila"
 
@@ -4070,7 +4086,7 @@ msgstr "Rádio (volume igual para todas as faixas)"
 msgid "Rain"
 msgstr "Chuva"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Chuva"
@@ -4182,7 +4198,7 @@ msgstr "Remover ação"
 msgid "Remove current song from playlist"
 msgstr "Remover a música em execução da lista de reprodução"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Remover duplicados da lista de reprodução"
 
@@ -4190,7 +4206,7 @@ msgstr "Remover duplicados da lista de reprodução"
 msgid "Remove folder"
 msgstr "Remover pasta"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Remover da lista de reprodução"
 
@@ -4202,7 +4218,7 @@ msgstr "Remover lista de reprodução"
 msgid "Remove playlists"
 msgstr "Remover listas de reprodução"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Remover faixas indisponíveis da lista de reprodução"
 
@@ -4214,7 +4230,7 @@ msgstr "Renomear lista de reprodução"
 msgid "Rename playlist..."
 msgstr "Renomear lista de reprodução..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Renumerar faixas nesta ordem..."
 
@@ -4305,7 +4321,7 @@ msgstr "Converter"
 msgid "Rip CD"
 msgstr "Extrair CD"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Extrair CD de áudio"
 
@@ -4383,7 +4399,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Salvar lista de reprodução"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Salvar lista de reprodução..."
 
@@ -4470,7 +4486,7 @@ msgstr "Pesquisa Subsonic"
 msgid "Search automatically"
 msgstr "Buscar automaticamente"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Buscar por álbum"
 
@@ -4483,7 +4499,7 @@ msgstr "Procurar por capas dos álbuns..."
 msgid "Search for anything"
 msgstr "Busca por qualquer coisa"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Buscar por artista"
 
@@ -4608,7 +4624,7 @@ msgstr "Detalhes do servidor"
 msgid "Service offline"
 msgstr "Serviço indisponível"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Mudar %1 para \"%2\"..."
@@ -4617,7 +4633,7 @@ msgstr "Mudar %1 para \"%2\"..."
 msgid "Set the volume to <value> percent"
 msgstr "Mudar volume para <value> por cento"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Mudar o valor para todas as faixas selecionadas..."
 
@@ -4688,7 +4704,7 @@ msgstr "Mostrar aviso estilizado na tela"
 msgid "Show above status bar"
 msgstr "Mostrar acima da barra de status"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Mostrar todas as músicas"
 
@@ -4708,12 +4724,12 @@ msgstr "Mostrar divisores"
 msgid "Show fullsize..."
 msgstr "Exibir em tamanho real..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Mostrar no navegador de arquivos..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Mostrar na biblioteca..."
 
@@ -4725,15 +4741,15 @@ msgstr "Exibir em vários artistas"
 msgid "Show moodbar"
 msgstr "Exibir moodbar"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Mostrar somente os duplicados"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Mostrar somente os sem tag"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Exibir ou ocultar a barra lateral"
 
@@ -4741,7 +4757,7 @@ msgstr "Exibir ou ocultar a barra lateral"
 msgid "Show search suggestions"
 msgstr "Exibir sugestões de busca"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Exibir a barra lateral"
 
@@ -4777,7 +4793,7 @@ msgstr "Embaralhar albuns"
 msgid "Shuffle all"
 msgstr "Embaralhar tudo"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Embaralhar lista de reprodução"
 
@@ -4821,11 +4837,15 @@ msgstr "Número de pulos"
 msgid "Skip forwards in playlist"
 msgstr "Pular para a próxima música da lista"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Pular faixas selecionadas"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Pular faixa"
 
@@ -4942,7 +4962,7 @@ msgstr "Iniciar conversão"
 msgid "Start the playlist currently playing"
 msgstr "Iniciar a lista que está em execução"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Começar conversão"
 
@@ -4952,7 +4972,7 @@ msgid ""
 "list"
 msgstr "Comece a digitar algo na caixa de pesquisa para preencher esta lista de resultados."
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Iniciando %1"
@@ -4962,7 +4982,7 @@ msgid "Starting..."
 msgstr "Iniciando..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Parar"
 
@@ -4978,7 +4998,7 @@ msgstr "Parar depois de cada faixa"
 msgid "Stop after every track"
 msgstr "Parar depois de todas as faixas"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Parar depois desta música"
 
@@ -5146,7 +5166,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "O período de testes para o servidor Subsonic acabou. Por favor, doe para obter uma chave de licença. Visite subsonic.org para mais detalhes."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5188,7 +5208,7 @@ msgid ""
 "continue?"
 msgstr "Estes arquivos serão deletados do dispositivo, tem certeza que deseja continuar?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5290,11 +5310,11 @@ msgstr "Ativar/desativar Pretty OSD"
 msgid "Toggle fullscreen"
 msgstr "Ativar/desativar tela cheia"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Mudar status da fila"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Ativar/desativar scrobbling"
 
@@ -5339,19 +5359,19 @@ msgstr "&Faixa"
 msgid "Track"
 msgstr "Faixa"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Converter Música"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Log do conversor"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr "Detalhes do transcodificador"
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Conversão"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Convertendo %1 arquivos usando %2 núcleos"
@@ -5428,11 +5448,11 @@ msgstr "Erro desconhecido"
 msgid "Unset cover"
 msgstr "Capa não fixada"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Não pular faixas selecionadas"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Não pular faixa"
 
@@ -5449,7 +5469,7 @@ msgstr "Próximos shows"
 msgid "Update all podcasts"
 msgstr "Atualizar todos os podcasts"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Atualizar pastas da biblioteca modificadas"
 
@@ -5610,7 +5630,7 @@ msgstr "Versão %1"
 msgid "View"
 msgstr "Exibir"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Ver detalhes da transmissão"
 
@@ -5618,7 +5638,7 @@ msgstr "Ver detalhes da transmissão"
 msgid "Visualization mode"
 msgstr "Modo de visualização"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Visualizações"
 
@@ -5659,7 +5679,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr "Atenção: o nível de compressão está fora do subconjunto de transmissão. Isso significa que um decodificador pode não conseguir iniciar a reprodução no meio da transmissão. Pode também afetar a performance de decodificadores por hardware."
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5755,7 +5775,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Áudio do Windows Media"
 
@@ -5769,7 +5789,7 @@ msgid ""
 "well?"
 msgstr "Gostaria de mover as outras músicas deste álbum para Vários Artistas?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Gostaria de realizar um reescaneamento completo agora?"
 

--- a/src/translations/pt_BR.po
+++ b/src/translations/pt_BR.po
@@ -19,8 +19,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-26 23:47+0000\n"
-"Last-Translator: John Maguire <john.maguire@gmail.com>\n"
+"PO-Revision-Date: 2021-01-27 12:48+0000\n"
+"Last-Translator: carlo giusepe tadei valente sasaki <carlo.gt.valente@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) (http://www.transifex.com/davidsansome/clementine/language/pt_BR/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -521,7 +521,7 @@ msgstr "Adicionar outro canal..."
 msgid "Add directory..."
 msgstr "Adicionar diretório..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Adicionar arquivo"
 
@@ -541,7 +541,7 @@ msgstr "Adicionar arquivo..."
 msgid "Add files to transcode"
 msgstr "Adicionar arquivos para converter"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Adicionar pasta"
@@ -646,7 +646,7 @@ msgstr "Adicionar às listas de reprodução do Spotify"
 msgid "Add to Spotify starred"
 msgstr "Adicionar ao Spotify com estrela"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Adicionar a outra lista de reprodução"
 
@@ -868,7 +868,7 @@ msgstr "Tem certeza que deseja escrever as estatísticas das músicas dentro dos
 msgid "Artist"
 msgstr "Artista"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Sobre o Artista"
 
@@ -1131,7 +1131,7 @@ msgstr "Procurar por novos episódios"
 msgid "Check for updates"
 msgstr "Verificar se há atualizações"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Procurar por atualizações..."
 
@@ -1371,7 +1371,7 @@ msgstr "Configurar Subsonic..."
 msgid "Configure global search..."
 msgstr "Configurar busca global..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Configurar biblioteca..."
 
@@ -1443,11 +1443,11 @@ msgid "Copy to clipboard"
 msgstr "Copiar para a área de transferência"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Copiar para o dispositivo..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Copiar para biblioteca..."
@@ -1665,7 +1665,7 @@ msgid "Delete downloaded data"
 msgstr "Apagar dados baixados"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Excluir arquivos"
 
@@ -1673,7 +1673,7 @@ msgstr "Excluir arquivos"
 msgid "Delete from device..."
 msgstr "Apagar do dispositivo..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Apagar do disco..."
@@ -1706,11 +1706,11 @@ msgstr "Apagando arquivos"
 msgid "Depth"
 msgstr "Profundidade"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Retirar faixas selecionadas da fila"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Retirar faixa da fila"
 
@@ -1739,7 +1739,7 @@ msgstr "Nome do dispositivo"
 msgid "Device properties..."
 msgstr "Propriedades do dispositivo..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Dispositivos"
 
@@ -1990,7 +1990,7 @@ msgstr "Mix aleatório dinâmico"
 msgid "Edit smart playlist..."
 msgstr "Editar lista de reprodução inteligente..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Editar tag \"%1\"..."
@@ -2129,8 +2129,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Equivalente ao --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Erro"
 
@@ -2250,7 +2250,7 @@ msgstr "Exportado %1 capa(s) de %2 (%3 pulado)"
 
 #: ../bin/src/ui_mainwindow.h:790
 msgid "F9"
-msgstr ""
+msgstr "F9"
 
 #: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
@@ -2276,7 +2276,7 @@ msgstr "Diminuindo"
 msgid "Fading duration"
 msgstr "Duração da dimunuição"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Falha ao ler o CD"
 
@@ -2399,7 +2399,7 @@ msgstr "Tipo de arquivo"
 msgid "Filename"
 msgstr "Nome do arquivo"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Arquivos"
 
@@ -2814,7 +2814,7 @@ msgstr "Instalado"
 msgid "Integrity check"
 msgstr "Verificar integridade"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -3002,7 +3002,7 @@ msgstr "Esquerda"
 msgid "Length"
 msgstr "Duração"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Biblioteca"
@@ -3011,7 +3011,7 @@ msgstr "Biblioteca"
 msgid "Library advanced grouping"
 msgstr "Organização avançada de biblioteca"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Aviso de reescaneamento da biblioteca"
 
@@ -3339,7 +3339,7 @@ msgstr "Pontos de montagem"
 msgid "Move down"
 msgstr "Para baixo"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Mover para biblioteca..."
 
@@ -3348,7 +3348,7 @@ msgstr "Mover para biblioteca..."
 msgid "Move up"
 msgstr "Para cima"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Música"
 
@@ -3410,7 +3410,7 @@ msgstr "Nunca iniciar tocando"
 msgid "New folder"
 msgstr "Nova pasta"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nova lista de reprodução"
 
@@ -3440,7 +3440,7 @@ msgstr "Próximo"
 
 #: ../bin/src/ui_mainwindow.h:785
 msgid "Next album"
-msgstr ""
+msgstr "Próximo disco"
 
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
 #: ../bin/src/ui_mainwindow.h:727
@@ -3481,7 +3481,7 @@ msgstr "Sem blocos curtos"
 msgid "None"
 msgstr "Nenhum"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Nenhuma das músicas selecionadas estão adequadas para copiar para um dispositivo"
 
@@ -3696,7 +3696,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organizar Arquivos"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Organizar arquivos..."
 
@@ -3780,7 +3780,7 @@ msgstr "Festa"
 msgid "Password"
 msgstr "Senha"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pausar"
@@ -3816,8 +3816,8 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Barra lateral simples"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3840,11 +3840,11 @@ msgstr "Reproduzir se estiver parado, pausar se estiver tocando"
 msgid "Play if there is nothing already playing"
 msgstr "Tocar se não houver nada tocando"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Reproduzir próxima"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Reproduzir as faixas selecionadas depois"
 
@@ -3883,7 +3883,7 @@ msgstr "Opções da lista de reprodução"
 msgid "Playlist type"
 msgstr "Tipo de lista de reprodução"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Listas de reprodução"
 
@@ -4065,12 +4065,12 @@ msgstr "Consultando dispositivo..."
 msgid "Queue Manager"
 msgstr "Gerenciador de Fila"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Colocar as faixas selecionadas na fila"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Colocar a faixa na fila"
 
@@ -4461,7 +4461,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Pesquisar"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Pesquisar"
@@ -4486,7 +4486,7 @@ msgstr "Pesquisa Subsonic"
 msgid "Search automatically"
 msgstr "Buscar automaticamente"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Buscar por álbum"
 
@@ -4499,7 +4499,7 @@ msgstr "Procurar por capas dos álbuns..."
 msgid "Search for anything"
 msgstr "Busca por qualquer coisa"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Buscar por artista"
 
@@ -4624,7 +4624,7 @@ msgstr "Detalhes do servidor"
 msgid "Service offline"
 msgstr "Serviço indisponível"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Mudar %1 para \"%2\"..."
@@ -4704,7 +4704,7 @@ msgstr "Mostrar aviso estilizado na tela"
 msgid "Show above status bar"
 msgstr "Mostrar acima da barra de status"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Mostrar todas as músicas"
 
@@ -4724,12 +4724,12 @@ msgstr "Mostrar divisores"
 msgid "Show fullsize..."
 msgstr "Exibir em tamanho real..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Mostrar no navegador de arquivos..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Mostrar na biblioteca..."
 
@@ -4741,11 +4741,11 @@ msgstr "Exibir em vários artistas"
 msgid "Show moodbar"
 msgstr "Exibir moodbar"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Mostrar somente os duplicados"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Mostrar somente os sem tag"
 
@@ -4837,15 +4837,15 @@ msgstr "Número de pulos"
 msgid "Skip forwards in playlist"
 msgstr "Pular para a próxima música da lista"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Pular faixas selecionadas"
 
 #: ../bin/src/ui_mainwindow.h:787
 msgid "Skip to the next album"
-msgstr ""
+msgstr "Passe para o próximo disco"
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Pular faixa"
 
@@ -4877,7 +4877,7 @@ msgstr "Soft Rock"
 msgid "Song Information"
 msgstr "Informações da Música"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Sobre a Música"
 
@@ -4998,7 +4998,7 @@ msgstr "Parar depois de cada faixa"
 msgid "Stop after every track"
 msgstr "Parar depois de todas as faixas"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Parar depois desta música"
 
@@ -5166,7 +5166,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "O período de testes para o servidor Subsonic acabou. Por favor, doe para obter uma chave de licença. Visite subsonic.org para mais detalhes."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5208,7 +5208,7 @@ msgid ""
 "continue?"
 msgstr "Estes arquivos serão deletados do dispositivo, tem certeza que deseja continuar?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5310,7 +5310,7 @@ msgstr "Ativar/desativar Pretty OSD"
 msgid "Toggle fullscreen"
 msgstr "Ativar/desativar tela cheia"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Mudar status da fila"
 
@@ -5448,11 +5448,11 @@ msgstr "Erro desconhecido"
 msgid "Unset cover"
 msgstr "Capa não fixada"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Não pular faixas selecionadas"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Não pular faixa"
 
@@ -5789,7 +5789,7 @@ msgid ""
 "well?"
 msgstr "Gostaria de mover as outras músicas deste álbum para Vários Artistas?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Gostaria de realizar um reescaneamento completo agora?"
 

--- a/src/translations/ro.po
+++ b/src/translations/ro.po
@@ -21,8 +21,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-14 15:52+0000\n"
-"Last-Translator: Daniel Șerbănescu <daniel@serbanescu.dk>\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
+"Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Romanian (http://www.transifex.com/davidsansome/clementine/language/ro/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -175,19 +175,19 @@ msgstr "%L1 piese"
 msgid "%filename%"
 msgstr "%nume fișier%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n eșuat"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n finalizat"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -205,7 +205,7 @@ msgstr "&Centrat"
 msgid "&Custom"
 msgstr "&Personalizat"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Extra"
 
@@ -213,7 +213,7 @@ msgstr "&Extra"
 msgid "&Grouping"
 msgstr "&Grupare"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Ajutor"
 
@@ -238,7 +238,7 @@ msgstr "&Blochează evaluarea"
 msgid "&Lyrics"
 msgstr "&Versuri"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Muzică"
 
@@ -246,15 +246,15 @@ msgstr "&Muzică"
 msgid "&None"
 msgstr "&Nimic"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&Listă de redare"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Termină"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "&Mod repetare"
 
@@ -262,7 +262,7 @@ msgstr "&Mod repetare"
 msgid "&Right"
 msgstr "&Dreapta"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "&Mod aleator"
 
@@ -270,7 +270,7 @@ msgstr "&Mod aleator"
 msgid "&Stretch columns to fit window"
 msgstr "&Îngustează coloanele pentru a se potrivi în fereastră"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Unelte"
 
@@ -459,11 +459,11 @@ msgstr "Anulează"
 msgid "About %1"
 msgstr "Despre %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Despre Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Despre Qt..."
 
@@ -523,32 +523,32 @@ msgstr "Adaugă alt flux..."
 msgid "Add directory..."
 msgstr "Adăugare dosar..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Adăugare fișier"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Adaugă fișier la transcodor"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Adaugă fișier(e) la transcodor"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Adaugă fișier..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Adaugă fișiere pentru transcodat"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Adăugare dosar"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Adaugă dosar..."
 
@@ -560,7 +560,7 @@ msgstr "Adaugă dosar nou..."
 msgid "Add podcast"
 msgstr "Adaugă podcast"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Adaugă podcast..."
 
@@ -636,7 +636,7 @@ msgstr "Adaugă eticheta piesei"
 msgid "Add song year tag"
 msgstr "Adaugă eticheta anului melodiei"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Adaugă flux..."
 
@@ -648,7 +648,7 @@ msgstr "Adaugă la listele de redare Spotify"
 msgid "Add to Spotify starred"
 msgstr "Adaugă la Spotify starred"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Adaugă la altă listă de redare"
 
@@ -742,7 +742,7 @@ msgstr "Toate"
 msgid "All Files (*)"
 msgstr "Toate fișierele (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Glorie Hypnotoadului!"
@@ -1133,7 +1133,7 @@ msgstr "Verifică după episoade noi"
 msgid "Check for updates"
 msgstr "Verifică după actualizări"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Verifică după actualizări..."
 
@@ -1182,18 +1182,18 @@ msgstr "Clasic"
 msgid "Cleaning up"
 msgstr "Curățare"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Curăță"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Curăță lista de redare"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1338,7 +1338,7 @@ msgstr "Comentariu"
 msgid "Complete tags automatically"
 msgstr "Completează etichetele automat"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Completează etichetele automat..."
 
@@ -1373,7 +1373,7 @@ msgstr "Configurați Subsonic..."
 msgid "Configure global search..."
 msgstr "Configurați căutarea globală..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Configurați colecția..."
 
@@ -1416,7 +1416,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Conexiunea a expirat, verificați adresa URL a serverului. Exemplu: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Consolă"
 
@@ -1445,11 +1445,11 @@ msgid "Copy to clipboard"
 msgstr "Copiază în memoria temporară"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Copiază pe dispozitiv..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Copiază în colecție..."
@@ -1492,14 +1492,14 @@ msgstr "Nu s.a putut autentifica la Last.fm. Încercați din nou."
 msgid "Couldn't create playlist"
 msgstr "Nu se poate crea lista de redare"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Nu s-a putut găsi un mixer pentru %1, verificați dacă aveți instalate modulele corecte GStreamer"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1514,7 +1514,7 @@ msgstr "Nu s-a putut deschide fișierul de ieșire %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Administrator coperți"
 
@@ -1667,7 +1667,7 @@ msgid "Delete downloaded data"
 msgstr "Șterge datele descărcate"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Șterge fișiere"
 
@@ -1675,7 +1675,7 @@ msgstr "Șterge fișiere"
 msgid "Delete from device..."
 msgstr "Șterge de pe dispozitiv..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Șterge de pe disc..."
@@ -1708,11 +1708,11 @@ msgstr "Se șterg fișierele"
 msgid "Depth"
 msgstr "Adâncime"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Elimină din coadă piesele selectate"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Elimină din coadă piesa"
 
@@ -1813,7 +1813,7 @@ msgstr "Afișează opțiunile"
 msgid "Display the on-screen-display"
 msgstr "Afișează afișarea pe ecran"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Rescanează complet colecția"
 
@@ -1992,12 +1992,12 @@ msgstr "Mixare aleatoare dinamică"
 msgid "Edit smart playlist..."
 msgstr "Editare listă de redare inteligentă..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Editare eticheta \"%1\"..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Editare etichetă..."
 
@@ -2010,7 +2010,7 @@ msgid "Edit track information"
 msgstr "Editare informație piesă"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Editare informație piesă..."
 
@@ -2118,7 +2118,7 @@ msgstr "Toată colecția"
 msgid "Episode information"
 msgstr "Informații episod"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Egalizator"
 
@@ -2131,8 +2131,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Echivalent cu --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Eroare"
 
@@ -2167,7 +2167,7 @@ msgstr "Eroare încărcare %1"
 msgid "Error loading di.fm playlist"
 msgstr "Eroare la încărcarea listă de redare di.fm"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Eroare procesare %1: %2"
@@ -2250,7 +2250,11 @@ msgstr "Export terminat"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "S-au exportat %1 coperți din %2 (%3 omise)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2274,7 +2278,7 @@ msgstr "Se estompează"
 msgid "Fading duration"
 msgstr "Durata estompării"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "A eșuat citirea unității CD"
 
@@ -2556,11 +2560,11 @@ msgstr "Dați-i un nume:"
 msgid "Go"
 msgstr "Mergi"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Mergi la fila listei de redare următoare"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Mergi la fila listei de redare anterioare"
 
@@ -2893,7 +2897,7 @@ msgstr "Baza de date Jamendo"
 msgid "Jump to previous song right away"
 msgstr "Sări imediat la melodia anterioară"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Sari la piesa în curs de redare"
 
@@ -2917,7 +2921,7 @@ msgstr "Menține rularea în fundal atunci când fereastra este închisă"
 msgid "Keep the original files"
 msgstr "Menține fișierele originale"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Pisicuțe"
@@ -3009,7 +3013,7 @@ msgstr "Colecție"
 msgid "Library advanced grouping"
 msgstr "Grupare avansată colecție"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Notă rescanare colecție"
 
@@ -3049,7 +3053,7 @@ msgstr "Încarcă copertă de pe disc..."
 msgid "Load playlist"
 msgstr "Încarcă listă de redare"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Încarcă listă de redare..."
 
@@ -3110,11 +3114,15 @@ msgstr "Autentificare"
 msgid "Login failed"
 msgstr "Autentificare eșuată"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Profil de predicție pe termen lung (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Apreciați"
 
@@ -3149,11 +3157,11 @@ msgstr "Versuri de pe %1"
 msgid "Lyrics from the tag"
 msgstr "Versuri pentru tag"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3195,7 +3203,7 @@ msgstr "Profil principal (MAIN)"
 msgid "Make it so!"
 msgstr "Fă-o așa!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Fă-o așa!"
@@ -3333,7 +3341,7 @@ msgstr "Puncte de montare"
 msgid "Move down"
 msgstr "Mută în jos"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Mută în colecție..."
 
@@ -3342,7 +3350,7 @@ msgstr "Mută în colecție..."
 msgid "Move up"
 msgstr "Mută în sus"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Muzică"
 
@@ -3355,7 +3363,7 @@ msgid "Music extensions remotely visible"
 msgstr "Extensii muzicale vizibile de la distanță"
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Mut"
 
@@ -3404,7 +3412,7 @@ msgstr "Nu va începe redarea niciodată"
 msgid "New folder"
 msgstr "Dosar nou"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Listă de redare nouă"
 
@@ -3432,8 +3440,12 @@ msgstr "Cele mai noi piese"
 msgid "Next"
 msgstr "Următorul"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Piesa următoare"
 
@@ -3471,7 +3483,7 @@ msgstr "Fără blocuri scurte"
 msgid "None"
 msgstr "Nimic"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Niciuna dintre melodiile selectate nu este potrivită pentru copierea pe un dispozitiv"
 
@@ -3556,19 +3568,19 @@ msgstr "Închis"
 msgid "Ogg FLAC"
 msgstr "FLAC Ogg"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3612,7 +3624,7 @@ msgstr "Opacitate"
 msgid "Open %1 in browser"
 msgstr "Deschide %1 în browser"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Deschide CD &audio..."
 
@@ -3624,7 +3636,7 @@ msgstr "Deschide fișier OPML"
 msgid "Open OPML file..."
 msgstr "Deschide fișier OPML..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Deschide un director pentru a se importa muzica din el"
 
@@ -3632,7 +3644,7 @@ msgstr "Deschide un director pentru a se importa muzica din el"
 msgid "Open device"
 msgstr "Deschide dispozitiv"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Deschide fișier..."
 
@@ -3686,7 +3698,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organizează fișiere"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Organizează fișiere..."
 
@@ -3770,7 +3782,7 @@ msgstr "Petrecere"
 msgid "Password"
 msgstr "Parolă"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pauză"
@@ -3794,6 +3806,10 @@ msgstr "Interpret"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Pixel"
@@ -3802,10 +3818,10 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Bară laterală simplă"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Redare"
 
@@ -3826,11 +3842,11 @@ msgstr "Redă dacă este oprit, întrerupe dacă se redă"
 msgid "Play if there is nothing already playing"
 msgstr "Redă numai dacă nu se redă deja ceva"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Redă următoarea"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Redă piesele selectate"
 
@@ -3929,7 +3945,7 @@ msgstr "Preferință"
 msgid "Preferences"
 msgstr "Preferințe"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Preferințe..."
 
@@ -3989,7 +4005,7 @@ msgid "Previous"
 msgstr "Anterior"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Piesa precedentă"
 
@@ -4047,16 +4063,16 @@ msgstr "Calitate"
 msgid "Querying device..."
 msgstr "Se interoghează dispozitivul..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Administrator coadă"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Adaugă în coadă piesele selectate"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Adaugă în coadă piesa"
 
@@ -4072,7 +4088,7 @@ msgstr "Radio (egalizare loudness pentru toate piesele)"
 msgid "Rain"
 msgstr "Ploaie"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Ploaie"
@@ -4184,7 +4200,7 @@ msgstr "Elimină acțiune"
 msgid "Remove current song from playlist"
 msgstr "Elimină melodia curentă din lista de redare"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Elimină dublurile din lista de redare"
 
@@ -4192,7 +4208,7 @@ msgstr "Elimină dublurile din lista de redare"
 msgid "Remove folder"
 msgstr "Elimină dosar"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Elimină din lista de redare"
 
@@ -4204,7 +4220,7 @@ msgstr "Elimină lista de redare"
 msgid "Remove playlists"
 msgstr "Elimină listele de redare"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Elimină piesele indisponibile din lista de redare"
 
@@ -4216,7 +4232,7 @@ msgstr "Redenumește lista de redare"
 msgid "Rename playlist..."
 msgstr "Redenumește lista de redare..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Renumerotează piesele în această ordine..."
 
@@ -4307,7 +4323,7 @@ msgstr "Extrage"
 msgid "Rip CD"
 msgstr "Extrage CD"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Extrage CD audio"
 
@@ -4385,7 +4401,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Salvează lista de redare"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Salvează lista de redare..."
 
@@ -4472,7 +4488,7 @@ msgstr "Caută în Subsonic"
 msgid "Search automatically"
 msgstr "Caută automat"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Caută după album"
 
@@ -4485,7 +4501,7 @@ msgstr "Caută coperți pentru album..."
 msgid "Search for anything"
 msgstr "Caută orice"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Caută după artist"
 
@@ -4610,7 +4626,7 @@ msgstr "Detalii server"
 msgid "Service offline"
 msgstr "Serviciu offline"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Setează %1 la „%2”..."
@@ -4619,7 +4635,7 @@ msgstr "Setează %1 la „%2”..."
 msgid "Set the volume to <value> percent"
 msgstr "Stabilește volumul la <value> procent"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Stabilește valoarea pentru toate piesele selectate..."
 
@@ -4690,7 +4706,7 @@ msgstr "Arată un OSD simpatic"
 msgid "Show above status bar"
 msgstr "Arată deasupra barei de stare"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Arată toate melodiile"
 
@@ -4710,12 +4726,12 @@ msgstr "Arată separatori"
 msgid "Show fullsize..."
 msgstr "Arată dimensiunea completă..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Arată în navigatorul de fișiere..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Arată în colecție..."
 
@@ -4727,15 +4743,15 @@ msgstr "Arată în Artiști diferiți"
 msgid "Show moodbar"
 msgstr "Arată bara de dispoziție"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Arată numai duplicatele"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Arată numai pe cele neetichetate"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Arată sau ascunde bara laterală"
 
@@ -4743,7 +4759,7 @@ msgstr "Arată sau ascunde bara laterală"
 msgid "Show search suggestions"
 msgstr "Arată sugestii de căutare"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Arată bara laterală."
 
@@ -4779,7 +4795,7 @@ msgstr "Amestecă albume"
 msgid "Shuffle all"
 msgstr "Amestecă tot"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Amestecă lista de redare"
 
@@ -4823,11 +4839,15 @@ msgstr "Omite numărătoarea"
 msgid "Skip forwards in playlist"
 msgstr "Sari înainte în lista de redare"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Omite piesele selectate"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Omite piesa"
 
@@ -4944,7 +4964,7 @@ msgstr "Pornire extragere"
 msgid "Start the playlist currently playing"
 msgstr "Pornește lista de redare curent redată"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Pornire transcodificare"
 
@@ -4954,7 +4974,7 @@ msgid ""
 "list"
 msgstr "Tastează ceva în caseta de căutare de deasupra pentru a umple lista cu rezultate ale căutării"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Se pornește %1"
@@ -4964,7 +4984,7 @@ msgid "Starting..."
 msgstr "Se pornește..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Oprire"
 
@@ -4980,7 +5000,7 @@ msgstr "Oprește după fiecare piesă"
 msgid "Stop after every track"
 msgstr "Oprește după fiecare piesă"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Oprește după această piesă"
 
@@ -5148,7 +5168,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Perioada de încercare pentru serverul Subsonic s-a terminat. Donați pentru a obține o cheie de licență. Vizitați subsonic.org pentru detalii."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5190,7 +5210,7 @@ msgid ""
 "continue?"
 msgstr "Aceste fișiere vor fi șterse de pe dispozitiv, sigur doriți să continuați?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5292,11 +5312,11 @@ msgstr "Comută OSD simpatic"
 msgid "Toggle fullscreen"
 msgstr "Comută afișare pe tot ecranul"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Comută stare coadă"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Comută scrobbling"
 
@@ -5341,19 +5361,19 @@ msgstr "Pie&să"
 msgid "Track"
 msgstr "Piesă"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Transcodează muzica"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Jurnal transcodor"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Se transcodifică"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Se transcodifică %1 utilizând %2 fire de execuție"
@@ -5430,11 +5450,11 @@ msgstr "Eroare necunoscută"
 msgid "Unset cover"
 msgstr "Deselectează coperta"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Nu omite piesele selectate"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Nu omite piesa"
 
@@ -5451,7 +5471,7 @@ msgstr "Concerte viitoare"
 msgid "Update all podcasts"
 msgstr "Actualizează toate podcasturile"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Actualizează dosarele modificate ale colecției"
 
@@ -5612,7 +5632,7 @@ msgstr "Versiunea %1"
 msgid "View"
 msgstr "Vizualizare"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Vizualizează detaliile fluxului"
 
@@ -5620,7 +5640,7 @@ msgstr "Vizualizează detaliile fluxului"
 msgid "Visualization mode"
 msgstr "Mod vizualizare"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Vizualizări"
 
@@ -5661,7 +5681,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr "Atenție: Nivelul de compresie este în afara setului de transmisie. Aceasta înseamnă că un decodor nu poate porni redarea în timpul transmisiei. Poate de asemenea afecta performanța decodoarelor fizice."
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5757,7 +5777,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "audio Windows Media"
 
@@ -5771,7 +5791,7 @@ msgid ""
 "well?"
 msgstr "Doriți să fie mutate, de asemenea, și celelalte melodii din acest album în Artiști diferiți?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Doriți să rulați o rescanare completă chiar acum?"
 

--- a/src/translations/ro.po
+++ b/src/translations/ro.po
@@ -21,8 +21,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-26 23:47+0000\n"
-"Last-Translator: John Maguire <john.maguire@gmail.com>\n"
+"PO-Revision-Date: 2021-01-27 17:20+0000\n"
+"Last-Translator: Daniel Șerbănescu <daniel@serbanescu.dk>\n"
 "Language-Team: Romanian (http://www.transifex.com/davidsansome/clementine/language/ro/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -523,7 +523,7 @@ msgstr "Adaugă alt flux..."
 msgid "Add directory..."
 msgstr "Adăugare dosar..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Adăugare fișier"
 
@@ -543,7 +543,7 @@ msgstr "Adaugă fișier..."
 msgid "Add files to transcode"
 msgstr "Adaugă fișiere pentru transcodat"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Adăugare dosar"
@@ -648,7 +648,7 @@ msgstr "Adaugă la listele de redare Spotify"
 msgid "Add to Spotify starred"
 msgstr "Adaugă la Spotify starred"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Adaugă la altă listă de redare"
 
@@ -870,7 +870,7 @@ msgstr "Sigur doriți să scrieți statisticile melodiei în fișierul melodiei 
 msgid "Artist"
 msgstr "Artist"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Informații artist"
 
@@ -1133,7 +1133,7 @@ msgstr "Verifică după episoade noi"
 msgid "Check for updates"
 msgstr "Verifică după actualizări"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Verifică după actualizări..."
 
@@ -1373,7 +1373,7 @@ msgstr "Configurați Subsonic..."
 msgid "Configure global search..."
 msgstr "Configurați căutarea globală..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Configurați colecția..."
 
@@ -1445,11 +1445,11 @@ msgid "Copy to clipboard"
 msgstr "Copiază în memoria temporară"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Copiază pe dispozitiv..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Copiază în colecție..."
@@ -1667,7 +1667,7 @@ msgid "Delete downloaded data"
 msgstr "Șterge datele descărcate"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Șterge fișiere"
 
@@ -1675,7 +1675,7 @@ msgstr "Șterge fișiere"
 msgid "Delete from device..."
 msgstr "Șterge de pe dispozitiv..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Șterge de pe disc..."
@@ -1708,11 +1708,11 @@ msgstr "Se șterg fișierele"
 msgid "Depth"
 msgstr "Adâncime"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Elimină din coadă piesele selectate"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Elimină din coadă piesa"
 
@@ -1741,7 +1741,7 @@ msgstr "Nume dispozitiv"
 msgid "Device properties..."
 msgstr "Proprietăți dispozitiv..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Dispozitive"
 
@@ -1992,7 +1992,7 @@ msgstr "Mixare aleatoare dinamică"
 msgid "Edit smart playlist..."
 msgstr "Editare listă de redare inteligentă..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Editare eticheta \"%1\"..."
@@ -2131,8 +2131,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Echivalent cu --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Eroare"
 
@@ -2252,7 +2252,7 @@ msgstr "S-au exportat %1 coperți din %2 (%3 omise)"
 
 #: ../bin/src/ui_mainwindow.h:790
 msgid "F9"
-msgstr ""
+msgstr "F9"
 
 #: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
@@ -2278,7 +2278,7 @@ msgstr "Se estompează"
 msgid "Fading duration"
 msgstr "Durata estompării"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "A eșuat citirea unității CD"
 
@@ -2401,7 +2401,7 @@ msgstr "Tip fișier"
 msgid "Filename"
 msgstr "Nume fișier"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Fișiere"
 
@@ -2816,7 +2816,7 @@ msgstr "Instalat"
 msgid "Integrity check"
 msgstr "Verificare integritate"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -3004,7 +3004,7 @@ msgstr "Stânga"
 msgid "Length"
 msgstr "Lungime"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Colecție"
@@ -3013,7 +3013,7 @@ msgstr "Colecție"
 msgid "Library advanced grouping"
 msgstr "Grupare avansată colecție"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Notă rescanare colecție"
 
@@ -3116,7 +3116,7 @@ msgstr "Autentificare eșuată"
 
 #: ../bin/src/ui_transcodelogdialog.h:107
 msgid "Logs"
-msgstr ""
+msgstr "Înregistrări"
 
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
@@ -3341,7 +3341,7 @@ msgstr "Puncte de montare"
 msgid "Move down"
 msgstr "Mută în jos"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Mută în colecție..."
 
@@ -3350,7 +3350,7 @@ msgstr "Mută în colecție..."
 msgid "Move up"
 msgstr "Mută în sus"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Muzică"
 
@@ -3412,7 +3412,7 @@ msgstr "Nu va începe redarea niciodată"
 msgid "New folder"
 msgstr "Dosar nou"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Listă de redare nouă"
 
@@ -3442,7 +3442,7 @@ msgstr "Următorul"
 
 #: ../bin/src/ui_mainwindow.h:785
 msgid "Next album"
-msgstr ""
+msgstr "Albumul următor"
 
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
 #: ../bin/src/ui_mainwindow.h:727
@@ -3483,7 +3483,7 @@ msgstr "Fără blocuri scurte"
 msgid "None"
 msgstr "Nimic"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Niciuna dintre melodiile selectate nu este potrivită pentru copierea pe un dispozitiv"
 
@@ -3698,7 +3698,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organizează fișiere"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Organizează fișiere..."
 
@@ -3782,7 +3782,7 @@ msgstr "Petrecere"
 msgid "Password"
 msgstr "Parolă"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pauză"
@@ -3818,8 +3818,8 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Bară laterală simplă"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3842,11 +3842,11 @@ msgstr "Redă dacă este oprit, întrerupe dacă se redă"
 msgid "Play if there is nothing already playing"
 msgstr "Redă numai dacă nu se redă deja ceva"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Redă următoarea"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Redă piesele selectate"
 
@@ -3885,7 +3885,7 @@ msgstr "Opțiuni listă de redare"
 msgid "Playlist type"
 msgstr "Tip listă de redare"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Liste de redare"
 
@@ -4067,12 +4067,12 @@ msgstr "Se interoghează dispozitivul..."
 msgid "Queue Manager"
 msgstr "Administrator coadă"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Adaugă în coadă piesele selectate"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Adaugă în coadă piesa"
 
@@ -4463,7 +4463,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Căutare"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Căutare"
@@ -4488,7 +4488,7 @@ msgstr "Caută în Subsonic"
 msgid "Search automatically"
 msgstr "Caută automat"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Caută după album"
 
@@ -4501,7 +4501,7 @@ msgstr "Caută coperți pentru album..."
 msgid "Search for anything"
 msgstr "Caută orice"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Caută după artist"
 
@@ -4626,7 +4626,7 @@ msgstr "Detalii server"
 msgid "Service offline"
 msgstr "Serviciu offline"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Setează %1 la „%2”..."
@@ -4706,7 +4706,7 @@ msgstr "Arată un OSD simpatic"
 msgid "Show above status bar"
 msgstr "Arată deasupra barei de stare"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Arată toate melodiile"
 
@@ -4726,12 +4726,12 @@ msgstr "Arată separatori"
 msgid "Show fullsize..."
 msgstr "Arată dimensiunea completă..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Arată în navigatorul de fișiere..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Arată în colecție..."
 
@@ -4743,11 +4743,11 @@ msgstr "Arată în Artiști diferiți"
 msgid "Show moodbar"
 msgstr "Arată bara de dispoziție"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Arată numai duplicatele"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Arată numai pe cele neetichetate"
 
@@ -4839,15 +4839,15 @@ msgstr "Omite numărătoarea"
 msgid "Skip forwards in playlist"
 msgstr "Sari înainte în lista de redare"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Omite piesele selectate"
 
 #: ../bin/src/ui_mainwindow.h:787
 msgid "Skip to the next album"
-msgstr ""
+msgstr "Sari la următorul album"
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Omite piesa"
 
@@ -4879,7 +4879,7 @@ msgstr "Soft Rock"
 msgid "Song Information"
 msgstr "Informații melodie"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Informație melodie"
 
@@ -5000,7 +5000,7 @@ msgstr "Oprește după fiecare piesă"
 msgid "Stop after every track"
 msgstr "Oprește după fiecare piesă"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Oprește după această piesă"
 
@@ -5168,7 +5168,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Perioada de încercare pentru serverul Subsonic s-a terminat. Donați pentru a obține o cheie de licență. Vizitați subsonic.org pentru detalii."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5210,7 +5210,7 @@ msgid ""
 "continue?"
 msgstr "Aceste fișiere vor fi șterse de pe dispozitiv, sigur doriți să continuați?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5312,7 +5312,7 @@ msgstr "Comută OSD simpatic"
 msgid "Toggle fullscreen"
 msgstr "Comută afișare pe tot ecranul"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Comută stare coadă"
 
@@ -5367,7 +5367,7 @@ msgstr "Transcodează muzica"
 
 #: ../bin/src/ui_transcodelogdialog.h:105
 msgid "Transcoder Details"
-msgstr ""
+msgstr "Detalii codor"
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
@@ -5450,11 +5450,11 @@ msgstr "Eroare necunoscută"
 msgid "Unset cover"
 msgstr "Deselectează coperta"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Nu omite piesele selectate"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Nu omite piesa"
 
@@ -5791,7 +5791,7 @@ msgid ""
 "well?"
 msgstr "Doriți să fie mutate, de asemenea, și celelalte melodii din acest album în Artiști diferiți?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Doriți să rulați o rescanare completă chiar acum?"
 

--- a/src/translations/ru.po
+++ b/src/translations/ru.po
@@ -36,8 +36,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-13 00:28+0000\n"
-"Last-Translator: Andrei Stepanov <adem4ik@gmail.com>\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
+"Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Russian (http://www.transifex.com/davidsansome/clementine/language/ru/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -190,19 +190,19 @@ msgstr "%L1 треков"
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n с ошибкой"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n завершено"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -220,7 +220,7 @@ msgstr "По &центру"
 msgid "&Custom"
 msgstr "Д&ругое"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Дополнения"
 
@@ -228,7 +228,7 @@ msgstr "&Дополнения"
 msgid "&Grouping"
 msgstr "&Группа"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Справка"
 
@@ -253,7 +253,7 @@ msgstr "&Заблокировать рейтинг"
 msgid "&Lyrics"
 msgstr "&Тексты песен"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Музыка"
 
@@ -261,15 +261,15 @@ msgstr "&Музыка"
 msgid "&None"
 msgstr "&Нет"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&Плейлист"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Выход"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "&Режим повтора"
 
@@ -277,7 +277,7 @@ msgstr "&Режим повтора"
 msgid "&Right"
 msgstr "С&права"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "&Режим перемешивания"
 
@@ -285,7 +285,7 @@ msgstr "&Режим перемешивания"
 msgid "&Stretch columns to fit window"
 msgstr "&Подгонять по размеру окна"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Инструменты"
 
@@ -474,11 +474,11 @@ msgstr "Прервать"
 msgid "About %1"
 msgstr "О %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "О Clementine"
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Информация о Qt"
 
@@ -538,32 +538,32 @@ msgstr "Добавить другой поток…"
 msgid "Add directory..."
 msgstr "Добавить каталог…"
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Добавить файл"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Конвертировать файл"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Конвертировать файл(ы)"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Добавить файл…"
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Конвертировать файлы"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Добавить папку"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Добавить папку…"
 
@@ -575,7 +575,7 @@ msgstr "Добавить новую папку"
 msgid "Add podcast"
 msgstr "Добавить подкаст"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Добавить подкаст…"
 
@@ -651,7 +651,7 @@ msgstr "Добавить тег «Номер дорожки»"
 msgid "Add song year tag"
 msgstr "Добавить тег «Год»"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Добавить поток…"
 
@@ -663,7 +663,7 @@ msgstr "Добавить в плейлисты Spotify"
 msgid "Add to Spotify starred"
 msgstr "Добавить в оценённые Spotify"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Добавить в другой плейлист"
 
@@ -757,7 +757,7 @@ msgstr "Все"
 msgid "All Files (*)"
 msgstr "Все файлы (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Cлава Гипножабе!"
@@ -1148,7 +1148,7 @@ msgstr "Проверять новые выпуски"
 msgid "Check for updates"
 msgstr "Проверить обновления"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Проверить обновления…"
 
@@ -1197,18 +1197,18 @@ msgstr "Классический"
 msgid "Cleaning up"
 msgstr "Очистка"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Очистить"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Очистить плейлист"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1353,7 +1353,7 @@ msgstr "Комментарий"
 msgid "Complete tags automatically"
 msgstr "Заполнить поля автоматически"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Заполнить теги автоматически"
 
@@ -1388,7 +1388,7 @@ msgstr "Настроить Subsonic…"
 msgid "Configure global search..."
 msgstr "Настроить глобальный поиск…"
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Настроить фонотеку…"
 
@@ -1431,7 +1431,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Время ожидания соединения истекло, проверьте адрес сервера. Пример: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Консоль"
 
@@ -1460,11 +1460,11 @@ msgid "Copy to clipboard"
 msgstr "Скопировать в буфер"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Копировать на носитель"
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Копировать в фонотеку…"
@@ -1507,14 +1507,14 @@ msgstr "Не удалось войти в Last.fm. Попробуйте ещё �
 msgid "Couldn't create playlist"
 msgstr "Невозможно создать плейлист"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Не возможно найти мультиплексор для %1. Убедитесь, что установлены необходимые модули GStreamer"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1529,7 +1529,7 @@ msgstr "Невозможно открыть выходной файл %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Менеджер обложек"
 
@@ -1682,7 +1682,7 @@ msgid "Delete downloaded data"
 msgstr "Удалить загруженные данные"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Удалить файлы"
 
@@ -1690,7 +1690,7 @@ msgstr "Удалить файлы"
 msgid "Delete from device..."
 msgstr "Удалить с носителя"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Удалить с диска…"
@@ -1723,11 +1723,11 @@ msgstr "Удаление файлов"
 msgid "Depth"
 msgstr "Глубина"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Убрать выбранные треки из очереди"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Убрать трек из очереди"
 
@@ -1828,7 +1828,7 @@ msgstr "Настройки вида"
 msgid "Display the on-screen-display"
 msgstr "Показывать экранное уведомление"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Пересканировать фонотеку"
 
@@ -2007,12 +2007,12 @@ msgstr "Случайный динамичный микс"
 msgid "Edit smart playlist..."
 msgstr "Изменить умный плейлист…"
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Изменить тег «%1»…"
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Изменить тег…"
 
@@ -2025,7 +2025,7 @@ msgid "Edit track information"
 msgstr "Изменить информацию о треке"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Изменить информацию о треке"
 
@@ -2133,7 +2133,7 @@ msgstr "Вся коллекция"
 msgid "Episode information"
 msgstr "Информация об эпизоде"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Эквалайзер"
 
@@ -2146,8 +2146,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Аналогично --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Ошибка"
 
@@ -2182,7 +2182,7 @@ msgstr "Ошибка загрузки %1"
 msgid "Error loading di.fm playlist"
 msgstr "Ошибка при загрузке плейлиста di.fm"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Ошибка при обработке %1: %2"
@@ -2265,7 +2265,11 @@ msgstr "Экспорт завершён"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "Экспортировано %1 обложек из %2 (%3 пропущено)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2289,7 +2293,7 @@ msgstr "Затухание звука"
 msgid "Fading duration"
 msgstr "Длительность затухания"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Не удалось прочесть CD-привод"
 
@@ -2571,11 +2575,11 @@ msgstr "Название:"
 msgid "Go"
 msgstr "Перейти"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Перейти к следующему плейлисту"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Перейти к предудыщему плейлисту"
 
@@ -2908,7 +2912,7 @@ msgstr "База данных Jamendo"
 msgid "Jump to previous song right away"
 msgstr "Немедленный переход к предыдущей песне"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Перейти к текущему треку"
 
@@ -2932,7 +2936,7 @@ msgstr "Продолжить работу в фоновом режиме при 
 msgid "Keep the original files"
 msgstr "Сохранять оригинальные файлы"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Котята"
@@ -3024,7 +3028,7 @@ msgstr "Фонотека"
 msgid "Library advanced grouping"
 msgstr "Расширенная группировка фонотеки"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Уведомление о сканировании фонотеки"
 
@@ -3064,7 +3068,7 @@ msgstr "Загрузить обложку с диска…"
 msgid "Load playlist"
 msgstr "Загрузить плейлист"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Загрузить плейлист…"
 
@@ -3125,11 +3129,15 @@ msgstr "Вход"
 msgid "Login failed"
 msgstr "Ошибка входа"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr "Журналы"
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Профиль Long term prediction (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "В любимые"
 
@@ -3164,11 +3172,11 @@ msgstr "Текст песни из %1"
 msgid "Lyrics from the tag"
 msgstr "Текст песни из тега"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "MP4 AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3210,7 +3218,7 @@ msgstr "Основной профиль (MAIN)"
 msgid "Make it so!"
 msgstr "Да будет так!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Да будет так!"
@@ -3348,7 +3356,7 @@ msgstr "Точки монтирования"
 msgid "Move down"
 msgstr "Переместить вниз"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Переместить в фонотеку…"
 
@@ -3357,7 +3365,7 @@ msgstr "Переместить в фонотеку…"
 msgid "Move up"
 msgstr "Переместить вверх"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Музыка"
 
@@ -3370,7 +3378,7 @@ msgid "Music extensions remotely visible"
 msgstr "Музыкальные расширения видны удалённо"
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Приглушить звук"
 
@@ -3419,7 +3427,7 @@ msgstr "Никогда не начинать воспроизведение"
 msgid "New folder"
 msgstr "Новая папка"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Новый плейлист"
 
@@ -3447,8 +3455,12 @@ msgstr "Последние треки"
 msgid "Next"
 msgstr "Дальше"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Следующий трек"
 
@@ -3486,7 +3498,7 @@ msgstr "Без коротких блоков"
 msgid "None"
 msgstr "Ничего"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Ни одна из выбранных песен не была скопирована на устройство"
 
@@ -3571,19 +3583,19 @@ msgstr "Откл."
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3627,7 +3639,7 @@ msgstr "Непрозрачность"
 msgid "Open %1 in browser"
 msgstr "Открыть «%1» в браузере"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Открыть аудио-&диск…"
 
@@ -3639,7 +3651,7 @@ msgstr "Открыть файл OPML"
 msgid "Open OPML file..."
 msgstr "Открыть файл OPML…"
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Открыть папку для импортирования музыки"
 
@@ -3647,7 +3659,7 @@ msgstr "Открыть папку для импортирования музык
 msgid "Open device"
 msgstr "Открыть устройство"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Открыть файл…"
 
@@ -3701,7 +3713,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Упорядочить файлы"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Упорядочить файлы…"
 
@@ -3785,7 +3797,7 @@ msgstr "Вечеринка"
 msgid "Password"
 msgstr "Пароль"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Пауза"
@@ -3809,6 +3821,10 @@ msgstr "Исполнитель"
 msgid "Pipeline"
 msgstr "Pipeline"
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr "Каналы обработки"
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Пиксель"
@@ -3817,10 +3833,10 @@ msgstr "Пиксель"
 msgid "Plain sidebar"
 msgstr "Нормальная боковая панель"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Воспроизвести"
 
@@ -3841,11 +3857,11 @@ msgstr "Воспроизвести если остановлено, приост
 msgid "Play if there is nothing already playing"
 msgstr "Проиграть, если ничего не проигрывается"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Воспроизвести следующий"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Проиграть выбранные треки следующими"
 
@@ -3944,7 +3960,7 @@ msgstr "Настройки"
 msgid "Preferences"
 msgstr "Настройки"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Настройки…"
 
@@ -4004,7 +4020,7 @@ msgid "Previous"
 msgstr "Предыдущий"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Предыдущий трек"
 
@@ -4062,16 +4078,16 @@ msgstr "Качество"
 msgid "Querying device..."
 msgstr "Опрашиваем устройство…"
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Управление очередью"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Выбранные треки в очередь"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Добавить трек в очередь"
 
@@ -4087,7 +4103,7 @@ msgstr "Радио (одинаковая громкость для всех тр
 msgid "Rain"
 msgstr "Дождь"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Дождь"
@@ -4199,7 +4215,7 @@ msgstr "Удалить действие"
 msgid "Remove current song from playlist"
 msgstr "Удалить текущую песню из плейлиста"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Удалить повторы из плейлиста"
 
@@ -4207,7 +4223,7 @@ msgstr "Удалить повторы из плейлиста"
 msgid "Remove folder"
 msgstr "Удалить папку"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Удалить из плейлиста"
 
@@ -4219,7 +4235,7 @@ msgstr "Удалить плейлист"
 msgid "Remove playlists"
 msgstr "Удалить плейлисты"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Удалить недоступные треки"
 
@@ -4231,7 +4247,7 @@ msgstr "Переименовать плейлист"
 msgid "Rename playlist..."
 msgstr "Переименовать плейлист…"
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Перенумеровать треки в данном порядке…"
 
@@ -4322,7 +4338,7 @@ msgstr "Конвертировать"
 msgid "Rip CD"
 msgstr "Конвертировать CD"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Конвертировать аудио-диск"
 
@@ -4400,7 +4416,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Сохранить плейлист"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Сохранить плейлист…"
 
@@ -4487,7 +4503,7 @@ msgstr "Поиск в Subsonic"
 msgid "Search automatically"
 msgstr "Искать автоматически"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Поиск альбома"
 
@@ -4500,7 +4516,7 @@ msgstr "Поиск обложек альбомов…"
 msgid "Search for anything"
 msgstr "Поиск чего-либо"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Поиск исполнителя"
 
@@ -4625,7 +4641,7 @@ msgstr "Информация о сервере"
 msgid "Service offline"
 msgstr "Служба недоступна"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Установить %1 в «%2»…"
@@ -4634,7 +4650,7 @@ msgstr "Установить %1 в «%2»…"
 msgid "Set the volume to <value> percent"
 msgstr "Установить громкость в <value> процентов"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Установить значение для всех выделенных треков…"
 
@@ -4705,7 +4721,7 @@ msgstr "Показывать OSD"
 msgid "Show above status bar"
 msgstr "Показать над строкой состояния"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Показать все композиции"
 
@@ -4725,12 +4741,12 @@ msgstr "Показывать разделители"
 msgid "Show fullsize..."
 msgstr "Показать в полный размер…"
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Открыть в диспетчере файлов"
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Показать в фонотеке…"
 
@@ -4742,15 +4758,15 @@ msgstr "Показать в «Различных исполнителях»"
 msgid "Show moodbar"
 msgstr "Показывать индикатор тона"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Показывать только повторяющиеся"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Показывать только без тегов"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Показать или скрыть боковую панель"
 
@@ -4758,7 +4774,7 @@ msgstr "Показать или скрыть боковую панель"
 msgid "Show search suggestions"
 msgstr "Показать поисковые подсказки"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Показать боковую панель"
 
@@ -4794,7 +4810,7 @@ msgstr "Перемешать альбомы"
 msgid "Shuffle all"
 msgstr "Перемешать все"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Перемешать плейлист"
 
@@ -4838,11 +4854,15 @@ msgstr "Количество пропусков"
 msgid "Skip forwards in playlist"
 msgstr "Переместить вперёд в плейлисте"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Пропустить выбранные треки"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Пропустить трек"
 
@@ -4959,7 +4979,7 @@ msgstr "Начать конвертирование"
 msgid "Start the playlist currently playing"
 msgstr "Запустить проигрываемый сейчас плейлист"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Конвертировать"
 
@@ -4969,7 +4989,7 @@ msgid ""
 "list"
 msgstr "Введите что-нибудь в поле для начала поиска"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Запуск %1"
@@ -4979,7 +4999,7 @@ msgid "Starting..."
 msgstr "Запуск…"
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Остановить"
 
@@ -4995,7 +5015,7 @@ msgstr "Останавливать после каждого трека"
 msgid "Stop after every track"
 msgstr "Останавливать после каждого трека"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Остановить после этого трека"
 
@@ -5163,7 +5183,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Пробный период для сервера Subsonic закончен. Пожалуйста, поддержите разработчика, чтобы получить лицензионный ключ. Посетите subsonic.org для подробной информации."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5205,7 +5225,7 @@ msgid ""
 "continue?"
 msgstr "Эти файлы будут удалены с устройства. Вы действительно хотите продолжить?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5307,11 +5327,11 @@ msgstr "Включить OSD"
 msgid "Toggle fullscreen"
 msgstr "Развернуть на весь экран"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Переключить состояние очереди"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Вкл./откл. скробблинг"
 
@@ -5356,19 +5376,19 @@ msgstr "&Трек"
 msgid "Track"
 msgstr "Трек"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Конвертер музыки"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Журнал конвертера"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr "Подробности перекодирования"
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Конвертер"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Конвертировано %1 файлов в %2 потока"
@@ -5445,11 +5465,11 @@ msgstr "Неизвестная ошибка"
 msgid "Unset cover"
 msgstr "Удалить обложку"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Не пропускать выбранные треки"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Не пропускать трек"
 
@@ -5466,7 +5486,7 @@ msgstr "Предстоящие концерты"
 msgid "Update all podcasts"
 msgstr "Обновить все подкасты"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Сканировать обновлённые папки"
 
@@ -5627,7 +5647,7 @@ msgstr "Версия %1"
 msgid "View"
 msgstr "Просмотр"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Информация о потоке"
 
@@ -5635,7 +5655,7 @@ msgstr "Информация о потоке"
 msgid "Visualization mode"
 msgstr "Режим визуализации"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Визуализации"
 
@@ -5676,7 +5696,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr "Предупреждение: данный уровень сжатия не относится к подмножеству подходящих для трансляции. Вероятно, декодер не сможет начать воспроизведение трансляции в процессе. Это также может значительно повлиять на производительность аппаратных декодеров."
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5772,7 +5792,7 @@ msgstr "Windows Media 40 кбит/c"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64 кбит/c"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media"
 
@@ -5786,7 +5806,7 @@ msgid ""
 "well?"
 msgstr "Хотите ли вы переместить и другие песни из этого альбома в «Различные исполнители»?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Желаете запустить повторное сканирование?"
 

--- a/src/translations/ru.po
+++ b/src/translations/ru.po
@@ -36,8 +36,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-26 23:47+0000\n"
-"Last-Translator: John Maguire <john.maguire@gmail.com>\n"
+"PO-Revision-Date: 2021-01-27 03:33+0000\n"
+"Last-Translator: Andrei Stepanov <adem4ik@gmail.com>\n"
 "Language-Team: Russian (http://www.transifex.com/davidsansome/clementine/language/ru/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -538,7 +538,7 @@ msgstr "Добавить другой поток…"
 msgid "Add directory..."
 msgstr "Добавить каталог…"
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Добавить файл"
 
@@ -558,7 +558,7 @@ msgstr "Добавить файл…"
 msgid "Add files to transcode"
 msgstr "Конвертировать файлы"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Добавить папку"
@@ -663,7 +663,7 @@ msgstr "Добавить в плейлисты Spotify"
 msgid "Add to Spotify starred"
 msgstr "Добавить в оценённые Spotify"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Добавить в другой плейлист"
 
@@ -885,7 +885,7 @@ msgstr "Вы действительно хотите записывать ста
 msgid "Artist"
 msgstr "Исполнитель"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Артист"
 
@@ -1148,7 +1148,7 @@ msgstr "Проверять новые выпуски"
 msgid "Check for updates"
 msgstr "Проверить обновления"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Проверить обновления…"
 
@@ -1388,7 +1388,7 @@ msgstr "Настроить Subsonic…"
 msgid "Configure global search..."
 msgstr "Настроить глобальный поиск…"
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Настроить фонотеку…"
 
@@ -1460,11 +1460,11 @@ msgid "Copy to clipboard"
 msgstr "Скопировать в буфер"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Копировать на носитель"
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Копировать в фонотеку…"
@@ -1682,7 +1682,7 @@ msgid "Delete downloaded data"
 msgstr "Удалить загруженные данные"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Удалить файлы"
 
@@ -1690,7 +1690,7 @@ msgstr "Удалить файлы"
 msgid "Delete from device..."
 msgstr "Удалить с носителя"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Удалить с диска…"
@@ -1723,11 +1723,11 @@ msgstr "Удаление файлов"
 msgid "Depth"
 msgstr "Глубина"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Убрать выбранные треки из очереди"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Убрать трек из очереди"
 
@@ -1756,7 +1756,7 @@ msgstr "Имя носителя"
 msgid "Device properties..."
 msgstr "Свойства носителя…"
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Носители"
 
@@ -2007,7 +2007,7 @@ msgstr "Случайный динамичный микс"
 msgid "Edit smart playlist..."
 msgstr "Изменить умный плейлист…"
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Изменить тег «%1»…"
@@ -2146,8 +2146,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Аналогично --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Ошибка"
 
@@ -2267,7 +2267,7 @@ msgstr "Экспортировано %1 обложек из %2 (%3 пропущ�
 
 #: ../bin/src/ui_mainwindow.h:790
 msgid "F9"
-msgstr ""
+msgstr "F9"
 
 #: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
@@ -2293,7 +2293,7 @@ msgstr "Затухание звука"
 msgid "Fading duration"
 msgstr "Длительность затухания"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Не удалось прочесть CD-привод"
 
@@ -2416,7 +2416,7 @@ msgstr "Тип файла"
 msgid "Filename"
 msgstr "Имя файла"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Файлы"
 
@@ -2831,7 +2831,7 @@ msgstr "Установлен"
 msgid "Integrity check"
 msgstr "Проверка целостности"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Интернет"
 
@@ -3019,7 +3019,7 @@ msgstr "Левый канал"
 msgid "Length"
 msgstr "Длина"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Фонотека"
@@ -3028,7 +3028,7 @@ msgstr "Фонотека"
 msgid "Library advanced grouping"
 msgstr "Расширенная группировка фонотеки"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Уведомление о сканировании фонотеки"
 
@@ -3356,7 +3356,7 @@ msgstr "Точки монтирования"
 msgid "Move down"
 msgstr "Переместить вниз"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Переместить в фонотеку…"
 
@@ -3365,7 +3365,7 @@ msgstr "Переместить в фонотеку…"
 msgid "Move up"
 msgstr "Переместить вверх"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Музыка"
 
@@ -3427,7 +3427,7 @@ msgstr "Никогда не начинать воспроизведение"
 msgid "New folder"
 msgstr "Новая папка"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Новый плейлист"
 
@@ -3457,7 +3457,7 @@ msgstr "Дальше"
 
 #: ../bin/src/ui_mainwindow.h:785
 msgid "Next album"
-msgstr ""
+msgstr "Следующий альбом"
 
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
 #: ../bin/src/ui_mainwindow.h:727
@@ -3498,7 +3498,7 @@ msgstr "Без коротких блоков"
 msgid "None"
 msgstr "Ничего"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Ни одна из выбранных песен не была скопирована на устройство"
 
@@ -3713,7 +3713,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Упорядочить файлы"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Упорядочить файлы…"
 
@@ -3797,7 +3797,7 @@ msgstr "Вечеринка"
 msgid "Password"
 msgstr "Пароль"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Пауза"
@@ -3833,8 +3833,8 @@ msgstr "Пиксель"
 msgid "Plain sidebar"
 msgstr "Нормальная боковая панель"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3857,11 +3857,11 @@ msgstr "Воспроизвести если остановлено, приост
 msgid "Play if there is nothing already playing"
 msgstr "Проиграть, если ничего не проигрывается"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Воспроизвести следующий"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Проиграть выбранные треки следующими"
 
@@ -3900,7 +3900,7 @@ msgstr "Настройки плейлиста"
 msgid "Playlist type"
 msgstr "Тип плейлиста"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Списки"
 
@@ -4082,12 +4082,12 @@ msgstr "Опрашиваем устройство…"
 msgid "Queue Manager"
 msgstr "Управление очередью"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Выбранные треки в очередь"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Добавить трек в очередь"
 
@@ -4478,7 +4478,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Поиск"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Поиск"
@@ -4503,7 +4503,7 @@ msgstr "Поиск в Subsonic"
 msgid "Search automatically"
 msgstr "Искать автоматически"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Поиск альбома"
 
@@ -4516,7 +4516,7 @@ msgstr "Поиск обложек альбомов…"
 msgid "Search for anything"
 msgstr "Поиск чего-либо"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Поиск исполнителя"
 
@@ -4641,7 +4641,7 @@ msgstr "Информация о сервере"
 msgid "Service offline"
 msgstr "Служба недоступна"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Установить %1 в «%2»…"
@@ -4721,7 +4721,7 @@ msgstr "Показывать OSD"
 msgid "Show above status bar"
 msgstr "Показать над строкой состояния"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Показать все композиции"
 
@@ -4741,12 +4741,12 @@ msgstr "Показывать разделители"
 msgid "Show fullsize..."
 msgstr "Показать в полный размер…"
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Открыть в диспетчере файлов"
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Показать в фонотеке…"
 
@@ -4758,11 +4758,11 @@ msgstr "Показать в «Различных исполнителях»"
 msgid "Show moodbar"
 msgstr "Показывать индикатор тона"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Показывать только повторяющиеся"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Показывать только без тегов"
 
@@ -4854,15 +4854,15 @@ msgstr "Количество пропусков"
 msgid "Skip forwards in playlist"
 msgstr "Переместить вперёд в плейлисте"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Пропустить выбранные треки"
 
 #: ../bin/src/ui_mainwindow.h:787
 msgid "Skip to the next album"
-msgstr ""
+msgstr "Перейти к следующему альбому"
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Пропустить трек"
 
@@ -4894,7 +4894,7 @@ msgstr "Лёгкий рок"
 msgid "Song Information"
 msgstr "Тексты песен"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Песня"
 
@@ -5015,7 +5015,7 @@ msgstr "Останавливать после каждого трека"
 msgid "Stop after every track"
 msgstr "Останавливать после каждого трека"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Остановить после этого трека"
 
@@ -5183,7 +5183,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Пробный период для сервера Subsonic закончен. Пожалуйста, поддержите разработчика, чтобы получить лицензионный ключ. Посетите subsonic.org для подробной информации."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5225,7 +5225,7 @@ msgid ""
 "continue?"
 msgstr "Эти файлы будут удалены с устройства. Вы действительно хотите продолжить?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5327,7 +5327,7 @@ msgstr "Включить OSD"
 msgid "Toggle fullscreen"
 msgstr "Развернуть на весь экран"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Переключить состояние очереди"
 
@@ -5465,11 +5465,11 @@ msgstr "Неизвестная ошибка"
 msgid "Unset cover"
 msgstr "Удалить обложку"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Не пропускать выбранные треки"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Не пропускать трек"
 
@@ -5806,7 +5806,7 @@ msgid ""
 "well?"
 msgstr "Хотите ли вы переместить и другие песни из этого альбома в «Различные исполнители»?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Желаете запустить повторное сканирование?"
 

--- a/src/translations/si_LK.po
+++ b/src/translations/si_LK.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Sinhala (Sri Lanka) (http://www.transifex.com/davidsansome/clementine/language/si_LK/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -160,19 +160,19 @@ msgstr ""
 msgid "%filename%"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -190,7 +190,7 @@ msgstr ""
 msgid "&Custom"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr ""
 
@@ -198,7 +198,7 @@ msgstr ""
 msgid "&Grouping"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr ""
 
@@ -223,7 +223,7 @@ msgstr ""
 msgid "&Lyrics"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr ""
 
@@ -231,15 +231,15 @@ msgstr ""
 msgid "&None"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr ""
 
@@ -247,7 +247,7 @@ msgstr ""
 msgid "&Right"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr ""
 
@@ -255,7 +255,7 @@ msgstr ""
 msgid "&Stretch columns to fit window"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr ""
 
@@ -444,11 +444,11 @@ msgstr ""
 msgid "About %1"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr ""
 
@@ -508,32 +508,32 @@ msgstr ""
 msgid "Add directory..."
 msgstr ""
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Add podcast"
 msgstr ""
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr ""
 
@@ -621,7 +621,7 @@ msgstr ""
 msgid "Add song year tag"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr ""
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr ""
 
@@ -727,7 +727,7 @@ msgstr ""
 msgid "All Files (*)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr ""
@@ -1118,7 +1118,7 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr ""
 
@@ -1167,18 +1167,18 @@ msgstr ""
 msgid "Cleaning up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr ""
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr ""
 
@@ -1323,7 +1323,7 @@ msgstr ""
 msgid "Complete tags automatically"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr ""
 
@@ -1401,7 +1401,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr ""
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr ""
 
@@ -1430,11 +1430,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1477,14 +1477,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr ""
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1499,7 +1499,7 @@ msgstr ""
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr ""
 
@@ -1660,7 +1660,7 @@ msgstr ""
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1693,11 +1693,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr ""
 
@@ -1798,7 +1798,7 @@ msgstr ""
 msgid "Display the on-screen-display"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr ""
 
@@ -1977,12 +1977,12 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr ""
 
@@ -1995,7 +1995,7 @@ msgid "Edit track information"
 msgstr ""
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr ""
 
@@ -2103,7 +2103,7 @@ msgstr ""
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr ""
 
@@ -2116,8 +2116,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr ""
 
@@ -2152,7 +2152,7 @@ msgstr ""
 msgid "Error loading di.fm playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr ""
@@ -2235,7 +2235,11 @@ msgstr ""
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr ""
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2259,7 +2263,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2541,11 +2545,11 @@ msgstr ""
 msgid "Go"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr ""
 
@@ -2878,7 +2882,7 @@ msgstr ""
 msgid "Jump to previous song right away"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr ""
 
@@ -2902,7 +2906,7 @@ msgstr ""
 msgid "Keep the original files"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr ""
@@ -2994,7 +2998,7 @@ msgstr ""
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3034,7 +3038,7 @@ msgstr ""
 msgid "Load playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr ""
 
@@ -3095,11 +3099,15 @@ msgstr ""
 msgid "Login failed"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr ""
 
@@ -3134,11 +3142,11 @@ msgstr ""
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr ""
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr ""
@@ -3180,7 +3188,7 @@ msgstr ""
 msgid "Make it so!"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr ""
@@ -3318,7 +3326,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3327,7 +3335,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr ""
 
@@ -3340,7 +3348,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr ""
 
@@ -3389,7 +3397,7 @@ msgstr ""
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3417,8 +3425,12 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr ""
 
@@ -3456,7 +3468,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3541,19 +3553,19 @@ msgstr ""
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr ""
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr ""
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr ""
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3597,7 +3609,7 @@ msgstr ""
 msgid "Open %1 in browser"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr ""
 
@@ -3609,7 +3621,7 @@ msgstr ""
 msgid "Open OPML file..."
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr ""
 
@@ -3617,7 +3629,7 @@ msgstr ""
 msgid "Open device"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr ""
 
@@ -3671,7 +3683,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr ""
 
@@ -3755,7 +3767,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr ""
@@ -3779,6 +3791,10 @@ msgstr ""
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr ""
@@ -3787,10 +3803,10 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr ""
 
@@ -3811,11 +3827,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3914,7 +3930,7 @@ msgstr ""
 msgid "Preferences"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr ""
 
@@ -3974,7 +3990,7 @@ msgid "Previous"
 msgstr ""
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr ""
 
@@ -4032,16 +4048,16 @@ msgstr ""
 msgid "Querying device..."
 msgstr ""
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr ""
 
@@ -4057,7 +4073,7 @@ msgstr ""
 msgid "Rain"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr ""
@@ -4169,7 +4185,7 @@ msgstr ""
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr ""
 
@@ -4177,7 +4193,7 @@ msgstr ""
 msgid "Remove folder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr ""
 
@@ -4189,7 +4205,7 @@ msgstr ""
 msgid "Remove playlists"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr ""
 
@@ -4201,7 +4217,7 @@ msgstr ""
 msgid "Rename playlist..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr ""
 
@@ -4292,7 +4308,7 @@ msgstr ""
 msgid "Rip CD"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr ""
 
@@ -4370,7 +4386,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr ""
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr ""
 
@@ -4457,7 +4473,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4470,7 +4486,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4595,7 +4611,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4604,7 +4620,7 @@ msgstr ""
 msgid "Set the volume to <value> percent"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr ""
 
@@ -4675,7 +4691,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr ""
 
@@ -4695,12 +4711,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr ""
 
@@ -4712,15 +4728,15 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4728,7 +4744,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4764,7 +4780,7 @@ msgstr ""
 msgid "Shuffle all"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr ""
 
@@ -4808,11 +4824,15 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr ""
 
@@ -4929,7 +4949,7 @@ msgstr ""
 msgid "Start the playlist currently playing"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr ""
 
@@ -4939,7 +4959,7 @@ msgid ""
 "list"
 msgstr ""
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr ""
@@ -4949,7 +4969,7 @@ msgid "Starting..."
 msgstr ""
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr ""
 
@@ -4965,7 +4985,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5133,7 +5153,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5175,7 +5195,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5277,11 +5297,11 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr ""
 
@@ -5326,19 +5346,19 @@ msgstr ""
 msgid "Track"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr ""
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
 msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr ""
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr ""
@@ -5415,11 +5435,11 @@ msgstr ""
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr ""
 
@@ -5436,7 +5456,7 @@ msgstr ""
 msgid "Update all podcasts"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr ""
 
@@ -5597,7 +5617,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5605,7 +5625,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr ""
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr ""
 
@@ -5646,7 +5666,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr ""
 
@@ -5742,7 +5762,7 @@ msgstr ""
 msgid "Windows Media 64k"
 msgstr ""
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr ""
 
@@ -5756,7 +5776,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/si_LK.po
+++ b/src/translations/si_LK.po
@@ -508,7 +508,7 @@ msgstr ""
 msgid "Add directory..."
 msgstr ""
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgstr ""
 msgid "Add files to transcode"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr ""
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr ""
 
@@ -855,7 +855,7 @@ msgstr ""
 msgid "Artist"
 msgstr ""
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr ""
 
@@ -1118,7 +1118,7 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr ""
 
@@ -1430,11 +1430,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1652,7 +1652,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr ""
 
@@ -1660,7 +1660,7 @@ msgstr ""
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1693,11 +1693,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr ""
 
@@ -1726,7 +1726,7 @@ msgstr ""
 msgid "Device properties..."
 msgstr ""
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr ""
 
@@ -1977,7 +1977,7 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
@@ -2116,8 +2116,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr ""
 
@@ -2263,7 +2263,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2386,7 +2386,7 @@ msgstr ""
 msgid "Filename"
 msgstr ""
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr ""
 
@@ -2801,7 +2801,7 @@ msgstr ""
 msgid "Integrity check"
 msgstr ""
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr ""
 
@@ -2989,7 +2989,7 @@ msgstr ""
 msgid "Length"
 msgstr ""
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr ""
@@ -2998,7 +2998,7 @@ msgstr ""
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3326,7 +3326,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3335,7 +3335,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr ""
 
@@ -3397,7 +3397,7 @@ msgstr ""
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3468,7 +3468,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3683,7 +3683,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr ""
 
@@ -3767,7 +3767,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr ""
@@ -3803,8 +3803,8 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3827,11 +3827,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3870,7 +3870,7 @@ msgstr ""
 msgid "Playlist type"
 msgstr ""
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr ""
 
@@ -4052,12 +4052,12 @@ msgstr ""
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr ""
 
@@ -4448,7 +4448,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr ""
@@ -4473,7 +4473,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4486,7 +4486,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4611,7 +4611,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4691,7 +4691,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr ""
 
@@ -4711,12 +4711,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr ""
 
@@ -4728,11 +4728,11 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr ""
 
@@ -4824,7 +4824,7 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr ""
 
@@ -4832,7 +4832,7 @@ msgstr ""
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr ""
 
@@ -4864,7 +4864,7 @@ msgstr ""
 msgid "Song Information"
 msgstr ""
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr ""
 
@@ -4985,7 +4985,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5153,7 +5153,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5195,7 +5195,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5297,7 +5297,7 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr ""
 
@@ -5435,11 +5435,11 @@ msgstr ""
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr ""
 
@@ -5776,7 +5776,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/sk.po
+++ b/src/translations/sk.po
@@ -13,7 +13,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Slovak (http://www.transifex.com/davidsansome/clementine/language/sk/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -167,19 +167,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n zlyhalo"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n dokončených"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -197,7 +197,7 @@ msgstr "Na &stred"
 msgid "&Custom"
 msgstr "&Vlastná"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "Bonusy"
 
@@ -205,7 +205,7 @@ msgstr "Bonusy"
 msgid "&Grouping"
 msgstr "&Zoskupenie"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Nápoveda"
 
@@ -230,7 +230,7 @@ msgstr "&Uzamknúť hodnotenie"
 msgid "&Lyrics"
 msgstr "&Texty piesní"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "Hudba"
 
@@ -238,15 +238,15 @@ msgstr "Hudba"
 msgid "&None"
 msgstr "&Nijaká"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "Playlist"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Zavrieť"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "Režim opakovania"
 
@@ -254,7 +254,7 @@ msgstr "Režim opakovania"
 msgid "&Right"
 msgstr "Vp&ravo"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Režim zamiešavania"
 
@@ -262,7 +262,7 @@ msgstr "Režim zamiešavania"
 msgid "&Stretch columns to fit window"
 msgstr "Roztiahnuť &stĺpce na prispôsobenie oknu"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "Nástroje"
 
@@ -451,11 +451,11 @@ msgstr "Zrušiť"
 msgid "About %1"
 msgstr "O %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "O Clemetine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "O Qt.."
 
@@ -515,32 +515,32 @@ msgstr "Pridať ďalší stream..."
 msgid "Add directory..."
 msgstr "Pridať priečinok..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Pridať súbor"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Pridať súbor na prekódovanie"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Pridať súbor(y) na prekódovanie"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Pridať súbor..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Pridať súbory na transkódovanie"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Pridať priečinok"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Pridať priečinok..."
 
@@ -552,7 +552,7 @@ msgstr "Pridať nový priečinok..."
 msgid "Add podcast"
 msgstr "Pridať podcast"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Pridať podcast..."
 
@@ -628,7 +628,7 @@ msgstr "Pridať tag čísla skladby"
 msgid "Add song year tag"
 msgstr "Pridať tag roka piesne"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Pridať stream..."
 
@@ -640,7 +640,7 @@ msgstr "Pridať do Spotify playlistov"
 msgid "Add to Spotify starred"
 msgstr "Pridať do S hviezdičkou na Spotify"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Pridať do iného playlistu"
 
@@ -734,7 +734,7 @@ msgstr "Všetko"
 msgid "All Files (*)"
 msgstr "Všetky súbory (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "All Glory to the Hypnotoad!"
@@ -1125,7 +1125,7 @@ msgstr "Skontrolovať, či sú nové časti"
 msgid "Check for updates"
 msgstr "Skontrolovať aktualizácie"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Skontrolovať aktualizácie..."
 
@@ -1174,18 +1174,18 @@ msgstr "Classical"
 msgid "Cleaning up"
 msgstr "Upratovanie"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Vyprázdniť"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Vyprázdniť playlist"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1330,7 +1330,7 @@ msgstr "Komentár"
 msgid "Complete tags automatically"
 msgstr "Vyplniť tagy automaticky"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Vyplniť tagy automaticky..."
 
@@ -1365,7 +1365,7 @@ msgstr "Nastaviť Subsonic..."
 msgid "Configure global search..."
 msgstr "Nastaviť globálne vyhľadávanie..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Nastaviť zbierku..."
 
@@ -1408,7 +1408,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Čas na spojenie vypršal, skontrolujte URL adresu serveru. Príklad: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Konzola"
 
@@ -1437,11 +1437,11 @@ msgid "Copy to clipboard"
 msgstr "Kopírovať do schránky"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Skopírovať na zariadenie..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Skopírovať do zbierky..."
@@ -1484,14 +1484,14 @@ msgstr "Nepodarilo sa prihlásiť k službe Last.fm. Prosím, skúste to znovu."
 msgid "Couldn't create playlist"
 msgstr "Nepodarilo sa vytvoriť playlist"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Nedal sa nájsť muxer pre %1, skontrolujte či máte korektne nainštalované GStreamer pluginy"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1506,7 +1506,7 @@ msgstr "Nedá sa otvoriť výstupný súbor %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Správca obalov"
 
@@ -1659,7 +1659,7 @@ msgid "Delete downloaded data"
 msgstr "Vymazať stiahnuté dáta"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Vymazať súbory"
 
@@ -1667,7 +1667,7 @@ msgstr "Vymazať súbory"
 msgid "Delete from device..."
 msgstr "Vymazať zo zariadenia..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Vymazať z disku..."
@@ -1700,11 +1700,11 @@ msgstr "Odstraňujú sa súbory"
 msgid "Depth"
 msgstr "Hĺbka"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Vybrať z radu vybrané skladby"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Vybrať z radu skladbu"
 
@@ -1805,7 +1805,7 @@ msgstr "Možnosti zobrazovania"
 msgid "Display the on-screen-display"
 msgstr "Zobrazovať OSD"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Vykonať preskenovanie celej zbierky"
 
@@ -1984,12 +1984,12 @@ msgstr "Dynamicky náhodná zmes"
 msgid "Edit smart playlist..."
 msgstr "Upraviť inteligentný playlist..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Upraviť tag \"%1\"..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Upraviť tag..."
 
@@ -2002,7 +2002,7 @@ msgid "Edit track information"
 msgstr "Upravť informácie o skladbe"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Upravť informácie o skladbe..."
 
@@ -2110,7 +2110,7 @@ msgstr "Celá zbierka"
 msgid "Episode information"
 msgstr "Informácie o dieli"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Ekvalizér"
 
@@ -2123,8 +2123,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Ekvivalent k --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Chyba"
 
@@ -2159,7 +2159,7 @@ msgstr "Chyba pri načítavaní %1"
 msgid "Error loading di.fm playlist"
 msgstr "Chyba pri načítavaní di.fm playlistu"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Chyba spracovania %1: %2"
@@ -2242,7 +2242,11 @@ msgstr "Exportovanie dokončené"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "Exportovaných %1 obalov z %2 (%3 preskočených)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2266,7 +2270,7 @@ msgstr "Zoslabovanie"
 msgid "Fading duration"
 msgstr "Trvanie zoslabovania"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Zlyhalo čítanie CD v mechanike"
 
@@ -2548,11 +2552,11 @@ msgstr "Pomenujte:"
 msgid "Go"
 msgstr "Prejsť"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Prejsť na kartu ďalšieho playlistu"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Prejsť na kartu predchádzajúceho playlistu"
 
@@ -2885,7 +2889,7 @@ msgstr "Jamendo databáza"
 msgid "Jump to previous song right away"
 msgstr "Okamžitý prechod na predchádzajúcu pieseň"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Prejsť na práve prehrávanú skladbu"
 
@@ -2909,7 +2913,7 @@ msgstr "Nechať bežať na pozadí, keď sa zavrie hlavné okno"
 msgid "Keep the original files"
 msgstr "Zachovať pôvodné súbory"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Mačiatka"
@@ -3001,7 +3005,7 @@ msgstr "Zbierka"
 msgid "Library advanced grouping"
 msgstr "Pokročilé zoraďovanie zbierky"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Poznámka k preskenovaniu zbierky"
 
@@ -3041,7 +3045,7 @@ msgstr "Načítať obal z disku..."
 msgid "Load playlist"
 msgstr "Načítať playlist"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Načítať playlist..."
 
@@ -3102,11 +3106,15 @@ msgstr "Prihlásiť sa"
 msgid "Login failed"
 msgstr "Prihlásenie zlyhalo"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Profil dlhodobej predpovede (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Obľúbené"
 
@@ -3141,11 +3149,11 @@ msgstr "Texty z %1"
 msgid "Lyrics from the tag"
 msgstr "Texty z tagu"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3187,7 +3195,7 @@ msgstr "Hlavný profil (MAIN)"
 msgid "Make it so!"
 msgstr "Make it so!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Make it so!"
@@ -3325,7 +3333,7 @@ msgstr "Body pripojenia"
 msgid "Move down"
 msgstr "Posunúť nižšie"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Presunúť do zbierky..."
 
@@ -3334,7 +3342,7 @@ msgstr "Presunúť do zbierky..."
 msgid "Move up"
 msgstr "Posunúť vyššie"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Hudba"
 
@@ -3347,7 +3355,7 @@ msgid "Music extensions remotely visible"
 msgstr "Vzdialene viditeľné prípony hudobných súborov"
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Stlmiť"
 
@@ -3396,7 +3404,7 @@ msgstr "Nezačne sa prehrávať"
 msgid "New folder"
 msgstr "Nový playlist"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nový playlist"
 
@@ -3424,8 +3432,12 @@ msgstr "Najnovšie skladby"
 msgid "Next"
 msgstr "Ďalšia"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Nasledujúca skladba"
 
@@ -3463,7 +3475,7 @@ msgstr "Žiadne krátke bloky"
 msgid "None"
 msgstr "Nijako"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Žiadna z vybratých piesní nieje vhodná na kopírovanie do zariadenia"
 
@@ -3548,19 +3560,19 @@ msgstr "Vypnuté"
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3604,7 +3616,7 @@ msgstr "Nepriehľadnosť"
 msgid "Open %1 in browser"
 msgstr "Otvoriť %1 v prehliadači"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Otvoriť &zvukové CD..."
 
@@ -3616,7 +3628,7 @@ msgstr "Otvoriť OPML súbor"
 msgid "Open OPML file..."
 msgstr "Otvoriť OPML súbor..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Otvoriť priečinok na importovanie hudby z neho"
 
@@ -3624,7 +3636,7 @@ msgstr "Otvoriť priečinok na importovanie hudby z neho"
 msgid "Open device"
 msgstr "Otvoriť zariadenie"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Otvoriť súbor ..."
 
@@ -3678,7 +3690,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organizovať súbory"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Spravovať súbory..."
 
@@ -3762,7 +3774,7 @@ msgstr "Party"
 msgid "Password"
 msgstr "Heslo"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pozastaviť"
@@ -3786,6 +3798,10 @@ msgstr "Účinkujúci"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Pixel"
@@ -3794,10 +3810,10 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Obyčajný bočný panel"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Hrať"
 
@@ -3818,11 +3834,11 @@ msgstr "Hrať ak je zastavené, pozastaviť ak hrá"
 msgid "Play if there is nothing already playing"
 msgstr "Začne hrať, ak sa nič neprehráva"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Prehrať nasledujúcu"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Prehrať vybrané skladby ako ďalšie"
 
@@ -3921,7 +3937,7 @@ msgstr "Nastavenie"
 msgid "Preferences"
 msgstr "Nastavenia"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Nastavenia..."
 
@@ -3981,7 +3997,7 @@ msgid "Previous"
 msgstr "Predchádzajúca"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Predchádzajúca skladba"
 
@@ -4039,16 +4055,16 @@ msgstr "Kvalita"
 msgid "Querying device..."
 msgstr "Zaraďuje sa zariadenie..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Správca poradia"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Zaradiť vybrané skladby"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Zaradiť skladbu"
 
@@ -4064,7 +4080,7 @@ msgstr "Rádio (rovnaká hlasitosť pre všetky skladby)"
 msgid "Rain"
 msgstr "Dážď"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Dážď"
@@ -4176,7 +4192,7 @@ msgstr "Odstrániť činnosť"
 msgid "Remove current song from playlist"
 msgstr "Odstrániť aktuálnu pieseň z playlistu"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Odstrániť duplikáty z playlistu"
 
@@ -4184,7 +4200,7 @@ msgstr "Odstrániť duplikáty z playlistu"
 msgid "Remove folder"
 msgstr "Odstrániť priečinok"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Odstrániť z playlistu"
 
@@ -4196,7 +4212,7 @@ msgstr "Odstrániť playlist"
 msgid "Remove playlists"
 msgstr "Odstrániť playlisty"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Odstrániť nedostupné skladby z playlistu"
 
@@ -4208,7 +4224,7 @@ msgstr "Premenovať playlist"
 msgid "Rename playlist..."
 msgstr "Premenovať playlist..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Prečíslovať skladby v tomto poradí..."
 
@@ -4299,7 +4315,7 @@ msgstr "Ripovať"
 msgid "Rip CD"
 msgstr "Ripovať CD"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Ripovať zvukové CD"
 
@@ -4377,7 +4393,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Uložiť playlist"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Uložiť playlist..."
 
@@ -4464,7 +4480,7 @@ msgstr "Vyhľadať na Subsonicu"
 msgid "Search automatically"
 msgstr "Hľadať automaticky"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Vyhľadať album"
 
@@ -4477,7 +4493,7 @@ msgstr "Hľadať obaly albumov..."
 msgid "Search for anything"
 msgstr "Hľadať všetko"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Vyhľadať interpreta"
 
@@ -4602,7 +4618,7 @@ msgstr "Podrobnosti o serveri"
 msgid "Service offline"
 msgstr "Služba je offline"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Nastaviť %1 do \"%2\"..."
@@ -4611,7 +4627,7 @@ msgstr "Nastaviť %1 do \"%2\"..."
 msgid "Set the volume to <value> percent"
 msgstr "Nastaviť hlasitosť na <value> percent"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Nastaviť hodnotu pre všetky vybraté skladby..."
 
@@ -4682,7 +4698,7 @@ msgstr "Zobrazovať krásne OSD"
 msgid "Show above status bar"
 msgstr "Zobraziť nad stavovým riadkom"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Zobraziť všetky piesne"
 
@@ -4702,12 +4718,12 @@ msgstr "Zobraziť oddeľovače"
 msgid "Show fullsize..."
 msgstr "Zobraziť celú veľkosť..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Zobraziť v prehliadači súborov..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Zobraziť v zbierke..."
 
@@ -4719,15 +4735,15 @@ msgstr "Zobrazovať v rôznych interprétoch"
 msgid "Show moodbar"
 msgstr "Zobraziť panel nálady"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Zobraziť iba duplikáty"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Zobraziť iba neotagované"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Zobraziť alebo skryť bočný panel"
 
@@ -4735,7 +4751,7 @@ msgstr "Zobraziť alebo skryť bočný panel"
 msgid "Show search suggestions"
 msgstr "Zobrazovať návrhy vyhľadávania"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Zobraziť bočný panel"
 
@@ -4771,7 +4787,7 @@ msgstr "Zamiešať albumy"
 msgid "Shuffle all"
 msgstr "Zamiešať všetko"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Zamiešať playlist"
 
@@ -4815,11 +4831,15 @@ msgstr "Počet preskočení"
 msgid "Skip forwards in playlist"
 msgstr "Preskočiť dopredu v playliste"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Preskočiť vybrané skladby"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Preskočiť skladbu"
 
@@ -4936,7 +4956,7 @@ msgstr "Začať ripovanie"
 msgid "Start the playlist currently playing"
 msgstr "Začať playlist práve prehrávanou"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Začať transkódovanie"
 
@@ -4946,7 +4966,7 @@ msgid ""
 "list"
 msgstr "Začnite písať niečo do vyhľadávacieho políčka vyššie, aby ste naplnili tento zoznam výsledkov hľadania"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Začína sa %1"
@@ -4956,7 +4976,7 @@ msgid "Starting..."
 msgstr "Začína sa ..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Zastaviť"
 
@@ -4972,7 +4992,7 @@ msgstr "Zastaviť po každej skladbe"
 msgid "Stop after every track"
 msgstr "Zastaviť po každej skladbe"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Zastaviť po tejto skladbe"
 
@@ -5140,7 +5160,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Skúšobná verzia Subsonic servera uplynula. Prosím prispejte, aby ste získali licenčný kľúč. Navštívte subsonic.org pre detaily."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5182,7 +5202,7 @@ msgid ""
 "continue?"
 msgstr "Tieto súbory budú vymazané zo zariadenia, ste si istý, že chcete pokračovať?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5284,11 +5304,11 @@ msgstr "Prepnúť Krásne OSD"
 msgid "Toggle fullscreen"
 msgstr "Prepnúť na celú obrazovku"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Prepínať stav radu"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Prepnúť skroblovanie"
 
@@ -5333,19 +5353,19 @@ msgstr "Č&."
 msgid "Track"
 msgstr "Č."
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Transkódovať hudbu"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Výpis transkódera"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Transkódovanie"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Transkódovanie %1 súborov použitím %2 vlákien."
@@ -5422,11 +5442,11 @@ msgstr "Neznáma chyba"
 msgid "Unset cover"
 msgstr "Nenastavený obal"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Nepreskočiť vybraté skladby"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Nepreskočiť skladbu"
 
@@ -5443,7 +5463,7 @@ msgstr "Pripravované koncerty"
 msgid "Update all podcasts"
 msgstr "Aktualizovať všetky podcasty"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Aktualizovať zmenené priečinky v zbierke"
 
@@ -5604,7 +5624,7 @@ msgstr "Verzia %1"
 msgid "View"
 msgstr "Zobraziť"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Zobraziť podrobnosti o streame"
 
@@ -5612,7 +5632,7 @@ msgstr "Zobraziť podrobnosti o streame"
 msgid "Visualization mode"
 msgstr "Režim vizualizácií"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Vizualizácie"
 
@@ -5653,7 +5673,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5749,7 +5769,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "WMa"
 
@@ -5763,7 +5783,7 @@ msgid ""
 "well?"
 msgstr "Chceli by ste presunúť tiež ostatné piesne v tomto albume do rôznych interprétov?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Chcete teraz spustiť úplné preskenovanie?"
 

--- a/src/translations/sk.po
+++ b/src/translations/sk.po
@@ -515,7 +515,7 @@ msgstr "Pridať ďalší stream..."
 msgid "Add directory..."
 msgstr "Pridať priečinok..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Pridať súbor"
 
@@ -535,7 +535,7 @@ msgstr "Pridať súbor..."
 msgid "Add files to transcode"
 msgstr "Pridať súbory na transkódovanie"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Pridať priečinok"
@@ -640,7 +640,7 @@ msgstr "Pridať do Spotify playlistov"
 msgid "Add to Spotify starred"
 msgstr "Pridať do S hviezdičkou na Spotify"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Pridať do iného playlistu"
 
@@ -862,7 +862,7 @@ msgstr "Ste si istý, že chcete ukladať štatistiky piesní do súboru piesne 
 msgid "Artist"
 msgstr "Interprét"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Interprét"
 
@@ -1125,7 +1125,7 @@ msgstr "Skontrolovať, či sú nové časti"
 msgid "Check for updates"
 msgstr "Skontrolovať aktualizácie"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Skontrolovať aktualizácie..."
 
@@ -1365,7 +1365,7 @@ msgstr "Nastaviť Subsonic..."
 msgid "Configure global search..."
 msgstr "Nastaviť globálne vyhľadávanie..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Nastaviť zbierku..."
 
@@ -1437,11 +1437,11 @@ msgid "Copy to clipboard"
 msgstr "Kopírovať do schránky"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Skopírovať na zariadenie..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Skopírovať do zbierky..."
@@ -1659,7 +1659,7 @@ msgid "Delete downloaded data"
 msgstr "Vymazať stiahnuté dáta"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Vymazať súbory"
 
@@ -1667,7 +1667,7 @@ msgstr "Vymazať súbory"
 msgid "Delete from device..."
 msgstr "Vymazať zo zariadenia..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Vymazať z disku..."
@@ -1700,11 +1700,11 @@ msgstr "Odstraňujú sa súbory"
 msgid "Depth"
 msgstr "Hĺbka"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Vybrať z radu vybrané skladby"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Vybrať z radu skladbu"
 
@@ -1733,7 +1733,7 @@ msgstr "Názov zariadenia"
 msgid "Device properties..."
 msgstr "Vlastnosti zariadenia..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Zariadenia"
 
@@ -1984,7 +1984,7 @@ msgstr "Dynamicky náhodná zmes"
 msgid "Edit smart playlist..."
 msgstr "Upraviť inteligentný playlist..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Upraviť tag \"%1\"..."
@@ -2123,8 +2123,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Ekvivalent k --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Chyba"
 
@@ -2270,7 +2270,7 @@ msgstr "Zoslabovanie"
 msgid "Fading duration"
 msgstr "Trvanie zoslabovania"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Zlyhalo čítanie CD v mechanike"
 
@@ -2393,7 +2393,7 @@ msgstr "Typ súboru"
 msgid "Filename"
 msgstr "Názov súboru"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Súbory"
 
@@ -2808,7 +2808,7 @@ msgstr "Nainštalované"
 msgid "Integrity check"
 msgstr "Kontrola integrity"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -2996,7 +2996,7 @@ msgstr "Ľavý"
 msgid "Length"
 msgstr "Dĺžka"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Zbierka"
@@ -3005,7 +3005,7 @@ msgstr "Zbierka"
 msgid "Library advanced grouping"
 msgstr "Pokročilé zoraďovanie zbierky"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Poznámka k preskenovaniu zbierky"
 
@@ -3333,7 +3333,7 @@ msgstr "Body pripojenia"
 msgid "Move down"
 msgstr "Posunúť nižšie"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Presunúť do zbierky..."
 
@@ -3342,7 +3342,7 @@ msgstr "Presunúť do zbierky..."
 msgid "Move up"
 msgstr "Posunúť vyššie"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Hudba"
 
@@ -3404,7 +3404,7 @@ msgstr "Nezačne sa prehrávať"
 msgid "New folder"
 msgstr "Nový playlist"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nový playlist"
 
@@ -3475,7 +3475,7 @@ msgstr "Žiadne krátke bloky"
 msgid "None"
 msgstr "Nijako"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Žiadna z vybratých piesní nieje vhodná na kopírovanie do zariadenia"
 
@@ -3690,7 +3690,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organizovať súbory"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Spravovať súbory..."
 
@@ -3774,7 +3774,7 @@ msgstr "Party"
 msgid "Password"
 msgstr "Heslo"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pozastaviť"
@@ -3810,8 +3810,8 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Obyčajný bočný panel"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3834,11 +3834,11 @@ msgstr "Hrať ak je zastavené, pozastaviť ak hrá"
 msgid "Play if there is nothing already playing"
 msgstr "Začne hrať, ak sa nič neprehráva"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Prehrať nasledujúcu"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Prehrať vybrané skladby ako ďalšie"
 
@@ -3877,7 +3877,7 @@ msgstr "Možnosti playlistu"
 msgid "Playlist type"
 msgstr "Typ playlistu"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Playlisty"
 
@@ -4059,12 +4059,12 @@ msgstr "Zaraďuje sa zariadenie..."
 msgid "Queue Manager"
 msgstr "Správca poradia"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Zaradiť vybrané skladby"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Zaradiť skladbu"
 
@@ -4455,7 +4455,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Hľadať"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Hľadať"
@@ -4480,7 +4480,7 @@ msgstr "Vyhľadať na Subsonicu"
 msgid "Search automatically"
 msgstr "Hľadať automaticky"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Vyhľadať album"
 
@@ -4493,7 +4493,7 @@ msgstr "Hľadať obaly albumov..."
 msgid "Search for anything"
 msgstr "Hľadať všetko"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Vyhľadať interpreta"
 
@@ -4618,7 +4618,7 @@ msgstr "Podrobnosti o serveri"
 msgid "Service offline"
 msgstr "Služba je offline"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Nastaviť %1 do \"%2\"..."
@@ -4698,7 +4698,7 @@ msgstr "Zobrazovať krásne OSD"
 msgid "Show above status bar"
 msgstr "Zobraziť nad stavovým riadkom"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Zobraziť všetky piesne"
 
@@ -4718,12 +4718,12 @@ msgstr "Zobraziť oddeľovače"
 msgid "Show fullsize..."
 msgstr "Zobraziť celú veľkosť..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Zobraziť v prehliadači súborov..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Zobraziť v zbierke..."
 
@@ -4735,11 +4735,11 @@ msgstr "Zobrazovať v rôznych interprétoch"
 msgid "Show moodbar"
 msgstr "Zobraziť panel nálady"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Zobraziť iba duplikáty"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Zobraziť iba neotagované"
 
@@ -4831,7 +4831,7 @@ msgstr "Počet preskočení"
 msgid "Skip forwards in playlist"
 msgstr "Preskočiť dopredu v playliste"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Preskočiť vybrané skladby"
 
@@ -4839,7 +4839,7 @@ msgstr "Preskočiť vybrané skladby"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Preskočiť skladbu"
 
@@ -4871,7 +4871,7 @@ msgstr "Soft Rock"
 msgid "Song Information"
 msgstr "Informácie o piesni"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Pieseň"
 
@@ -4992,7 +4992,7 @@ msgstr "Zastaviť po každej skladbe"
 msgid "Stop after every track"
 msgstr "Zastaviť po každej skladbe"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Zastaviť po tejto skladbe"
 
@@ -5160,7 +5160,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Skúšobná verzia Subsonic servera uplynula. Prosím prispejte, aby ste získali licenčný kľúč. Navštívte subsonic.org pre detaily."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5202,7 +5202,7 @@ msgid ""
 "continue?"
 msgstr "Tieto súbory budú vymazané zo zariadenia, ste si istý, že chcete pokračovať?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5304,7 +5304,7 @@ msgstr "Prepnúť Krásne OSD"
 msgid "Toggle fullscreen"
 msgstr "Prepnúť na celú obrazovku"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Prepínať stav radu"
 
@@ -5442,11 +5442,11 @@ msgstr "Neznáma chyba"
 msgid "Unset cover"
 msgstr "Nenastavený obal"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Nepreskočiť vybraté skladby"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Nepreskočiť skladbu"
 
@@ -5783,7 +5783,7 @@ msgid ""
 "well?"
 msgstr "Chceli by ste presunúť tiež ostatné piesne v tomto albume do rôznych interprétov?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Chcete teraz spustiť úplné preskenovanie?"
 

--- a/src/translations/sl.po
+++ b/src/translations/sl.po
@@ -13,7 +13,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Slovenian (http://www.transifex.com/davidsansome/clementine/language/sl/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -167,19 +167,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n spodletelih"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n končanih"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -197,7 +197,7 @@ msgstr "U&sredini"
 msgid "&Custom"
 msgstr "Po &meri"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "Dodatki"
 
@@ -205,7 +205,7 @@ msgstr "Dodatki"
 msgid "&Grouping"
 msgstr "&Združevanje"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Pomoč"
 
@@ -230,7 +230,7 @@ msgstr "Zak&leni oceno"
 msgid "&Lyrics"
 msgstr "Besedi&la"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Glasba"
 
@@ -238,15 +238,15 @@ msgstr "&Glasba"
 msgid "&None"
 msgstr "&Brez"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "Seznam &predvajanja"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Končaj"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "Način p&onavljanja"
 
@@ -254,7 +254,7 @@ msgstr "Način p&onavljanja"
 msgid "&Right"
 msgstr "&Desno"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Pre&mešani način"
 
@@ -262,7 +262,7 @@ msgstr "Pre&mešani način"
 msgid "&Stretch columns to fit window"
 msgstr "Raztegni &stolpce, da se prilegajo oknu"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Orodja"
 
@@ -451,11 +451,11 @@ msgstr "Prekini"
 msgid "About %1"
 msgstr "O %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "O Clementine ..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "O Qt ..."
 
@@ -515,32 +515,32 @@ msgstr "Dodaj še en pretok ..."
 msgid "Add directory..."
 msgstr "Dodaj mapo ..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Dodaj datoteko"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Dodaj datoteko v prekodirnik"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Dodaj datoteko(-e) v prekodirnik"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Dodaj datoteko ..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Dodajte datoteke za prekodiranje"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Dodaj mapo"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Dodaj mapo ..."
 
@@ -552,7 +552,7 @@ msgstr "Dodaj novo mapo ..."
 msgid "Add podcast"
 msgstr "Dodaj podcast"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Dodaj podcast ..."
 
@@ -628,7 +628,7 @@ msgstr "Dodaj oznako: številka skladbe"
 msgid "Add song year tag"
 msgstr "Dodaj oznako: leto"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Dodaj pretok ..."
 
@@ -640,7 +640,7 @@ msgstr "Dodaj na sezname predvajanja Spotify"
 msgid "Add to Spotify starred"
 msgstr "Dodaj med priljubljene v Spotify"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Dodaj na drug seznam predvajanja"
 
@@ -734,7 +734,7 @@ msgstr "Vse"
 msgid "All Files (*)"
 msgstr "Vse datoteke (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "All Glory to the Hypnotoad!"
@@ -1125,7 +1125,7 @@ msgstr "Preveri za novimi epizodami"
 msgid "Check for updates"
 msgstr "Preveri za posodobitvami"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Preveri za posodobitvami ..."
 
@@ -1174,18 +1174,18 @@ msgstr "Klasična"
 msgid "Cleaning up"
 msgstr "Čiščenje"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Počisti"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Počisti seznam predvajanja"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1330,7 +1330,7 @@ msgstr "Opomba"
 msgid "Complete tags automatically"
 msgstr "Samodejno dopolni oznake"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Samodejno dopolni oznake ..."
 
@@ -1365,7 +1365,7 @@ msgstr "Nastavite Subsonic ..."
 msgid "Configure global search..."
 msgstr "Nastavi splošno iskanje"
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Nastavi knjižnico ..."
 
@@ -1408,7 +1408,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Povezava je časovno pretekla, preverite naslov URL strežnika. Primer: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Konzola"
 
@@ -1437,11 +1437,11 @@ msgid "Copy to clipboard"
 msgstr "Kopiraj v odložišče"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopiraj na napravo ..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kopiraj v knjižnico ..."
@@ -1484,14 +1484,14 @@ msgstr "Ni se bilo mogoče prijaviti v Last.fm. Poskusite znova."
 msgid "Couldn't create playlist"
 msgstr "Ni bilo mogoče ustvariti seznama predvajanja"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Zvijalnika za %1 ni bilo mogoče najti. Preverite, če so nameščeni pravilni vstavki GStreamer"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1506,7 +1506,7 @@ msgstr "Izhodne datoteke %1 ni bilo mogoče odpreti"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Upravljalnik ovitkov"
 
@@ -1659,7 +1659,7 @@ msgid "Delete downloaded data"
 msgstr "Izbriši prejete podatke"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Izbriši datoteke"
 
@@ -1667,7 +1667,7 @@ msgstr "Izbriši datoteke"
 msgid "Delete from device..."
 msgstr "Izbriši iz naprave ..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Izbriši iz diska ..."
@@ -1700,11 +1700,11 @@ msgstr "Brisanje datotek"
 msgid "Depth"
 msgstr "Globina"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Odstrani izbrane skladbe iz vrste"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Odstrani skladbo iz vrste"
 
@@ -1805,7 +1805,7 @@ msgstr "Možnosti prikaza"
 msgid "Display the on-screen-display"
 msgstr "Pokaži prikaz na zaslonu"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Ponovno preišči celotno knjižnico"
 
@@ -1984,12 +1984,12 @@ msgstr "Dinamični naključni miks"
 msgid "Edit smart playlist..."
 msgstr "Uredi pametni seznam predvajanja ..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Uredi oznako \"%1\" ..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Uredi oznako ..."
 
@@ -2002,7 +2002,7 @@ msgid "Edit track information"
 msgstr "Uredi podrobnosti o skladbi"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Uredi podrobnosti o skladbi ..."
 
@@ -2110,7 +2110,7 @@ msgstr "Celotna zbirka"
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Uravnalnik"
 
@@ -2123,8 +2123,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Enakovredno --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Napaka"
 
@@ -2159,7 +2159,7 @@ msgstr "Napaka med nalaganjem %1"
 msgid "Error loading di.fm playlist"
 msgstr "Napaka med nalaganjem seznama predvajanja di.fm"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Napaka med obdelavo %1: %2"
@@ -2242,7 +2242,11 @@ msgstr "Izvoz končan"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "Izvoženih %1 od %2 ovitkov (%3 preskočenih)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2266,7 +2270,7 @@ msgstr "Pojemanje"
 msgid "Fading duration"
 msgstr "Trajanje pojemanja"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Napaka med branjem iz pogona CD"
 
@@ -2548,11 +2552,11 @@ msgstr "Vnesite ime:"
 msgid "Go"
 msgstr "Pojdi"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Pojdi na naslednji zavihek seznama predvajanja"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Pojdi na predhodni zavihek seznama predvajanja"
 
@@ -2885,7 +2889,7 @@ msgstr "Podatkovna zbirka Jamendo"
 msgid "Jump to previous song right away"
 msgstr "takoj skočilo na predhodno skladbo"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Skoči na trenutno predvajano skladbo"
 
@@ -2909,7 +2913,7 @@ msgstr "Ostani zagnan v ozadju dokler se ne zapre okno"
 msgid "Keep the original files"
 msgstr "Ohrani izvorne datoteke"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Mucke"
@@ -3001,7 +3005,7 @@ msgstr "Knjižnica"
 msgid "Library advanced grouping"
 msgstr "Napredno združevanje v knjižnici"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Obvestilo ponovnega preiskovanja knjižnice"
 
@@ -3041,7 +3045,7 @@ msgstr "Naloži ovitek iz diska ..."
 msgid "Load playlist"
 msgstr "Naloži seznam predvajanja"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Naloži seznam predvajanja ..."
 
@@ -3102,11 +3106,15 @@ msgstr "Prijava"
 msgid "Login failed"
 msgstr "Prijava je spodletela"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Profil daljnosežnega predvidevanja (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Priljubljena"
 
@@ -3141,11 +3149,11 @@ msgstr "Besedila iz %1"
 msgid "Lyrics from the tag"
 msgstr "Besedila iz oznake"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3187,7 +3195,7 @@ msgstr "Glavni profil (MAIN)"
 msgid "Make it so!"
 msgstr "Make it so!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Make it so!"
@@ -3325,7 +3333,7 @@ msgstr "Priklopne točke"
 msgid "Move down"
 msgstr "Premakni dol"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Premakni v knjižnico ..."
 
@@ -3334,7 +3342,7 @@ msgstr "Premakni v knjižnico ..."
 msgid "Move up"
 msgstr "Premakni gor"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Glasba"
 
@@ -3347,7 +3355,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Utišaj"
 
@@ -3396,7 +3404,7 @@ msgstr "Nikoli ne začni s predvajanjem"
 msgid "New folder"
 msgstr "Nova mapa"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nov seznam predvajanja"
 
@@ -3424,8 +3432,12 @@ msgstr "Najnovejše skladbe"
 msgid "Next"
 msgstr "Naslednji"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Naslednja skladba"
 
@@ -3463,7 +3475,7 @@ msgstr "Brez kratkih blokov"
 msgid "None"
 msgstr "Brez"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Nobena izmed izbranih skladb ni bila primerna za kopiranje na napravo"
 
@@ -3548,19 +3560,19 @@ msgstr "Izklopljeno"
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3604,7 +3616,7 @@ msgstr "Motnost"
 msgid "Open %1 in browser"
 msgstr "Odpri %1 v brskalniku"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Odpri  &zvočni CD ..."
 
@@ -3616,7 +3628,7 @@ msgstr "Odpri datoteko OPML"
 msgid "Open OPML file..."
 msgstr "Odpri datoteko OPML ..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Odpri mapo, iz katere bo uvožena glasba"
 
@@ -3624,7 +3636,7 @@ msgstr "Odpri mapo, iz katere bo uvožena glasba"
 msgid "Open device"
 msgstr "Odpri napravo"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Odpri datoteko ..."
 
@@ -3678,7 +3690,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organiziraj datoteke"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Organiziraj datoteke ..."
 
@@ -3762,7 +3774,7 @@ msgstr "Zabava"
 msgid "Password"
 msgstr "Geslo"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Naredi premor"
@@ -3786,6 +3798,10 @@ msgstr "Izvajalec"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Slikovna točka"
@@ -3794,10 +3810,10 @@ msgstr "Slikovna točka"
 msgid "Plain sidebar"
 msgstr "Navadna stranska vrstica"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Predvajaj"
 
@@ -3818,11 +3834,11 @@ msgstr "Predvajaj, če je zaustavljeno, napravi premor, če se predvaja"
 msgid "Play if there is nothing already playing"
 msgstr "Predvajaj, če se trenutno ne predvaja nič"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3921,7 +3937,7 @@ msgstr "Možnost"
 msgid "Preferences"
 msgstr "Možnosti"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Možnosti ..."
 
@@ -3981,7 +3997,7 @@ msgid "Previous"
 msgstr "Predhodni"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Predhodna skladba"
 
@@ -4039,16 +4055,16 @@ msgstr "Kakovost"
 msgid "Querying device..."
 msgstr "Poizvedovanje po napravi ..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Upravljalnik vrste"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Postavi izbrane skladbe v vrsto"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Postavi skladbo v vrsto"
 
@@ -4064,7 +4080,7 @@ msgstr "Radio (enaka glasnost za vse skladbe)"
 msgid "Rain"
 msgstr "Dež"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Dež"
@@ -4176,7 +4192,7 @@ msgstr "Odstrani dejanje"
 msgid "Remove current song from playlist"
 msgstr "Odstrani trenutno skladbo iz seznama predvajanja"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Odstrani podvojene iz seznama predvajanja"
 
@@ -4184,7 +4200,7 @@ msgstr "Odstrani podvojene iz seznama predvajanja"
 msgid "Remove folder"
 msgstr "Odstrani mapo"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Odstrani iz seznama predvajanja"
 
@@ -4196,7 +4212,7 @@ msgstr "Odstrani seznam predvajanja"
 msgid "Remove playlists"
 msgstr "Odstrani sezname predvajanja"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Iz seznama predvajanja odstrani skladbe, ki niso na voljo"
 
@@ -4208,7 +4224,7 @@ msgstr "Preimenuj seznam predvajanja"
 msgid "Rename playlist..."
 msgstr "Preimenuj seznam predvajanja ..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Znova oštevilči skladbe v naslednjem vrstnem redu ..."
 
@@ -4299,7 +4315,7 @@ msgstr "Zajemi"
 msgid "Rip CD"
 msgstr "Zajemi CD"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Zajemi zvočni CD"
 
@@ -4377,7 +4393,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Shrani seznam predvajanja"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Shrani seznam predvajanja ..."
 
@@ -4464,7 +4480,7 @@ msgstr "Poišči na Subsonicu"
 msgid "Search automatically"
 msgstr "Samodejno najdi"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Poišči album"
 
@@ -4477,7 +4493,7 @@ msgstr "Poišči ovitke albumov ..."
 msgid "Search for anything"
 msgstr "Poišči karkoli"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Poišči izvajalca"
 
@@ -4602,7 +4618,7 @@ msgstr "Podrobnosti strežnika"
 msgid "Service offline"
 msgstr "Storitev je nepovezana"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Nastavi %1 na \"%2\" ..."
@@ -4611,7 +4627,7 @@ msgstr "Nastavi %1 na \"%2\" ..."
 msgid "Set the volume to <value> percent"
 msgstr "Nastavi glasnost na <value> odstotkov"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Nastavi vrednost za vse izbrane skladbe ..."
 
@@ -4682,7 +4698,7 @@ msgstr "Pokaži lep prikaz na zaslonu"
 msgid "Show above status bar"
 msgstr "Pokaži nad vrstico stanja"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Pokaži vse skladbe"
 
@@ -4702,12 +4718,12 @@ msgstr "Pokaži razdelilnike"
 msgid "Show fullsize..."
 msgstr "Pokaži v polni velikosti ..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Pokaži v brskalniku datotek ..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Pokaži v knjižnici ..."
 
@@ -4719,15 +4735,15 @@ msgstr "Pokaži med \"Različni izvajalci\""
 msgid "Show moodbar"
 msgstr "Pokaži vrstico razpoloženja"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Pokaži samo podvojene"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Pokaži samo tiste brez oznak"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Preklopi stransko vrstico"
 
@@ -4735,7 +4751,7 @@ msgstr "Preklopi stransko vrstico"
 msgid "Show search suggestions"
 msgstr "Prikaži iskalne predloge"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Pokaži stransko vrstico"
 
@@ -4771,7 +4787,7 @@ msgstr "Premešaj albume"
 msgid "Shuffle all"
 msgstr "Premešaj vse"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Premešaj seznam predvajanja"
 
@@ -4815,11 +4831,15 @@ msgstr "Število preskočenih"
 msgid "Skip forwards in playlist"
 msgstr "Skoči naprej po seznamu predvajanja"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Preskoči izbrane skladbe"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Preskoči skladbo"
 
@@ -4936,7 +4956,7 @@ msgstr "Začni z zajemanjem"
 msgid "Start the playlist currently playing"
 msgstr "Predvajaj skladbo, ki je označena v seznamu predvajanja"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Začni s prekodiranjem"
 
@@ -4946,7 +4966,7 @@ msgid ""
 "list"
 msgstr "Natipkajte nekaj v iskalno polje, da napolnite te seznam z rezultati iskanja"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Začenjanje %1"
@@ -4956,7 +4976,7 @@ msgid "Starting..."
 msgstr "Začenjanje ..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Zaustavi"
 
@@ -4972,7 +4992,7 @@ msgstr "Zaustavi po vsaki skladbi"
 msgid "Stop after every track"
 msgstr "Zaustavi po vsaki skladbi"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Zaustavi po tej skladbi"
 
@@ -5140,7 +5160,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Preizkusno obdobje za strežnik Subsonic je končano. Da pridobite licenčni ključ, morate donirati. Za podrobnosti si oglejte subsonic.org."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5182,7 +5202,7 @@ msgid ""
 "continue?"
 msgstr "Te datoteke bodo izbrisane iz naprave. Ali ste prepričani, da želite nadaljevati?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5284,11 +5304,11 @@ msgstr "Preklopi lep prikaz na zaslonu"
 msgid "Toggle fullscreen"
 msgstr "Preklopi celozaslonski način"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Preklopi stanje vrste"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Preklopi med pošiljanjem podatkov o predvajanih skladbah"
 
@@ -5333,19 +5353,19 @@ msgstr "S&kladba"
 msgid "Track"
 msgstr "Skladba"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Prekodiraj glasbo"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Dnevnik prekodirnika"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Prekodiranje"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Prekodiranje %1 datotek z uporabo %2 niti"
@@ -5422,11 +5442,11 @@ msgstr "Neznana napaka"
 msgid "Unset cover"
 msgstr "Odstrani ovitek"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Ne preskoči izbranih skladb"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Ne preskoči skladbe"
 
@@ -5443,7 +5463,7 @@ msgstr "Prihajajoči koncerti"
 msgid "Update all podcasts"
 msgstr "Posodobi vse podcaste"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Posodobi spremenjene mape v knjižnici"
 
@@ -5604,7 +5624,7 @@ msgstr "Različica %1"
 msgid "View"
 msgstr "Pogled"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Ogled podrobnosti pretoka"
 
@@ -5612,7 +5632,7 @@ msgstr "Ogled podrobnosti pretoka"
 msgid "Visualization mode"
 msgstr "Način predočenja"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Predočenja"
 
@@ -5653,7 +5673,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5749,7 +5769,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media Audio"
 
@@ -5763,7 +5783,7 @@ msgid ""
 "well?"
 msgstr "Ali bi želeli tudi druge skladbe v tem albumu premakniti med kategorijo Različni izvajalci?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Ali želite opraviti ponovno preiskovanje celotne knjižnice?"
 

--- a/src/translations/sl.po
+++ b/src/translations/sl.po
@@ -515,7 +515,7 @@ msgstr "Dodaj še en pretok ..."
 msgid "Add directory..."
 msgstr "Dodaj mapo ..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Dodaj datoteko"
 
@@ -535,7 +535,7 @@ msgstr "Dodaj datoteko ..."
 msgid "Add files to transcode"
 msgstr "Dodajte datoteke za prekodiranje"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Dodaj mapo"
@@ -640,7 +640,7 @@ msgstr "Dodaj na sezname predvajanja Spotify"
 msgid "Add to Spotify starred"
 msgstr "Dodaj med priljubljene v Spotify"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Dodaj na drug seznam predvajanja"
 
@@ -862,7 +862,7 @@ msgstr "Ali ste prepričani, da želite zapisati statistike skladbe v datoteko s
 msgid "Artist"
 msgstr "Izvajalec"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "O izvajalcu"
 
@@ -1125,7 +1125,7 @@ msgstr "Preveri za novimi epizodami"
 msgid "Check for updates"
 msgstr "Preveri za posodobitvami"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Preveri za posodobitvami ..."
 
@@ -1365,7 +1365,7 @@ msgstr "Nastavite Subsonic ..."
 msgid "Configure global search..."
 msgstr "Nastavi splošno iskanje"
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Nastavi knjižnico ..."
 
@@ -1437,11 +1437,11 @@ msgid "Copy to clipboard"
 msgstr "Kopiraj v odložišče"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopiraj na napravo ..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kopiraj v knjižnico ..."
@@ -1659,7 +1659,7 @@ msgid "Delete downloaded data"
 msgstr "Izbriši prejete podatke"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Izbriši datoteke"
 
@@ -1667,7 +1667,7 @@ msgstr "Izbriši datoteke"
 msgid "Delete from device..."
 msgstr "Izbriši iz naprave ..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Izbriši iz diska ..."
@@ -1700,11 +1700,11 @@ msgstr "Brisanje datotek"
 msgid "Depth"
 msgstr "Globina"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Odstrani izbrane skladbe iz vrste"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Odstrani skladbo iz vrste"
 
@@ -1733,7 +1733,7 @@ msgstr "Ime naprave"
 msgid "Device properties..."
 msgstr "Lastnosti naprave ..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Naprave"
 
@@ -1984,7 +1984,7 @@ msgstr "Dinamični naključni miks"
 msgid "Edit smart playlist..."
 msgstr "Uredi pametni seznam predvajanja ..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Uredi oznako \"%1\" ..."
@@ -2123,8 +2123,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Enakovredno --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Napaka"
 
@@ -2270,7 +2270,7 @@ msgstr "Pojemanje"
 msgid "Fading duration"
 msgstr "Trajanje pojemanja"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Napaka med branjem iz pogona CD"
 
@@ -2393,7 +2393,7 @@ msgstr "Vrsta datoteke"
 msgid "Filename"
 msgstr "Ime datoteke"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Datoteke"
 
@@ -2808,7 +2808,7 @@ msgstr "Nameščeno"
 msgid "Integrity check"
 msgstr "Preverjanje celovitosti"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -2996,7 +2996,7 @@ msgstr "Levo"
 msgid "Length"
 msgstr "Dolžina"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Knjižnica"
@@ -3005,7 +3005,7 @@ msgstr "Knjižnica"
 msgid "Library advanced grouping"
 msgstr "Napredno združevanje v knjižnici"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Obvestilo ponovnega preiskovanja knjižnice"
 
@@ -3333,7 +3333,7 @@ msgstr "Priklopne točke"
 msgid "Move down"
 msgstr "Premakni dol"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Premakni v knjižnico ..."
 
@@ -3342,7 +3342,7 @@ msgstr "Premakni v knjižnico ..."
 msgid "Move up"
 msgstr "Premakni gor"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Glasba"
 
@@ -3404,7 +3404,7 @@ msgstr "Nikoli ne začni s predvajanjem"
 msgid "New folder"
 msgstr "Nova mapa"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nov seznam predvajanja"
 
@@ -3475,7 +3475,7 @@ msgstr "Brez kratkih blokov"
 msgid "None"
 msgstr "Brez"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Nobena izmed izbranih skladb ni bila primerna za kopiranje na napravo"
 
@@ -3690,7 +3690,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organiziraj datoteke"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Organiziraj datoteke ..."
 
@@ -3774,7 +3774,7 @@ msgstr "Zabava"
 msgid "Password"
 msgstr "Geslo"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Naredi premor"
@@ -3810,8 +3810,8 @@ msgstr "Slikovna točka"
 msgid "Plain sidebar"
 msgstr "Navadna stranska vrstica"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3834,11 +3834,11 @@ msgstr "Predvajaj, če je zaustavljeno, napravi premor, če se predvaja"
 msgid "Play if there is nothing already playing"
 msgstr "Predvajaj, če se trenutno ne predvaja nič"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3877,7 +3877,7 @@ msgstr "Možnosti seznama predvajanja"
 msgid "Playlist type"
 msgstr "Vrsta seznama predvajanja"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Seznami predvajanja"
 
@@ -4059,12 +4059,12 @@ msgstr "Poizvedovanje po napravi ..."
 msgid "Queue Manager"
 msgstr "Upravljalnik vrste"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Postavi izbrane skladbe v vrsto"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Postavi skladbo v vrsto"
 
@@ -4455,7 +4455,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Poišči"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Išči"
@@ -4480,7 +4480,7 @@ msgstr "Poišči na Subsonicu"
 msgid "Search automatically"
 msgstr "Samodejno najdi"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Poišči album"
 
@@ -4493,7 +4493,7 @@ msgstr "Poišči ovitke albumov ..."
 msgid "Search for anything"
 msgstr "Poišči karkoli"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Poišči izvajalca"
 
@@ -4618,7 +4618,7 @@ msgstr "Podrobnosti strežnika"
 msgid "Service offline"
 msgstr "Storitev je nepovezana"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Nastavi %1 na \"%2\" ..."
@@ -4698,7 +4698,7 @@ msgstr "Pokaži lep prikaz na zaslonu"
 msgid "Show above status bar"
 msgstr "Pokaži nad vrstico stanja"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Pokaži vse skladbe"
 
@@ -4718,12 +4718,12 @@ msgstr "Pokaži razdelilnike"
 msgid "Show fullsize..."
 msgstr "Pokaži v polni velikosti ..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Pokaži v brskalniku datotek ..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Pokaži v knjižnici ..."
 
@@ -4735,11 +4735,11 @@ msgstr "Pokaži med \"Različni izvajalci\""
 msgid "Show moodbar"
 msgstr "Pokaži vrstico razpoloženja"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Pokaži samo podvojene"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Pokaži samo tiste brez oznak"
 
@@ -4831,7 +4831,7 @@ msgstr "Število preskočenih"
 msgid "Skip forwards in playlist"
 msgstr "Skoči naprej po seznamu predvajanja"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Preskoči izbrane skladbe"
 
@@ -4839,7 +4839,7 @@ msgstr "Preskoči izbrane skladbe"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Preskoči skladbo"
 
@@ -4871,7 +4871,7 @@ msgstr "Soft Rock"
 msgid "Song Information"
 msgstr "Podrobnosti o skladbi"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "O skladbi"
 
@@ -4992,7 +4992,7 @@ msgstr "Zaustavi po vsaki skladbi"
 msgid "Stop after every track"
 msgstr "Zaustavi po vsaki skladbi"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Zaustavi po tej skladbi"
 
@@ -5160,7 +5160,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Preizkusno obdobje za strežnik Subsonic je končano. Da pridobite licenčni ključ, morate donirati. Za podrobnosti si oglejte subsonic.org."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5202,7 +5202,7 @@ msgid ""
 "continue?"
 msgstr "Te datoteke bodo izbrisane iz naprave. Ali ste prepričani, da želite nadaljevati?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5304,7 +5304,7 @@ msgstr "Preklopi lep prikaz na zaslonu"
 msgid "Toggle fullscreen"
 msgstr "Preklopi celozaslonski način"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Preklopi stanje vrste"
 
@@ -5442,11 +5442,11 @@ msgstr "Neznana napaka"
 msgid "Unset cover"
 msgstr "Odstrani ovitek"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Ne preskoči izbranih skladb"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Ne preskoči skladbe"
 
@@ -5783,7 +5783,7 @@ msgid ""
 "well?"
 msgstr "Ali bi želeli tudi druge skladbe v tem albumu premakniti med kategorijo Različni izvajalci?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Ali želite opraviti ponovno preiskovanje celotne knjižnice?"
 

--- a/src/translations/sr.po
+++ b/src/translations/sr.po
@@ -12,7 +12,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-20 10:17+0000\n"
+"PO-Revision-Date: 2021-01-21 18:08+0000\n"
 "Last-Translator: Slobodan Simić <slsimic@gmail.com>\n"
 "Language-Team: Serbian (http://www.transifex.com/davidsansome/clementine/language/sr/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -3343,7 +3343,7 @@ msgstr "Музичка библиотека"
 
 #: ../bin/src/ui_networkremotesettingspage.h:380
 msgid "Music extensions remotely visible"
-msgstr ""
+msgstr "Музичка проширења видљива даљински"
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
 #: ../bin/src/ui_mainwindow.h:763
@@ -5841,7 +5841,7 @@ msgid ""
 "You can find <a href=\"%1\">here on GitHub</a> the new cross platform "
 "remote.<br/>It is available on <b>Linux</b>, <b>MacOS</b> and "
 "<b>Windows</b><br/>"
-msgstr ""
+msgstr "Можете наћи <a href=\"%1\">овде на Гитхабу</a> нови више-платформски даљински.<br/>Доступан је за <b>Линукс</b>, <b>МекОС</b> и <b>Виндоуз</b><br/>"
 
 #: internet/magnatune/magnatunesettingspage.cpp:59
 msgid ""
@@ -5973,7 +5973,7 @@ msgstr "темпо"
 msgid ""
 "coma separated list of the allowed extensions that will be visible from the "
 "network remote (ex: m3u,mp3,flac,ogg,wav)"
-msgstr ""
+msgstr "списак дозвољених проширења, одвојених запетом, који ће бити видљиви са удаљене мреже (нпр: m3u,mp3,flac,ogg,wav)"
 
 #: smartplaylists/searchterm.cpp:249
 msgid "contains"
@@ -6091,7 +6091,7 @@ msgstr "Опције"
 #: ../bin/src/ui_networkremotesettingspage.h:384
 #: ../bin/src/ui_networkremotesettingspage.h:386
 msgid "or scan the QR code: "
-msgstr ""
+msgstr "или скенирајте КуеР кôд:"
 
 #: widgets/didyoumean.cpp:56
 msgid "press enter"

--- a/src/translations/sr.po
+++ b/src/translations/sr.po
@@ -12,7 +12,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-19 14:32+0000\n"
+"PO-Revision-Date: 2021-01-20 10:17+0000\n"
 "Last-Translator: Slobodan Simić <slsimic@gmail.com>\n"
 "Language-Team: Serbian (http://www.transifex.com/davidsansome/clementine/language/sr/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1469,7 +1469,7 @@ msgstr "Не могу да откријем ток звука у %1"
 
 #: internet/googledrive/googledriveservice.cpp:208
 msgid "Could not find Google Drive file."
-msgstr ""
+msgstr "Не могу да нађем фајл Гугл диска"
 
 #: songinfo/streamdiscoverer.cpp:124
 msgid "Could not get details"
@@ -2298,7 +2298,7 @@ msgstr "Неуспех учитавања подкаста"
 msgid ""
 "Failed to parse %1 response:\n"
 "%2"
-msgstr ""
+msgstr "Не могу да рашчланим %1 одговор:\n%2"
 
 #: internet/podcasts/podcasturlloader.cpp:177
 msgid "Failed to parse the XML for this RSS feed"
@@ -2348,7 +2348,7 @@ msgstr "Грешка добављања омота"
 #: internet/subsonic/subsonicdynamicplaylist.cpp:98
 #: internet/subsonic/subsonicdynamicplaylist.cpp:164
 msgid "Fetching playlist items"
-msgstr ""
+msgstr "Добављам ставке листе пуштања"
 
 #: ../bin/src/ui_ripcddialog.h:319
 msgid "File Format"
@@ -2394,7 +2394,7 @@ msgstr "Фајлови"
 
 #: ../bin/src/ui_networkremotesettingspage.h:376
 msgid "Files root folder"
-msgstr ""
+msgstr "Корена фасцикла фајлова"
 
 #: ../bin/src/ui_transcodedialog.h:214
 msgid "Files to transcode"
@@ -2484,7 +2484,7 @@ msgstr "Сличица по баферу"
 
 #: internet/subsonic/subsonicservice.cpp:107
 msgid "Frequently Played Albums"
-msgstr ""
+msgstr "Често пуштани албуми"
 
 #: moodbar/moodbarrenderer.cpp:173
 msgid "Frozen"
@@ -3238,7 +3238,7 @@ msgstr "Највећи битски проток"
 
 #: ../bin/src/ui_behavioursettingspage.h:449
 msgid "Maximum number of child processes for tag handling (requires restart)"
-msgstr ""
+msgstr "Највећи број потпроцеса за руковање ознакама (захтева поновно покретање)"
 
 #: ripper/ripcddialog.cpp:154
 msgid "Media has changed. Reloading"
@@ -3413,7 +3413,7 @@ msgstr "Нове нумере ће бити аутоматски додате."
 
 #: internet/subsonic/subsonicservice.cpp:101
 msgid "Newest Albums"
-msgstr ""
+msgstr "Најновији албуми"
 
 #: library/library.cpp:96
 msgid "Newest tracks"
@@ -3533,7 +3533,7 @@ msgstr "Број епизода за приказ"
 
 #: ../bin/src/ui_behavioursettingspage.h:450
 msgid "Number of processes:"
-msgstr ""
+msgstr "Број процеса:"
 
 #: ui/notificationssettingspage.cpp:40
 msgid "OSD Preview"
@@ -3806,7 +3806,7 @@ msgstr "број пуштања"
 
 #: core/commandlineoptions.cpp:183
 msgid "Play given playlist"
-msgstr ""
+msgstr "Пусти дату листу"
 
 #: core/commandlineoptions.cpp:162
 msgid "Play if stopped, pause if playing"
@@ -4053,7 +4053,7 @@ msgstr "Стави нумеру у ред"
 
 #: ../bin/src/ui_lovedialog.h:115
 msgid "Quickly rate the playing track"
-msgstr ""
+msgstr "Брзо оцените тренутну нумеру"
 
 #: ../bin/src/ui_playbacksettingspage.h:358
 msgid "Radio (equal loudness for all tracks)"
@@ -4070,11 +4070,11 @@ msgstr "Киша"
 
 #: internet/subsonic/subsonicservice.cpp:104
 msgid "Random Albums"
-msgstr ""
+msgstr "Насумично албуми"
 
 #: internet/subsonic/subsonicservice.cpp:122
 msgid "Random Songs"
-msgstr ""
+msgstr "Насумично песме"
 
 #: ../bin/src/ui_visualisationselector.h:111
 msgid "Random visualization"
@@ -4115,7 +4115,7 @@ msgstr "Заиста одустајете?"
 
 #: internet/subsonic/subsonicservice.cpp:115
 msgid "Recently Played Albums"
-msgstr ""
+msgstr "Недавно пуштани албуми"
 
 #: internet/subsonic/subsonicsettingspage.cpp:161
 msgid "Redirect limit exceeded, verify server configuration."
@@ -4308,7 +4308,7 @@ msgstr "рок"
 
 #: ../bin/src/ui_networkremotesettingspage.h:374
 msgid "Root folder that will be browsable from the network remote"
-msgstr ""
+msgstr "Корена фасцикла која ће бити доступна за преглед са мреже"
 
 #: ../bin/src/ui_console.h:130
 msgid "Run"
@@ -4547,11 +4547,11 @@ msgstr "Очисти избор"
 
 #: ui/filechooserwidget.cpp:95
 msgid "Select a directory"
-msgstr ""
+msgstr "Изаберите директоријум"
 
 #: ui/filechooserwidget.cpp:92
 msgid "Select a file"
-msgstr ""
+msgstr "Изаберите фајл"
 
 #: ../bin/src/ui_appearancesettingspage.h:303
 msgid "Select background color:"
@@ -4925,7 +4925,7 @@ msgstr "Са звездицом"
 
 #: internet/subsonic/subsonicservice.cpp:119
 msgid "Starred Albums"
-msgstr ""
+msgstr "Озвездани албуми"
 
 #: ripper/ripcddialog.cpp:73
 msgid "Start ripping"
@@ -5305,7 +5305,7 @@ msgstr "Превише преусмеравања"
 
 #: internet/subsonic/subsonicservice.cpp:111
 msgid "Top Rated Albums"
-msgstr ""
+msgstr "Највише оцењени албуми"
 
 #: internet/spotify/spotifyservice.cpp:423
 msgid "Top tracks"
@@ -5375,7 +5375,7 @@ msgstr "УРЛ"
 
 #: ../bin/src/ui_addstreamdialog.h:128
 msgid "URL of its Logo:"
-msgstr ""
+msgstr "УРЛ за лого:"
 
 #: core/commandlineoptions.cpp:159
 msgid "URL(s)"
@@ -5792,7 +5792,7 @@ msgstr "година — албум"
 
 #: playlist/playlist.cpp:1392
 msgid "Year - original"
-msgstr ""
+msgstr "Година — оригинална"
 
 #: smartplaylists/searchterm.cpp:427
 msgid "Years"

--- a/src/translations/sr.po
+++ b/src/translations/sr.po
@@ -12,8 +12,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-21 18:08+0000\n"
-"Last-Translator: Slobodan Simić <slsimic@gmail.com>\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
+"Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Serbian (http://www.transifex.com/davidsansome/clementine/language/sr/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -166,19 +166,19 @@ msgstr "%L1 нумера"
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n неуспешно"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n завршено"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -196,7 +196,7 @@ msgstr "&центрирај"
 msgid "&Custom"
 msgstr "&Посебна"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Додаци"
 
@@ -204,7 +204,7 @@ msgstr "&Додаци"
 msgid "&Grouping"
 msgstr "&Груписање"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Помоћ"
 
@@ -229,7 +229,7 @@ msgstr "&Закључај оцену"
 msgid "&Lyrics"
 msgstr "&Стихови"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Музика"
 
@@ -237,15 +237,15 @@ msgstr "&Музика"
 msgid "&None"
 msgstr "&Ниједна"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&Листа нумера"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Напусти"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "&Режим понављања"
 
@@ -253,7 +253,7 @@ msgstr "&Режим понављања"
 msgid "&Right"
 msgstr "&десно"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "&Насумични режим"
 
@@ -261,7 +261,7 @@ msgstr "&Насумични режим"
 msgid "&Stretch columns to fit window"
 msgstr "&Уклопи колоне у прозор"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Алатке"
 
@@ -450,11 +450,11 @@ msgstr "Прекини"
 msgid "About %1"
 msgstr "О %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "О Клементини..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Више о Куту..."
 
@@ -514,32 +514,32 @@ msgstr "Додај други ток..."
 msgid "Add directory..."
 msgstr "Додај фасциклу..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Додавање фајла"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Додај фајл у прекодер"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Додај фајло(ове) у прекодер"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Додај фајл..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Додавање фајлова за прекодирање"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Додавање фасцикле"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Додај фасциклу..."
 
@@ -551,7 +551,7 @@ msgstr "Додај нову фасциклу..."
 msgid "Add podcast"
 msgstr "Додавање подкаста"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Додај подкаст..."
 
@@ -627,7 +627,7 @@ msgstr "Уметни нумеру песме"
 msgid "Add song year tag"
 msgstr "Уметни годину песме"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Додај ток..."
 
@@ -639,7 +639,7 @@ msgstr "Додај у Спотифај листе нумера"
 msgid "Add to Spotify starred"
 msgstr "Додај на Спотифај оцењено"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Додај у другу листу"
 
@@ -733,7 +733,7 @@ msgstr "Све"
 msgid "All Files (*)"
 msgstr "Сви фајлови (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Слава Хипножапцу!"
@@ -1124,7 +1124,7 @@ msgstr "Тражи нове епизоде"
 msgid "Check for updates"
 msgstr "Потражи надоградње"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Потражи надоградње..."
 
@@ -1173,18 +1173,18 @@ msgstr "класична"
 msgid "Cleaning up"
 msgstr "Чишћење"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Очисти"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Очисти листу нумера"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Клементина"
 
@@ -1329,7 +1329,7 @@ msgstr "коментар"
 msgid "Complete tags automatically"
 msgstr "Попуни ознаке аутоматски"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Попуни ознаке аутоматски..."
 
@@ -1364,7 +1364,7 @@ msgstr "Подеси Субсоник..."
 msgid "Configure global search..."
 msgstr "Подеси општу претрагу..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Подеси библиотеку..."
 
@@ -1407,7 +1407,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Прековреме истекло, проверите УРЛ сервера. Пример: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Конзола"
 
@@ -1436,11 +1436,11 @@ msgid "Copy to clipboard"
 msgstr "Копирај на клипборд"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Копирај на уређај...."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Копирај у библиотеку..."
@@ -1483,14 +1483,14 @@ msgstr "Не могу да се пријавим на Ласт.фм. Покуш�
 msgid "Couldn't create playlist"
 msgstr "Не могу да направим листу нумера"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Не могу да нађем муксер за %1, проверите да ли имате инсталиране потребне прикључке за Гстример"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1505,7 +1505,7 @@ msgstr "Не могу да отворим излазни фајл %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Менаџер омота"
 
@@ -1658,7 +1658,7 @@ msgid "Delete downloaded data"
 msgstr "Обриши преузете податке"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Брисање фајлова"
 
@@ -1666,7 +1666,7 @@ msgstr "Брисање фајлова"
 msgid "Delete from device..."
 msgstr "Обриши са уређаја..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Обриши са диска..."
@@ -1699,11 +1699,11 @@ msgstr "Бришем фајлове"
 msgid "Depth"
 msgstr "Дубина"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Избаци изабране нумере из реда"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Избаци нумеру из реда"
 
@@ -1804,7 +1804,7 @@ msgstr "Опције приказа"
 msgid "Display the on-screen-display"
 msgstr "Прикажи екрански преглед"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Поново скенирај библиотеку"
 
@@ -1983,12 +1983,12 @@ msgstr "Динамички насумични микс"
 msgid "Edit smart playlist..."
 msgstr "Уреди паметну листу..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Уреди ознаку „%1“..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Уреди ознаку..."
 
@@ -2001,7 +2001,7 @@ msgid "Edit track information"
 msgstr "Уређивање података нумере"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Уреди податке нумере..."
 
@@ -2109,7 +2109,7 @@ msgstr "читаву колекцију"
 msgid "Episode information"
 msgstr "Подаци о Епизоди"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Еквилајзер"
 
@@ -2122,8 +2122,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Исто као и --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Грешка"
 
@@ -2158,7 +2158,7 @@ msgstr "Грешка учитавања %1"
 msgid "Error loading di.fm playlist"
 msgstr "Грешка учитавања di.fm листе нумера"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Грешка обраде %1: %2"
@@ -2241,7 +2241,11 @@ msgstr "Извоз завршен"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "Извезено %1 омота од %2 (%3 прескочено)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2265,7 +2269,7 @@ msgstr "Утапање"
 msgid "Fading duration"
 msgstr "Трајање претапања"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Неуспех читања ЦД уређаја"
 
@@ -2547,11 +2551,11 @@ msgstr "Дајте јој име:"
 msgid "Go"
 msgstr "Иди"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Иди на следећи језичак листе"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Иди на претходни језичак листе"
 
@@ -2884,7 +2888,7 @@ msgstr "Џамендова база података"
 msgid "Jump to previous song right away"
 msgstr "пушта претходну песму одмах"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Скочи на текућу нумеру"
 
@@ -2908,7 +2912,7 @@ msgstr "Настави рад у позадини кад се прозор за�
 msgid "Keep the original files"
 msgstr "задржи оригиналне фајлове"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Мачићи"
@@ -3000,7 +3004,7 @@ msgstr "Библиотека"
 msgid "Library advanced grouping"
 msgstr "Напредно груписање библиотеке"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Обавештење о поновном скенирању библиотеке"
 
@@ -3040,7 +3044,7 @@ msgstr "Учитај омот са диска..."
 msgid "Load playlist"
 msgstr "Учитавање листе нумера"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Учитај листу нумера..."
 
@@ -3101,11 +3105,15 @@ msgstr "Пријава"
 msgid "Login failed"
 msgstr "Пријава није успела"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "дугорочно предвиђање (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Волим"
 
@@ -3140,11 +3148,11 @@ msgstr "Стихови са %1"
 msgid "Lyrics from the tag"
 msgstr "Стихови из ознаке"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "М4А ААЦ"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MП3"
@@ -3186,7 +3194,7 @@ msgstr "главни профил (MAIN)"
 msgid "Make it so!"
 msgstr "Ентерпрајз!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Ентерпрајз!"
@@ -3324,7 +3332,7 @@ msgstr "Тачке монтирања"
 msgid "Move down"
 msgstr "Помери доле"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Премести у библиотеку"
 
@@ -3333,7 +3341,7 @@ msgstr "Премести у библиотеку"
 msgid "Move up"
 msgstr "Помери горе"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Музика"
 
@@ -3346,7 +3354,7 @@ msgid "Music extensions remotely visible"
 msgstr "Музичка проширења видљива даљински"
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Утишај"
 
@@ -3395,7 +3403,7 @@ msgstr "неће почети пуштање"
 msgid "New folder"
 msgstr "Нова фасцикла"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Нова листа нумера"
 
@@ -3423,8 +3431,12 @@ msgstr "Најновије нумере"
 msgid "Next"
 msgstr "Следећа"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Следећа нумера"
 
@@ -3462,7 +3474,7 @@ msgstr "без кратких блокова"
 msgid "None"
 msgstr "ништа"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Ниједна од изабраних песама није погодна за копирање на уређај"
 
@@ -3547,19 +3559,19 @@ msgstr "искључено"
 msgid "Ogg FLAC"
 msgstr "ОГГ ФЛАЦ"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "ОГГ ФЛАЦ"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "ОГГ Опус"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "ОГГ Спикс"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3603,7 +3615,7 @@ msgstr "Прозирност"
 msgid "Open %1 in browser"
 msgstr "Отвори %1 у прегледачу"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Отвори &аудио ЦД..."
 
@@ -3615,7 +3627,7 @@ msgstr "Отварање ОПМЛ фајла"
 msgid "Open OPML file..."
 msgstr "Отвори ОПМЛ фајл..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Отварање фасцикле за увоз музике"
 
@@ -3623,7 +3635,7 @@ msgstr "Отварање фасцикле за увоз музике"
 msgid "Open device"
 msgstr "Отвори уређај"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Отвори фајл..."
 
@@ -3677,7 +3689,7 @@ msgstr "Опус"
 msgid "Organise Files"
 msgstr "Организовање фајлова"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Организуј фајлове..."
 
@@ -3761,7 +3773,7 @@ msgstr "журка"
 msgid "Password"
 msgstr "Лозинка"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Паузирај"
@@ -3785,6 +3797,10 @@ msgstr "извођач"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "пиксела"
@@ -3793,10 +3809,10 @@ msgstr "пиксела"
 msgid "Plain sidebar"
 msgstr "Обична трака"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Пусти"
 
@@ -3817,11 +3833,11 @@ msgstr "Пусти ако је заустављено, заустави ако �
 msgid "Play if there is nothing already playing"
 msgstr "почеће пуштање ако тренутно ништа није пуштено"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Репродуковати следеће"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Репродуковати следеће изабране песме"
 
@@ -3920,7 +3936,7 @@ msgstr "Поставка"
 msgid "Preferences"
 msgstr "Поставке"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Подешавање..."
 
@@ -3980,7 +3996,7 @@ msgid "Previous"
 msgstr "Претходна"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Претходна нумера"
 
@@ -4038,16 +4054,16 @@ msgstr "Квалитет"
 msgid "Querying device..."
 msgstr "Испитујем уређај..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Менаџер редоследа"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Стави у ред изабране нумере"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Стави нумеру у ред"
 
@@ -4063,7 +4079,7 @@ msgstr "радио (једнака јачина за све песме)"
 msgid "Rain"
 msgstr "Киша"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Киша"
@@ -4175,7 +4191,7 @@ msgstr "Уклони радњу"
 msgid "Remove current song from playlist"
 msgstr "Уклони текућу песму са листе нумера"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Уклони дупликате са листе"
 
@@ -4183,7 +4199,7 @@ msgstr "Уклони дупликате са листе"
 msgid "Remove folder"
 msgstr "Уклони фасциклу"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Уклони са листе нумера"
 
@@ -4195,7 +4211,7 @@ msgstr "Уклањање листе нумера"
 msgid "Remove playlists"
 msgstr "Уклони листе нумера"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Уклони недоступне нумере са листе нумера"
 
@@ -4207,7 +4223,7 @@ msgstr "Преименовање листе нумера"
 msgid "Rename playlist..."
 msgstr "Преименуј листу нумера..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Нумериши овим редом..."
 
@@ -4298,7 +4314,7 @@ msgstr "чупај"
 msgid "Rip CD"
 msgstr "Чупање ЦД-а"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Чупај аудио ЦД"
 
@@ -4376,7 +4392,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Упис листе нумера"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Сачувај листу нумера..."
 
@@ -4463,7 +4479,7 @@ msgstr "Тражи на Субсонику"
 msgid "Search automatically"
 msgstr "Тражи аутоматски"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Тражи албум"
 
@@ -4476,7 +4492,7 @@ msgstr "Тражи омоте албума..."
 msgid "Search for anything"
 msgstr "Тражи било шта"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Тражи извођача"
 
@@ -4601,7 +4617,7 @@ msgstr "Детаљи сервера"
 msgid "Service offline"
 msgstr "Сервис ван мреже"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Промени %1 у „%2“..."
@@ -4610,7 +4626,7 @@ msgstr "Промени %1 у „%2“..."
 msgid "Set the volume to <value> percent"
 msgstr "Постави јачину звука на <вредност> процената"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Подеси вредност за све изабране нумере..."
 
@@ -4681,7 +4697,7 @@ msgstr "Лепи ОСД"
 msgid "Show above status bar"
 msgstr "Прикажи изнад траке стања"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Прикажи све песме"
 
@@ -4701,12 +4717,12 @@ msgstr "Прикажи раздвајаче"
 msgid "Show fullsize..."
 msgstr "Пуна величина..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Прикажи у менаџеру фајлова"
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Прикажи у библиотеци..."
 
@@ -4718,15 +4734,15 @@ msgstr "Приказуј у разним извођачима"
 msgid "Show moodbar"
 msgstr "Прикажи расположење"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Прикажи само дупликате"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Прикажи само неозначене"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Приказ или скривање бочне траке"
 
@@ -4734,7 +4750,7 @@ msgstr "Приказ или скривање бочне траке"
 msgid "Show search suggestions"
 msgstr "прикажи предлоге претраге"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Прикажи бочну траку"
 
@@ -4770,7 +4786,7 @@ msgstr "Насумично албуми"
 msgid "Shuffle all"
 msgstr "Насумично све"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Претумбај листу"
 
@@ -4814,11 +4830,15 @@ msgstr "број прескакања"
 msgid "Skip forwards in playlist"
 msgstr "Прескочи унапред у листи нумера"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Прескочи изабране нумере"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Прескочи нумеру"
 
@@ -4935,7 +4955,7 @@ msgstr "Почни чупање"
 msgid "Start the playlist currently playing"
 msgstr "Пусти текућу листу нумера"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Почни прекодирање"
 
@@ -4945,7 +4965,7 @@ msgid ""
 "list"
 msgstr "Почните нешто да куцате у поље за претрагу изнад да бисте испунили овај списак резултата претраге"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Почињем %1"
@@ -4955,7 +4975,7 @@ msgid "Starting..."
 msgstr "Почињем..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Заустави"
 
@@ -4971,7 +4991,7 @@ msgstr "Заустави после сваке нумере"
 msgid "Stop after every track"
 msgstr "Заустављање после сваке нумере"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Заустави после ове нумере"
 
@@ -5139,7 +5159,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Пробни период за Субсоников сервер је истекао. Донирајте да бисте добили лиценцни кључ. Посетите subsonic.org за више детаља."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5181,7 +5201,7 @@ msgid ""
 "continue?"
 msgstr "Ови фајлови ће бити обрисани са уређаја, желите ли заиста да наставите?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5283,11 +5303,11 @@ msgstr "Лепи ОСД"
 msgid "Toggle fullscreen"
 msgstr "Цео екран"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Мењај стање редоследа"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Мењај скробловање"
 
@@ -5332,19 +5352,19 @@ msgstr "&Нумера"
 msgid "Track"
 msgstr "нумера"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Прекодирање музике"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Дневник прекодирања"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Прекодирање"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Прекодирам %1 фајлова користећи %2 ниски"
@@ -5421,11 +5441,11 @@ msgstr "Непозната грешка"
 msgid "Unset cover"
 msgstr "Уклони омот"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Уклони прескакање нумера"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Уклони прескакање"
 
@@ -5442,7 +5462,7 @@ msgstr "Предстојећи концерти"
 msgid "Update all podcasts"
 msgstr "Ажурирај све подкасте"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Ажурирај измењене фасцикле библиотеке"
 
@@ -5603,7 +5623,7 @@ msgstr "Издање %1"
 msgid "View"
 msgstr "Приказ"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Прикажи детаље тока"
 
@@ -5611,7 +5631,7 @@ msgstr "Прикажи детаље тока"
 msgid "Visualization mode"
 msgstr "Режим визуелизација"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Визуелизације"
 
@@ -5652,7 +5672,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "ВАВ"
 
@@ -5748,7 +5768,7 @@ msgstr "Виндоуз медија 40k"
 msgid "Windows Media 64k"
 msgstr "Виндоуз медија 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Виндоуз медија аудио"
 
@@ -5762,7 +5782,7 @@ msgid ""
 "well?"
 msgstr "Желите ли да померите и остале песме из овог албума у разне извођаче такође?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Желите ли сада да покренете потпуно скенирање?"
 

--- a/src/translations/sr.po
+++ b/src/translations/sr.po
@@ -8,12 +8,12 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2010
 # Jovana Savic <joa.uniq@gmail.com>, 2012
 # Mladen Pejaković, 2014-2017
-# Slobodan Simić <slsimic@gmail.com>, 2020
+# Slobodan Simić <slsimic@gmail.com>, 2020-2021
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
-"Last-Translator: John Maguire <john.maguire@gmail.com>\n"
+"PO-Revision-Date: 2021-01-19 14:32+0000\n"
+"Last-Translator: Slobodan Simić <slsimic@gmail.com>\n"
 "Language-Team: Serbian (http://www.transifex.com/davidsansome/clementine/language/sr/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -104,7 +104,7 @@ msgstr "%1 листи нумера (%2)"
 msgid ""
 "%1 request failed:\n"
 "%2"
-msgstr ""
+msgstr "%1 захтев пропао:\n%2"
 
 #: devices/deviceview.cpp:122
 #, qt-format
@@ -150,7 +150,7 @@ msgstr "%L1 других слушалаца"
 #: playlist/playlistmanager.cpp:439
 #, qt-format
 msgid "%L1 selected of"
-msgstr ""
+msgstr "селектовано %L1 од"
 
 #: songinfo/lastfmtrackinfoprovider.cpp:94
 #, qt-format
@@ -160,7 +160,7 @@ msgstr "%L1 укупних слушања"
 #: playlist/playlistmanager.cpp:445
 #, qt-format
 msgid "%L1 tracks"
-msgstr ""
+msgstr "%L1 нумера"
 
 #: ../bin/src/ui_notificationssettingspage.h:432
 msgid "%filename%"
@@ -1060,7 +1060,7 @@ msgstr "дугмад"
 
 #: internet/podcasts/addpodcastdialog.cpp:95
 msgid "CBC Podcasts"
-msgstr ""
+msgstr "ЦБЦ подкастови"
 
 #: core/song.cpp:453
 msgid "CDDA"
@@ -1318,7 +1318,7 @@ msgstr "Листа речи раздвојених зарезом које тр�
 
 #: ../bin/src/ui_console.h:129
 msgid "Command"
-msgstr ""
+msgstr "Команда"
 
 #: playlist/playlist.cpp:1436 smartplaylists/searchterm.cpp:386
 #: ui/organisedialog.cpp:77 ../bin/src/ui_edittagdialog.h:719
@@ -1590,7 +1590,7 @@ msgstr "денс"
 
 #: ../bin/src/ui_console.h:131
 msgid "Database"
-msgstr ""
+msgstr "База података"
 
 #: core/database.cpp:629
 msgid ""
@@ -1903,11 +1903,11 @@ msgstr "Поставке преузимања"
 
 #: ../bin/src/ui_networkremotesettingspage.h:385
 msgid "Download the original Android app"
-msgstr ""
+msgstr "Преузми оригиналну Андроид апликацију"
 
 #: ../bin/src/ui_networkremotesettingspage.h:381
 msgid "Download the remote for Desktops, Android and iOS"
-msgstr ""
+msgstr "Преузми даљински за рачунар, Андроид и иОС"
 
 #: internet/magnatune/magnatuneservice.cpp:279
 msgid "Download this album"
@@ -1965,7 +1965,7 @@ msgstr ""
 
 #: ../bin/src/ui_console.h:132
 msgid "Dump To Logs"
-msgstr ""
+msgstr "Баци у дневнике"
 
 #: ../bin/src/ui_episodeinfowidget.h:134 ../bin/src/ui_ripcddialog.h:308
 msgid "Duration"
@@ -2286,7 +2286,7 @@ msgstr "Неуспех добављања подкаста"
 msgid ""
 "Failed to get channel list:\n"
 "%1"
-msgstr ""
+msgstr "Не могу да добијем листу канала:\n%1"
 
 #: internet/podcasts/addpodcastbyurl.cpp:71
 #: internet/podcasts/fixedopmlpage.cpp:55

--- a/src/translations/sr.po
+++ b/src/translations/sr.po
@@ -514,7 +514,7 @@ msgstr "Додај други ток..."
 msgid "Add directory..."
 msgstr "Додај фасциклу..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Додавање фајла"
 
@@ -534,7 +534,7 @@ msgstr "Додај фајл..."
 msgid "Add files to transcode"
 msgstr "Додавање фајлова за прекодирање"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Додавање фасцикле"
@@ -639,7 +639,7 @@ msgstr "Додај у Спотифај листе нумера"
 msgid "Add to Spotify starred"
 msgstr "Додај на Спотифај оцењено"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Додај у другу листу"
 
@@ -861,7 +861,7 @@ msgstr "Желите ли заиста да упишете статистику 
 msgid "Artist"
 msgstr "извођач"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Подаци о извођачу"
 
@@ -1124,7 +1124,7 @@ msgstr "Тражи нове епизоде"
 msgid "Check for updates"
 msgstr "Потражи надоградње"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Потражи надоградње..."
 
@@ -1364,7 +1364,7 @@ msgstr "Подеси Субсоник..."
 msgid "Configure global search..."
 msgstr "Подеси општу претрагу..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Подеси библиотеку..."
 
@@ -1436,11 +1436,11 @@ msgid "Copy to clipboard"
 msgstr "Копирај на клипборд"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Копирај на уређај...."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Копирај у библиотеку..."
@@ -1658,7 +1658,7 @@ msgid "Delete downloaded data"
 msgstr "Обриши преузете податке"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Брисање фајлова"
 
@@ -1666,7 +1666,7 @@ msgstr "Брисање фајлова"
 msgid "Delete from device..."
 msgstr "Обриши са уређаја..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Обриши са диска..."
@@ -1699,11 +1699,11 @@ msgstr "Бришем фајлове"
 msgid "Depth"
 msgstr "Дубина"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Избаци изабране нумере из реда"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Избаци нумеру из реда"
 
@@ -1732,7 +1732,7 @@ msgstr "Име уређаја"
 msgid "Device properties..."
 msgstr "Својства уређаја..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Уређаји"
 
@@ -1983,7 +1983,7 @@ msgstr "Динамички насумични микс"
 msgid "Edit smart playlist..."
 msgstr "Уреди паметну листу..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Уреди ознаку „%1“..."
@@ -2122,8 +2122,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Исто као и --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Грешка"
 
@@ -2269,7 +2269,7 @@ msgstr "Утапање"
 msgid "Fading duration"
 msgstr "Трајање претапања"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Неуспех читања ЦД уређаја"
 
@@ -2392,7 +2392,7 @@ msgstr "тип фајла"
 msgid "Filename"
 msgstr "име фајла"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Фајлови"
 
@@ -2807,7 +2807,7 @@ msgstr "инсталиран"
 msgid "Integrity check"
 msgstr "Провера интегритета"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Интернет"
 
@@ -2995,7 +2995,7 @@ msgstr "Лево"
 msgid "Length"
 msgstr "дужина"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Библиотека"
@@ -3004,7 +3004,7 @@ msgstr "Библиотека"
 msgid "Library advanced grouping"
 msgstr "Напредно груписање библиотеке"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Обавештење о поновном скенирању библиотеке"
 
@@ -3332,7 +3332,7 @@ msgstr "Тачке монтирања"
 msgid "Move down"
 msgstr "Помери доле"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Премести у библиотеку"
 
@@ -3341,7 +3341,7 @@ msgstr "Премести у библиотеку"
 msgid "Move up"
 msgstr "Помери горе"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Музика"
 
@@ -3403,7 +3403,7 @@ msgstr "неће почети пуштање"
 msgid "New folder"
 msgstr "Нова фасцикла"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Нова листа нумера"
 
@@ -3474,7 +3474,7 @@ msgstr "без кратких блокова"
 msgid "None"
 msgstr "ништа"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Ниједна од изабраних песама није погодна за копирање на уређај"
 
@@ -3689,7 +3689,7 @@ msgstr "Опус"
 msgid "Organise Files"
 msgstr "Организовање фајлова"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Организуј фајлове..."
 
@@ -3773,7 +3773,7 @@ msgstr "журка"
 msgid "Password"
 msgstr "Лозинка"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Паузирај"
@@ -3809,8 +3809,8 @@ msgstr "пиксела"
 msgid "Plain sidebar"
 msgstr "Обична трака"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3833,11 +3833,11 @@ msgstr "Пусти ако је заустављено, заустави ако �
 msgid "Play if there is nothing already playing"
 msgstr "почеће пуштање ако тренутно ништа није пуштено"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Репродуковати следеће"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Репродуковати следеће изабране песме"
 
@@ -3876,7 +3876,7 @@ msgstr "Опције листе нумера"
 msgid "Playlist type"
 msgstr "Тип листе"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Листе нумера"
 
@@ -4058,12 +4058,12 @@ msgstr "Испитујем уређај..."
 msgid "Queue Manager"
 msgstr "Менаџер редоследа"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Стави у ред изабране нумере"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Стави нумеру у ред"
 
@@ -4454,7 +4454,7 @@ msgstr "Сифајл"
 msgid "Search"
 msgstr "Тражи"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Претрага"
@@ -4479,7 +4479,7 @@ msgstr "Тражи на Субсонику"
 msgid "Search automatically"
 msgstr "Тражи аутоматски"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Тражи албум"
 
@@ -4492,7 +4492,7 @@ msgstr "Тражи омоте албума..."
 msgid "Search for anything"
 msgstr "Тражи било шта"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Тражи извођача"
 
@@ -4617,7 +4617,7 @@ msgstr "Детаљи сервера"
 msgid "Service offline"
 msgstr "Сервис ван мреже"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Промени %1 у „%2“..."
@@ -4697,7 +4697,7 @@ msgstr "Лепи ОСД"
 msgid "Show above status bar"
 msgstr "Прикажи изнад траке стања"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Прикажи све песме"
 
@@ -4717,12 +4717,12 @@ msgstr "Прикажи раздвајаче"
 msgid "Show fullsize..."
 msgstr "Пуна величина..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Прикажи у менаџеру фајлова"
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Прикажи у библиотеци..."
 
@@ -4734,11 +4734,11 @@ msgstr "Приказуј у разним извођачима"
 msgid "Show moodbar"
 msgstr "Прикажи расположење"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Прикажи само дупликате"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Прикажи само неозначене"
 
@@ -4830,7 +4830,7 @@ msgstr "број прескакања"
 msgid "Skip forwards in playlist"
 msgstr "Прескочи унапред у листи нумера"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Прескочи изабране нумере"
 
@@ -4838,7 +4838,7 @@ msgstr "Прескочи изабране нумере"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Прескочи нумеру"
 
@@ -4870,7 +4870,7 @@ msgstr "лагани рок"
 msgid "Song Information"
 msgstr "Подаци о песми"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Подаци о песми"
 
@@ -4991,7 +4991,7 @@ msgstr "Заустави после сваке нумере"
 msgid "Stop after every track"
 msgstr "Заустављање после сваке нумере"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Заустави после ове нумере"
 
@@ -5159,7 +5159,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Пробни период за Субсоников сервер је истекао. Донирајте да бисте добили лиценцни кључ. Посетите subsonic.org за више детаља."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5201,7 +5201,7 @@ msgid ""
 "continue?"
 msgstr "Ови фајлови ће бити обрисани са уређаја, желите ли заиста да наставите?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5303,7 +5303,7 @@ msgstr "Лепи ОСД"
 msgid "Toggle fullscreen"
 msgstr "Цео екран"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Мењај стање редоследа"
 
@@ -5441,11 +5441,11 @@ msgstr "Непозната грешка"
 msgid "Unset cover"
 msgstr "Уклони омот"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Уклони прескакање нумера"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Уклони прескакање"
 
@@ -5782,7 +5782,7 @@ msgid ""
 "well?"
 msgstr "Желите ли да померите и остале песме из овог албума у разне извођаче такође?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Желите ли сада да покренете потпуно скенирање?"
 

--- a/src/translations/sr@latin.po
+++ b/src/translations/sr@latin.po
@@ -11,7 +11,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Serbian (Latin) (http://www.transifex.com/davidsansome/clementine/language/sr@latin/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -165,19 +165,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n neuspešno"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n završeno"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -195,7 +195,7 @@ msgstr "&centriraj"
 msgid "&Custom"
 msgstr "&Posebna"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Dodaci"
 
@@ -203,7 +203,7 @@ msgstr "&Dodaci"
 msgid "&Grouping"
 msgstr "&Grupisanje"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Pomoć"
 
@@ -228,7 +228,7 @@ msgstr "&Zaključaj ocenu"
 msgid "&Lyrics"
 msgstr "&Stihovi"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Muzika"
 
@@ -236,15 +236,15 @@ msgstr "&Muzika"
 msgid "&None"
 msgstr "&Nijedna"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&Lista numera"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Napusti"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "&Režim ponavljanja"
 
@@ -252,7 +252,7 @@ msgstr "&Režim ponavljanja"
 msgid "&Right"
 msgstr "&desno"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "&Nasumični režim"
 
@@ -260,7 +260,7 @@ msgstr "&Nasumični režim"
 msgid "&Stretch columns to fit window"
 msgstr "&Uklopi kolone u prozor"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Alatke"
 
@@ -449,11 +449,11 @@ msgstr "Prekini"
 msgid "About %1"
 msgstr "O %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "O Klementini..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Više o Kutu..."
 
@@ -513,32 +513,32 @@ msgstr "Dodaj drugi tok..."
 msgid "Add directory..."
 msgstr "Dodaj fasciklu..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Dodavanje fajla"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Dodaj fajl u prekoder"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Dodaj fajlo(ove) u prekoder"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Dodaj fajl..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Dodavanje fajlova za prekodiranje"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Dodavanje fascikle"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Dodaj fasciklu..."
 
@@ -550,7 +550,7 @@ msgstr "Dodaj novu fasciklu..."
 msgid "Add podcast"
 msgstr "Dodavanje podkasta"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Dodaj podkast..."
 
@@ -626,7 +626,7 @@ msgstr "Umetni numeru pesme"
 msgid "Add song year tag"
 msgstr "Umetni godinu pesme"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Dodaj tok..."
 
@@ -638,7 +638,7 @@ msgstr "Dodaj u Spotifaj liste numera"
 msgid "Add to Spotify starred"
 msgstr "Dodaj na Spotifaj ocenjeno"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Dodaj u drugu listu"
 
@@ -732,7 +732,7 @@ msgstr "Sve"
 msgid "All Files (*)"
 msgstr "Svi fajlovi (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Slava Hipnožapcu!"
@@ -1123,7 +1123,7 @@ msgstr "Traži nove epizode"
 msgid "Check for updates"
 msgstr "Potraži nadogradnje"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Potraži nadogradnje..."
 
@@ -1172,18 +1172,18 @@ msgstr "klasična"
 msgid "Cleaning up"
 msgstr "Čišćenje"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Očisti"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Očisti listu numera"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Klementina"
 
@@ -1328,7 +1328,7 @@ msgstr "komentar"
 msgid "Complete tags automatically"
 msgstr "Popuni oznake automatski"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Popuni oznake automatski..."
 
@@ -1363,7 +1363,7 @@ msgstr "Podesi Subsonik..."
 msgid "Configure global search..."
 msgstr "Podesi opštu pretragu..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Podesi biblioteku..."
 
@@ -1406,7 +1406,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Prekovreme isteklo, proverite URL servera. Primer: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Konzola"
 
@@ -1435,11 +1435,11 @@ msgid "Copy to clipboard"
 msgstr "Kopiraj na klipbord"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopiraj na uređaj...."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kopiraj u biblioteku..."
@@ -1482,14 +1482,14 @@ msgstr "Ne mogu da se prijavim na Last.fm. Pokušajte ponovo kasnije."
 msgid "Couldn't create playlist"
 msgstr "Ne mogu da napravim listu numera"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Ne mogu da nađem mukser za %1, proverite da li imate instalirane potrebne priključke za Gstrimer"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1504,7 +1504,7 @@ msgstr "Ne mogu da otvorim izlazni fajl %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Menadžer omota"
 
@@ -1657,7 +1657,7 @@ msgid "Delete downloaded data"
 msgstr "Obriši preuzete podatke"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Brisanje fajlova"
 
@@ -1665,7 +1665,7 @@ msgstr "Brisanje fajlova"
 msgid "Delete from device..."
 msgstr "Obriši sa uređaja..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Obriši sa diska..."
@@ -1698,11 +1698,11 @@ msgstr "Brišem fajlove"
 msgid "Depth"
 msgstr "Dubina"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Izbaci izabrane numere iz reda"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Izbaci numeru iz reda"
 
@@ -1803,7 +1803,7 @@ msgstr "Opcije prikaza"
 msgid "Display the on-screen-display"
 msgstr "Prikaži ekranski pregled"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Ponovo skeniraj biblioteku"
 
@@ -1982,12 +1982,12 @@ msgstr "Dinamički nasumični miks"
 msgid "Edit smart playlist..."
 msgstr "Uredi pametnu listu..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Uredi oznaku „%1“..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Uredi oznaku..."
 
@@ -2000,7 +2000,7 @@ msgid "Edit track information"
 msgstr "Uređivanje podataka numere"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Uredi podatke numere..."
 
@@ -2108,7 +2108,7 @@ msgstr "čitavu kolekciju"
 msgid "Episode information"
 msgstr "Informacije o epizodi"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Ekvilajzer"
 
@@ -2121,8 +2121,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Isto kao i --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Greška"
 
@@ -2157,7 +2157,7 @@ msgstr "Greška učitavanja %1"
 msgid "Error loading di.fm playlist"
 msgstr "Greška učitavanja di.fm liste numera"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Greška obrade %1: %2"
@@ -2240,7 +2240,11 @@ msgstr "Izvoz završen"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "Izvezeno %1 omota od %2 (%3 preskočeno)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2264,7 +2268,7 @@ msgstr "Utapanje"
 msgid "Fading duration"
 msgstr "Trajanje pretapanja"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Neuspeh čitanja CD uređaja"
 
@@ -2546,11 +2550,11 @@ msgstr "Dajte joj ime:"
 msgid "Go"
 msgstr "Idi"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Idi na sledeći jezičak liste"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Idi na prethodni jezičak liste"
 
@@ -2883,7 +2887,7 @@ msgstr "Džamendova baza podataka"
 msgid "Jump to previous song right away"
 msgstr "pušta prethodnu pesmu odmah"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Skoči na tekuću numeru"
 
@@ -2907,7 +2911,7 @@ msgstr "Nastavi rad u pozadini kad se prozor zatvori"
 msgid "Keep the original files"
 msgstr "zadrži originalne fajlove"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Mačići"
@@ -2999,7 +3003,7 @@ msgstr "Biblioteka"
 msgid "Library advanced grouping"
 msgstr "Napredno grupisanje biblioteke"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Obaveštenje o ponovnom skeniranju biblioteke"
 
@@ -3039,7 +3043,7 @@ msgstr "Učitaj omot sa diska..."
 msgid "Load playlist"
 msgstr "Učitavanje liste numera"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Učitaj listu numera..."
 
@@ -3100,11 +3104,15 @@ msgstr "Prijava"
 msgid "Login failed"
 msgstr "Prijava nije uspela"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "dugoročno predviđanje (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Volim"
 
@@ -3139,11 +3147,11 @@ msgstr "Stihovi sa %1"
 msgid "Lyrics from the tag"
 msgstr "Stihovi iz oznake"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3185,7 +3193,7 @@ msgstr "glavni profil (MAIN)"
 msgid "Make it so!"
 msgstr "Enterprajz!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Enterprajz!"
@@ -3323,7 +3331,7 @@ msgstr "Tačke montiranja"
 msgid "Move down"
 msgstr "Pomeri dole"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Premesti u biblioteku"
 
@@ -3332,7 +3340,7 @@ msgstr "Premesti u biblioteku"
 msgid "Move up"
 msgstr "Pomeri gore"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Muzika"
 
@@ -3345,7 +3353,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Utišaj"
 
@@ -3394,7 +3402,7 @@ msgstr "neće početi puštanje"
 msgid "New folder"
 msgstr "Nova fascikla"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nova lista numera"
 
@@ -3422,8 +3430,12 @@ msgstr "Najnovije numere"
 msgid "Next"
 msgstr "Sledeća"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Sledeća numera"
 
@@ -3461,7 +3473,7 @@ msgstr "bez kratkih blokova"
 msgid "None"
 msgstr "ništa"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Nijedna od izabranih pesama nije pogodna za kopiranje na uređaj"
 
@@ -3546,19 +3558,19 @@ msgstr "isključeno"
 msgid "Ogg FLAC"
 msgstr "OGG FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "OGG FLAC"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "OGG Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "OGG Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3602,7 +3614,7 @@ msgstr "Prozirnost"
 msgid "Open %1 in browser"
 msgstr "Otvori %1 u pregledaču"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Otvori &audio CD..."
 
@@ -3614,7 +3626,7 @@ msgstr "Otvaranje OPML fajla"
 msgid "Open OPML file..."
 msgstr "Otvori OPML fajl..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Otvaranje fascikle za uvoz muzike"
 
@@ -3622,7 +3634,7 @@ msgstr "Otvaranje fascikle za uvoz muzike"
 msgid "Open device"
 msgstr "Otvori uređaj"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Otvori fajl..."
 
@@ -3676,7 +3688,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organizovanje fajlova"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Organizuj fajlove..."
 
@@ -3760,7 +3772,7 @@ msgstr "žurka"
 msgid "Password"
 msgstr "Lozinka"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pauziraj"
@@ -3784,6 +3796,10 @@ msgstr "izvođač"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "piksela"
@@ -3792,10 +3808,10 @@ msgstr "piksela"
 msgid "Plain sidebar"
 msgstr "Obična traka"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Pusti"
 
@@ -3816,11 +3832,11 @@ msgstr "Pusti ako je zaustavljeno, zaustavi ako se pušta"
 msgid "Play if there is nothing already playing"
 msgstr "počeće puštanje ako trenutno ništa nije pušteno"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Pusti sledeće"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Pusti obeležene numere sledeće"
 
@@ -3919,7 +3935,7 @@ msgstr "Postavka"
 msgid "Preferences"
 msgstr "Postavke"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Podešavanje..."
 
@@ -3979,7 +3995,7 @@ msgid "Previous"
 msgstr "Prethodna"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Prethodna numera"
 
@@ -4037,16 +4053,16 @@ msgstr "Kvalitet"
 msgid "Querying device..."
 msgstr "Ispitujem uređaj..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Menadžer redosleda"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Stavi u red izabrane numere"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Stavi numeru u red"
 
@@ -4062,7 +4078,7 @@ msgstr "radio (jednaka jačina za sve pesme)"
 msgid "Rain"
 msgstr "Kiša"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Kiša"
@@ -4174,7 +4190,7 @@ msgstr "Ukloni radnju"
 msgid "Remove current song from playlist"
 msgstr "Ukloni tekuću pesmu sa liste numera"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Ukloni duplikate sa liste"
 
@@ -4182,7 +4198,7 @@ msgstr "Ukloni duplikate sa liste"
 msgid "Remove folder"
 msgstr "Ukloni fasciklu"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Ukloni sa liste numera"
 
@@ -4194,7 +4210,7 @@ msgstr "Uklanjanje liste numera"
 msgid "Remove playlists"
 msgstr "Ukloni liste numera"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Ukloni nedostupne numere sa liste numera"
 
@@ -4206,7 +4222,7 @@ msgstr "Preimenovanje liste numera"
 msgid "Rename playlist..."
 msgstr "Preimenuj listu numera..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Numeriši ovim redom..."
 
@@ -4297,7 +4313,7 @@ msgstr "čupaj"
 msgid "Rip CD"
 msgstr "Čupanje CD-a"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Čupaj audio CD"
 
@@ -4375,7 +4391,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Upis liste numera"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Sačuvaj listu numera..."
 
@@ -4462,7 +4478,7 @@ msgstr "Traži na Subsoniku"
 msgid "Search automatically"
 msgstr "Traži automatski"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Traži album"
 
@@ -4475,7 +4491,7 @@ msgstr "Traži omote albuma..."
 msgid "Search for anything"
 msgstr "Traži bilo šta"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Traži izvođača"
 
@@ -4600,7 +4616,7 @@ msgstr "Detalji servera"
 msgid "Service offline"
 msgstr "Servis van mreže"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Promeni %1 u „%2“..."
@@ -4609,7 +4625,7 @@ msgstr "Promeni %1 u „%2“..."
 msgid "Set the volume to <value> percent"
 msgstr "Postavi jačinu zvuka na <vrednost> procenata"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Podesi vrednost za sve izabrane numere..."
 
@@ -4680,7 +4696,7 @@ msgstr "Lepi OSD"
 msgid "Show above status bar"
 msgstr "Prikaži iznad trake stanja"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Prikaži sve pesme"
 
@@ -4700,12 +4716,12 @@ msgstr "Prikaži razdvajače"
 msgid "Show fullsize..."
 msgstr "Puna veličina..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Prikaži u menadžeru fajlova"
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Prikaži u biblioteci..."
 
@@ -4717,15 +4733,15 @@ msgstr "Prikazuj u raznim izvođačima"
 msgid "Show moodbar"
 msgstr "Prikaži raspoloženje"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Prikaži samo duplikate"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Prikaži samo neoznačene"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Prikaz ili skrivanje bočne trake"
 
@@ -4733,7 +4749,7 @@ msgstr "Prikaz ili skrivanje bočne trake"
 msgid "Show search suggestions"
 msgstr "prikaži predloge pretrage"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Prikaži bočnu traku"
 
@@ -4769,7 +4785,7 @@ msgstr "Nasumično albumi"
 msgid "Shuffle all"
 msgstr "Nasumično sve"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Pretumbaj listu"
 
@@ -4813,11 +4829,15 @@ msgstr "broj preskakanja"
 msgid "Skip forwards in playlist"
 msgstr "Preskoči unapred u listi numera"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Preskoči izabrane numere"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Preskoči numeru"
 
@@ -4934,7 +4954,7 @@ msgstr "Počni čupanje"
 msgid "Start the playlist currently playing"
 msgstr "Pusti tekuću listu numera"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Počni prekodiranje"
 
@@ -4944,7 +4964,7 @@ msgid ""
 "list"
 msgstr "Počnite nešto da kucate u polje za pretragu iznad da biste ispunili ovaj spisak rezultata pretrage"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Počinjem %1"
@@ -4954,7 +4974,7 @@ msgid "Starting..."
 msgstr "Počinjem..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Zaustavi"
 
@@ -4970,7 +4990,7 @@ msgstr "Zaustavi posle svake numere"
 msgid "Stop after every track"
 msgstr "Zaustavljanje posle svake numere"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Zaustavi posle ove numere"
 
@@ -5138,7 +5158,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Probni period za Subsonikov server je istekao. Donirajte da biste dobili licencni ključ. Posetite subsonic.org za više detalja."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5180,7 +5200,7 @@ msgid ""
 "continue?"
 msgstr "Ovi fajlovi će biti obrisani sa uređaja, želite li zaista da nastavite?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5282,11 +5302,11 @@ msgstr "Lepi OSD"
 msgid "Toggle fullscreen"
 msgstr "Ceo ekran"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Menjaj stanje redosleda"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Menjaj skroblovanje"
 
@@ -5331,19 +5351,19 @@ msgstr "&Numera"
 msgid "Track"
 msgstr "numera"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Prekodiranje muzike"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Dnevnik prekodiranja"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Prekodiranje"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Prekodiram %1 fajlova koristeći %2 niski"
@@ -5420,11 +5440,11 @@ msgstr "Nepoznata greška"
 msgid "Unset cover"
 msgstr "Ukloni omot"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Ukloni preskakanje numera"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Ukloni preskakanje"
 
@@ -5441,7 +5461,7 @@ msgstr "Predstojeći koncerti"
 msgid "Update all podcasts"
 msgstr "Ažuriraj sve podkaste"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Ažuriraj izmenjene fascikle biblioteke"
 
@@ -5602,7 +5622,7 @@ msgstr "Izdanje %1"
 msgid "View"
 msgstr "Prikaz"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Prikaži detalje toka"
 
@@ -5610,7 +5630,7 @@ msgstr "Prikaži detalje toka"
 msgid "Visualization mode"
 msgstr "Režim vizuelizacija"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Vizuelizacije"
 
@@ -5651,7 +5671,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "VAV"
 
@@ -5747,7 +5767,7 @@ msgstr "Vindouz medija 40k"
 msgid "Windows Media 64k"
 msgstr "Vindouz medija 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Vindouz medija audio"
 
@@ -5761,7 +5781,7 @@ msgid ""
 "well?"
 msgstr "Želite li da pomerite i ostale pesme iz ovog albuma u razne izvođače takođe?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Želite li sada da pokrenete potpuno skeniranje?"
 

--- a/src/translations/sr@latin.po
+++ b/src/translations/sr@latin.po
@@ -513,7 +513,7 @@ msgstr "Dodaj drugi tok..."
 msgid "Add directory..."
 msgstr "Dodaj fasciklu..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Dodavanje fajla"
 
@@ -533,7 +533,7 @@ msgstr "Dodaj fajl..."
 msgid "Add files to transcode"
 msgstr "Dodavanje fajlova za prekodiranje"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Dodavanje fascikle"
@@ -638,7 +638,7 @@ msgstr "Dodaj u Spotifaj liste numera"
 msgid "Add to Spotify starred"
 msgstr "Dodaj na Spotifaj ocenjeno"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Dodaj u drugu listu"
 
@@ -860,7 +860,7 @@ msgstr "Želite li zaista da upišete statistiku pesme u fajl pesme za sve pesme
 msgid "Artist"
 msgstr "izvođač"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Podaci o izvođaču"
 
@@ -1123,7 +1123,7 @@ msgstr "Traži nove epizode"
 msgid "Check for updates"
 msgstr "Potraži nadogradnje"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Potraži nadogradnje..."
 
@@ -1363,7 +1363,7 @@ msgstr "Podesi Subsonik..."
 msgid "Configure global search..."
 msgstr "Podesi opštu pretragu..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Podesi biblioteku..."
 
@@ -1435,11 +1435,11 @@ msgid "Copy to clipboard"
 msgstr "Kopiraj na klipbord"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopiraj na uređaj...."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kopiraj u biblioteku..."
@@ -1657,7 +1657,7 @@ msgid "Delete downloaded data"
 msgstr "Obriši preuzete podatke"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Brisanje fajlova"
 
@@ -1665,7 +1665,7 @@ msgstr "Brisanje fajlova"
 msgid "Delete from device..."
 msgstr "Obriši sa uređaja..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Obriši sa diska..."
@@ -1698,11 +1698,11 @@ msgstr "Brišem fajlove"
 msgid "Depth"
 msgstr "Dubina"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Izbaci izabrane numere iz reda"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Izbaci numeru iz reda"
 
@@ -1731,7 +1731,7 @@ msgstr "Ime uređaja"
 msgid "Device properties..."
 msgstr "Svojstva uređaja..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Uređaji"
 
@@ -1982,7 +1982,7 @@ msgstr "Dinamički nasumični miks"
 msgid "Edit smart playlist..."
 msgstr "Uredi pametnu listu..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Uredi oznaku „%1“..."
@@ -2121,8 +2121,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Isto kao i --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Greška"
 
@@ -2268,7 +2268,7 @@ msgstr "Utapanje"
 msgid "Fading duration"
 msgstr "Trajanje pretapanja"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Neuspeh čitanja CD uređaja"
 
@@ -2391,7 +2391,7 @@ msgstr "tip fajla"
 msgid "Filename"
 msgstr "ime fajla"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Fajlovi"
 
@@ -2806,7 +2806,7 @@ msgstr "instaliran"
 msgid "Integrity check"
 msgstr "Provera integriteta"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -2994,7 +2994,7 @@ msgstr "Levo"
 msgid "Length"
 msgstr "dužina"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Biblioteka"
@@ -3003,7 +3003,7 @@ msgstr "Biblioteka"
 msgid "Library advanced grouping"
 msgstr "Napredno grupisanje biblioteke"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Obaveštenje o ponovnom skeniranju biblioteke"
 
@@ -3331,7 +3331,7 @@ msgstr "Tačke montiranja"
 msgid "Move down"
 msgstr "Pomeri dole"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Premesti u biblioteku"
 
@@ -3340,7 +3340,7 @@ msgstr "Premesti u biblioteku"
 msgid "Move up"
 msgstr "Pomeri gore"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Muzika"
 
@@ -3402,7 +3402,7 @@ msgstr "neće početi puštanje"
 msgid "New folder"
 msgstr "Nova fascikla"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Nova lista numera"
 
@@ -3473,7 +3473,7 @@ msgstr "bez kratkih blokova"
 msgid "None"
 msgstr "ništa"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Nijedna od izabranih pesama nije pogodna za kopiranje na uređaj"
 
@@ -3688,7 +3688,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organizovanje fajlova"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Organizuj fajlove..."
 
@@ -3772,7 +3772,7 @@ msgstr "žurka"
 msgid "Password"
 msgstr "Lozinka"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pauziraj"
@@ -3808,8 +3808,8 @@ msgstr "piksela"
 msgid "Plain sidebar"
 msgstr "Obična traka"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3832,11 +3832,11 @@ msgstr "Pusti ako je zaustavljeno, zaustavi ako se pušta"
 msgid "Play if there is nothing already playing"
 msgstr "počeće puštanje ako trenutno ništa nije pušteno"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Pusti sledeće"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Pusti obeležene numere sledeće"
 
@@ -3875,7 +3875,7 @@ msgstr "Opcije liste numera"
 msgid "Playlist type"
 msgstr "Tip liste"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Liste numera"
 
@@ -4057,12 +4057,12 @@ msgstr "Ispitujem uređaj..."
 msgid "Queue Manager"
 msgstr "Menadžer redosleda"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Stavi u red izabrane numere"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Stavi numeru u red"
 
@@ -4453,7 +4453,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Traži"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Pretraga"
@@ -4478,7 +4478,7 @@ msgstr "Traži na Subsoniku"
 msgid "Search automatically"
 msgstr "Traži automatski"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Traži album"
 
@@ -4491,7 +4491,7 @@ msgstr "Traži omote albuma..."
 msgid "Search for anything"
 msgstr "Traži bilo šta"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Traži izvođača"
 
@@ -4616,7 +4616,7 @@ msgstr "Detalji servera"
 msgid "Service offline"
 msgstr "Servis van mreže"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Promeni %1 u „%2“..."
@@ -4696,7 +4696,7 @@ msgstr "Lepi OSD"
 msgid "Show above status bar"
 msgstr "Prikaži iznad trake stanja"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Prikaži sve pesme"
 
@@ -4716,12 +4716,12 @@ msgstr "Prikaži razdvajače"
 msgid "Show fullsize..."
 msgstr "Puna veličina..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Prikaži u menadžeru fajlova"
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Prikaži u biblioteci..."
 
@@ -4733,11 +4733,11 @@ msgstr "Prikazuj u raznim izvođačima"
 msgid "Show moodbar"
 msgstr "Prikaži raspoloženje"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Prikaži samo duplikate"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Prikaži samo neoznačene"
 
@@ -4829,7 +4829,7 @@ msgstr "broj preskakanja"
 msgid "Skip forwards in playlist"
 msgstr "Preskoči unapred u listi numera"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Preskoči izabrane numere"
 
@@ -4837,7 +4837,7 @@ msgstr "Preskoči izabrane numere"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Preskoči numeru"
 
@@ -4869,7 +4869,7 @@ msgstr "lagani rok"
 msgid "Song Information"
 msgstr "Podaci o pesmi"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Podaci o pesmi"
 
@@ -4990,7 +4990,7 @@ msgstr "Zaustavi posle svake numere"
 msgid "Stop after every track"
 msgstr "Zaustavljanje posle svake numere"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Zaustavi posle ove numere"
 
@@ -5158,7 +5158,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Probni period za Subsonikov server je istekao. Donirajte da biste dobili licencni ključ. Posetite subsonic.org za više detalja."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5200,7 +5200,7 @@ msgid ""
 "continue?"
 msgstr "Ovi fajlovi će biti obrisani sa uređaja, želite li zaista da nastavite?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5302,7 +5302,7 @@ msgstr "Lepi OSD"
 msgid "Toggle fullscreen"
 msgstr "Ceo ekran"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Menjaj stanje redosleda"
 
@@ -5440,11 +5440,11 @@ msgstr "Nepoznata greška"
 msgid "Unset cover"
 msgstr "Ukloni omot"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Ukloni preskakanje numera"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Ukloni preskakanje"
 
@@ -5781,7 +5781,7 @@ msgid ""
 "well?"
 msgstr "Želite li da pomerite i ostale pesme iz ovog albuma u razne izvođače takođe?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Želite li sada da pokrenete potpuno skeniranje?"
 

--- a/src/translations/sv.po
+++ b/src/translations/sv.po
@@ -10,9 +10,9 @@
 # elfa <thomas.elfstrom@gmail.com>, 2013
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2010
 # Hoven1 <thomas.hofverberg@tavelsjo.se>, 2012
-# Jonatan Nyberg <jonatan.nyberg.karl@gmail.com>, 2017
-# Jonatan Nyberg <jonatan.nyberg.karl@gmail.com>, 2019-2021
-# Jonatan Nyberg <jonatan.nyberg.karl@gmail.com>, 2021
+# efef6ec5b435a041fce803c7f8af77d2_2341d43, 2017
+# efef6ec5b435a041fce803c7f8af77d2_2341d43, 2019-2021
+# efef6ec5b435a041fce803c7f8af77d2_2341d43, 2021
 # Kristian <kristianm24@gmail.com>, 2012-2017
 # Kristian <kristianm24@gmail.com>, 2012
 # Kristoffer Grundström <lovaren@gmail.com>, 2014,2017
@@ -33,7 +33,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
 "PO-Revision-Date: 2021-01-16 08:50+0000\n"
-"Last-Translator: Jonatan Nyberg <jonatan.nyberg.karl@gmail.com>\n"
+"Last-Translator: efef6ec5b435a041fce803c7f8af77d2_2341d43\n"
 "Language-Team: Swedish (http://www.transifex.com/davidsansome/clementine/language/sv/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/src/translations/sv.po
+++ b/src/translations/sv.po
@@ -11,7 +11,7 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2010
 # Hoven1 <thomas.hofverberg@tavelsjo.se>, 2012
 # efef6ec5b435a041fce803c7f8af77d2_2341d43, 2017
-# efef6ec5b435a041fce803c7f8af77d2_2341d43, 2019-2021
+# Jonatan Nyberg <jonatan.nyberg.karl@gmail.com>, 2019-2021
 # efef6ec5b435a041fce803c7f8af77d2_2341d43, 2021
 # Kristian <kristianm24@gmail.com>, 2012-2017
 # Kristian <kristianm24@gmail.com>, 2012
@@ -32,8 +32,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-16 08:50+0000\n"
-"Last-Translator: efef6ec5b435a041fce803c7f8af77d2_2341d43\n"
+"PO-Revision-Date: 2021-01-20 10:16+0000\n"
+"Last-Translator: Jonatan Nyberg <jonatan.nyberg.karl@gmail.com>\n"
 "Language-Team: Swedish (http://www.transifex.com/davidsansome/clementine/language/sv/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -777,7 +777,7 @@ msgstr "Alla spellistor (%1)"
 
 #: ui/about.cpp:86
 msgid "All the translators"
-msgstr "Alla översättare"
+msgstr "Alla översättarna"
 
 #: library/library.cpp:102
 msgid "All tracks"

--- a/src/translations/sv.po
+++ b/src/translations/sv.po
@@ -32,8 +32,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-20 10:16+0000\n"
-"Last-Translator: Jonatan Nyberg <jonatan.nyberg.karl@gmail.com>\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
+"Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Swedish (http://www.transifex.com/davidsansome/clementine/language/sv/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -186,19 +186,19 @@ msgstr "%L1 spår"
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n misslyckades"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n är klar"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -216,7 +216,7 @@ msgstr "&Centrera"
 msgid "&Custom"
 msgstr "A&npassad"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Extrafunktioner"
 
@@ -224,7 +224,7 @@ msgstr "&Extrafunktioner"
 msgid "&Grouping"
 msgstr "&Gruppering"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Hjälp"
 
@@ -249,7 +249,7 @@ msgstr "&Lås betyg"
 msgid "&Lyrics"
 msgstr "&Sångtexter"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Musik"
 
@@ -257,15 +257,15 @@ msgstr "&Musik"
 msgid "&None"
 msgstr "I&nga"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&Spellista"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "A&vsluta"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "&Upprepningsläge"
 
@@ -273,7 +273,7 @@ msgstr "&Upprepningsläge"
 msgid "&Right"
 msgstr "&Höger"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "&Blandningsläge"
 
@@ -281,7 +281,7 @@ msgstr "&Blandningsläge"
 msgid "&Stretch columns to fit window"
 msgstr "&Sträck ut kolumner så de passar i fönstret"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Verktyg"
 
@@ -470,11 +470,11 @@ msgstr "Avbryt"
 msgid "About %1"
 msgstr "Om %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Om Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Om Qt..."
 
@@ -534,32 +534,32 @@ msgstr "Lägg till en annan ström..."
 msgid "Add directory..."
 msgstr "Lägg till mapp..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Lägg till fil"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Lägg till fil till omkodaren"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Lägg till fil(er) till omkodaren"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Lägg till fil..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Lägg till filer för omkodning"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Lägg till mapp"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Lägg till mapp..."
 
@@ -571,7 +571,7 @@ msgstr "Lägg till ny mapp..."
 msgid "Add podcast"
 msgstr "Lägg till poddsändning"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Lägg till poddsändning..."
 
@@ -647,7 +647,7 @@ msgstr "Lägg till tagg för spårnummer"
 msgid "Add song year tag"
 msgstr "Lägg till tagg för år"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Lägg till ström..."
 
@@ -659,7 +659,7 @@ msgstr "Lägg till i Spotifys spellistor"
 msgid "Add to Spotify starred"
 msgstr "Lägg till Spotifys stjärnmärkta"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Lägg till i en annan spellista"
 
@@ -753,7 +753,7 @@ msgstr "Alla"
 msgid "All Files (*)"
 msgstr "Alla filer (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Ärad vare Hypnotoad!"
@@ -1144,7 +1144,7 @@ msgstr "Sök efter nya avsnitt"
 msgid "Check for updates"
 msgstr "Sök efter uppdateringar"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Sök efter uppdateringar..."
 
@@ -1193,18 +1193,18 @@ msgstr "Klassisk"
 msgid "Cleaning up"
 msgstr "Rensa upp"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Rensa"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Rensa spellista"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1349,7 +1349,7 @@ msgstr "Kommentar"
 msgid "Complete tags automatically"
 msgstr "Fyll i taggar automatiskt"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Fyll i taggar automatiskt..."
 
@@ -1384,7 +1384,7 @@ msgstr "Konfigurera Subsonic..."
 msgid "Configure global search..."
 msgstr "Konfigurera global sökning..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Konfigurera bibliotek..."
 
@@ -1427,7 +1427,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Uppkopplingens tidsgräns nåddes, kontrollera serverns webbadress. Exempel: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Konsol"
 
@@ -1456,11 +1456,11 @@ msgid "Copy to clipboard"
 msgstr "Kopiera till klippbordet"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopiera till enhet..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kopiera till bibliotek..."
@@ -1503,14 +1503,14 @@ msgstr "Det gick inte att logga in på Last.fm. Vänligen försök igen."
 msgid "Couldn't create playlist"
 msgstr "Kunde inte skapa spellista"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Kunde inte hitta en muxer för %1, kontrollera att du har de korrekta GStreamer-insticksmodulerna installerade"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1525,7 +1525,7 @@ msgstr "Kunde inte öppna utdatafilen %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Omslagshanterare"
 
@@ -1678,7 +1678,7 @@ msgid "Delete downloaded data"
 msgstr "Ta bort hämtade data"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Ta bort filer"
 
@@ -1686,7 +1686,7 @@ msgstr "Ta bort filer"
 msgid "Delete from device..."
 msgstr "Ta bort från enhet..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Ta bort från disk..."
@@ -1719,11 +1719,11 @@ msgstr "Tar bort filer"
 msgid "Depth"
 msgstr "Djup"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Ta bort valda spår från kön"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Ta bort spår från kön"
 
@@ -1824,7 +1824,7 @@ msgstr "Visningsalternativ"
 msgid "Display the on-screen-display"
 msgstr "Visa on-screen-display"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Gör en fullständig omsökning av biblioteket"
 
@@ -2003,12 +2003,12 @@ msgstr "Dynamisk slumpmässig blandning"
 msgid "Edit smart playlist..."
 msgstr "Redigera smart spellista..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Redigera taggen \"%1\"..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Redigera tagg..."
 
@@ -2021,7 +2021,7 @@ msgid "Edit track information"
 msgstr "Redigera spårinformation"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Redigera spårinformation..."
 
@@ -2129,7 +2129,7 @@ msgstr "Hela samlingen"
 msgid "Episode information"
 msgstr "Avsnittsinformation"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Frekvenskorrigerare"
 
@@ -2142,8 +2142,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Motsvarar --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Fel"
 
@@ -2178,7 +2178,7 @@ msgstr "Fel vid insläsning av %1"
 msgid "Error loading di.fm playlist"
 msgstr "Fel vid laddning av di.fm spellista"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Fel vid bearbetning av %1: %2"
@@ -2261,7 +2261,11 @@ msgstr "Exporten är klar"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "Exporterat %1 omslag av %2 (%3 överhoppade)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2285,7 +2289,7 @@ msgstr "Toning"
 msgid "Fading duration"
 msgstr "Toningsvaraktighet"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Fel vid läsning av CD-enhet"
 
@@ -2567,11 +2571,11 @@ msgstr "Ge den ett namn:"
 msgid "Go"
 msgstr "Starta"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Gå till nästa spellisteflik"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Gå till föregående spellisteflik"
 
@@ -2904,7 +2908,7 @@ msgstr "Jamendo-databas"
 msgid "Jump to previous song right away"
 msgstr "Hoppa till föregående låt direkt"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Hoppa till spår som nu spelas"
 
@@ -2928,7 +2932,7 @@ msgstr "Fortsätt köra i bakgrunden när fönstret är stängt"
 msgid "Keep the original files"
 msgstr "Behåll originalfiler"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Kattungar"
@@ -3020,7 +3024,7 @@ msgstr "Bibliotek"
 msgid "Library advanced grouping"
 msgstr "Avancerad bibliotekgruppering"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Notis om omsökning av biblioteket"
 
@@ -3060,7 +3064,7 @@ msgstr "Läs in omslagsbild från disk..."
 msgid "Load playlist"
 msgstr "Läs in spellista"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Läs in spellista..."
 
@@ -3121,11 +3125,15 @@ msgstr "Logga in"
 msgid "Login failed"
 msgstr "Inloggningen misslyckades"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr "Loggar"
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Långsiktig förutsägelseprofil (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Älska"
 
@@ -3160,11 +3168,11 @@ msgstr "Låttext från %1"
 msgid "Lyrics from the tag"
 msgstr "Låttext från taggen"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3206,7 +3214,7 @@ msgstr "Huvudprofil (MAIN)"
 msgid "Make it so!"
 msgstr "Gör så!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Gör så!"
@@ -3344,7 +3352,7 @@ msgstr "Monteringspunkter"
 msgid "Move down"
 msgstr "Flytta nedåt"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Flytta till biblioteket..."
 
@@ -3353,7 +3361,7 @@ msgstr "Flytta till biblioteket..."
 msgid "Move up"
 msgstr "Flytta uppåt"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Musik"
 
@@ -3366,7 +3374,7 @@ msgid "Music extensions remotely visible"
 msgstr "Fjärrsynliga musikändelser"
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Tysta"
 
@@ -3415,7 +3423,7 @@ msgstr "Aldrig starta uppspelning"
 msgid "New folder"
 msgstr "Ny mapp"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Ny spellista"
 
@@ -3443,8 +3451,12 @@ msgstr "Nyaste spåren"
 msgid "Next"
 msgstr "Nästa"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Nästa spår"
 
@@ -3482,7 +3494,7 @@ msgstr "Inga korta block"
 msgid "None"
 msgstr "Inga"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Ingen av de valda låtarna lämpar sig för kopiering till en enhet"
 
@@ -3567,19 +3579,19 @@ msgstr "Av"
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg FLAC"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3623,7 +3635,7 @@ msgstr "Opacitet"
 msgid "Open %1 in browser"
 msgstr "Öppna %1 i webbläsare"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Öppna &ljud-CD..."
 
@@ -3635,7 +3647,7 @@ msgstr "Öppna OPML-fil"
 msgid "Open OPML file..."
 msgstr "Öppna OPML-fil..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Öppna en mapp att importera musik från"
 
@@ -3643,7 +3655,7 @@ msgstr "Öppna en mapp att importera musik från"
 msgid "Open device"
 msgstr "Öppna enhet"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Öppna fil..."
 
@@ -3697,7 +3709,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organisera filer"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Organisera filer..."
 
@@ -3781,7 +3793,7 @@ msgstr "Fest"
 msgid "Password"
 msgstr "Lösenord"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pausa"
@@ -3805,6 +3817,10 @@ msgstr "Aktör"
 msgid "Pipeline"
 msgstr "Rörledning"
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr "Rörledningar"
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Pixel"
@@ -3813,10 +3829,10 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Vanligt sidofält"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Spela"
 
@@ -3837,11 +3853,11 @@ msgstr "Spela om stoppad, pausa vid spelning"
 msgid "Play if there is nothing already playing"
 msgstr "Spela om ingenting redan spelas"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Spela nästa"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Spela valda spår som nästa"
 
@@ -3940,7 +3956,7 @@ msgstr "Inställning"
 msgid "Preferences"
 msgstr "Inställningar"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Inställningar..."
 
@@ -4000,7 +4016,7 @@ msgid "Previous"
 msgstr "Föregående"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Föregående spår"
 
@@ -4058,16 +4074,16 @@ msgstr "Kvalitet"
 msgid "Querying device..."
 msgstr "Kommunicerar med enhet..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Köhanterare"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Lägg till valda spår i kön"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Lägg till spår i kön"
 
@@ -4083,7 +4099,7 @@ msgstr "Radio (samma ljudstyrka för alla spår"
 msgid "Rain"
 msgstr "Regn"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Regn"
@@ -4195,7 +4211,7 @@ msgstr "Ta bort åtgärd"
 msgid "Remove current song from playlist"
 msgstr "Ta bort nuvarande låt från spellista"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Ta bort dubbletter från spellista"
 
@@ -4203,7 +4219,7 @@ msgstr "Ta bort dubbletter från spellista"
 msgid "Remove folder"
 msgstr "Ta bort mapp"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Ta bort från spellista"
 
@@ -4215,7 +4231,7 @@ msgstr "Ta bort spellista"
 msgid "Remove playlists"
 msgstr "Ta bort spellistor"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Ta bort otillgängliga spår från spellista"
 
@@ -4227,7 +4243,7 @@ msgstr "Byt namn på spellista"
 msgid "Rename playlist..."
 msgstr "Byt namn på spellista..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Omnumrera spår i denna ordning..."
 
@@ -4318,7 +4334,7 @@ msgstr "Kopiera"
 msgid "Rip CD"
 msgstr "Kopiera CD-skiva"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Kopiera ljud-CD"
 
@@ -4396,7 +4412,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Spara spellista"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Spara spellista..."
 
@@ -4483,7 +4499,7 @@ msgstr "Sök på Subsonic"
 msgid "Search automatically"
 msgstr "Sök automatiskt"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Sök efter album"
 
@@ -4496,7 +4512,7 @@ msgstr "Sök efter albumomslag..."
 msgid "Search for anything"
 msgstr "Sök efter vad som helst"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Sök efter artist"
 
@@ -4621,7 +4637,7 @@ msgstr "Serverdetaljer"
 msgid "Service offline"
 msgstr "Tjänsten inte tillgänglig"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Ställ in %1 till \"%2\"..."
@@ -4630,7 +4646,7 @@ msgstr "Ställ in %1 till \"%2\"..."
 msgid "Set the volume to <value> percent"
 msgstr "Ställ in volymen till <value> procent"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Ställ in värde för alla valda spår..."
 
@@ -4701,7 +4717,7 @@ msgstr "Visa en snygg avisering"
 msgid "Show above status bar"
 msgstr "Visa ovanför statusraden"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Visa alla låtar"
 
@@ -4721,12 +4737,12 @@ msgstr "Visa avdelare"
 msgid "Show fullsize..."
 msgstr "Visa i full storlek..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Visa i filhanterare..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Visa i biblioteket..."
 
@@ -4738,15 +4754,15 @@ msgstr "Visa i diverse artister"
 msgid "Show moodbar"
 msgstr "Visa stämningsdiagram"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Visa endast dubbletter"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Visa med saknade taggar"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Visa eller dölj sidofältet"
 
@@ -4754,7 +4770,7 @@ msgstr "Visa eller dölj sidofältet"
 msgid "Show search suggestions"
 msgstr "Visa sökförslag"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Visa sidofält"
 
@@ -4790,7 +4806,7 @@ msgstr "Blanda album"
 msgid "Shuffle all"
 msgstr "Blanda alla"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Blanda spellista"
 
@@ -4834,11 +4850,15 @@ msgstr "Antal överhoppningar"
 msgid "Skip forwards in playlist"
 msgstr "Hoppa framåt i spellista"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Hoppa över valda spår"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Hoppa över spår"
 
@@ -4955,7 +4975,7 @@ msgstr "Starta kopiering"
 msgid "Start the playlist currently playing"
 msgstr "Starta spellistan som nu spelas"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Starta omkodning"
 
@@ -4965,7 +4985,7 @@ msgid ""
 "list"
 msgstr "Skriv nånting i sökrutan ovan för att få sökresultat i denna lista"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Startar %1"
@@ -4975,7 +4995,7 @@ msgid "Starting..."
 msgstr "Startar..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Stoppa"
 
@@ -4991,7 +5011,7 @@ msgstr "Stoppa efter varje låt"
 msgid "Stop after every track"
 msgstr "Stoppa efter varje låt"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Stoppa efter detta spår"
 
@@ -5159,7 +5179,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Provperioden för Subsonic-servern är över. Vänligen donera för att få en licensnyckel. Besök subsonic.org för detaljer."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5201,7 +5221,7 @@ msgid ""
 "continue?"
 msgstr "Filerna kommer att tas bort från enheten, är du säker på att du vill fortsätta?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5303,11 +5323,11 @@ msgstr "Växla snygg avisering"
 msgid "Toggle fullscreen"
 msgstr "Växla fullskärm"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Växla köstatus"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Växla skrobbling"
 
@@ -5352,19 +5372,19 @@ msgstr "Spå&r"
 msgid "Track"
 msgstr "Spår"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Omkoda musik"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Omkodningslogg"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr "Omkodningsdetaljer"
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Omkodare"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Omkodar %1 filer med %2 trådar"
@@ -5441,11 +5461,11 @@ msgstr "Okänt fel"
 msgid "Unset cover"
 msgstr "Ta bort omslag"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Hoppa inte över valda spår"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Hoppa inte över valt spår"
 
@@ -5462,7 +5482,7 @@ msgstr "Kommande konserter"
 msgid "Update all podcasts"
 msgstr "Uppdatera alla poddsändningar"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Uppdatera ändrade biblioteksmappar"
 
@@ -5623,7 +5643,7 @@ msgstr "Version %1"
 msgid "View"
 msgstr "Visa"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Visa strömdetaljer"
 
@@ -5631,7 +5651,7 @@ msgstr "Visa strömdetaljer"
 msgid "Visualization mode"
 msgstr "Visualiseringsläge"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Visualiseringar"
 
@@ -5672,7 +5692,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr "Varning: Denna komprimeringsnivå ligger utanför den strömningsbara delmängden. Detta innebär att en avkodare kanske inte kan börja spela den i mitten av strömmen. Det kan också påverka prestanda för hårdvaruavkodare."
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5768,7 +5788,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media-ljud"
 
@@ -5782,7 +5802,7 @@ msgid ""
 "well?"
 msgstr "Vill du flytta de andra låtarna i det här albumet till Diverse artister också?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Vill du köra en fullständig omsökning nu?"
 

--- a/src/translations/sv.po
+++ b/src/translations/sv.po
@@ -32,7 +32,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-27 10:52+0000\n"
+"PO-Revision-Date: 2021-01-28 11:19+0000\n"
 "Last-Translator: Jonatan Nyberg <jonatan.nyberg.karl@gmail.com>\n"
 "Language-Team: Swedish (http://www.transifex.com/davidsansome/clementine/language/sv/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1280,7 +1280,7 @@ msgstr "Klicka här för att lägga till musik"
 msgid ""
 "Click here to favorite this playlist so it will be saved and remain "
 "accessible through the \"Playlists\" panel on the left side bar"
-msgstr "Klicka här för att favorisera denna spellista så att den sparas och förblir tillgänglig från \"Spellistor\" på det vänstra sidofältet"
+msgstr "Klicka här för att favorisera denna spellista så att den sparas och förblir tillgänglig från panelen \"Spellistor\" på det vänstra sidofältet"
 
 #: ../bin/src/ui_trackslider.h:71
 msgid "Click to toggle between remaining time and total time"

--- a/src/translations/sv.po
+++ b/src/translations/sv.po
@@ -32,8 +32,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-26 23:47+0000\n"
-"Last-Translator: John Maguire <john.maguire@gmail.com>\n"
+"PO-Revision-Date: 2021-01-27 10:52+0000\n"
+"Last-Translator: Jonatan Nyberg <jonatan.nyberg.karl@gmail.com>\n"
 "Language-Team: Swedish (http://www.transifex.com/davidsansome/clementine/language/sv/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -534,7 +534,7 @@ msgstr "Lägg till en annan ström..."
 msgid "Add directory..."
 msgstr "Lägg till mapp..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Lägg till fil"
 
@@ -554,7 +554,7 @@ msgstr "Lägg till fil..."
 msgid "Add files to transcode"
 msgstr "Lägg till filer för omkodning"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Lägg till mapp"
@@ -659,7 +659,7 @@ msgstr "Lägg till i Spotifys spellistor"
 msgid "Add to Spotify starred"
 msgstr "Lägg till Spotifys stjärnmärkta"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Lägg till i en annan spellista"
 
@@ -881,7 +881,7 @@ msgstr "Är du säker på att du vill skriva låtstatistik till låtfilerna på 
 msgid "Artist"
 msgstr "Artist"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Artistinfo"
 
@@ -1144,7 +1144,7 @@ msgstr "Sök efter nya avsnitt"
 msgid "Check for updates"
 msgstr "Sök efter uppdateringar"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Sök efter uppdateringar..."
 
@@ -1384,7 +1384,7 @@ msgstr "Konfigurera Subsonic..."
 msgid "Configure global search..."
 msgstr "Konfigurera global sökning..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Konfigurera bibliotek..."
 
@@ -1456,11 +1456,11 @@ msgid "Copy to clipboard"
 msgstr "Kopiera till klippbordet"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Kopiera till enhet..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kopiera till bibliotek..."
@@ -1678,7 +1678,7 @@ msgid "Delete downloaded data"
 msgstr "Ta bort hämtade data"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Ta bort filer"
 
@@ -1686,7 +1686,7 @@ msgstr "Ta bort filer"
 msgid "Delete from device..."
 msgstr "Ta bort från enhet..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Ta bort från disk..."
@@ -1719,11 +1719,11 @@ msgstr "Tar bort filer"
 msgid "Depth"
 msgstr "Djup"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Ta bort valda spår från kön"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Ta bort spår från kön"
 
@@ -1752,7 +1752,7 @@ msgstr "Enhetsnamn"
 msgid "Device properties..."
 msgstr "Enhetsegenskaper..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Enheter"
 
@@ -2003,7 +2003,7 @@ msgstr "Dynamisk slumpmässig blandning"
 msgid "Edit smart playlist..."
 msgstr "Redigera smart spellista..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Redigera taggen \"%1\"..."
@@ -2142,8 +2142,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Motsvarar --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Fel"
 
@@ -2263,7 +2263,7 @@ msgstr "Exporterat %1 omslag av %2 (%3 överhoppade)"
 
 #: ../bin/src/ui_mainwindow.h:790
 msgid "F9"
-msgstr ""
+msgstr "F9"
 
 #: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
@@ -2289,7 +2289,7 @@ msgstr "Toning"
 msgid "Fading duration"
 msgstr "Toningsvaraktighet"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Fel vid läsning av CD-enhet"
 
@@ -2412,7 +2412,7 @@ msgstr "Filtyp"
 msgid "Filename"
 msgstr "Filnamn"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Filer"
 
@@ -2827,7 +2827,7 @@ msgstr "Installerad"
 msgid "Integrity check"
 msgstr "Integritetskontroll"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -3015,7 +3015,7 @@ msgstr "Vänster"
 msgid "Length"
 msgstr "Längd"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Bibliotek"
@@ -3024,7 +3024,7 @@ msgstr "Bibliotek"
 msgid "Library advanced grouping"
 msgstr "Avancerad bibliotekgruppering"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Notis om omsökning av biblioteket"
 
@@ -3352,7 +3352,7 @@ msgstr "Monteringspunkter"
 msgid "Move down"
 msgstr "Flytta nedåt"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Flytta till biblioteket..."
 
@@ -3361,7 +3361,7 @@ msgstr "Flytta till biblioteket..."
 msgid "Move up"
 msgstr "Flytta uppåt"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Musik"
 
@@ -3423,7 +3423,7 @@ msgstr "Aldrig starta uppspelning"
 msgid "New folder"
 msgstr "Ny mapp"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Ny spellista"
 
@@ -3453,7 +3453,7 @@ msgstr "Nästa"
 
 #: ../bin/src/ui_mainwindow.h:785
 msgid "Next album"
-msgstr ""
+msgstr "Nästa album"
 
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
 #: ../bin/src/ui_mainwindow.h:727
@@ -3494,7 +3494,7 @@ msgstr "Inga korta block"
 msgid "None"
 msgstr "Inga"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Ingen av de valda låtarna lämpar sig för kopiering till en enhet"
 
@@ -3709,7 +3709,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Organisera filer"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Organisera filer..."
 
@@ -3793,7 +3793,7 @@ msgstr "Fest"
 msgid "Password"
 msgstr "Lösenord"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Pausa"
@@ -3829,8 +3829,8 @@ msgstr "Pixel"
 msgid "Plain sidebar"
 msgstr "Vanligt sidofält"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3853,11 +3853,11 @@ msgstr "Spela om stoppad, pausa vid spelning"
 msgid "Play if there is nothing already playing"
 msgstr "Spela om ingenting redan spelas"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Spela nästa"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Spela valda spår som nästa"
 
@@ -3896,7 +3896,7 @@ msgstr "Alternativ för spellista"
 msgid "Playlist type"
 msgstr "Spellistetyp"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Spellistor"
 
@@ -4078,12 +4078,12 @@ msgstr "Kommunicerar med enhet..."
 msgid "Queue Manager"
 msgstr "Köhanterare"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Lägg till valda spår i kön"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Lägg till spår i kön"
 
@@ -4474,7 +4474,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Sök"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Sök"
@@ -4499,7 +4499,7 @@ msgstr "Sök på Subsonic"
 msgid "Search automatically"
 msgstr "Sök automatiskt"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Sök efter album"
 
@@ -4512,7 +4512,7 @@ msgstr "Sök efter albumomslag..."
 msgid "Search for anything"
 msgstr "Sök efter vad som helst"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Sök efter artist"
 
@@ -4637,7 +4637,7 @@ msgstr "Serverdetaljer"
 msgid "Service offline"
 msgstr "Tjänsten inte tillgänglig"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Ställ in %1 till \"%2\"..."
@@ -4717,7 +4717,7 @@ msgstr "Visa en snygg avisering"
 msgid "Show above status bar"
 msgstr "Visa ovanför statusraden"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Visa alla låtar"
 
@@ -4737,12 +4737,12 @@ msgstr "Visa avdelare"
 msgid "Show fullsize..."
 msgstr "Visa i full storlek..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Visa i filhanterare..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Visa i biblioteket..."
 
@@ -4754,11 +4754,11 @@ msgstr "Visa i diverse artister"
 msgid "Show moodbar"
 msgstr "Visa stämningsdiagram"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Visa endast dubbletter"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Visa med saknade taggar"
 
@@ -4850,15 +4850,15 @@ msgstr "Antal överhoppningar"
 msgid "Skip forwards in playlist"
 msgstr "Hoppa framåt i spellista"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Hoppa över valda spår"
 
 #: ../bin/src/ui_mainwindow.h:787
 msgid "Skip to the next album"
-msgstr ""
+msgstr "Hoppa till nästa album"
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Hoppa över spår"
 
@@ -4890,7 +4890,7 @@ msgstr "Soft Rock"
 msgid "Song Information"
 msgstr "Låtinformation"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Låtinfo"
 
@@ -5011,7 +5011,7 @@ msgstr "Stoppa efter varje låt"
 msgid "Stop after every track"
 msgstr "Stoppa efter varje låt"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Stoppa efter detta spår"
 
@@ -5179,7 +5179,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Provperioden för Subsonic-servern är över. Vänligen donera för att få en licensnyckel. Besök subsonic.org för detaljer."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5221,7 +5221,7 @@ msgid ""
 "continue?"
 msgstr "Filerna kommer att tas bort från enheten, är du säker på att du vill fortsätta?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5323,7 +5323,7 @@ msgstr "Växla snygg avisering"
 msgid "Toggle fullscreen"
 msgstr "Växla fullskärm"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Växla köstatus"
 
@@ -5461,11 +5461,11 @@ msgstr "Okänt fel"
 msgid "Unset cover"
 msgstr "Ta bort omslag"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Hoppa inte över valda spår"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Hoppa inte över valt spår"
 
@@ -5802,7 +5802,7 @@ msgid ""
 "well?"
 msgstr "Vill du flytta de andra låtarna i det här albumet till Diverse artister också?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Vill du köra en fullständig omsökning nu?"
 

--- a/src/translations/te.po
+++ b/src/translations/te.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Telugu (http://www.transifex.com/davidsansome/clementine/language/te/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -161,19 +161,19 @@ msgstr ""
 msgid "%filename%"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n విఫలమయ్యాయి"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n పూర్తయ్యాయి"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -191,7 +191,7 @@ msgstr "&మధ్యస్థం"
 msgid "&Custom"
 msgstr "&అనురూపితం"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr ""
 
@@ -199,7 +199,7 @@ msgstr ""
 msgid "&Grouping"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr ""
 
@@ -224,7 +224,7 @@ msgstr ""
 msgid "&Lyrics"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr ""
 
@@ -232,15 +232,15 @@ msgstr ""
 msgid "&None"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr ""
 
@@ -248,7 +248,7 @@ msgstr ""
 msgid "&Right"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr ""
 
@@ -256,7 +256,7 @@ msgstr ""
 msgid "&Stretch columns to fit window"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr ""
 
@@ -445,11 +445,11 @@ msgstr ""
 msgid "About %1"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr ""
 
@@ -509,32 +509,32 @@ msgstr ""
 msgid "Add directory..."
 msgstr ""
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr ""
 
@@ -546,7 +546,7 @@ msgstr ""
 msgid "Add podcast"
 msgstr ""
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr ""
 
@@ -622,7 +622,7 @@ msgstr ""
 msgid "Add song year tag"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr ""
 
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr ""
 
@@ -728,7 +728,7 @@ msgstr ""
 msgid "All Files (*)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr ""
@@ -1119,7 +1119,7 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr ""
 
@@ -1168,18 +1168,18 @@ msgstr ""
 msgid "Cleaning up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr ""
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr ""
 
@@ -1324,7 +1324,7 @@ msgstr ""
 msgid "Complete tags automatically"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr ""
 
@@ -1359,7 +1359,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr ""
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr ""
 
@@ -1431,11 +1431,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1478,14 +1478,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr ""
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1500,7 +1500,7 @@ msgstr ""
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr ""
 
@@ -1653,7 +1653,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr ""
 
@@ -1661,7 +1661,7 @@ msgstr ""
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1694,11 +1694,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr ""
 
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "Display the on-screen-display"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr ""
 
@@ -1978,12 +1978,12 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr ""
 
@@ -1996,7 +1996,7 @@ msgid "Edit track information"
 msgstr ""
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr ""
 
@@ -2104,7 +2104,7 @@ msgstr ""
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr ""
 
@@ -2117,8 +2117,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr ""
 
@@ -2153,7 +2153,7 @@ msgstr ""
 msgid "Error loading di.fm playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr ""
@@ -2236,7 +2236,11 @@ msgstr ""
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr ""
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2260,7 +2264,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2542,11 +2546,11 @@ msgstr ""
 msgid "Go"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr ""
 
@@ -2879,7 +2883,7 @@ msgstr ""
 msgid "Jump to previous song right away"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr ""
 
@@ -2903,7 +2907,7 @@ msgstr ""
 msgid "Keep the original files"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr ""
@@ -2995,7 +2999,7 @@ msgstr ""
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3035,7 +3039,7 @@ msgstr ""
 msgid "Load playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr ""
 
@@ -3096,11 +3100,15 @@ msgstr ""
 msgid "Login failed"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr ""
 
@@ -3135,11 +3143,11 @@ msgstr ""
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr ""
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr ""
@@ -3181,7 +3189,7 @@ msgstr ""
 msgid "Make it so!"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr ""
@@ -3319,7 +3327,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3328,7 +3336,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr ""
 
@@ -3341,7 +3349,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr ""
 
@@ -3390,7 +3398,7 @@ msgstr ""
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3418,8 +3426,12 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr ""
 
@@ -3457,7 +3469,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3542,19 +3554,19 @@ msgstr ""
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr ""
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr ""
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr ""
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3598,7 +3610,7 @@ msgstr ""
 msgid "Open %1 in browser"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr ""
 
@@ -3610,7 +3622,7 @@ msgstr ""
 msgid "Open OPML file..."
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr ""
 
@@ -3618,7 +3630,7 @@ msgstr ""
 msgid "Open device"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr ""
 
@@ -3672,7 +3684,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr ""
 
@@ -3756,7 +3768,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr ""
@@ -3780,6 +3792,10 @@ msgstr ""
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr ""
@@ -3788,10 +3804,10 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr ""
 
@@ -3812,11 +3828,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3915,7 +3931,7 @@ msgstr ""
 msgid "Preferences"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr ""
 
@@ -3975,7 +3991,7 @@ msgid "Previous"
 msgstr ""
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr ""
 
@@ -4033,16 +4049,16 @@ msgstr ""
 msgid "Querying device..."
 msgstr ""
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr ""
 
@@ -4058,7 +4074,7 @@ msgstr ""
 msgid "Rain"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr ""
@@ -4170,7 +4186,7 @@ msgstr ""
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr ""
 
@@ -4178,7 +4194,7 @@ msgstr ""
 msgid "Remove folder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr ""
 
@@ -4190,7 +4206,7 @@ msgstr ""
 msgid "Remove playlists"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr ""
 
@@ -4202,7 +4218,7 @@ msgstr ""
 msgid "Rename playlist..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr ""
 
@@ -4293,7 +4309,7 @@ msgstr ""
 msgid "Rip CD"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr ""
 
@@ -4371,7 +4387,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr ""
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr ""
 
@@ -4458,7 +4474,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4471,7 +4487,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4596,7 +4612,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4605,7 +4621,7 @@ msgstr ""
 msgid "Set the volume to <value> percent"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr ""
 
@@ -4676,7 +4692,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr ""
 
@@ -4696,12 +4712,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr ""
 
@@ -4713,15 +4729,15 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4729,7 +4745,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4765,7 +4781,7 @@ msgstr ""
 msgid "Shuffle all"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr ""
 
@@ -4809,11 +4825,15 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr ""
 
@@ -4930,7 +4950,7 @@ msgstr ""
 msgid "Start the playlist currently playing"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr ""
 
@@ -4940,7 +4960,7 @@ msgid ""
 "list"
 msgstr ""
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr ""
@@ -4950,7 +4970,7 @@ msgid "Starting..."
 msgstr ""
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr ""
 
@@ -4966,7 +4986,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5134,7 +5154,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5176,7 +5196,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5278,11 +5298,11 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr ""
 
@@ -5327,19 +5347,19 @@ msgstr ""
 msgid "Track"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr ""
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
 msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr ""
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr ""
@@ -5416,11 +5436,11 @@ msgstr ""
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr ""
 
@@ -5437,7 +5457,7 @@ msgstr ""
 msgid "Update all podcasts"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr ""
 
@@ -5598,7 +5618,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5606,7 +5626,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr ""
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr ""
 
@@ -5647,7 +5667,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr ""
 
@@ -5743,7 +5763,7 @@ msgstr ""
 msgid "Windows Media 64k"
 msgstr ""
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr ""
 
@@ -5757,7 +5777,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/te.po
+++ b/src/translations/te.po
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add directory..."
 msgstr ""
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgstr ""
 msgid "Add files to transcode"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr ""
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr ""
 
@@ -856,7 +856,7 @@ msgstr ""
 msgid "Artist"
 msgstr ""
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr ""
 
@@ -1119,7 +1119,7 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr ""
 
@@ -1359,7 +1359,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr ""
 
@@ -1431,11 +1431,11 @@ msgid "Copy to clipboard"
 msgstr ""
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr ""
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr ""
@@ -1653,7 +1653,7 @@ msgid "Delete downloaded data"
 msgstr ""
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr ""
 
@@ -1661,7 +1661,7 @@ msgstr ""
 msgid "Delete from device..."
 msgstr ""
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr ""
@@ -1694,11 +1694,11 @@ msgstr ""
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr ""
 
@@ -1727,7 +1727,7 @@ msgstr ""
 msgid "Device properties..."
 msgstr ""
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr ""
 
@@ -1978,7 +1978,7 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr ""
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
@@ -2117,8 +2117,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr ""
 
@@ -2264,7 +2264,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2387,7 +2387,7 @@ msgstr ""
 msgid "Filename"
 msgstr ""
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr ""
 
@@ -2802,7 +2802,7 @@ msgstr ""
 msgid "Integrity check"
 msgstr ""
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr ""
 
@@ -2990,7 +2990,7 @@ msgstr ""
 msgid "Length"
 msgstr ""
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr ""
@@ -2999,7 +2999,7 @@ msgstr ""
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3327,7 +3327,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3336,7 +3336,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr ""
 
@@ -3398,7 +3398,7 @@ msgstr ""
 msgid "New folder"
 msgstr ""
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr ""
 
@@ -3469,7 +3469,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3684,7 +3684,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr ""
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr ""
 
@@ -3768,7 +3768,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr ""
@@ -3804,8 +3804,8 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3828,11 +3828,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Playlist type"
 msgstr ""
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr ""
 
@@ -4053,12 +4053,12 @@ msgstr ""
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr ""
 
@@ -4449,7 +4449,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr ""
@@ -4474,7 +4474,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4487,7 +4487,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4692,7 +4692,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr ""
 
@@ -4712,12 +4712,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr ""
 
@@ -4729,11 +4729,11 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr ""
 
@@ -4825,7 +4825,7 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr ""
 
@@ -4833,7 +4833,7 @@ msgstr ""
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr ""
 
@@ -4865,7 +4865,7 @@ msgstr ""
 msgid "Song Information"
 msgstr ""
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr ""
 
@@ -4986,7 +4986,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5154,7 +5154,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5196,7 +5196,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5298,7 +5298,7 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr ""
 
@@ -5436,11 +5436,11 @@ msgstr ""
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr ""
 
@@ -5777,7 +5777,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/tr.po
+++ b/src/translations/tr.po
@@ -26,7 +26,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Turkish (http://www.transifex.com/davidsansome/clementine/language/tr/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -180,19 +180,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n başarısız"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n tamamlandı"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -210,7 +210,7 @@ msgstr "&Ortala"
 msgid "&Custom"
 msgstr "&Özel"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "Ekler"
 
@@ -218,7 +218,7 @@ msgstr "Ekler"
 msgid "&Grouping"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Yardım"
 
@@ -243,7 +243,7 @@ msgstr ""
 msgid "&Lyrics"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "Müzik"
 
@@ -251,15 +251,15 @@ msgstr "Müzik"
 msgid "&None"
 msgstr "&Hiçbiri"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "Çalma Listesi"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Çık"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "Tekrar kipi"
 
@@ -267,7 +267,7 @@ msgstr "Tekrar kipi"
 msgid "&Right"
 msgstr "&Sağ"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Rastgele kipi"
 
@@ -275,7 +275,7 @@ msgstr "Rastgele kipi"
 msgid "&Stretch columns to fit window"
 msgstr "&Sütunları pencereye sığacak şekilde ayarla"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Araçlar"
 
@@ -464,11 +464,11 @@ msgstr "İptal"
 msgid "About %1"
 msgstr "%1 Hakkında"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Clementine Hakkında..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Qt Hakkında..."
 
@@ -528,32 +528,32 @@ msgstr "Başka bir yayın ekle..."
 msgid "Add directory..."
 msgstr "Dizin ekle..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Dosya ekle"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Dosyayı dönüştürücüye ekle"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Dosyayı/dosyaları dönüştürücüye ekle"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Dosya ekle..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Dönüştürülecek dosyaları ekle"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Klasör ekle"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Klasör ekle..."
 
@@ -565,7 +565,7 @@ msgstr "Yeni klasör ekle..."
 msgid "Add podcast"
 msgstr "Podcast ekle"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Podcast ekle..."
 
@@ -641,7 +641,7 @@ msgstr "Şarkıya parça etiketi ekle"
 msgid "Add song year tag"
 msgstr "Yıl etiketi ekle"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Yayın ekle..."
 
@@ -653,7 +653,7 @@ msgstr "Spotify çalma listelerine ekle"
 msgid "Add to Spotify starred"
 msgstr "Spotify yıldızlılarına ekle"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Başka bir çalma listesine ekle"
 
@@ -747,7 +747,7 @@ msgstr "Tümü"
 msgid "All Files (*)"
 msgstr "Tüm Dosyalar (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "All Glory to the Hypnotoad!"
@@ -1138,7 +1138,7 @@ msgstr "Yeni bölümler için kontrol et"
 msgid "Check for updates"
 msgstr "Güncellemeleri denetle"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Güncellemeleri denetle..."
 
@@ -1187,18 +1187,18 @@ msgstr "Klasik"
 msgid "Cleaning up"
 msgstr "Temizliyor"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Temizle"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Çalma listesini temizle"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1343,7 +1343,7 @@ msgstr "Yorum"
 msgid "Complete tags automatically"
 msgstr "Etiketleri otomatik tamamla"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Etiketleri otomatik tamamla..."
 
@@ -1378,7 +1378,7 @@ msgstr "Subsonic'i yapılandır..."
 msgid "Configure global search..."
 msgstr "Genel aramayı düzenle..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Kütüphaneyi düzenle..."
 
@@ -1421,7 +1421,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Bağlantı zaman aşımına uğradı, sunucu adresini denetleyin. Örnek: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Konsol"
 
@@ -1450,11 +1450,11 @@ msgid "Copy to clipboard"
 msgstr "Panoya kopyala"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Aygıta kopyala..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kütüphaneye kopyala..."
@@ -1497,14 +1497,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr "Çalma listesi oluşturulamadı"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "%1 için ayrıştırıcı bulunamadı, gerekli GStreamer eklentilerinin kurulu olup olmadığını kontrol edin"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1519,7 +1519,7 @@ msgstr "%1 çıktı dosyası açılamadı"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Kapak Yöneticisi"
 
@@ -1672,7 +1672,7 @@ msgid "Delete downloaded data"
 msgstr "İndirilmiş veriyi sil"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Dosyaları sil"
 
@@ -1680,7 +1680,7 @@ msgstr "Dosyaları sil"
 msgid "Delete from device..."
 msgstr "Aygıttan sil..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Diskten sil..."
@@ -1713,11 +1713,11 @@ msgstr "Dosyalar siliniyor"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Seçili parçaları kuyruktan çıkar"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Parçayı kuyruktan çıkar"
 
@@ -1818,7 +1818,7 @@ msgstr "Gösterim seçenekleri"
 msgid "Display the on-screen-display"
 msgstr "Ekran görselini göster"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Tüm kütüphaneyi yeniden tara"
 
@@ -1997,12 +1997,12 @@ msgstr "Dinamik rastgele karışım"
 msgid "Edit smart playlist..."
 msgstr "Akıllı çalma listesini düzenleyin"
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "\"%1\" etiketini düzenle..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Etiketi düzenle..."
 
@@ -2015,7 +2015,7 @@ msgid "Edit track information"
 msgstr "Parça bilgisini düzenle"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Parça bilgisini düzenle..."
 
@@ -2123,7 +2123,7 @@ msgstr "Tüm koleksiyon"
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Ekolayzır"
 
@@ -2136,8 +2136,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "--log-levels *:3'e eşdeğer"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Hata"
 
@@ -2172,7 +2172,7 @@ msgstr "%1 yüklenirken hata"
 msgid "Error loading di.fm playlist"
 msgstr "di.fm çalma listesi yüklenirken hata oluştu"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "%1 işlenirken hata: %2"
@@ -2255,7 +2255,11 @@ msgstr "Biteni aktar"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "%2 kapağın %1 tanesi aktarıldı (%3 atlandı)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2279,7 +2283,7 @@ msgstr "Yumuşak geçiş"
 msgid "Fading duration"
 msgstr "Yumuşak geçiş süresi"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "CD sürücünü okuma başarısız"
 
@@ -2561,11 +2565,11 @@ msgstr "Bir isim verin:"
 msgid "Go"
 msgstr "Git"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Sıradaki listeye git"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Önceki listeye git"
 
@@ -2898,7 +2902,7 @@ msgstr "Jamendo veritabanı"
 msgid "Jump to previous song right away"
 msgstr "Hemen bir önceki şarkıya gidecek"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Şu anda çalınan parçaya atla"
 
@@ -2922,7 +2926,7 @@ msgstr "Pencere kapandığında arkaplanda çalışmaya devam et"
 msgid "Keep the original files"
 msgstr "Orijinal dosyaları sakla"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Kedicikler"
@@ -3014,7 +3018,7 @@ msgstr "Kütüphane"
 msgid "Library advanced grouping"
 msgstr "Kütüphane gelişmiş gruplama"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Kütüphane yeniden tarama bildirisi"
 
@@ -3054,7 +3058,7 @@ msgstr "Albüm kapağını diskten yükle..."
 msgid "Load playlist"
 msgstr "Çalma listesini yükle"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Çalma listesi yükle..."
 
@@ -3115,11 +3119,15 @@ msgstr "Oturum aç"
 msgid "Login failed"
 msgstr "Giriş başarısız oldu."
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Long term prediction profile (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Beğen"
 
@@ -3154,11 +3162,11 @@ msgstr "%1 sitesinden şarkı sözleri"
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3200,7 +3208,7 @@ msgstr "Ana profil (MAIN)"
 msgid "Make it so!"
 msgstr "Yap gitsin!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Yap gitsin!"
@@ -3338,7 +3346,7 @@ msgstr "Bağlama noktaları"
 msgid "Move down"
 msgstr "Aşağı taşı"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Kütüphaneye taşı..."
 
@@ -3347,7 +3355,7 @@ msgstr "Kütüphaneye taşı..."
 msgid "Move up"
 msgstr "Yukarı taşı"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Müzik"
 
@@ -3360,7 +3368,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Sessiz"
 
@@ -3409,7 +3417,7 @@ msgstr "Asla çalarak başlama"
 msgid "New folder"
 msgstr "Yeni klasör"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Yeni çalma listesi"
 
@@ -3437,8 +3445,12 @@ msgstr "En yeni parçalar"
 msgid "Next"
 msgstr "İleri"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Sonraki parça"
 
@@ -3476,7 +3488,7 @@ msgstr "Kısa blok yok"
 msgid "None"
 msgstr "Hiçbiri"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Seçili şarkıların hiçbiri aygıta yüklemeye uygun değil"
 
@@ -3561,19 +3573,19 @@ msgstr "Kapalı"
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3617,7 +3629,7 @@ msgstr "Opaklık"
 msgid "Open %1 in browser"
 msgstr "Tarayıcıda aç: %1"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "&Ses CD'si aç..."
 
@@ -3629,7 +3641,7 @@ msgstr "OPML dosyası aç"
 msgid "Open OPML file..."
 msgstr "OPML dosyasını aç..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Müziğin içe aktarılacağı bir dizin aç"
 
@@ -3637,7 +3649,7 @@ msgstr "Müziğin içe aktarılacağı bir dizin aç"
 msgid "Open device"
 msgstr "Aygıtı aç"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Dosya aç..."
 
@@ -3691,7 +3703,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Dosyaları Düzenle"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Dosyaları düzenle..."
 
@@ -3775,7 +3787,7 @@ msgstr "Parti"
 msgid "Password"
 msgstr "Parola"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Duraklat"
@@ -3799,6 +3811,10 @@ msgstr "Sanatçı"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Piksel"
@@ -3807,10 +3823,10 @@ msgstr "Piksel"
 msgid "Plain sidebar"
 msgstr "Düz kenar çubuğu"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Çal"
 
@@ -3831,11 +3847,11 @@ msgstr "Duraklatılmışsa çal, çalıyorsa beklet"
 msgid "Play if there is nothing already playing"
 msgstr "Çalan bir şey yoksa çal"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3934,7 +3950,7 @@ msgstr "Tercih"
 msgid "Preferences"
 msgstr "Tercihler"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Tercihler..."
 
@@ -3994,7 +4010,7 @@ msgid "Previous"
 msgstr "Önceki"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Önceki parça"
 
@@ -4052,16 +4068,16 @@ msgstr "Kalite"
 msgid "Querying device..."
 msgstr "Aygıt sorgulanıyor..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Kuyruk Yöneticisi"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Seçili parçaları kuyruğa ekle"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Parçayı kuyruğa ekle"
 
@@ -4077,7 +4093,7 @@ msgstr "Radyo (tüm parçalar için eşit ses seviyesi)"
 msgid "Rain"
 msgstr "Yağmur"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Yağmur"
@@ -4189,7 +4205,7 @@ msgstr "Eylemi kaldır"
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Şarkı listesindeki çiftleri birleştir"
 
@@ -4197,7 +4213,7 @@ msgstr "Şarkı listesindeki çiftleri birleştir"
 msgid "Remove folder"
 msgstr "Klasörü kaldır..."
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Çalma listesinden kaldır"
 
@@ -4209,7 +4225,7 @@ msgstr "Çalma listesini kaldır"
 msgid "Remove playlists"
 msgstr "Çalma listesini kaldır"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Şarkı listesindeki kullanılamayan parçaları kaldır"
 
@@ -4221,7 +4237,7 @@ msgstr "Çalma listesini yeniden adlandır"
 msgid "Rename playlist..."
 msgstr "Çalma listesini yeniden adlandır..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Parçaları bu sırada hatırla..."
 
@@ -4312,7 +4328,7 @@ msgstr "Dönüştür"
 msgid "Rip CD"
 msgstr "CD Dönüştür"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Ses CD'si dönüştür"
 
@@ -4390,7 +4406,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Çalma listesini kaydet"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Çalma listesini kaydet..."
 
@@ -4477,7 +4493,7 @@ msgstr "Subsonic'de Ara"
 msgid "Search automatically"
 msgstr "Otomatik ara"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4490,7 +4506,7 @@ msgstr "Albüm kapaklarını ara..."
 msgid "Search for anything"
 msgstr "Herhangi bir şey ara"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4615,7 +4631,7 @@ msgstr "Sunucu ayrıntıları"
 msgid "Service offline"
 msgstr "Hizmet çevrim dışı"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "%1'i \"%2\" olarak ayarla"
@@ -4624,7 +4640,7 @@ msgstr "%1'i \"%2\" olarak ayarla"
 msgid "Set the volume to <value> percent"
 msgstr "Ses seviyesini yüzde <value> yap"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Seçili tüm parçalar için değeri ayarla..."
 
@@ -4695,7 +4711,7 @@ msgstr "Şirin bir OSD göster"
 msgid "Show above status bar"
 msgstr "Durum çubuğunun üzerinde göster"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Tüm şarkıları göster"
 
@@ -4715,12 +4731,12 @@ msgstr "Ayırıcıları göster"
 msgid "Show fullsize..."
 msgstr "Tam boyutta göster"
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Dosya gözatıcısında göster..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Kütüphanede göster..."
 
@@ -4732,15 +4748,15 @@ msgstr "Çeşitli sanatçılarda göster"
 msgid "Show moodbar"
 msgstr "Atmosfer çubuğunu göster"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Sadece aynı olanları göster"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Sadece etiketi olmayanları göster"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4748,7 +4764,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr "Arama önerilerini göster"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4784,7 +4800,7 @@ msgstr "Albümleri karıştır"
 msgid "Shuffle all"
 msgstr "Hepsini karıştır"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Çalma listesini karıştır"
 
@@ -4828,11 +4844,15 @@ msgstr "Atlama sayısı"
 msgid "Skip forwards in playlist"
 msgstr "Parça listesinde ileri git"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Seçili parçaları atla"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Parçayı atla"
 
@@ -4949,7 +4969,7 @@ msgstr "Dönüştürmeyi başlat"
 msgid "Start the playlist currently playing"
 msgstr "Çalma listesini mevcut çalınanla başlat"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Dönüştürmeye başla"
 
@@ -4959,7 +4979,7 @@ msgid ""
 "list"
 msgstr "Arama sonucunu görmek için arama kutusuna bir şeyler yazmaya başlayın."
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "%1 Başlatılıyor"
@@ -4969,7 +4989,7 @@ msgid "Starting..."
 msgstr "Başlatılıyor..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Durdur"
 
@@ -4985,7 +5005,7 @@ msgstr "Her parçadan sonra dur"
 msgid "Stop after every track"
 msgstr "Her parçadan sonra dur"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Bu parçadan sonra durdur"
 
@@ -5153,7 +5173,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Subsonic sunucusunun deneme süresi bitti. Lisans anahtarı almak için lütfen bağış yapın. Ayrıntılar için subsonic.org'u ziyaret edin."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5195,7 +5215,7 @@ msgid ""
 "continue?"
 msgstr "Bu dosyalar aygıttan silinecek, devam etmek istiyor musunuz?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5297,11 +5317,11 @@ msgstr "Şirin OSD'yi Aç/Kapa"
 msgid "Toggle fullscreen"
 msgstr "Tam ekran göster/gizle"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Kuyruk durumunu göster/gizle"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Skroplamayı aç/kapa"
 
@@ -5346,19 +5366,19 @@ msgstr ""
 msgid "Track"
 msgstr "Parça"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Müzik Dönüştür"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Dönüştürücü Kaydı"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Kod çevrimi"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "%1 adet dosya %2 adet thread ile dönüştürülüyor"
@@ -5435,11 +5455,11 @@ msgstr "Bilinmeyen hata"
 msgid "Unset cover"
 msgstr "Albüm kapağını çıkar"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Seçili parçaları atlama"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Parçayı atlama"
 
@@ -5456,7 +5476,7 @@ msgstr "Yaklaşan Konserler"
 msgid "Update all podcasts"
 msgstr "Bütün podcastları güncelle"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Değişen kütüphane klasörlerini güncelle"
 
@@ -5617,7 +5637,7 @@ msgstr "Sürüm %1"
 msgid "View"
 msgstr "Görünüm"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5625,7 +5645,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr "Görüntüleme kipi"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Görseller"
 
@@ -5666,7 +5686,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5762,7 +5782,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Medya 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media audio"
 
@@ -5776,7 +5796,7 @@ msgid ""
 "well?"
 msgstr "Bu albümdeki diğer şarkıları da Çeşitli Sanatçılar'a taşımak ister misiniz?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Şu anda tam bir yeniden tarama çalıştırmak ister misiniz?"
 

--- a/src/translations/tr.po
+++ b/src/translations/tr.po
@@ -528,7 +528,7 @@ msgstr "Başka bir yayın ekle..."
 msgid "Add directory..."
 msgstr "Dizin ekle..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Dosya ekle"
 
@@ -548,7 +548,7 @@ msgstr "Dosya ekle..."
 msgid "Add files to transcode"
 msgstr "Dönüştürülecek dosyaları ekle"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Klasör ekle"
@@ -653,7 +653,7 @@ msgstr "Spotify çalma listelerine ekle"
 msgid "Add to Spotify starred"
 msgstr "Spotify yıldızlılarına ekle"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Başka bir çalma listesine ekle"
 
@@ -875,7 +875,7 @@ msgstr "Şarkıların istatistiklerini, kütüphanenizdeki tüm şarkıların ke
 msgid "Artist"
 msgstr "Sanatçı"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Sanatçı bilgisi"
 
@@ -1138,7 +1138,7 @@ msgstr "Yeni bölümler için kontrol et"
 msgid "Check for updates"
 msgstr "Güncellemeleri denetle"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Güncellemeleri denetle..."
 
@@ -1378,7 +1378,7 @@ msgstr "Subsonic'i yapılandır..."
 msgid "Configure global search..."
 msgstr "Genel aramayı düzenle..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Kütüphaneyi düzenle..."
 
@@ -1450,11 +1450,11 @@ msgid "Copy to clipboard"
 msgstr "Panoya kopyala"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Aygıta kopyala..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kütüphaneye kopyala..."
@@ -1672,7 +1672,7 @@ msgid "Delete downloaded data"
 msgstr "İndirilmiş veriyi sil"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Dosyaları sil"
 
@@ -1680,7 +1680,7 @@ msgstr "Dosyaları sil"
 msgid "Delete from device..."
 msgstr "Aygıttan sil..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Diskten sil..."
@@ -1713,11 +1713,11 @@ msgstr "Dosyalar siliniyor"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Seçili parçaları kuyruktan çıkar"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Parçayı kuyruktan çıkar"
 
@@ -1746,7 +1746,7 @@ msgstr "Aygıt adı"
 msgid "Device properties..."
 msgstr "Aygıt özellikleri..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Aygıtlar"
 
@@ -1997,7 +1997,7 @@ msgstr "Dinamik rastgele karışım"
 msgid "Edit smart playlist..."
 msgstr "Akıllı çalma listesini düzenleyin"
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "\"%1\" etiketini düzenle..."
@@ -2136,8 +2136,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "--log-levels *:3'e eşdeğer"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Hata"
 
@@ -2283,7 +2283,7 @@ msgstr "Yumuşak geçiş"
 msgid "Fading duration"
 msgstr "Yumuşak geçiş süresi"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "CD sürücünü okuma başarısız"
 
@@ -2406,7 +2406,7 @@ msgstr "Dosya türü"
 msgid "Filename"
 msgstr "Dosya adı"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Dosyalar"
 
@@ -2821,7 +2821,7 @@ msgstr "Kuruldu"
 msgid "Integrity check"
 msgstr "Bütünlük doğrulaması"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -3009,7 +3009,7 @@ msgstr "So"
 msgid "Length"
 msgstr "Süre"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Kütüphane"
@@ -3018,7 +3018,7 @@ msgstr "Kütüphane"
 msgid "Library advanced grouping"
 msgstr "Kütüphane gelişmiş gruplama"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Kütüphane yeniden tarama bildirisi"
 
@@ -3346,7 +3346,7 @@ msgstr "Bağlama noktaları"
 msgid "Move down"
 msgstr "Aşağı taşı"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Kütüphaneye taşı..."
 
@@ -3355,7 +3355,7 @@ msgstr "Kütüphaneye taşı..."
 msgid "Move up"
 msgstr "Yukarı taşı"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Müzik"
 
@@ -3417,7 +3417,7 @@ msgstr "Asla çalarak başlama"
 msgid "New folder"
 msgstr "Yeni klasör"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Yeni çalma listesi"
 
@@ -3488,7 +3488,7 @@ msgstr "Kısa blok yok"
 msgid "None"
 msgstr "Hiçbiri"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Seçili şarkıların hiçbiri aygıta yüklemeye uygun değil"
 
@@ -3703,7 +3703,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Dosyaları Düzenle"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Dosyaları düzenle..."
 
@@ -3787,7 +3787,7 @@ msgstr "Parti"
 msgid "Password"
 msgstr "Parola"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Duraklat"
@@ -3823,8 +3823,8 @@ msgstr "Piksel"
 msgid "Plain sidebar"
 msgstr "Düz kenar çubuğu"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3847,11 +3847,11 @@ msgstr "Duraklatılmışsa çal, çalıyorsa beklet"
 msgid "Play if there is nothing already playing"
 msgstr "Çalan bir şey yoksa çal"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3890,7 +3890,7 @@ msgstr "Çalma listesi seçenekleri"
 msgid "Playlist type"
 msgstr "Çalma listesi türü"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Çalma listeleri"
 
@@ -4072,12 +4072,12 @@ msgstr "Aygıt sorgulanıyor..."
 msgid "Queue Manager"
 msgstr "Kuyruk Yöneticisi"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Seçili parçaları kuyruğa ekle"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Parçayı kuyruğa ekle"
 
@@ -4468,7 +4468,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Ara"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Ara"
@@ -4493,7 +4493,7 @@ msgstr "Subsonic'de Ara"
 msgid "Search automatically"
 msgstr "Otomatik ara"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4506,7 +4506,7 @@ msgstr "Albüm kapaklarını ara..."
 msgid "Search for anything"
 msgstr "Herhangi bir şey ara"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4631,7 +4631,7 @@ msgstr "Sunucu ayrıntıları"
 msgid "Service offline"
 msgstr "Hizmet çevrim dışı"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "%1'i \"%2\" olarak ayarla"
@@ -4711,7 +4711,7 @@ msgstr "Şirin bir OSD göster"
 msgid "Show above status bar"
 msgstr "Durum çubuğunun üzerinde göster"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Tüm şarkıları göster"
 
@@ -4731,12 +4731,12 @@ msgstr "Ayırıcıları göster"
 msgid "Show fullsize..."
 msgstr "Tam boyutta göster"
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Dosya gözatıcısında göster..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Kütüphanede göster..."
 
@@ -4748,11 +4748,11 @@ msgstr "Çeşitli sanatçılarda göster"
 msgid "Show moodbar"
 msgstr "Atmosfer çubuğunu göster"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Sadece aynı olanları göster"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Sadece etiketi olmayanları göster"
 
@@ -4844,7 +4844,7 @@ msgstr "Atlama sayısı"
 msgid "Skip forwards in playlist"
 msgstr "Parça listesinde ileri git"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Seçili parçaları atla"
 
@@ -4852,7 +4852,7 @@ msgstr "Seçili parçaları atla"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Parçayı atla"
 
@@ -4884,7 +4884,7 @@ msgstr "Hafif Rock"
 msgid "Song Information"
 msgstr "Şarkı Bilgisi"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Şarkı bilgisi"
 
@@ -5005,7 +5005,7 @@ msgstr "Her parçadan sonra dur"
 msgid "Stop after every track"
 msgstr "Her parçadan sonra dur"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Bu parçadan sonra durdur"
 
@@ -5173,7 +5173,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Subsonic sunucusunun deneme süresi bitti. Lisans anahtarı almak için lütfen bağış yapın. Ayrıntılar için subsonic.org'u ziyaret edin."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5215,7 +5215,7 @@ msgid ""
 "continue?"
 msgstr "Bu dosyalar aygıttan silinecek, devam etmek istiyor musunuz?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5317,7 +5317,7 @@ msgstr "Şirin OSD'yi Aç/Kapa"
 msgid "Toggle fullscreen"
 msgstr "Tam ekran göster/gizle"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Kuyruk durumunu göster/gizle"
 
@@ -5455,11 +5455,11 @@ msgstr "Bilinmeyen hata"
 msgid "Unset cover"
 msgstr "Albüm kapağını çıkar"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Seçili parçaları atlama"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Parçayı atlama"
 
@@ -5796,7 +5796,7 @@ msgid ""
 "well?"
 msgstr "Bu albümdeki diğer şarkıları da Çeşitli Sanatçılar'a taşımak ister misiniz?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Şu anda tam bir yeniden tarama çalıştırmak ister misiniz?"
 

--- a/src/translations/tr_TR.po
+++ b/src/translations/tr_TR.po
@@ -545,7 +545,7 @@ msgstr "Başka bir yayın ekle..."
 msgid "Add directory..."
 msgstr "Dizin ekle..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Dosya ekle"
 
@@ -565,7 +565,7 @@ msgstr "Dosya ekle..."
 msgid "Add files to transcode"
 msgstr "Dönüştürülecek dosyaları ekle"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Klasör ekle"
@@ -670,7 +670,7 @@ msgstr "Spotify çalma listelerine ekle"
 msgid "Add to Spotify starred"
 msgstr "Spotify yıldızlılarına ekle"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Başka bir çalma listesine ekle"
 
@@ -892,7 +892,7 @@ msgstr "Şarkıların istatistiklerini, kütüphanenizdeki tüm şarkıların ke
 msgid "Artist"
 msgstr "Sanatçı"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Sanatçı bilgisi"
 
@@ -1155,7 +1155,7 @@ msgstr "Yeni bölümler için kontrol et"
 msgid "Check for updates"
 msgstr "Güncellemeleri denetle"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Güncellemeleri denetle..."
 
@@ -1395,7 +1395,7 @@ msgstr "Subsonic'i yapılandır..."
 msgid "Configure global search..."
 msgstr "Genel aramayı düzenle..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Kütüphaneyi düzenle..."
 
@@ -1467,11 +1467,11 @@ msgid "Copy to clipboard"
 msgstr "Panoya kopyala"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Aygıta kopyala..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kütüphaneye kopyala..."
@@ -1689,7 +1689,7 @@ msgid "Delete downloaded data"
 msgstr "İndirilmiş veriyi sil"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Dosyaları sil"
 
@@ -1697,7 +1697,7 @@ msgstr "Dosyaları sil"
 msgid "Delete from device..."
 msgstr "Aygıttan sil..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Diskten sil..."
@@ -1730,11 +1730,11 @@ msgstr "Dosyalar siliniyor"
 msgid "Depth"
 msgstr "Derinlik"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Seçili parçaları kuyruktan çıkar"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Parçayı kuyruktan çıkar"
 
@@ -1763,7 +1763,7 @@ msgstr "Aygıt adı"
 msgid "Device properties..."
 msgstr "Aygıt özellikleri..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Aygıtlar"
 
@@ -2014,7 +2014,7 @@ msgstr "Dinamik rastgele karışım"
 msgid "Edit smart playlist..."
 msgstr "Akıllı çalma listesini düzenleyin"
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "\"%1\" etiketini düzenle..."
@@ -2153,8 +2153,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "--log-levels *:3'e eşdeğer"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Hata"
 
@@ -2300,7 +2300,7 @@ msgstr "Yumuşak geçiş"
 msgid "Fading duration"
 msgstr "Yumuşak geçiş süresi"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "CD sürücünü okuma başarısız"
 
@@ -2423,7 +2423,7 @@ msgstr "Dosya türü"
 msgid "Filename"
 msgstr "Dosya adı"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Dosyalar"
 
@@ -2838,7 +2838,7 @@ msgstr "Kuruldu"
 msgid "Integrity check"
 msgstr "Bütünlük doğrulaması"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -3026,7 +3026,7 @@ msgstr "Sol"
 msgid "Length"
 msgstr "Süre"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Kütüphane"
@@ -3035,7 +3035,7 @@ msgstr "Kütüphane"
 msgid "Library advanced grouping"
 msgstr "Kütüphane gelişmiş gruplama"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Kütüphane yeniden tarama bildirisi"
 
@@ -3363,7 +3363,7 @@ msgstr "Bağlama noktaları"
 msgid "Move down"
 msgstr "Aşağı taşı"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Kütüphaneye taşı..."
 
@@ -3372,7 +3372,7 @@ msgstr "Kütüphaneye taşı..."
 msgid "Move up"
 msgstr "Yukarı taşı"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Müzik"
 
@@ -3434,7 +3434,7 @@ msgstr "Asla çalarak başlama"
 msgid "New folder"
 msgstr "Yeni klasör"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Yeni çalma listesi"
 
@@ -3505,7 +3505,7 @@ msgstr "Kısa blok yok"
 msgid "None"
 msgstr "Hiçbiri"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Seçili şarkıların hiçbiri aygıta yüklemeye uygun değil"
 
@@ -3720,7 +3720,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Dosyaları Düzenle"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Dosyaları düzenle..."
 
@@ -3804,7 +3804,7 @@ msgstr "Parti"
 msgid "Password"
 msgstr "Parola"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Duraklat"
@@ -3840,8 +3840,8 @@ msgstr "Piksel"
 msgid "Plain sidebar"
 msgstr "Düz kenar çubuğu"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3864,11 +3864,11 @@ msgstr "Duraklatılmışsa çal, çalıyorsa beklet"
 msgid "Play if there is nothing already playing"
 msgstr "Çalan bir şey yoksa çal"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Sonrakini oynat"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Sonraki parçaları oynat"
 
@@ -3907,7 +3907,7 @@ msgstr "Çalma listesi seçenekleri"
 msgid "Playlist type"
 msgstr "Çalma listesi türü"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Çalma listeleri"
 
@@ -4089,12 +4089,12 @@ msgstr "Aygıt sorgulanıyor..."
 msgid "Queue Manager"
 msgstr "Kuyruk Yöneticisi"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Seçili parçaları kuyruğa ekle"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Parçayı kuyruğa ekle"
 
@@ -4485,7 +4485,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Ara"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Ara"
@@ -4510,7 +4510,7 @@ msgstr "Subsonic'de Ara"
 msgid "Search automatically"
 msgstr "Otomatik ara"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Albüme göre ara"
 
@@ -4523,7 +4523,7 @@ msgstr "Albüm kapaklarını ara..."
 msgid "Search for anything"
 msgstr "Herhangi bir şey ara"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Sanatçıya göre ara"
 
@@ -4648,7 +4648,7 @@ msgstr "Sunucu ayrıntıları"
 msgid "Service offline"
 msgstr "Hizmet çevrim dışı"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "%1'i \"%2\" olarak ayarla"
@@ -4728,7 +4728,7 @@ msgstr "Zarif bir OSD göster"
 msgid "Show above status bar"
 msgstr "Durum çubuğunun üzerinde göster"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Tüm şarkıları göster"
 
@@ -4748,12 +4748,12 @@ msgstr "Ayırıcıları göster"
 msgid "Show fullsize..."
 msgstr "Tam boyutta göster"
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Dosya gözatıcısında göster..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Kütüphanede göster..."
 
@@ -4765,11 +4765,11 @@ msgstr "Çeşitli sanatçılarda göster"
 msgid "Show moodbar"
 msgstr "Atmosfer çubuğunu göster"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Sadece aynı olanları göster"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Sadece etiketi olmayanları göster"
 
@@ -4861,7 +4861,7 @@ msgstr "Atlama sayısı"
 msgid "Skip forwards in playlist"
 msgstr "Parça listesinde ileri git"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Seçili parçaları atla"
 
@@ -4869,7 +4869,7 @@ msgstr "Seçili parçaları atla"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Parçayı atla"
 
@@ -4901,7 +4901,7 @@ msgstr "Hafif Rock"
 msgid "Song Information"
 msgstr "Şarkı Bilgisi"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Şarkı bilgisi"
 
@@ -5022,7 +5022,7 @@ msgstr "Her parçadan sonra dur"
 msgid "Stop after every track"
 msgstr "Her parçadan sonra dur"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Bu parçadan sonra durdur"
 
@@ -5190,7 +5190,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Subsonic sunucusunun deneme süresi bitti. Lisans anahtarı almak için lütfen bağış yapın. Ayrıntılar için subsonic.org'u ziyaret edin."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5232,7 +5232,7 @@ msgid ""
 "continue?"
 msgstr "Bu dosyalar aygıttan silinecek, devam etmek istiyor musunuz?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5334,7 +5334,7 @@ msgstr "Zarif OSD'yi Aç/Kapa"
 msgid "Toggle fullscreen"
 msgstr "Tam ekran göster/gizle"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Kuyruk durumunu göster/gizle"
 
@@ -5472,11 +5472,11 @@ msgstr "Bilinmeyen hata"
 msgid "Unset cover"
 msgstr "Albüm kapağını çıkar"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Seçili parçaları atlama"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Parçayı atlama"
 
@@ -5813,7 +5813,7 @@ msgid ""
 "well?"
 msgstr "Bu albümdeki diğer şarkıları da Çeşitli Sanatçılar'a taşımak ister misiniz?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Şu anda tam bir yeniden tarama çalıştırmak ister misiniz?"
 

--- a/src/translations/tr_TR.po
+++ b/src/translations/tr_TR.po
@@ -43,7 +43,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Turkish (Turkey) (http://www.transifex.com/davidsansome/clementine/language/tr_TR/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -197,19 +197,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n başarısız"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n tamamlandı"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -227,7 +227,7 @@ msgstr "&Ortala"
 msgid "&Custom"
 msgstr "&Özel"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "Ekler"
 
@@ -235,7 +235,7 @@ msgstr "Ekler"
 msgid "&Grouping"
 msgstr "&Gruplandırma"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Yardım"
 
@@ -260,7 +260,7 @@ msgstr "Reyting &Kilitle"
 msgid "&Lyrics"
 msgstr "&Şarkı sözleri"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "Müzik"
 
@@ -268,15 +268,15 @@ msgstr "Müzik"
 msgid "&None"
 msgstr "&Hiçbiri"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "Çalma Listesi"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Çık"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "Tekrar kipi"
 
@@ -284,7 +284,7 @@ msgstr "Tekrar kipi"
 msgid "&Right"
 msgstr "&Sağ"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Rastgele kipi"
 
@@ -292,7 +292,7 @@ msgstr "Rastgele kipi"
 msgid "&Stretch columns to fit window"
 msgstr "&Sütunları pencereye sığacak şekilde ayarla"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Araçlar"
 
@@ -481,11 +481,11 @@ msgstr "İptal"
 msgid "About %1"
 msgstr "%1 Hakkında"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Clementine Hakkında..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Qt Hakkında..."
 
@@ -545,32 +545,32 @@ msgstr "Başka bir yayın ekle..."
 msgid "Add directory..."
 msgstr "Dizin ekle..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Dosya ekle"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Dosyayı dönüştürücüye ekle"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Dosyayı/dosyaları dönüştürücüye ekle"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Dosya ekle..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Dönüştürülecek dosyaları ekle"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Klasör ekle"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Klasör ekle..."
 
@@ -582,7 +582,7 @@ msgstr "Yeni klasör ekle..."
 msgid "Add podcast"
 msgstr "Podcast ekle"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Podcast ekle..."
 
@@ -658,7 +658,7 @@ msgstr "Şarkıya parça etiketi ekle"
 msgid "Add song year tag"
 msgstr "Yıl etiketi ekle"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Yayın ekle..."
 
@@ -670,7 +670,7 @@ msgstr "Spotify çalma listelerine ekle"
 msgid "Add to Spotify starred"
 msgstr "Spotify yıldızlılarına ekle"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Başka bir çalma listesine ekle"
 
@@ -764,7 +764,7 @@ msgstr "Tümü"
 msgid "All Files (*)"
 msgstr "Tüm Dosyalar (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Tüm şeref Hypnotoad'a gitsin!"
@@ -1155,7 +1155,7 @@ msgstr "Yeni bölümler için kontrol et"
 msgid "Check for updates"
 msgstr "Güncellemeleri denetle"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Güncellemeleri denetle..."
 
@@ -1204,18 +1204,18 @@ msgstr "Klasik"
 msgid "Cleaning up"
 msgstr "Temizliyor"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Temizle"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Çalma listesini temizle"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1360,7 +1360,7 @@ msgstr "Yorum"
 msgid "Complete tags automatically"
 msgstr "Etiketleri otomatik tamamla"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Etiketleri otomatik tamamla..."
 
@@ -1395,7 +1395,7 @@ msgstr "Subsonic'i yapılandır..."
 msgid "Configure global search..."
 msgstr "Genel aramayı düzenle..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Kütüphaneyi düzenle..."
 
@@ -1438,7 +1438,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Bağlantı zaman aşımına uğradı, sunucu adresini denetleyin. Örnek: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Konsol"
 
@@ -1467,11 +1467,11 @@ msgid "Copy to clipboard"
 msgstr "Panoya kopyala"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Aygıta kopyala..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kütüphaneye kopyala..."
@@ -1514,14 +1514,14 @@ msgstr "Last.fm'e giriş yapılamadı. Lütfen tekrar deneyiniz."
 msgid "Couldn't create playlist"
 msgstr "Çalma listesi oluşturulamadı"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "%1 için ayrıştırıcı bulunamadı, gerekli GStreamer eklentilerinin kurulu olup olmadığını kontrol edin"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1536,7 +1536,7 @@ msgstr "%1 çıktı dosyası açılamadı"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Kapak Yöneticisi"
 
@@ -1689,7 +1689,7 @@ msgid "Delete downloaded data"
 msgstr "İndirilmiş veriyi sil"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Dosyaları sil"
 
@@ -1697,7 +1697,7 @@ msgstr "Dosyaları sil"
 msgid "Delete from device..."
 msgstr "Aygıttan sil..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Diskten sil..."
@@ -1730,11 +1730,11 @@ msgstr "Dosyalar siliniyor"
 msgid "Depth"
 msgstr "Derinlik"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Seçili parçaları kuyruktan çıkar"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Parçayı kuyruktan çıkar"
 
@@ -1835,7 +1835,7 @@ msgstr "Gösterim seçenekleri"
 msgid "Display the on-screen-display"
 msgstr "Ekran görselini göster"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Tüm kütüphaneyi yeniden tara"
 
@@ -2014,12 +2014,12 @@ msgstr "Dinamik rastgele karışım"
 msgid "Edit smart playlist..."
 msgstr "Akıllı çalma listesini düzenleyin"
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "\"%1\" etiketini düzenle..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Etiketi düzenle..."
 
@@ -2032,7 +2032,7 @@ msgid "Edit track information"
 msgstr "Parça bilgisini düzenle"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Parça bilgisini düzenle..."
 
@@ -2140,7 +2140,7 @@ msgstr "Tüm koleksiyon"
 msgid "Episode information"
 msgstr "Bölüm bilgisi"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Ekolayzır"
 
@@ -2153,8 +2153,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "--log-levels *:3'e eşdeğer"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Hata"
 
@@ -2189,7 +2189,7 @@ msgstr "%1 yüklenirken hata"
 msgid "Error loading di.fm playlist"
 msgstr "di.fm çalma listesi yüklenirken hata oluştu"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "%1 işlenirken hata: %2"
@@ -2272,7 +2272,11 @@ msgstr "Biteni aktar"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "%2 kapağın %1 tanesi aktarıldı (%3 atlandı)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2296,7 +2300,7 @@ msgstr "Yumuşak geçiş"
 msgid "Fading duration"
 msgstr "Yumuşak geçiş süresi"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "CD sürücünü okuma başarısız"
 
@@ -2578,11 +2582,11 @@ msgstr "Bir isim verin:"
 msgid "Go"
 msgstr "Git"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Sıradaki listeye git"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Önceki listeye git"
 
@@ -2915,7 +2919,7 @@ msgstr "Jamendo veritabanı"
 msgid "Jump to previous song right away"
 msgstr "Hemen bir önceki şarkıya gidecek"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Şu anda çalınan parçaya atla"
 
@@ -2939,7 +2943,7 @@ msgstr "Pencere kapandığında arkaplanda çalışmaya devam et"
 msgid "Keep the original files"
 msgstr "Orijinal dosyaları sakla"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Kedicikler"
@@ -3031,7 +3035,7 @@ msgstr "Kütüphane"
 msgid "Library advanced grouping"
 msgstr "Kütüphane gelişmiş gruplama"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Kütüphane yeniden tarama bildirisi"
 
@@ -3071,7 +3075,7 @@ msgstr "Albüm kapağını diskten yükle..."
 msgid "Load playlist"
 msgstr "Çalma listesini yükle"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Çalma listesi yükle..."
 
@@ -3132,11 +3136,15 @@ msgstr "Oturum aç"
 msgid "Login failed"
 msgstr "Giriş başarısız oldu."
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Uzun vadeli tahmin profili (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Beğen"
 
@@ -3171,11 +3179,11 @@ msgstr "%1 sitesinden şarkı sözleri"
 msgid "Lyrics from the tag"
 msgstr "Etiketteki Şarkı Sözleri"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3217,7 +3225,7 @@ msgstr "Ana profil (MAIN)"
 msgid "Make it so!"
 msgstr "Yap gitsin!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Yap gitsin!"
@@ -3355,7 +3363,7 @@ msgstr "Bağlama noktaları"
 msgid "Move down"
 msgstr "Aşağı taşı"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Kütüphaneye taşı..."
 
@@ -3364,7 +3372,7 @@ msgstr "Kütüphaneye taşı..."
 msgid "Move up"
 msgstr "Yukarı taşı"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Müzik"
 
@@ -3377,7 +3385,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Sessiz"
 
@@ -3426,7 +3434,7 @@ msgstr "Asla çalarak başlama"
 msgid "New folder"
 msgstr "Yeni klasör"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Yeni çalma listesi"
 
@@ -3454,8 +3462,12 @@ msgstr "En yeni parçalar"
 msgid "Next"
 msgstr "İleri"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Sonraki parça"
 
@@ -3493,7 +3505,7 @@ msgstr "Kısa blok yok"
 msgid "None"
 msgstr "Hiçbiri"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Seçili şarkıların hiçbiri aygıta yüklemeye uygun değil"
 
@@ -3578,19 +3590,19 @@ msgstr "Kapalı"
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3634,7 +3646,7 @@ msgstr "Opaklık"
 msgid "Open %1 in browser"
 msgstr " Tarayıcıda %1 aç"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "&Ses CD'si aç..."
 
@@ -3646,7 +3658,7 @@ msgstr "OPML dosyası aç"
 msgid "Open OPML file..."
 msgstr "OPML dosyasını aç..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Müziğin içe aktarılacağı bir dizin aç"
 
@@ -3654,7 +3666,7 @@ msgstr "Müziğin içe aktarılacağı bir dizin aç"
 msgid "Open device"
 msgstr "Aygıtı aç"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Dosya aç..."
 
@@ -3708,7 +3720,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Dosyaları Düzenle"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Dosyaları düzenle..."
 
@@ -3792,7 +3804,7 @@ msgstr "Parti"
 msgid "Password"
 msgstr "Parola"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Duraklat"
@@ -3816,6 +3828,10 @@ msgstr "Sanatçı"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Piksel"
@@ -3824,10 +3840,10 @@ msgstr "Piksel"
 msgid "Plain sidebar"
 msgstr "Düz kenar çubuğu"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Çal"
 
@@ -3848,11 +3864,11 @@ msgstr "Duraklatılmışsa çal, çalıyorsa beklet"
 msgid "Play if there is nothing already playing"
 msgstr "Çalan bir şey yoksa çal"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Sonrakini oynat"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Sonraki parçaları oynat"
 
@@ -3951,7 +3967,7 @@ msgstr "Tercih"
 msgid "Preferences"
 msgstr "Tercihler"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Tercihler..."
 
@@ -4011,7 +4027,7 @@ msgid "Previous"
 msgstr "Önceki"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Önceki parça"
 
@@ -4069,16 +4085,16 @@ msgstr "Kalite"
 msgid "Querying device..."
 msgstr "Aygıt sorgulanıyor..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Kuyruk Yöneticisi"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Seçili parçaları kuyruğa ekle"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Parçayı kuyruğa ekle"
 
@@ -4094,7 +4110,7 @@ msgstr "Radyo (tüm parçalar için eşit ses seviyesi)"
 msgid "Rain"
 msgstr "Yağmur"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Yağmur"
@@ -4206,7 +4222,7 @@ msgstr "Eylemi kaldır"
 msgid "Remove current song from playlist"
 msgstr "Geçerli şarkıyı çalma listesinden kaldır"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Şarkı listesindeki çiftleri birleştir"
 
@@ -4214,7 +4230,7 @@ msgstr "Şarkı listesindeki çiftleri birleştir"
 msgid "Remove folder"
 msgstr "Klasörü kaldır..."
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Çalma listesinden kaldır"
 
@@ -4226,7 +4242,7 @@ msgstr "Çalma listesini kaldır"
 msgid "Remove playlists"
 msgstr "Çalma listesini kaldır"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Şarkı listesindeki kullanılamayan parçaları kaldır"
 
@@ -4238,7 +4254,7 @@ msgstr "Çalma listesini yeniden adlandır"
 msgid "Rename playlist..."
 msgstr "Çalma listesini yeniden adlandır..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Parçaları bu sırada hatırla..."
 
@@ -4329,7 +4345,7 @@ msgstr "Dönüştür"
 msgid "Rip CD"
 msgstr "CD Dönüştür"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Ses CD'si dönüştür"
 
@@ -4407,7 +4423,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Çalma listesini kaydet"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Çalma listesini kaydet..."
 
@@ -4494,7 +4510,7 @@ msgstr "Subsonic'de Ara"
 msgid "Search automatically"
 msgstr "Otomatik ara"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Albüme göre ara"
 
@@ -4507,7 +4523,7 @@ msgstr "Albüm kapaklarını ara..."
 msgid "Search for anything"
 msgstr "Herhangi bir şey ara"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Sanatçıya göre ara"
 
@@ -4632,7 +4648,7 @@ msgstr "Sunucu ayrıntıları"
 msgid "Service offline"
 msgstr "Hizmet çevrim dışı"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "%1'i \"%2\" olarak ayarla"
@@ -4641,7 +4657,7 @@ msgstr "%1'i \"%2\" olarak ayarla"
 msgid "Set the volume to <value> percent"
 msgstr "Ses seviyesini yüzde <value> yap"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Seçili tüm parçalar için değeri ayarla..."
 
@@ -4712,7 +4728,7 @@ msgstr "Zarif bir OSD göster"
 msgid "Show above status bar"
 msgstr "Durum çubuğunun üzerinde göster"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Tüm şarkıları göster"
 
@@ -4732,12 +4748,12 @@ msgstr "Ayırıcıları göster"
 msgid "Show fullsize..."
 msgstr "Tam boyutta göster"
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Dosya gözatıcısında göster..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Kütüphanede göster..."
 
@@ -4749,15 +4765,15 @@ msgstr "Çeşitli sanatçılarda göster"
 msgid "Show moodbar"
 msgstr "Atmosfer çubuğunu göster"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Sadece aynı olanları göster"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Sadece etiketi olmayanları göster"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Kenar çubuğunu gösterin veya gizleyin"
 
@@ -4765,7 +4781,7 @@ msgstr "Kenar çubuğunu gösterin veya gizleyin"
 msgid "Show search suggestions"
 msgstr "Arama önerilerini göster"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Kenar çubuğunu göster"
 
@@ -4801,7 +4817,7 @@ msgstr "Albümleri karıştır"
 msgid "Shuffle all"
 msgstr "Hepsini karıştır"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Çalma listesini karıştır"
 
@@ -4845,11 +4861,15 @@ msgstr "Atlama sayısı"
 msgid "Skip forwards in playlist"
 msgstr "Parça listesinde ileri git"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Seçili parçaları atla"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Parçayı atla"
 
@@ -4966,7 +4986,7 @@ msgstr "Dönüştürmeyi başlat"
 msgid "Start the playlist currently playing"
 msgstr "Çalma listesini mevcut çalınanla başlat"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Dönüştürmeye başla"
 
@@ -4976,7 +4996,7 @@ msgid ""
 "list"
 msgstr "Arama sonucunu görmek için arama kutusuna bir şeyler yazmaya başlayın."
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "%1 Başlatılıyor"
@@ -4986,7 +5006,7 @@ msgid "Starting..."
 msgstr "Başlatılıyor..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Durdur"
 
@@ -5002,7 +5022,7 @@ msgstr "Her parçadan sonra dur"
 msgid "Stop after every track"
 msgstr "Her parçadan sonra dur"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Bu parçadan sonra durdur"
 
@@ -5170,7 +5190,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Subsonic sunucusunun deneme süresi bitti. Lisans anahtarı almak için lütfen bağış yapın. Ayrıntılar için subsonic.org'u ziyaret edin."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5212,7 +5232,7 @@ msgid ""
 "continue?"
 msgstr "Bu dosyalar aygıttan silinecek, devam etmek istiyor musunuz?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5314,11 +5334,11 @@ msgstr "Zarif OSD'yi Aç/Kapa"
 msgid "Toggle fullscreen"
 msgstr "Tam ekran göster/gizle"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Kuyruk durumunu göster/gizle"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Skroplamayı aç/kapa"
 
@@ -5363,19 +5383,19 @@ msgstr "Par&ça"
 msgid "Track"
 msgstr "Parça"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Müzik Dönüştür"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Dönüştürücü Kaydı"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Kod çevrimi"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "%1 adet dosya %2 adet thread ile dönüştürülüyor"
@@ -5452,11 +5472,11 @@ msgstr "Bilinmeyen hata"
 msgid "Unset cover"
 msgstr "Albüm kapağını çıkar"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Seçili parçaları atlama"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Parçayı atlama"
 
@@ -5473,7 +5493,7 @@ msgstr "Yaklaşan Konserler"
 msgid "Update all podcasts"
 msgstr "Bütün podcastları güncelle"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Değişen kütüphane klasörlerini güncelle"
 
@@ -5634,7 +5654,7 @@ msgstr "Sürüm %1"
 msgid "View"
 msgstr "Görünüm"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Akış Detaylarını Göster"
 
@@ -5642,7 +5662,7 @@ msgstr "Akış Detaylarını Göster"
 msgid "Visualization mode"
 msgstr "Görüntüleme kipi"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Görseller"
 
@@ -5683,7 +5703,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5779,7 +5799,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Medya 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media audio"
 
@@ -5793,7 +5813,7 @@ msgid ""
 "well?"
 msgstr "Bu albümdeki diğer şarkıları da Çeşitli Sanatçılar'a taşımak ister misiniz?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Şu anda tam bir yeniden tarama çalıştırmak ister misiniz?"
 

--- a/src/translations/uk.po
+++ b/src/translations/uk.po
@@ -9,8 +9,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 12:52+0000\n"
-"Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
+"Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Ukrainian (http://www.transifex.com/davidsansome/clementine/language/uk/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -163,19 +163,19 @@ msgstr "%L1 композицій"
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n з помилкою"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n завершено"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -193,7 +193,7 @@ msgstr "По &центру"
 msgid "&Custom"
 msgstr "&Нетипово"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "Додатково"
 
@@ -201,7 +201,7 @@ msgstr "Додатково"
 msgid "&Grouping"
 msgstr "&Групування"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Довідка"
 
@@ -226,7 +226,7 @@ msgstr "За&фіксувати оцінку"
 msgid "&Lyrics"
 msgstr "&Текст"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "Музика"
 
@@ -234,15 +234,15 @@ msgstr "Музика"
 msgid "&None"
 msgstr "&Немає"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "Список відтворення"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "Ви&йти"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "Режим повтору"
 
@@ -250,7 +250,7 @@ msgstr "Режим повтору"
 msgid "&Right"
 msgstr "&Праворуч"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Режим перемішування"
 
@@ -258,7 +258,7 @@ msgstr "Режим перемішування"
 msgid "&Stretch columns to fit window"
 msgstr "Розтягнути стовпчики відповідно вмісту вікна"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Інструменти"
 
@@ -447,11 +447,11 @@ msgstr "Перервати"
 msgid "About %1"
 msgstr "Про %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Про Clementine…"
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Про Qt…"
 
@@ -511,32 +511,32 @@ msgstr "Додати інший потік…"
 msgid "Add directory..."
 msgstr "Додати теку…"
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Додати файл"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Додати файл для перекодування"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Додати файли для перекодування"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Додати файл…"
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Додати файли для перекодування"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Додати теку"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Додати теку…"
 
@@ -548,7 +548,7 @@ msgstr "Додати нову теку…"
 msgid "Add podcast"
 msgstr "Додати подкаст"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Додати подкаст..."
 
@@ -624,7 +624,7 @@ msgstr "Додати мітку номера композиції"
 msgid "Add song year tag"
 msgstr "Додати мітку року пісні"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Додати потік…"
 
@@ -636,7 +636,7 @@ msgstr "Додати до списків відтворення Spotify"
 msgid "Add to Spotify starred"
 msgstr "Додати до оцінених у Spotify"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Додати до іншого списку відтворення"
 
@@ -730,7 +730,7 @@ msgstr "Усі"
 msgid "All Files (*)"
 msgstr "Всі файли (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Вся слава Гіпножабі!"
@@ -1121,7 +1121,7 @@ msgstr "Перевіряти наявність нових випусків"
 msgid "Check for updates"
 msgstr "Перевірити наявність оновлень"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Перевірити оновлення…"
 
@@ -1170,18 +1170,18 @@ msgstr "Класична"
 msgid "Cleaning up"
 msgstr "Вичищаю"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Очистити"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Очистити список відтворення"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1326,7 +1326,7 @@ msgstr "Коментар"
 msgid "Complete tags automatically"
 msgstr "Заповнити мітки автоматично"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Заповнити мітки автоматично…"
 
@@ -1361,7 +1361,7 @@ msgstr "Налаштувати Subsonic…"
 msgid "Configure global search..."
 msgstr "Налаштувати загальні правила пошуку…"
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Налаштувати фонотеку"
 
@@ -1404,7 +1404,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Вичерпано строк очікування на з’єднання. Переконайтеся, що адресу сервера вказано правильно. Приклад: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Консоль"
 
@@ -1433,11 +1433,11 @@ msgid "Copy to clipboard"
 msgstr "Копіювати до буфера"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Копіювати до пристрою…"
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Скопіювати до фонотеки…"
@@ -1480,14 +1480,14 @@ msgstr "Не вдалося увійти до last.fm. Будь ласка, по
 msgid "Couldn't create playlist"
 msgstr "Не вдалося створити список відтворення"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Не вдалось знайти ущільнювач для %1, перевірте чи правильно встановлений модуль GStreamer"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1502,7 +1502,7 @@ msgstr "Не вдалось відкрити вихідний файл %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Менеджер обкладинок"
 
@@ -1655,7 +1655,7 @@ msgid "Delete downloaded data"
 msgstr "Видалити завантажені дані"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Вилучити файли"
 
@@ -1663,7 +1663,7 @@ msgstr "Вилучити файли"
 msgid "Delete from device..."
 msgstr "Вилучити з пристрою…"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Вилучити з диска…"
@@ -1696,11 +1696,11 @@ msgstr "Вилучення файлів"
 msgid "Depth"
 msgstr "Глибина"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Вилучити з черги вибрані композиції"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Вилучити композицію з черги"
 
@@ -1801,7 +1801,7 @@ msgstr "Налаштування відображення"
 msgid "Display the on-screen-display"
 msgstr "Показувати екранні повідомлення"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Повторити повне сканування фонотеки"
 
@@ -1980,12 +1980,12 @@ msgstr "Динамічний випадковий мікс"
 msgid "Edit smart playlist..."
 msgstr "Редагувати розумний список відтворення…"
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Змінити «%1»…"
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Редагувати мітку…"
 
@@ -1998,7 +1998,7 @@ msgid "Edit track information"
 msgstr "Редагувати дані композиції"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Редагувати дані щодо композиції…"
 
@@ -2106,7 +2106,7 @@ msgstr "Вся фонотека"
 msgid "Episode information"
 msgstr "Дані щодо серії"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Еквалайзер"
 
@@ -2119,8 +2119,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Відповідає --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Помилка"
 
@@ -2155,7 +2155,7 @@ msgstr "Помилка завантаження %1"
 msgid "Error loading di.fm playlist"
 msgstr "Помилка завантаження списку відтворення di.fm"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Помилка обробляння %1: %2"
@@ -2238,7 +2238,11 @@ msgstr "Експортування завершено"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "Експортовано %1 обкладинок з %2 (%3 пропущено)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2262,7 +2266,7 @@ msgstr "Згасання"
 msgid "Fading duration"
 msgstr "Тривалість згасання"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Не вдалося виконати читання з простою читання компакт-дисків"
 
@@ -2544,11 +2548,11 @@ msgstr "Дати назву:"
 msgid "Go"
 msgstr "Вперед"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "До наступної вкладки списку відтворення"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "До попередньої вкладки списку відтворення"
 
@@ -2881,7 +2885,7 @@ msgstr "База даних Jamendo"
 msgid "Jump to previous song right away"
 msgstr "Перейти до попередньої композиції негайно"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Перейти до відтворюваної композиції"
 
@@ -2905,7 +2909,7 @@ msgstr "Продовжувати виконання у фоні коли вік�
 msgid "Keep the original files"
 msgstr "Зберегти оригінальні файли"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Кошенята"
@@ -2997,7 +3001,7 @@ msgstr "Фонотека"
 msgid "Library advanced grouping"
 msgstr "Розширене групування фонотеки"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Повідомлення про повторне сканування фонотеки"
 
@@ -3037,7 +3041,7 @@ msgstr "Завантажити обкладинку з диска"
 msgid "Load playlist"
 msgstr "Завантажити список відтворення"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Завантажити список відтворення…"
 
@@ -3098,11 +3102,15 @@ msgstr "Увійти"
 msgid "Login failed"
 msgstr "Не вдалося увійти"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr "Журнал"
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Профіль довготривалого передбачення (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Додати до улюблених"
 
@@ -3137,11 +3145,11 @@ msgstr "Текст пісні з %1"
 msgid "Lyrics from the tag"
 msgstr "Текст пісні з мітки"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3183,7 +3191,7 @@ msgstr "Основний профіль (MAIN)"
 msgid "Make it so!"
 msgstr "Гаразд!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "Гаразд!"
@@ -3321,7 +3329,7 @@ msgstr "Точки монтування"
 msgid "Move down"
 msgstr "Перемістити вниз"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Перемістити до фонотеки…"
 
@@ -3330,7 +3338,7 @@ msgstr "Перемістити до фонотеки…"
 msgid "Move up"
 msgstr "Перемістити вгору"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Музика"
 
@@ -3343,7 +3351,7 @@ msgid "Music extensions remotely visible"
 msgstr "Віддалено видимі музичні суфікси назв"
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Вимкнути звук"
 
@@ -3392,7 +3400,7 @@ msgstr "Ніколи не починати відтворення"
 msgid "New folder"
 msgstr "Нова тека"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Новий список відтворення"
 
@@ -3420,8 +3428,12 @@ msgstr "Найновіші композиції"
 msgid "Next"
 msgstr "Наступна"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Наступна композиція"
 
@@ -3459,7 +3471,7 @@ msgstr "Без коротких блоків"
 msgid "None"
 msgstr "Немає"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Жодна з вибраних композицій не придатна для копіювання на пристрій"
 
@@ -3544,19 +3556,19 @@ msgstr "Вимкн."
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Opus Ogg"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3600,7 +3612,7 @@ msgstr "Непрозорість"
 msgid "Open %1 in browser"
 msgstr "Відкрити %1 у переглядачі"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Відкрити &аудіо CD…"
 
@@ -3612,7 +3624,7 @@ msgstr "Відкрити файл OPML"
 msgid "Open OPML file..."
 msgstr "Відкрити файл OPML…"
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Відкрити каталог для імпортування музичних творів"
 
@@ -3620,7 +3632,7 @@ msgstr "Відкрити каталог для імпортування музи
 msgid "Open device"
 msgstr "Відкрити пристрій"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Відкрити файл…"
 
@@ -3674,7 +3686,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Упорядкування файлів"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Упорядкування файлів…"
 
@@ -3758,7 +3770,7 @@ msgstr "Вечірка"
 msgid "Password"
 msgstr "Пароль"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Призупинити"
@@ -3782,6 +3794,10 @@ msgstr "Виконавець"
 msgid "Pipeline"
 msgstr "Канал обробки"
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr "Канали обробки"
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Піксель"
@@ -3790,10 +3806,10 @@ msgstr "Піксель"
 msgid "Plain sidebar"
 msgstr "Звичайна бічна панель"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Відтворити"
 
@@ -3814,11 +3830,11 @@ msgstr "Відтворити, якщо зупинено; призупинити,
 msgid "Play if there is nothing already playing"
 msgstr "Відтворювати, якщо зараз нічого не відтворюється"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "Відтворити наступну"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "Відтворити наступні позначені композиції"
 
@@ -3917,7 +3933,7 @@ msgstr "Пріоритет"
 msgid "Preferences"
 msgstr "Параметри"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Параметри…"
 
@@ -3977,7 +3993,7 @@ msgid "Previous"
 msgstr "Попередня"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Попередня композиція"
 
@@ -4035,16 +4051,16 @@ msgstr "Якість"
 msgid "Querying device..."
 msgstr "Опитування пристрою…"
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Керування чергою"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Додати до черги позначені композиції"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Додати композицію до черги"
 
@@ -4060,7 +4076,7 @@ msgstr "Радіо (однакова гучність всіх композиц�
 msgid "Rain"
 msgstr "Дощ"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Дощ"
@@ -4172,7 +4188,7 @@ msgstr "Вилучити дію"
 msgid "Remove current song from playlist"
 msgstr "Вилучити поточну композицію зі списку відтворення"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Вилучити повтори зі списку відтворення"
 
@@ -4180,7 +4196,7 @@ msgstr "Вилучити повтори зі списку відтворення
 msgid "Remove folder"
 msgstr "Вилучити теку"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Вилучити зі списку відтворення"
 
@@ -4192,7 +4208,7 @@ msgstr "Вилучення списку відтворення"
 msgid "Remove playlists"
 msgstr "Вилучення списків відтворення"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Вилучити недоступні композиції зі списку відтворення"
 
@@ -4204,7 +4220,7 @@ msgstr "Перейменувати список відтворення"
 msgid "Rename playlist..."
 msgstr "Перейменувати список відтворення…"
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Пронумерувати композиції у такому порядку…"
 
@@ -4295,7 +4311,7 @@ msgstr "Оцифрувати"
 msgid "Rip CD"
 msgstr "Оцифрувати КД"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Оцифрувати звуковий КД"
 
@@ -4373,7 +4389,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Збереження списку відтворення"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Зберегти список відтворення…"
 
@@ -4460,7 +4476,7 @@ msgstr "Шукати на Subsonic"
 msgid "Search automatically"
 msgstr "Шукати автоматично"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Шукати альбом"
 
@@ -4473,7 +4489,7 @@ msgstr "Пошук обкладинок альбомів…"
 msgid "Search for anything"
 msgstr "Шукати всюди"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Шукати виконавця"
 
@@ -4598,7 +4614,7 @@ msgstr "Параметри сервера"
 msgid "Service offline"
 msgstr "Служба вимкнена"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Встановити %1 до \"%2\"…"
@@ -4607,7 +4623,7 @@ msgstr "Встановити %1 до \"%2\"…"
 msgid "Set the volume to <value> percent"
 msgstr "Встановити гучність до <value> відсотків"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Встановити значення для всіх вибраних композицій…"
 
@@ -4678,7 +4694,7 @@ msgstr "Показувати приємні повідомлення OSD"
 msgid "Show above status bar"
 msgstr "Показати вище, в рядку стану"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Показати всі композиції"
 
@@ -4698,12 +4714,12 @@ msgstr "Показати розділювачі"
 msgid "Show fullsize..."
 msgstr "Показати на повний розмір…"
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Показати в оглядачі файлів…"
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Показати у фонотеці…"
 
@@ -4715,15 +4731,15 @@ msgstr "Показувати в різних виконавцях"
 msgid "Show moodbar"
 msgstr "Показувати смужку настрою"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Показати тільки дублікати"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Показати тільки без міток"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "Показати або приховати бічну панель"
 
@@ -4731,7 +4747,7 @@ msgstr "Показати або приховати бічну панель"
 msgid "Show search suggestions"
 msgstr "Показувати пропозиції щодо пошуку"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "Показувати бічну панель"
 
@@ -4767,7 +4783,7 @@ msgstr "Перемішати альбоми"
 msgid "Shuffle all"
 msgstr "Перемішати все"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Перемішати список відтворення"
 
@@ -4811,11 +4827,15 @@ msgstr "Кількість пропусків"
 msgid "Skip forwards in playlist"
 msgstr "Перескочити вперед у списку композицій"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Пропустити позначені композиції"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Пропустити композицію"
 
@@ -4932,7 +4952,7 @@ msgstr "Почати оцифрування"
 msgid "Start the playlist currently playing"
 msgstr "Запустити список відтворення, що відтворюється на цей час"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Почати перекодування"
 
@@ -4942,7 +4962,7 @@ msgid ""
 "list"
 msgstr "Введіть щось у полі пошуку, розташованому вище, щоб побачити на цій панелі список результатів пошуку"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Запуск %1"
@@ -4952,7 +4972,7 @@ msgid "Starting..."
 msgstr "Запуск…"
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Зупинити"
 
@@ -4968,7 +4988,7 @@ msgstr "Зупинятися після кожної композиції"
 msgid "Stop after every track"
 msgstr "Зупинятися після будь-якої композиції"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Зупинити після цієї композиції"
 
@@ -5136,7 +5156,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Час тестування сервера Subsonic завершено. Будь ласка, придбайте ліцензійний ключ. Відвідайте subsonic.org, щоб дізнатися більше."
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5178,7 +5198,7 @@ msgid ""
 "continue?"
 msgstr "Ці файли будуть вилучені з пристрою. Ви впевнені? Вилучити їх?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5280,11 +5300,11 @@ msgstr "Змінити режим приємних OSD"
 msgid "Toggle fullscreen"
 msgstr "Повноекранний режим"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Перемикнути статус черги"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Змінити режим скроблінгу"
 
@@ -5329,19 +5349,19 @@ msgstr "Ко&мпозиція"
 msgid "Track"
 msgstr "Композиція"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Перекодування музики"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Журнал перекодування"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr "Параметри перекодувальника"
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Перекодування"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Перекодовано %1 файлів, використовуючи %2 гілки"
@@ -5418,11 +5438,11 @@ msgstr "Невідома помилка"
 msgid "Unset cover"
 msgstr "Вилучити обкладинку"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Не пропускати позначені композиції"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Не пропускати композицію"
 
@@ -5439,7 +5459,7 @@ msgstr "Найближчі виступи"
 msgid "Update all podcasts"
 msgstr "Оновити всі подкасти"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Оновити змінені теки у фонотеці"
 
@@ -5600,7 +5620,7 @@ msgstr "Версія %1"
 msgid "View"
 msgstr "Перегляд"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Перегляд параметрів потоку"
 
@@ -5608,7 +5628,7 @@ msgstr "Перегляд параметрів потоку"
 msgid "Visualization mode"
 msgstr "Режим візуалізації"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Візуалізації"
 
@@ -5649,7 +5669,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr "Попердження: цей рівень стискання не належить до підмножини придатних до трансляції рівнів. Це означає, що декодер, можливо, не зможе почати відтворення трансляції з середини. Вибір такого рівня також може значно вплинути на швидкодію апаратних декодерів."
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5745,7 +5765,7 @@ msgstr "Windows Media, 40 кб"
 msgid "Windows Media 64k"
 msgstr "Windows Media, 64 кб"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media audio"
 
@@ -5759,7 +5779,7 @@ msgid ""
 "well?"
 msgstr "Хочете пересунути всі ініші композиції цього альбому до розділу «Різні виконавці»?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Бажаєте зараз виконати повторне сканування фонотеки?"
 

--- a/src/translations/uk.po
+++ b/src/translations/uk.po
@@ -9,8 +9,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-26 23:47+0000\n"
-"Last-Translator: John Maguire <john.maguire@gmail.com>\n"
+"PO-Revision-Date: 2021-01-27 06:40+0000\n"
+"Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
 "Language-Team: Ukrainian (http://www.transifex.com/davidsansome/clementine/language/uk/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -511,7 +511,7 @@ msgstr "Додати інший потік…"
 msgid "Add directory..."
 msgstr "Додати теку…"
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Додати файл"
 
@@ -531,7 +531,7 @@ msgstr "Додати файл…"
 msgid "Add files to transcode"
 msgstr "Додати файли для перекодування"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Додати теку"
@@ -636,7 +636,7 @@ msgstr "Додати до списків відтворення Spotify"
 msgid "Add to Spotify starred"
 msgstr "Додати до оцінених у Spotify"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Додати до іншого списку відтворення"
 
@@ -858,7 +858,7 @@ msgstr "Ви справді хочете записати статистичні
 msgid "Artist"
 msgstr "Виконавець"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Виконавець"
 
@@ -1121,7 +1121,7 @@ msgstr "Перевіряти наявність нових випусків"
 msgid "Check for updates"
 msgstr "Перевірити наявність оновлень"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Перевірити оновлення…"
 
@@ -1361,7 +1361,7 @@ msgstr "Налаштувати Subsonic…"
 msgid "Configure global search..."
 msgstr "Налаштувати загальні правила пошуку…"
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Налаштувати фонотеку"
 
@@ -1433,11 +1433,11 @@ msgid "Copy to clipboard"
 msgstr "Копіювати до буфера"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Копіювати до пристрою…"
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Скопіювати до фонотеки…"
@@ -1655,7 +1655,7 @@ msgid "Delete downloaded data"
 msgstr "Видалити завантажені дані"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Вилучити файли"
 
@@ -1663,7 +1663,7 @@ msgstr "Вилучити файли"
 msgid "Delete from device..."
 msgstr "Вилучити з пристрою…"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Вилучити з диска…"
@@ -1696,11 +1696,11 @@ msgstr "Вилучення файлів"
 msgid "Depth"
 msgstr "Глибина"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Вилучити з черги вибрані композиції"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Вилучити композицію з черги"
 
@@ -1729,7 +1729,7 @@ msgstr "Назва пристрою"
 msgid "Device properties..."
 msgstr "Налаштування пристрою…"
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Пристрої"
 
@@ -1980,7 +1980,7 @@ msgstr "Динамічний випадковий мікс"
 msgid "Edit smart playlist..."
 msgstr "Редагувати розумний список відтворення…"
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Змінити «%1»…"
@@ -2119,8 +2119,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Відповідає --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Помилка"
 
@@ -2240,7 +2240,7 @@ msgstr "Експортовано %1 обкладинок з %2 (%3 пропущ�
 
 #: ../bin/src/ui_mainwindow.h:790
 msgid "F9"
-msgstr ""
+msgstr "F9"
 
 #: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
@@ -2266,7 +2266,7 @@ msgstr "Згасання"
 msgid "Fading duration"
 msgstr "Тривалість згасання"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Не вдалося виконати читання з простою читання компакт-дисків"
 
@@ -2389,7 +2389,7 @@ msgstr "Тип файлу"
 msgid "Filename"
 msgstr "Назва файлу"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Файли"
 
@@ -2804,7 +2804,7 @@ msgstr "Встановлено"
 msgid "Integrity check"
 msgstr "Перевірка цілісності даних"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Інтернет"
 
@@ -2992,7 +2992,7 @@ msgstr "Ліворуч"
 msgid "Length"
 msgstr "Тривалість"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Фонотека"
@@ -3001,7 +3001,7 @@ msgstr "Фонотека"
 msgid "Library advanced grouping"
 msgstr "Розширене групування фонотеки"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Повідомлення про повторне сканування фонотеки"
 
@@ -3329,7 +3329,7 @@ msgstr "Точки монтування"
 msgid "Move down"
 msgstr "Перемістити вниз"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Перемістити до фонотеки…"
 
@@ -3338,7 +3338,7 @@ msgstr "Перемістити до фонотеки…"
 msgid "Move up"
 msgstr "Перемістити вгору"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Музика"
 
@@ -3400,7 +3400,7 @@ msgstr "Ніколи не починати відтворення"
 msgid "New folder"
 msgstr "Нова тека"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Новий список відтворення"
 
@@ -3430,7 +3430,7 @@ msgstr "Наступна"
 
 #: ../bin/src/ui_mainwindow.h:785
 msgid "Next album"
-msgstr ""
+msgstr "Наступний альбом"
 
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
 #: ../bin/src/ui_mainwindow.h:727
@@ -3471,7 +3471,7 @@ msgstr "Без коротких блоків"
 msgid "None"
 msgstr "Немає"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Жодна з вибраних композицій не придатна для копіювання на пристрій"
 
@@ -3686,7 +3686,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Упорядкування файлів"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Упорядкування файлів…"
 
@@ -3770,7 +3770,7 @@ msgstr "Вечірка"
 msgid "Password"
 msgstr "Пароль"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Призупинити"
@@ -3806,8 +3806,8 @@ msgstr "Піксель"
 msgid "Plain sidebar"
 msgstr "Звичайна бічна панель"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3830,11 +3830,11 @@ msgstr "Відтворити, якщо зупинено; призупинити,
 msgid "Play if there is nothing already playing"
 msgstr "Відтворювати, якщо зараз нічого не відтворюється"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "Відтворити наступну"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "Відтворити наступні позначені композиції"
 
@@ -3873,7 +3873,7 @@ msgstr "Налаштування списку відтворення"
 msgid "Playlist type"
 msgstr "Тип списку відтворення"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Списки"
 
@@ -4055,12 +4055,12 @@ msgstr "Опитування пристрою…"
 msgid "Queue Manager"
 msgstr "Керування чергою"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Додати до черги позначені композиції"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Додати композицію до черги"
 
@@ -4451,7 +4451,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Пошук"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Пошук"
@@ -4476,7 +4476,7 @@ msgstr "Шукати на Subsonic"
 msgid "Search automatically"
 msgstr "Шукати автоматично"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Шукати альбом"
 
@@ -4489,7 +4489,7 @@ msgstr "Пошук обкладинок альбомів…"
 msgid "Search for anything"
 msgstr "Шукати всюди"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Шукати виконавця"
 
@@ -4614,7 +4614,7 @@ msgstr "Параметри сервера"
 msgid "Service offline"
 msgstr "Служба вимкнена"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Встановити %1 до \"%2\"…"
@@ -4694,7 +4694,7 @@ msgstr "Показувати приємні повідомлення OSD"
 msgid "Show above status bar"
 msgstr "Показати вище, в рядку стану"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Показати всі композиції"
 
@@ -4714,12 +4714,12 @@ msgstr "Показати розділювачі"
 msgid "Show fullsize..."
 msgstr "Показати на повний розмір…"
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Показати в оглядачі файлів…"
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Показати у фонотеці…"
 
@@ -4731,11 +4731,11 @@ msgstr "Показувати в різних виконавцях"
 msgid "Show moodbar"
 msgstr "Показувати смужку настрою"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Показати тільки дублікати"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Показати тільки без міток"
 
@@ -4827,15 +4827,15 @@ msgstr "Кількість пропусків"
 msgid "Skip forwards in playlist"
 msgstr "Перескочити вперед у списку композицій"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Пропустити позначені композиції"
 
 #: ../bin/src/ui_mainwindow.h:787
 msgid "Skip to the next album"
-msgstr ""
+msgstr "Перейти до наступного альбому"
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Пропустити композицію"
 
@@ -4867,7 +4867,7 @@ msgstr "Легкий рок"
 msgid "Song Information"
 msgstr "Про композицію"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Композиція"
 
@@ -4988,7 +4988,7 @@ msgstr "Зупинятися після кожної композиції"
 msgid "Stop after every track"
 msgstr "Зупинятися після будь-якої композиції"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Зупинити після цієї композиції"
 
@@ -5156,7 +5156,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Час тестування сервера Subsonic завершено. Будь ласка, придбайте ліцензійний ключ. Відвідайте subsonic.org, щоб дізнатися більше."
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5198,7 +5198,7 @@ msgid ""
 "continue?"
 msgstr "Ці файли будуть вилучені з пристрою. Ви впевнені? Вилучити їх?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5300,7 +5300,7 @@ msgstr "Змінити режим приємних OSD"
 msgid "Toggle fullscreen"
 msgstr "Повноекранний режим"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Перемикнути статус черги"
 
@@ -5438,11 +5438,11 @@ msgstr "Невідома помилка"
 msgid "Unset cover"
 msgstr "Вилучити обкладинку"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Не пропускати позначені композиції"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Не пропускати композицію"
 
@@ -5779,7 +5779,7 @@ msgid ""
 "well?"
 msgstr "Хочете пересунути всі ініші композиції цього альбому до розділу «Різні виконавці»?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Бажаєте зараз виконати повторне сканування фонотеки?"
 

--- a/src/translations/uz.po
+++ b/src/translations/uz.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Uzbek (http://www.transifex.com/davidsansome/clementine/language/uz/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -162,19 +162,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n muvaffaqiyatsiz tugadi"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n tugadi"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -192,7 +192,7 @@ msgstr "&Markaz"
 msgid "&Custom"
 msgstr "&Boshqa"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Extras"
 
@@ -200,7 +200,7 @@ msgstr "&Extras"
 msgid "&Grouping"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "&Yordam"
 
@@ -225,7 +225,7 @@ msgstr ""
 msgid "&Lyrics"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Musiqa"
 
@@ -233,15 +233,15 @@ msgstr "&Musiqa"
 msgid "&None"
 msgstr "&Yo'q"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&Pleylist"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "&Chiqish"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "&Takrorlash"
 
@@ -249,7 +249,7 @@ msgstr "&Takrorlash"
 msgid "&Right"
 msgstr "&O'ng"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "&Tasodifan"
 
@@ -257,7 +257,7 @@ msgstr "&Tasodifan"
 msgid "&Stretch columns to fit window"
 msgstr "&Ustunlarni oynaga moslash"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Vositalar"
 
@@ -446,11 +446,11 @@ msgstr ""
 msgid "About %1"
 msgstr "%1 haqida"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Clementine haqida..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Qt haqida..."
 
@@ -510,32 +510,32 @@ msgstr "Boshqa to'lqinni qo'shish..."
 msgid "Add directory..."
 msgstr "Jild qo'shish..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Fayl qo'shish"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr ""
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Fayl qo'shish..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Transkodlash uchun fayllar qo'shish"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Jild qo'shish"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Jild qo'shish..."
 
@@ -547,7 +547,7 @@ msgstr "Yangi jild qo'shish..."
 msgid "Add podcast"
 msgstr "Podcast qo'shish"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Podcast qo'shish..."
 
@@ -623,7 +623,7 @@ msgstr "Qo'shiq treki tegini qo'shish"
 msgid "Add song year tag"
 msgstr "Qo'shiq yili tegini qo'shish"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "To'lqinni qo'shish..."
 
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Boshqa pleylistga qo'shish"
 
@@ -729,7 +729,7 @@ msgstr ""
 msgid "All Files (*)"
 msgstr "Hamma fayllar (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr ""
@@ -1120,7 +1120,7 @@ msgstr "Yangi epizodlarni tekshirish"
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Yangilanishlarni tekshirish..."
 
@@ -1169,18 +1169,18 @@ msgstr "Classical"
 msgid "Cleaning up"
 msgstr "Tozalanmoqda"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Tozalash"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Pleylistni tozalash"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1325,7 +1325,7 @@ msgstr "Izoh"
 msgid "Complete tags automatically"
 msgstr "Teglarni avtomatik ravishda yakunlash"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Teglarni avtomatik ravishda yakunlash..."
 
@@ -1360,7 +1360,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Kutubxonani sozlash..."
 
@@ -1403,7 +1403,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr ""
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Konsol"
 
@@ -1432,11 +1432,11 @@ msgid "Copy to clipboard"
 msgstr "Klipbordga nusxa olish"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Uskunaga nusxa olish..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kutubxonaga nusxa ko'chirish..."
@@ -1479,14 +1479,14 @@ msgstr ""
 msgid "Couldn't create playlist"
 msgstr ""
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr ""
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1501,7 +1501,7 @@ msgstr ""
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Albom rasmi boshqaruvchisi"
 
@@ -1654,7 +1654,7 @@ msgid "Delete downloaded data"
 msgstr "Yuklab olingan ma'lumotni o'chirish"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Fayllarni o'chirish"
 
@@ -1662,7 +1662,7 @@ msgstr "Fayllarni o'chirish"
 msgid "Delete from device..."
 msgstr "Uskunadan o'chirish..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Diskdan o'chirish..."
@@ -1695,11 +1695,11 @@ msgstr "Fayllar o'chirilmoqda"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr ""
 
@@ -1800,7 +1800,7 @@ msgstr "Ko'rsatish parametrlari"
 msgid "Display the on-screen-display"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr ""
 
@@ -1979,12 +1979,12 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr "Smart ijro ro'yxatini tahrirlash..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Tegni tahrirlash..."
 
@@ -1997,7 +1997,7 @@ msgid "Edit track information"
 msgstr "Trek ma'lumotini tahrirlash"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Trek ma'lumotini tahrirlash..."
 
@@ -2105,7 +2105,7 @@ msgstr ""
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Ekvalayzer"
 
@@ -2118,8 +2118,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Xato"
 
@@ -2154,7 +2154,7 @@ msgstr "%1'ni yuklaganda xato ro'y berdi"
 msgid "Error loading di.fm playlist"
 msgstr "di.fm pleylistini yuklaganda xato ro'y berdi"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr ""
@@ -2237,7 +2237,11 @@ msgstr ""
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr ""
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2261,7 +2265,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2543,11 +2547,11 @@ msgstr ""
 msgid "Go"
 msgstr "O'tish"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr ""
 
@@ -2880,7 +2884,7 @@ msgstr "Jamendo ma'lumot bazasi"
 msgid "Jump to previous song right away"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr ""
 
@@ -2904,7 +2908,7 @@ msgstr ""
 msgid "Keep the original files"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr ""
@@ -2996,7 +3000,7 @@ msgstr "Kutubxona"
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3036,7 +3040,7 @@ msgstr "Albom rasmini diskdan yuklash..."
 msgid "Load playlist"
 msgstr "Pleylistni yuklash"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Pleylistni yuklash..."
 
@@ -3097,11 +3101,15 @@ msgstr "Kirish"
 msgid "Login failed"
 msgstr "Kirish muvaffaqiyatsiz tugadi"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr ""
 
@@ -3136,11 +3144,11 @@ msgstr "%1'dan qo'shiq matnlari"
 msgid "Lyrics from the tag"
 msgstr ""
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr ""
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3182,7 +3190,7 @@ msgstr ""
 msgid "Make it so!"
 msgstr "Shunday qilinsin!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr ""
@@ -3320,7 +3328,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3329,7 +3337,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Musiqa"
 
@@ -3342,7 +3350,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr ""
 
@@ -3391,7 +3399,7 @@ msgstr ""
 msgid "New folder"
 msgstr "Yangi jild"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Yangi pleylist"
 
@@ -3419,8 +3427,12 @@ msgstr ""
 msgid "Next"
 msgstr "Keyingi"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Keyingi trek"
 
@@ -3458,7 +3470,7 @@ msgstr ""
 msgid "None"
 msgstr "Yo'q"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3543,19 +3555,19 @@ msgstr ""
 msgid "Ogg FLAC"
 msgstr ""
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr ""
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3599,7 +3611,7 @@ msgstr ""
 msgid "Open %1 in browser"
 msgstr "%1 brauzerda ochish"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "&Audio CD ochish..."
 
@@ -3611,7 +3623,7 @@ msgstr ""
 msgid "Open OPML file..."
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr ""
 
@@ -3619,7 +3631,7 @@ msgstr ""
 msgid "Open device"
 msgstr "Uskunani ochish"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Failni ochish..."
 
@@ -3673,7 +3685,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr "Fayllarni boshqarish"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Fayllarni boshqarish..."
 
@@ -3757,7 +3769,7 @@ msgstr ""
 msgid "Password"
 msgstr "Maxfiy so'z"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr ""
@@ -3781,6 +3793,10 @@ msgstr ""
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr ""
@@ -3789,10 +3805,10 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr ""
 
@@ -3813,11 +3829,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3916,7 +3932,7 @@ msgstr ""
 msgid "Preferences"
 msgstr "Moslamalar"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Moslamalar..."
 
@@ -3976,7 +3992,7 @@ msgid "Previous"
 msgstr "Oldingi"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Oldingi trek"
 
@@ -4034,16 +4050,16 @@ msgstr ""
 msgid "Querying device..."
 msgstr ""
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr ""
 
@@ -4059,7 +4075,7 @@ msgstr ""
 msgid "Rain"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr ""
@@ -4171,7 +4187,7 @@ msgstr ""
 msgid "Remove current song from playlist"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr ""
 
@@ -4179,7 +4195,7 @@ msgstr ""
 msgid "Remove folder"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr ""
 
@@ -4191,7 +4207,7 @@ msgstr ""
 msgid "Remove playlists"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr ""
 
@@ -4203,7 +4219,7 @@ msgstr ""
 msgid "Rename playlist..."
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr ""
 
@@ -4294,7 +4310,7 @@ msgstr ""
 msgid "Rip CD"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr ""
 
@@ -4372,7 +4388,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr ""
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Pleylistni saqlash..."
 
@@ -4459,7 +4475,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr ""
 
@@ -4472,7 +4488,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr ""
 
@@ -4597,7 +4613,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4606,7 +4622,7 @@ msgstr ""
 msgid "Set the volume to <value> percent"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr ""
 
@@ -4677,7 +4693,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Hamma qo'shiqlarni ko'rsatish"
 
@@ -4697,12 +4713,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr ""
 
@@ -4714,15 +4730,15 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4730,7 +4746,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4766,7 +4782,7 @@ msgstr ""
 msgid "Shuffle all"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr ""
 
@@ -4810,11 +4826,15 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr ""
 
@@ -4931,7 +4951,7 @@ msgstr ""
 msgid "Start the playlist currently playing"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr ""
 
@@ -4941,7 +4961,7 @@ msgid ""
 "list"
 msgstr ""
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr ""
@@ -4951,7 +4971,7 @@ msgid "Starting..."
 msgstr ""
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr ""
 
@@ -4967,7 +4987,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5135,7 +5155,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5177,7 +5197,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5279,11 +5299,11 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr ""
 
@@ -5328,19 +5348,19 @@ msgstr ""
 msgid "Track"
 msgstr "Trek"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Musiqani transkodlash"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
 msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr ""
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr ""
@@ -5417,11 +5437,11 @@ msgstr "Noma'lum xato"
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr ""
 
@@ -5438,7 +5458,7 @@ msgstr ""
 msgid "Update all podcasts"
 msgstr ""
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr ""
 
@@ -5599,7 +5619,7 @@ msgstr "Versiya %1"
 msgid "View"
 msgstr "Ko'rish"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5607,7 +5627,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr "Vizualizatsiya usuli"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Vizualizatsiyalar"
 
@@ -5648,7 +5668,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5744,7 +5764,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media audio"
 
@@ -5758,7 +5778,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/uz.po
+++ b/src/translations/uz.po
@@ -510,7 +510,7 @@ msgstr "Boshqa to'lqinni qo'shish..."
 msgid "Add directory..."
 msgstr "Jild qo'shish..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Fayl qo'shish"
 
@@ -530,7 +530,7 @@ msgstr "Fayl qo'shish..."
 msgid "Add files to transcode"
 msgstr "Transkodlash uchun fayllar qo'shish"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Jild qo'shish"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Add to Spotify starred"
 msgstr ""
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Boshqa pleylistga qo'shish"
 
@@ -857,7 +857,7 @@ msgstr ""
 msgid "Artist"
 msgstr "Artist"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Artist haqida ma'lumot"
 
@@ -1120,7 +1120,7 @@ msgstr "Yangi epizodlarni tekshirish"
 msgid "Check for updates"
 msgstr ""
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Yangilanishlarni tekshirish..."
 
@@ -1360,7 +1360,7 @@ msgstr ""
 msgid "Configure global search..."
 msgstr ""
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Kutubxonani sozlash..."
 
@@ -1432,11 +1432,11 @@ msgid "Copy to clipboard"
 msgstr "Klipbordga nusxa olish"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Uskunaga nusxa olish..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Kutubxonaga nusxa ko'chirish..."
@@ -1654,7 +1654,7 @@ msgid "Delete downloaded data"
 msgstr "Yuklab olingan ma'lumotni o'chirish"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Fayllarni o'chirish"
 
@@ -1662,7 +1662,7 @@ msgstr "Fayllarni o'chirish"
 msgid "Delete from device..."
 msgstr "Uskunadan o'chirish..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Diskdan o'chirish..."
@@ -1695,11 +1695,11 @@ msgstr "Fayllar o'chirilmoqda"
 msgid "Depth"
 msgstr ""
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr ""
 
@@ -1728,7 +1728,7 @@ msgstr "Uskuna nomi"
 msgid "Device properties..."
 msgstr "Uskuna hossalari..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Uskunalar"
 
@@ -1979,7 +1979,7 @@ msgstr ""
 msgid "Edit smart playlist..."
 msgstr "Smart ijro ro'yxatini tahrirlash..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr ""
@@ -2118,8 +2118,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr ""
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Xato"
 
@@ -2265,7 +2265,7 @@ msgstr ""
 msgid "Fading duration"
 msgstr ""
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr ""
 
@@ -2388,7 +2388,7 @@ msgstr "Fayl turi"
 msgid "Filename"
 msgstr "Fayl nomi"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Fayllar"
 
@@ -2803,7 +2803,7 @@ msgstr "O'rnatilgan"
 msgid "Integrity check"
 msgstr ""
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -2991,7 +2991,7 @@ msgstr ""
 msgid "Length"
 msgstr "Uzunligi"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Kutubxona"
@@ -3000,7 +3000,7 @@ msgstr "Kutubxona"
 msgid "Library advanced grouping"
 msgstr ""
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr ""
 
@@ -3328,7 +3328,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr ""
 
@@ -3337,7 +3337,7 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Musiqa"
 
@@ -3399,7 +3399,7 @@ msgstr ""
 msgid "New folder"
 msgstr "Yangi jild"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Yangi pleylist"
 
@@ -3470,7 +3470,7 @@ msgstr ""
 msgid "None"
 msgstr "Yo'q"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr ""
 
@@ -3685,7 +3685,7 @@ msgstr ""
 msgid "Organise Files"
 msgstr "Fayllarni boshqarish"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Fayllarni boshqarish..."
 
@@ -3769,7 +3769,7 @@ msgstr ""
 msgid "Password"
 msgstr "Maxfiy so'z"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr ""
@@ -3805,8 +3805,8 @@ msgstr ""
 msgid "Plain sidebar"
 msgstr ""
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3829,11 +3829,11 @@ msgstr ""
 msgid "Play if there is nothing already playing"
 msgstr ""
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3872,7 +3872,7 @@ msgstr "Pleylist parametrlari"
 msgid "Playlist type"
 msgstr "Pleylist turi"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Pleylistlar"
 
@@ -4054,12 +4054,12 @@ msgstr ""
 msgid "Queue Manager"
 msgstr ""
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr ""
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr ""
 
@@ -4450,7 +4450,7 @@ msgstr ""
 msgid "Search"
 msgstr "Qidirish"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr ""
@@ -4475,7 +4475,7 @@ msgstr ""
 msgid "Search automatically"
 msgstr ""
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr ""
 
@@ -4488,7 +4488,7 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr ""
 
@@ -4613,7 +4613,7 @@ msgstr ""
 msgid "Service offline"
 msgstr ""
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr ""
@@ -4693,7 +4693,7 @@ msgstr ""
 msgid "Show above status bar"
 msgstr ""
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Hamma qo'shiqlarni ko'rsatish"
 
@@ -4713,12 +4713,12 @@ msgstr ""
 msgid "Show fullsize..."
 msgstr ""
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr ""
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr ""
 
@@ -4730,11 +4730,11 @@ msgstr ""
 msgid "Show moodbar"
 msgstr ""
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr ""
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr ""
 
@@ -4826,7 +4826,7 @@ msgstr ""
 msgid "Skip forwards in playlist"
 msgstr ""
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr ""
 
@@ -4834,7 +4834,7 @@ msgstr ""
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr ""
 
@@ -4866,7 +4866,7 @@ msgstr "Soft Rock"
 msgid "Song Information"
 msgstr "Qo'shiq haqida ma'lumot"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Qo'shiq haqida ma'lumot"
 
@@ -4987,7 +4987,7 @@ msgstr ""
 msgid "Stop after every track"
 msgstr ""
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr ""
 
@@ -5155,7 +5155,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5197,7 +5197,7 @@ msgid ""
 "continue?"
 msgstr ""
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5299,7 +5299,7 @@ msgstr ""
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr ""
 
@@ -5437,11 +5437,11 @@ msgstr "Noma'lum xato"
 msgid "Unset cover"
 msgstr ""
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr ""
 
@@ -5778,7 +5778,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr ""
 

--- a/src/translations/vi.po
+++ b/src/translations/vi.po
@@ -515,7 +515,7 @@ msgstr "Thêm luồng dữ liệu khác..."
 msgid "Add directory..."
 msgstr "Thêm thư mục..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "Thêm tập tin"
 
@@ -535,7 +535,7 @@ msgstr "Thêm tập tin..."
 msgid "Add files to transcode"
 msgstr "Thêm các tập tin để chuyển mã"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Thêm thư mục"
@@ -640,7 +640,7 @@ msgstr "Thêm vào danh sách Spotify"
 msgid "Add to Spotify starred"
 msgstr "Thêm vào Spotify và đánh dấu sao"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "Thêm vào danh sách khác"
 
@@ -862,7 +862,7 @@ msgstr "Bạn có muốn ghi thông tin thống kê về tất cả các bài h�
 msgid "Artist"
 msgstr "Nghệ sĩ"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "Nghệ sĩ"
 
@@ -1125,7 +1125,7 @@ msgstr "Kiểm tra tập mới"
 msgid "Check for updates"
 msgstr "Kiểm tra cập nhật"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "Kiểm tra cập nhật..."
 
@@ -1365,7 +1365,7 @@ msgstr "Cấu hình Subsonic..."
 msgid "Configure global search..."
 msgstr "Cấu hình tìm kiếm chung..."
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "Cấu hình thư viện..."
 
@@ -1437,11 +1437,11 @@ msgid "Copy to clipboard"
 msgstr "Chép vào bộ đệm"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Chép vào thiết bị..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Chép vào thư viện..."
@@ -1659,7 +1659,7 @@ msgid "Delete downloaded data"
 msgstr "Xóa dữ liệu đã tải về"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Xóa các tập tin"
 
@@ -1667,7 +1667,7 @@ msgstr "Xóa các tập tin"
 msgid "Delete from device..."
 msgstr "Xóa khỏi thiết bị..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Xóa khỏi ổ cứng..."
@@ -1700,11 +1700,11 @@ msgstr "Đang xóa các tập tin"
 msgid "Depth"
 msgstr "Chiều sâu"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "Loại các bài đã chọn khỏi danh sách chờ"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "Loại bài hát khỏi d.sách chờ"
 
@@ -1733,7 +1733,7 @@ msgstr "Tên thiết bị"
 msgid "Device properties..."
 msgstr "Thuộc tính của thiết bị..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "Thiết bị"
 
@@ -1984,7 +1984,7 @@ msgstr "Hòa trộn âm thanh động ngẫu nhiên"
 msgid "Edit smart playlist..."
 msgstr "Cập nhật danh sách thông minh..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Sửa \"%1\"..."
@@ -2123,8 +2123,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Tương đương với --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "Lỗi"
 
@@ -2270,7 +2270,7 @@ msgstr "Giảm dần âm lượng"
 msgid "Fading duration"
 msgstr "Thời gian giảm dần âm lượng"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "Không đọc được ổ đĩa CD"
 
@@ -2393,7 +2393,7 @@ msgstr "Loại tập tin"
 msgid "Filename"
 msgstr "Tên tập tin"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "Tập tin"
 
@@ -2808,7 +2808,7 @@ msgstr "Đã cài đặt"
 msgid "Integrity check"
 msgstr "Kiểm tra tính toàn vẹn"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "Internet"
 
@@ -2996,7 +2996,7 @@ msgstr "Trái"
 msgid "Length"
 msgstr "Thời lượng"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "Thư viện"
@@ -3005,7 +3005,7 @@ msgstr "Thư viện"
 msgid "Library advanced grouping"
 msgstr "Nhóm thư viện nâng cao"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "Chú ý quét lại thư viện"
 
@@ -3333,7 +3333,7 @@ msgstr "Các điểm gắn"
 msgid "Move down"
 msgstr "Chuyển xuống"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Dời vào thư viện..."
 
@@ -3342,7 +3342,7 @@ msgstr "Dời vào thư viện..."
 msgid "Move up"
 msgstr "Chuyển lên"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "Nhạc"
 
@@ -3404,7 +3404,7 @@ msgstr "Không phát nhạc"
 msgid "New folder"
 msgstr "Thư mục mới"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Tạo danh sách mới"
 
@@ -3475,7 +3475,7 @@ msgstr "Các khối ngắn"
 msgid "None"
 msgstr "Không"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Không bài hát nào phù hợp để chép qua thiết bị"
 
@@ -3690,7 +3690,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Sao chép tập tin"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "Sao chép tập tin..."
 
@@ -3774,7 +3774,7 @@ msgstr "Party"
 msgid "Password"
 msgstr "Mật khẩu"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Tạm dừng"
@@ -3810,8 +3810,8 @@ msgstr "Điểm ảnh"
 msgid "Plain sidebar"
 msgstr "Thanh bên đơn giản"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3834,11 +3834,11 @@ msgstr "Phát nếu như đang dừng, tạm dừng nếu như đang phát"
 msgid "Play if there is nothing already playing"
 msgstr "Phát nhạc nếu không có bài khác đang phát"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3877,7 +3877,7 @@ msgstr "Tùy chọn danh sách"
 msgid "Playlist type"
 msgstr "Loại danh sách"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "Danh sách"
 
@@ -4059,12 +4059,12 @@ msgstr "Truy vấn thiết bị..."
 msgid "Queue Manager"
 msgstr "Quản lý danh sách chờ"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "Chờ phát những bài đã chọn"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "Chờ phát sau"
 
@@ -4455,7 +4455,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "Tìm kiếm"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "Tìm kiếm"
@@ -4480,7 +4480,7 @@ msgstr "Tìm trên Subsonic"
 msgid "Search automatically"
 msgstr "Tìm kiếm tự động"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "Tìm album"
 
@@ -4493,7 +4493,7 @@ msgstr "Tìm ảnh bìa..."
 msgid "Search for anything"
 msgstr "Tìm tất cả"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "Tìm nghệ sĩ"
 
@@ -4618,7 +4618,7 @@ msgstr "Chi tiết máy chủ"
 msgid "Service offline"
 msgstr "Dịch vụ ngoại tuyến"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Thiết lập %1 sang \"%2\"..."
@@ -4698,7 +4698,7 @@ msgstr "Tùy chỉnh thông báo"
 msgid "Show above status bar"
 msgstr "Hiện phía trên thanh trạng thái"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "Hiện tất cả bài hát"
 
@@ -4718,12 +4718,12 @@ msgstr "Hiện đường phân cách"
 msgid "Show fullsize..."
 msgstr "Hiện với kích thước gốc..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Mở thư mục lưu..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "Hiện trong thư viện..."
 
@@ -4735,11 +4735,11 @@ msgstr "Hiện trong mục nhiều nghệ sĩ"
 msgid "Show moodbar"
 msgstr "Hiện thanh sắc thái"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "Chỉ hiện những mục bị trùng"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "Chỉ hiện những mục không được gán thẻ"
 
@@ -4831,7 +4831,7 @@ msgstr "Không đếm"
 msgid "Skip forwards in playlist"
 msgstr "Không cho chuyển bài trong danh sách"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "Bỏ qua các bài đã chọn"
 
@@ -4839,7 +4839,7 @@ msgstr "Bỏ qua các bài đã chọn"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "Bỏ qua bài hát"
 
@@ -4871,7 +4871,7 @@ msgstr "Soft Rock"
 msgid "Song Information"
 msgstr "Thông tin bài hát"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "Bài hát"
 
@@ -4992,7 +4992,7 @@ msgstr "Dừng lại sau mỗi bài"
 msgid "Stop after every track"
 msgstr "Dừng lại sau mỗi bài"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Dừng sau khi phát xong bài này"
 
@@ -5160,7 +5160,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Thời hạn dùng thử Subsonic đã hết. Hãy nộp phí để nhận giấy phép. Xem thêm chi tiết tại subsonic.org"
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5202,7 +5202,7 @@ msgid ""
 "continue?"
 msgstr "Các tập tin này sẽ bị xóa khỏi thiết bị, bạn có muốn tiếp tục?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5304,7 +5304,7 @@ msgstr "Bật/Tắt hộp thông báo"
 msgid "Toggle fullscreen"
 msgstr "Tắt/Bật toàn màn hình"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "Tắt/Bật trạng thái chờ"
 
@@ -5442,11 +5442,11 @@ msgstr "Lỗi không xác định"
 msgid "Unset cover"
 msgstr "Bỏ thiết đặt ảnh bìa"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "Hủy việc bỏ qua các bài đã chọn"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "Hủy bỏ qua bài hát"
 
@@ -5783,7 +5783,7 @@ msgid ""
 "well?"
 msgstr "Bạn có muốn chuyển những bài khác trong album này vào mục nhiều nghệ sĩ không?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "Bạn muốn quét lại toàn bộ ngay bây giờ?"
 

--- a/src/translations/vi.po
+++ b/src/translations/vi.po
@@ -13,7 +13,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Vietnamese (http://www.transifex.com/davidsansome/clementine/language/vi/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -167,19 +167,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%filename%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n thất bại"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n kết thúc"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -197,7 +197,7 @@ msgstr "&Giữa"
 msgid "&Custom"
 msgstr "&Tùy chọn"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "&Hiệu ứng"
 
@@ -205,7 +205,7 @@ msgstr "&Hiệu ứng"
 msgid "&Grouping"
 msgstr "Nhó&m"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "Trợ &giúp"
 
@@ -230,7 +230,7 @@ msgstr "&Khoá đánh giá"
 msgid "&Lyrics"
 msgstr "&Lời"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "&Nhạc"
 
@@ -238,15 +238,15 @@ msgstr "&Nhạc"
 msgid "&None"
 msgstr "&Không"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "&Danh sách"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "T&hoát"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "&Chế độ lặp lại"
 
@@ -254,7 +254,7 @@ msgstr "&Chế độ lặp lại"
 msgid "&Right"
 msgstr "&Phải"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "Chế độ phát n&gẫu nhiên"
 
@@ -262,7 +262,7 @@ msgstr "Chế độ phát n&gẫu nhiên"
 msgid "&Stretch columns to fit window"
 msgstr "Căng các cột ra cho &vừa với cửa sổ"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "&Công cụ"
 
@@ -451,11 +451,11 @@ msgstr "Huỷ bỏ"
 msgid "About %1"
 msgstr "Giới thiệu %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "Giới thiệu Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "Giới thiệu Qt..."
 
@@ -515,32 +515,32 @@ msgstr "Thêm luồng dữ liệu khác..."
 msgid "Add directory..."
 msgstr "Thêm thư mục..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "Thêm tập tin"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "Thêm tập tin vào bộ chuyển mã"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "Thêm (các) tập tin vào bộ chuyển mã"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "Thêm tập tin..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "Thêm các tập tin để chuyển mã"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "Thêm thư mục"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "Thêm thư mục..."
 
@@ -552,7 +552,7 @@ msgstr "Thêm thư mục mới..."
 msgid "Add podcast"
 msgstr "Thêm podcast"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "Thêm podcast..."
 
@@ -628,7 +628,7 @@ msgstr "Thêm thẻ bài hát"
 msgid "Add song year tag"
 msgstr "Thêm thẻ năm của bài hát"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "Thêm luồng dữ liệu..."
 
@@ -640,7 +640,7 @@ msgstr "Thêm vào danh sách Spotify"
 msgid "Add to Spotify starred"
 msgstr "Thêm vào Spotify và đánh dấu sao"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "Thêm vào danh sách khác"
 
@@ -734,7 +734,7 @@ msgstr "Tất cả"
 msgid "All Files (*)"
 msgstr "Mọi tập tin (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "Hypnotoad vạn tuế!"
@@ -1125,7 +1125,7 @@ msgstr "Kiểm tra tập mới"
 msgid "Check for updates"
 msgstr "Kiểm tra cập nhật"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "Kiểm tra cập nhật..."
 
@@ -1174,18 +1174,18 @@ msgstr "Cổ điển"
 msgid "Cleaning up"
 msgstr "Dọn dẹp"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "Loại bỏ tất cả"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "Loại bỏ tất cả b.hát trong d.sách"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1330,7 +1330,7 @@ msgstr "Lời bình"
 msgid "Complete tags automatically"
 msgstr "Điền thông tin bài hát"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "Điền thông tin bài hát..."
 
@@ -1365,7 +1365,7 @@ msgstr "Cấu hình Subsonic..."
 msgid "Configure global search..."
 msgstr "Cấu hình tìm kiếm chung..."
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "Cấu hình thư viện..."
 
@@ -1408,7 +1408,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "Hết thời gian kết nối, kiểm tra URL máy chủ. Ví dụ: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "Console"
 
@@ -1437,11 +1437,11 @@ msgid "Copy to clipboard"
 msgstr "Chép vào bộ đệm"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "Chép vào thiết bị..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "Chép vào thư viện..."
@@ -1484,14 +1484,14 @@ msgstr "Không thể đăng nhập vào Last.fm. Hãy thử lại sau."
 msgid "Couldn't create playlist"
 msgstr "Không thể tạo danh sách"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "Không tìm thấy thiết bị ghép kênh cho %1, hãy chắn chắn là bạn đã cài đặt đủ các phần bổ sung của GStreamer"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1506,7 +1506,7 @@ msgstr "Không thể mở tập tin %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "Quản lí ảnh bìa"
 
@@ -1659,7 +1659,7 @@ msgid "Delete downloaded data"
 msgstr "Xóa dữ liệu đã tải về"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "Xóa các tập tin"
 
@@ -1667,7 +1667,7 @@ msgstr "Xóa các tập tin"
 msgid "Delete from device..."
 msgstr "Xóa khỏi thiết bị..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "Xóa khỏi ổ cứng..."
@@ -1700,11 +1700,11 @@ msgstr "Đang xóa các tập tin"
 msgid "Depth"
 msgstr "Chiều sâu"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "Loại các bài đã chọn khỏi danh sách chờ"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "Loại bài hát khỏi d.sách chờ"
 
@@ -1805,7 +1805,7 @@ msgstr "Tùy chọn hiển thị"
 msgid "Display the on-screen-display"
 msgstr "Hiện hộp thông báo trên màn hình"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "Quét toàn bộ thư viện"
 
@@ -1984,12 +1984,12 @@ msgstr "Hòa trộn âm thanh động ngẫu nhiên"
 msgid "Edit smart playlist..."
 msgstr "Cập nhật danh sách thông minh..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "Sửa \"%1\"..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "Cập nhật thẻ..."
 
@@ -2002,7 +2002,7 @@ msgid "Edit track information"
 msgstr "Sửa thông tin bài hát"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "Sửa thông tin bài hát..."
 
@@ -2110,7 +2110,7 @@ msgstr "Trọn bộ sưu tập"
 msgid "Episode information"
 msgstr ""
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "Bộ cân chỉnh âm"
 
@@ -2123,8 +2123,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "Tương đương với --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "Lỗi"
 
@@ -2159,7 +2159,7 @@ msgstr "Lỗi nạp %1"
 msgid "Error loading di.fm playlist"
 msgstr "Lỗi khi nạp danh sách di.fm"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "Lỗi xử lý %1: %2"
@@ -2242,7 +2242,11 @@ msgstr "Đã xuất xong"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "Đã xuất %1 trên %2 ảnh bìa (đã bỏ qua %3)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2266,7 +2270,7 @@ msgstr "Giảm dần âm lượng"
 msgid "Fading duration"
 msgstr "Thời gian giảm dần âm lượng"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "Không đọc được ổ đĩa CD"
 
@@ -2548,11 +2552,11 @@ msgstr "Đặt tên:"
 msgid "Go"
 msgstr "Đi"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "Đến tab danh sách tiếp theo"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "Trở về tab danh sách trước"
 
@@ -2885,7 +2889,7 @@ msgstr "Cơ sở dữ liệu Jamendo"
 msgid "Jump to previous song right away"
 msgstr "Nhảy ngay tới bài trước"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "Chọn bài đang được phát"
 
@@ -2909,7 +2913,7 @@ msgstr "Chạy nền khi đã đóng cửa sổ chính"
 msgid "Keep the original files"
 msgstr "Giữ nguyên tập tin gốc"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "Mèo con"
@@ -3001,7 +3005,7 @@ msgstr "Thư viện"
 msgid "Library advanced grouping"
 msgstr "Nhóm thư viện nâng cao"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "Chú ý quét lại thư viện"
 
@@ -3041,7 +3045,7 @@ msgstr "Nạp ảnh bìa từ đĩa..."
 msgid "Load playlist"
 msgstr "Mở danh sách"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "Mở danh sách..."
 
@@ -3102,11 +3106,15 @@ msgstr "Đăng nhập"
 msgid "Login failed"
 msgstr "Đăng nhập thất bại"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "Hồ sơ dự báo lâu dài (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "Yêu thích"
 
@@ -3141,11 +3149,11 @@ msgstr "Lời bài hát từ %1"
 msgid "Lyrics from the tag"
 msgstr "Lời bài hát từ thẻ"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3187,7 +3195,7 @@ msgstr "Hồ sơ chính (MAIN)"
 msgid "Make it so!"
 msgstr "Make it so!"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr ""
@@ -3325,7 +3333,7 @@ msgstr "Các điểm gắn"
 msgid "Move down"
 msgstr "Chuyển xuống"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "Dời vào thư viện..."
 
@@ -3334,7 +3342,7 @@ msgstr "Dời vào thư viện..."
 msgid "Move up"
 msgstr "Chuyển lên"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "Nhạc"
 
@@ -3347,7 +3355,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "Tắt âm"
 
@@ -3396,7 +3404,7 @@ msgstr "Không phát nhạc"
 msgid "New folder"
 msgstr "Thư mục mới"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "Tạo danh sách mới"
 
@@ -3424,8 +3432,12 @@ msgstr "Những bài mới nhất"
 msgid "Next"
 msgstr "Tiếp theo"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "Phát bài tiếp theo"
 
@@ -3463,7 +3475,7 @@ msgstr "Các khối ngắn"
 msgid "None"
 msgstr "Không"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "Không bài hát nào phù hợp để chép qua thiết bị"
 
@@ -3548,19 +3560,19 @@ msgstr "Tắt"
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3604,7 +3616,7 @@ msgstr "Độ mờ"
 msgid "Open %1 in browser"
 msgstr "Mở %1 bằng trình duyệt"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "Mở đĩa &CD..."
 
@@ -3616,7 +3628,7 @@ msgstr "Mở tập tin OPML"
 msgid "Open OPML file..."
 msgstr "Mở tập tin OPML..."
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "Mở một thư mục để thêm nhạc"
 
@@ -3624,7 +3636,7 @@ msgstr "Mở một thư mục để thêm nhạc"
 msgid "Open device"
 msgstr "Mở thiết bị"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "Mở tập tin..."
 
@@ -3678,7 +3690,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "Sao chép tập tin"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "Sao chép tập tin..."
 
@@ -3762,7 +3774,7 @@ msgstr "Party"
 msgid "Password"
 msgstr "Mật khẩu"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "Tạm dừng"
@@ -3786,6 +3798,10 @@ msgstr "Biểu diễn"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "Điểm ảnh"
@@ -3794,10 +3810,10 @@ msgstr "Điểm ảnh"
 msgid "Plain sidebar"
 msgstr "Thanh bên đơn giản"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "Phát"
 
@@ -3818,11 +3834,11 @@ msgstr "Phát nếu như đang dừng, tạm dừng nếu như đang phát"
 msgid "Play if there is nothing already playing"
 msgstr "Phát nhạc nếu không có bài khác đang phát"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr ""
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr ""
 
@@ -3921,7 +3937,7 @@ msgstr "Tùy chỉnh"
 msgid "Preferences"
 msgstr "Tùy chỉnh"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "Tùy chỉnh..."
 
@@ -3981,7 +3997,7 @@ msgid "Previous"
 msgstr "Trước"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "Phát bài trước"
 
@@ -4039,16 +4055,16 @@ msgstr "Chất lượng"
 msgid "Querying device..."
 msgstr "Truy vấn thiết bị..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "Quản lý danh sách chờ"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "Chờ phát những bài đã chọn"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "Chờ phát sau"
 
@@ -4064,7 +4080,7 @@ msgstr "Phát thanh (âm thanh bằng nhau cho mọi bài hát)"
 msgid "Rain"
 msgstr "Rain"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "Mưa"
@@ -4176,7 +4192,7 @@ msgstr "Loại bỏ hành động"
 msgid "Remove current song from playlist"
 msgstr "Loại bỏ bài hát hiện tại khỏi danh sách"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "Loại bỏ mục trùng nhau khỏi d.sách"
 
@@ -4184,7 +4200,7 @@ msgstr "Loại bỏ mục trùng nhau khỏi d.sách"
 msgid "Remove folder"
 msgstr "Loại bỏ thư mục"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "Loại bỏ khỏi danh sách"
 
@@ -4196,7 +4212,7 @@ msgstr "Loại bỏ danh sách"
 msgid "Remove playlists"
 msgstr "Loại bỏ danh sách"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "Xoá các bài không phát được khỏi danh sách"
 
@@ -4208,7 +4224,7 @@ msgstr "Đổi tên danh sách"
 msgid "Rename playlist..."
 msgstr "Đổi tên danh sách..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "Đánh số lại các bài hát theo thứ tự này..."
 
@@ -4299,7 +4315,7 @@ msgstr ""
 msgid "Rip CD"
 msgstr "Chép CD"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "Chép CD nhạc"
 
@@ -4377,7 +4393,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "Lưu danh sách"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "Lưu danh sách..."
 
@@ -4464,7 +4480,7 @@ msgstr "Tìm trên Subsonic"
 msgid "Search automatically"
 msgstr "Tìm kiếm tự động"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "Tìm album"
 
@@ -4477,7 +4493,7 @@ msgstr "Tìm ảnh bìa..."
 msgid "Search for anything"
 msgstr "Tìm tất cả"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "Tìm nghệ sĩ"
 
@@ -4602,7 +4618,7 @@ msgstr "Chi tiết máy chủ"
 msgid "Service offline"
 msgstr "Dịch vụ ngoại tuyến"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "Thiết lập %1 sang \"%2\"..."
@@ -4611,7 +4627,7 @@ msgstr "Thiết lập %1 sang \"%2\"..."
 msgid "Set the volume to <value> percent"
 msgstr "Đặt âm lượng ở mức <value> phần trăm"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "Đặt giá trị cho tất cả những bài được chọn..."
 
@@ -4682,7 +4698,7 @@ msgstr "Tùy chỉnh thông báo"
 msgid "Show above status bar"
 msgstr "Hiện phía trên thanh trạng thái"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "Hiện tất cả bài hát"
 
@@ -4702,12 +4718,12 @@ msgstr "Hiện đường phân cách"
 msgid "Show fullsize..."
 msgstr "Hiện với kích thước gốc..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "Mở thư mục lưu..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "Hiện trong thư viện..."
 
@@ -4719,15 +4735,15 @@ msgstr "Hiện trong mục nhiều nghệ sĩ"
 msgid "Show moodbar"
 msgstr "Hiện thanh sắc thái"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "Chỉ hiện những mục bị trùng"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "Chỉ hiện những mục không được gán thẻ"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr ""
 
@@ -4735,7 +4751,7 @@ msgstr ""
 msgid "Show search suggestions"
 msgstr "Hiện đề nghị tìm kiếm"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr ""
 
@@ -4771,7 +4787,7 @@ msgstr "Phát ngẫu nhiên album"
 msgid "Shuffle all"
 msgstr "Phát ngẫu nhiên tất cả"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "Phát ngẫu nhiên danh sách"
 
@@ -4815,11 +4831,15 @@ msgstr "Không đếm"
 msgid "Skip forwards in playlist"
 msgstr "Không cho chuyển bài trong danh sách"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "Bỏ qua các bài đã chọn"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "Bỏ qua bài hát"
 
@@ -4936,7 +4956,7 @@ msgstr "Bắt đầu sao chép"
 msgid "Start the playlist currently playing"
 msgstr "Bắt đầu danh sách đang phát"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "Bắt đầu chuyển mã"
 
@@ -4946,7 +4966,7 @@ msgid ""
 "list"
 msgstr "Gõ gì đó vào ô tìm kiếm"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "Bắt đầu %1"
@@ -4956,7 +4976,7 @@ msgid "Starting..."
 msgstr "Đang bắt đầu..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "Dừng"
 
@@ -4972,7 +4992,7 @@ msgstr "Dừng lại sau mỗi bài"
 msgid "Stop after every track"
 msgstr "Dừng lại sau mỗi bài"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "Dừng sau khi phát xong bài này"
 
@@ -5140,7 +5160,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Thời hạn dùng thử Subsonic đã hết. Hãy nộp phí để nhận giấy phép. Xem thêm chi tiết tại subsonic.org"
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5182,7 +5202,7 @@ msgid ""
 "continue?"
 msgstr "Các tập tin này sẽ bị xóa khỏi thiết bị, bạn có muốn tiếp tục?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5284,11 +5304,11 @@ msgstr "Bật/Tắt hộp thông báo"
 msgid "Toggle fullscreen"
 msgstr "Tắt/Bật toàn màn hình"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "Tắt/Bật trạng thái chờ"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "Bật/Tắt Chuyển thông tin bài hát"
 
@@ -5333,19 +5353,19 @@ msgstr ""
 msgid "Track"
 msgstr "Bài hát"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "Chuyển mã nhạc"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "Nhật kí chuyển mã"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "Chuyển mã"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "Đang chuyển mã %1 tập tin sử dụng %2 luồng"
@@ -5422,11 +5442,11 @@ msgstr "Lỗi không xác định"
 msgid "Unset cover"
 msgstr "Bỏ thiết đặt ảnh bìa"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "Hủy việc bỏ qua các bài đã chọn"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "Hủy bỏ qua bài hát"
 
@@ -5443,7 +5463,7 @@ msgstr "Các buổi hòa nhạc sắp diễn ra"
 msgid "Update all podcasts"
 msgstr "Cập nhật tất cả podcast"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "Cập nhập thư mục thư viện đã thay đổi"
 
@@ -5604,7 +5624,7 @@ msgstr "Phiên bản %1"
 msgid "View"
 msgstr "Hiển thị"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "Xem chi tiết luồng"
 
@@ -5612,7 +5632,7 @@ msgstr "Xem chi tiết luồng"
 msgid "Visualization mode"
 msgstr "Chế độ hình ảnh ảo"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "Hình ảnh ảo"
 
@@ -5653,7 +5673,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5749,7 +5769,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Âm thanh Windows Media"
 
@@ -5763,7 +5783,7 @@ msgid ""
 "well?"
 msgstr "Bạn có muốn chuyển những bài khác trong album này vào mục nhiều nghệ sĩ không?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "Bạn muốn quét lại toàn bộ ngay bây giờ?"
 

--- a/src/translations/zh_CN.po
+++ b/src/translations/zh_CN.po
@@ -22,7 +22,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Chinese (China) (http://www.transifex.com/davidsansome/clementine/language/zh_CN/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -176,19 +176,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%f文件名%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n 失败"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n 完成"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -206,7 +206,7 @@ msgstr "居中(&C)"
 msgid "&Custom"
 msgstr "自定义(&C)"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "附件(&E)"
 
@@ -214,7 +214,7 @@ msgstr "附件(&E)"
 msgid "&Grouping"
 msgstr "分组(&G)"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "帮助(&H)"
 
@@ -239,7 +239,7 @@ msgstr "锁定评分 (&L)"
 msgid "&Lyrics"
 msgstr "歌词(&L)"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "音乐(&M)"
 
@@ -247,15 +247,15 @@ msgstr "音乐(&M)"
 msgid "&None"
 msgstr "无(&N)"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "播放列表(&P)"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "退出(&Q)"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "循环模式(&R)"
 
@@ -263,7 +263,7 @@ msgstr "循环模式(&R)"
 msgid "&Right"
 msgstr "右对齐(&R)"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "随机播放模式(&S)"
 
@@ -271,7 +271,7 @@ msgstr "随机播放模式(&S)"
 msgid "&Stretch columns to fit window"
 msgstr "拉伸栏以适应窗口(&S)"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "工具(&T)"
 
@@ -460,11 +460,11 @@ msgstr "中止"
 msgid "About %1"
 msgstr "关于 %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "关于 Clementine..."
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "关于 Qt..."
 
@@ -524,32 +524,32 @@ msgstr "添加其他流媒体..."
 msgid "Add directory..."
 msgstr "添加目录..."
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "添加文件"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "添加文件至转码器"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "添加文件至转码器"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "添加文件..."
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "添加需转码文件"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "添加文件夹"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "添加文件夹..."
 
@@ -561,7 +561,7 @@ msgstr "添加新文件夹..."
 msgid "Add podcast"
 msgstr "添加播客"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "添加播客..."
 
@@ -637,7 +637,7 @@ msgstr "添加歌曲曲目标签"
 msgid "Add song year tag"
 msgstr "添加歌曲年份标签"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "添加流媒体..."
 
@@ -649,7 +649,7 @@ msgstr "添加到 Spotify 播放列表"
 msgid "Add to Spotify starred"
 msgstr "添加到 Spotify 收藏"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "添加到另一播放列表"
 
@@ -743,7 +743,7 @@ msgstr "所有"
 msgid "All Files (*)"
 msgstr "全部文件 (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "全部归功于睡蛙！"
@@ -1134,7 +1134,7 @@ msgstr "检测新节目"
 msgid "Check for updates"
 msgstr "检查更新"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "检查更新..."
 
@@ -1183,18 +1183,18 @@ msgstr "古典"
 msgid "Cleaning up"
 msgstr "清理"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "清除"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "清空播放列表"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1339,7 +1339,7 @@ msgstr "备注"
 msgid "Complete tags automatically"
 msgstr "自动补全标签"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "自动补全标签..."
 
@@ -1374,7 +1374,7 @@ msgstr "配置 Subsonic..."
 msgid "Configure global search..."
 msgstr "配置全局搜索…"
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "配置媒体库..."
 
@@ -1417,7 +1417,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "连接超时，请检查服务器链接。例如: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "终端"
 
@@ -1446,11 +1446,11 @@ msgid "Copy to clipboard"
 msgstr "复制到剪切板"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "复制到设备..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "复制到媒体库..."
@@ -1493,14 +1493,14 @@ msgstr "无法登录Last.fm.请再试一次。"
 msgid "Couldn't create playlist"
 msgstr "无法创建列表"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "无法为%1找到混音器，请检查是否安装了正确的Gstreamer插件"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1515,7 +1515,7 @@ msgstr "无法打开输出文件 %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "封面管理器"
 
@@ -1668,7 +1668,7 @@ msgid "Delete downloaded data"
 msgstr "删除已下载的数据"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "删除文件"
 
@@ -1676,7 +1676,7 @@ msgstr "删除文件"
 msgid "Delete from device..."
 msgstr "从设备删除..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "从硬盘删除..."
@@ -1709,11 +1709,11 @@ msgstr "删除文件"
 msgid "Depth"
 msgstr "深度"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "移除选定曲目"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "移除曲目"
 
@@ -1814,7 +1814,7 @@ msgstr "显示选项"
 msgid "Display the on-screen-display"
 msgstr "显示屏幕显示"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "重新扫描整个媒体库"
 
@@ -1993,12 +1993,12 @@ msgstr "动态随机混音"
 msgid "Edit smart playlist..."
 msgstr "编辑智能播放列表..."
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "编辑标签 \"%1\"..."
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "编辑标签..."
 
@@ -2011,7 +2011,7 @@ msgid "Edit track information"
 msgstr "编辑曲目信息"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "编辑曲目信息..."
 
@@ -2119,7 +2119,7 @@ msgstr "整个集合"
 msgid "Episode information"
 msgstr "歌集信息"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "均衡器"
 
@@ -2132,8 +2132,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "相当于 --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "错误"
 
@@ -2168,7 +2168,7 @@ msgstr "载入 %1 出错"
 msgid "Error loading di.fm playlist"
 msgstr "读取di.fm播放列表错误"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "处理 %1 出错：%2"
@@ -2251,7 +2251,11 @@ msgstr "导出完成"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "已导出 %1 个封面，共 %2 个(跳过 %3 个)"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2275,7 +2279,7 @@ msgstr "淡出"
 msgid "Fading duration"
 msgstr "淡出时长"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "读取 CD 失败"
 
@@ -2557,11 +2561,11 @@ msgstr "给它起个名字"
 msgid "Go"
 msgstr "Go"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "转到下一播放列表标签"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "转到上一播放列表标签"
 
@@ -2894,7 +2898,7 @@ msgstr "Jamendo 数据库"
 msgid "Jump to previous song right away"
 msgstr "立即跳到上首歌"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "跳转到当前播放的曲目"
 
@@ -2918,7 +2922,7 @@ msgstr "当窗口关闭时仍在后台运行"
 msgid "Keep the original files"
 msgstr "保留原始文件"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "小猫咪"
@@ -3010,7 +3014,7 @@ msgstr "媒体库"
 msgid "Library advanced grouping"
 msgstr "媒体库高级分组"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "重新扫描媒体库提示"
 
@@ -3050,7 +3054,7 @@ msgstr "从磁盘载入封面..."
 msgid "Load playlist"
 msgstr "载入播放列表"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "载入播放列表..."
 
@@ -3111,11 +3115,15 @@ msgstr "登录"
 msgid "Login failed"
 msgstr "登录失败"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "长期预测 (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "喜爱"
 
@@ -3150,11 +3158,11 @@ msgstr "歌词来自 %1"
 msgid "Lyrics from the tag"
 msgstr "此标签中的歌词"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3196,7 +3204,7 @@ msgstr "主要档案(MAIN)"
 msgid "Make it so!"
 msgstr "就这样吧！"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "定时响铃！"
@@ -3334,7 +3342,7 @@ msgstr "挂载点"
 msgid "Move down"
 msgstr "下移"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "移动至媒体库..."
 
@@ -3343,7 +3351,7 @@ msgstr "移动至媒体库..."
 msgid "Move up"
 msgstr "上移"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "音乐"
 
@@ -3356,7 +3364,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "静音"
 
@@ -3405,7 +3413,7 @@ msgstr "从未播放"
 msgid "New folder"
 msgstr "创建新文件夹"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "新建播放列表"
 
@@ -3433,8 +3441,12 @@ msgstr "最新曲目"
 msgid "Next"
 msgstr "下一首"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "下一个曲目"
 
@@ -3472,7 +3484,7 @@ msgstr "无短块"
 msgid "None"
 msgstr "无"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "已选择的曲目均不适合复制到设备"
 
@@ -3557,19 +3569,19 @@ msgstr "关闭"
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3613,7 +3625,7 @@ msgstr "不透明度"
 msgid "Open %1 in browser"
 msgstr "在浏览器中打开%1"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "打开音频CD...(&a)"
 
@@ -3625,7 +3637,7 @@ msgstr "打开 OPML 文件"
 msgid "Open OPML file..."
 msgstr "打开 OPML 文件…"
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "打开目录导入音乐"
 
@@ -3633,7 +3645,7 @@ msgstr "打开目录导入音乐"
 msgid "Open device"
 msgstr "打开设备"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "打开文件..."
 
@@ -3687,7 +3699,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "组织文件"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "组织文件..."
 
@@ -3771,7 +3783,7 @@ msgstr "晚会"
 msgid "Password"
 msgstr "密码"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "暂停"
@@ -3795,6 +3807,10 @@ msgstr "表演者"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "像素"
@@ -3803,10 +3819,10 @@ msgstr "像素"
 msgid "Plain sidebar"
 msgstr "普通侧边栏"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "播放"
 
@@ -3827,11 +3843,11 @@ msgstr "若停止则播放，若播放则停止"
 msgid "Play if there is nothing already playing"
 msgstr "如无歌曲播放则自动播放添加的歌曲"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "播放下一首"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "在下一首播放所选曲目"
 
@@ -3930,7 +3946,7 @@ msgstr "首选项"
 msgid "Preferences"
 msgstr "首选项"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "首选项..."
 
@@ -3990,7 +4006,7 @@ msgid "Previous"
 msgstr "上一首"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "上一个曲目"
 
@@ -4048,16 +4064,16 @@ msgstr "质量"
 msgid "Querying device..."
 msgstr "正在查询设备..."
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "队列管理器"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "将选定曲目加入队列"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "加入队列"
 
@@ -4073,7 +4089,7 @@ msgstr "电台(所有曲目采用相同的音量)"
 msgid "Rain"
 msgstr "雨声"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "雨"
@@ -4185,7 +4201,7 @@ msgstr "删除操作"
 msgid "Remove current song from playlist"
 msgstr "从播放列表中移除此曲"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "从播放列表中移除重复项"
 
@@ -4193,7 +4209,7 @@ msgstr "从播放列表中移除重复项"
 msgid "Remove folder"
 msgstr "删除文件夹"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "从播放列表中移除"
 
@@ -4205,7 +4221,7 @@ msgstr "删除播放列表"
 msgid "Remove playlists"
 msgstr "删除播放列表"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "从播放列表中移除不可用项"
 
@@ -4217,7 +4233,7 @@ msgstr "重命名播放列表"
 msgid "Rename playlist..."
 msgstr "重命名播放列表..."
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "以此顺序为曲目重新编号..."
 
@@ -4308,7 +4324,7 @@ msgstr "抓轨"
 msgid "Rip CD"
 msgstr "CD 抓轨"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "音乐 CD 抓轨"
 
@@ -4386,7 +4402,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "保存播放列表"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "保存播放列表..."
 
@@ -4473,7 +4489,7 @@ msgstr "搜索 Subsonic"
 msgid "Search automatically"
 msgstr "自动搜索"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "搜索专辑"
 
@@ -4486,7 +4502,7 @@ msgstr "搜索专辑封面..."
 msgid "Search for anything"
 msgstr "搜索一切"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "搜索艺术家"
 
@@ -4611,7 +4627,7 @@ msgstr "服务器详情"
 msgid "Service offline"
 msgstr "服务离线"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "将 %1 设置为 %2..."
@@ -4620,7 +4636,7 @@ msgstr "将 %1 设置为 %2..."
 msgid "Set the volume to <value> percent"
 msgstr "设置音量为 <value>%"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "为全部选中的曲目设置值..."
 
@@ -4691,7 +4707,7 @@ msgstr "显示漂亮的 OSD"
 msgid "Show above status bar"
 msgstr "在状态栏之上显示"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "显示所有歌曲"
 
@@ -4711,12 +4727,12 @@ msgstr "显示分频器"
 msgid "Show fullsize..."
 msgstr "显示完整尺寸..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "在文件管理器中打开..."
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "在媒体库中显示"
 
@@ -4728,15 +4744,15 @@ msgstr "在群星中显示"
 msgid "Show moodbar"
 msgstr "显示心情指示条"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "只显示重复"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "只显示未加标签的"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "显示或隐藏侧边栏"
 
@@ -4744,7 +4760,7 @@ msgstr "显示或隐藏侧边栏"
 msgid "Show search suggestions"
 msgstr "显示搜索建议"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "显示侧边栏"
 
@@ -4780,7 +4796,7 @@ msgstr "乱序专辑"
 msgid "Shuffle all"
 msgstr "乱序全部"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "随机播放列表"
 
@@ -4824,11 +4840,15 @@ msgstr "跳过计数"
 msgid "Skip forwards in playlist"
 msgstr "在播放列表中前进"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "跳过所选择的曲目"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "跳过曲目"
 
@@ -4945,7 +4965,7 @@ msgstr "开始抓轨"
 msgid "Start the playlist currently playing"
 msgstr "开始播放当前播放列表"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "开始转换"
 
@@ -4955,7 +4975,7 @@ msgid ""
 "list"
 msgstr "请在上方搜索栏中输入一些词条，来充实搜索结果列表"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "正在开始 %1"
@@ -4965,7 +4985,7 @@ msgid "Starting..."
 msgstr "正在开始..."
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "停止"
 
@@ -4981,7 +5001,7 @@ msgstr "播放完每个曲目后停止"
 msgid "Stop after every track"
 msgstr "播放每个曲目前停止"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "在此曲目后停止"
 
@@ -5149,7 +5169,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Subsonic 服务器的试用期已过。请捐助来获得许可文件。详情请访问 subsonic.org 。"
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5191,7 +5211,7 @@ msgid ""
 "continue?"
 msgstr "将从设备中删除这些文件.确定删除吗?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5293,11 +5313,11 @@ msgstr "切换漂亮的 OSD"
 msgid "Toggle fullscreen"
 msgstr "切换全屏"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "切换队列状态"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "切换歌曲记录"
 
@@ -5342,19 +5362,19 @@ msgstr "曲目(&k)"
 msgid "Track"
 msgstr "曲目"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "音乐转码"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "转换日志"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "转码"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "正在转码 %1 个文件，占用线程 %2 个"
@@ -5431,11 +5451,11 @@ msgstr "未知错误"
 msgid "Unset cover"
 msgstr "撤销封面"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr "取消略过的选定曲目"
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr "取消掠过曲目"
 
@@ -5452,7 +5472,7 @@ msgstr "近期音乐会"
 msgid "Update all podcasts"
 msgstr "更新所有播客"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "更新改变的媒体库文件夹"
 
@@ -5613,7 +5633,7 @@ msgstr "版本 %1"
 msgid "View"
 msgstr "查看"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr "查看流详情"
 
@@ -5621,7 +5641,7 @@ msgstr "查看流详情"
 msgid "Visualization mode"
 msgstr "视觉效果模式"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "视觉效果"
 
@@ -5662,7 +5682,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5758,7 +5778,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media 音频"
 
@@ -5772,7 +5792,7 @@ msgid ""
 "well?"
 msgstr "您想要把此专辑的其它歌曲移动到 群星?"
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "您要立即做个全部重新扫描？"
 

--- a/src/translations/zh_CN.po
+++ b/src/translations/zh_CN.po
@@ -524,7 +524,7 @@ msgstr "添加其他流媒体..."
 msgid "Add directory..."
 msgstr "添加目录..."
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "添加文件"
 
@@ -544,7 +544,7 @@ msgstr "添加文件..."
 msgid "Add files to transcode"
 msgstr "添加需转码文件"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "添加文件夹"
@@ -649,7 +649,7 @@ msgstr "添加到 Spotify 播放列表"
 msgid "Add to Spotify starred"
 msgstr "添加到 Spotify 收藏"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "添加到另一播放列表"
 
@@ -871,7 +871,7 @@ msgstr "您确定要将媒体库中所有歌曲的统计信息写入相应的歌
 msgid "Artist"
 msgstr "歌手"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "歌手信息"
 
@@ -1134,7 +1134,7 @@ msgstr "检测新节目"
 msgid "Check for updates"
 msgstr "检查更新"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "检查更新..."
 
@@ -1374,7 +1374,7 @@ msgstr "配置 Subsonic..."
 msgid "Configure global search..."
 msgstr "配置全局搜索…"
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "配置媒体库..."
 
@@ -1446,11 +1446,11 @@ msgid "Copy to clipboard"
 msgstr "复制到剪切板"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "复制到设备..."
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "复制到媒体库..."
@@ -1668,7 +1668,7 @@ msgid "Delete downloaded data"
 msgstr "删除已下载的数据"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "删除文件"
 
@@ -1676,7 +1676,7 @@ msgstr "删除文件"
 msgid "Delete from device..."
 msgstr "从设备删除..."
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "从硬盘删除..."
@@ -1709,11 +1709,11 @@ msgstr "删除文件"
 msgid "Depth"
 msgstr "深度"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "移除选定曲目"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "移除曲目"
 
@@ -1742,7 +1742,7 @@ msgstr "设备名称"
 msgid "Device properties..."
 msgstr "设备属性..."
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "设备"
 
@@ -1993,7 +1993,7 @@ msgstr "动态随机混音"
 msgid "Edit smart playlist..."
 msgstr "编辑智能播放列表..."
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "编辑标签 \"%1\"..."
@@ -2132,8 +2132,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "相当于 --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "错误"
 
@@ -2279,7 +2279,7 @@ msgstr "淡出"
 msgid "Fading duration"
 msgstr "淡出时长"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "读取 CD 失败"
 
@@ -2402,7 +2402,7 @@ msgstr "文件类型"
 msgid "Filename"
 msgstr "文件名"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "文件"
 
@@ -2817,7 +2817,7 @@ msgstr "已安装"
 msgid "Integrity check"
 msgstr "完整性检验"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "互联网"
 
@@ -3005,7 +3005,7 @@ msgstr "左"
 msgid "Length"
 msgstr "长度"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "媒体库"
@@ -3014,7 +3014,7 @@ msgstr "媒体库"
 msgid "Library advanced grouping"
 msgstr "媒体库高级分组"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "重新扫描媒体库提示"
 
@@ -3342,7 +3342,7 @@ msgstr "挂载点"
 msgid "Move down"
 msgstr "下移"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "移动至媒体库..."
 
@@ -3351,7 +3351,7 @@ msgstr "移动至媒体库..."
 msgid "Move up"
 msgstr "上移"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "音乐"
 
@@ -3413,7 +3413,7 @@ msgstr "从未播放"
 msgid "New folder"
 msgstr "创建新文件夹"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "新建播放列表"
 
@@ -3484,7 +3484,7 @@ msgstr "无短块"
 msgid "None"
 msgstr "无"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "已选择的曲目均不适合复制到设备"
 
@@ -3699,7 +3699,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "组织文件"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "组织文件..."
 
@@ -3783,7 +3783,7 @@ msgstr "晚会"
 msgid "Password"
 msgstr "密码"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "暂停"
@@ -3819,8 +3819,8 @@ msgstr "像素"
 msgid "Plain sidebar"
 msgstr "普通侧边栏"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3843,11 +3843,11 @@ msgstr "若停止则播放，若播放则停止"
 msgid "Play if there is nothing already playing"
 msgstr "如无歌曲播放则自动播放添加的歌曲"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "播放下一首"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "在下一首播放所选曲目"
 
@@ -3886,7 +3886,7 @@ msgstr "播放列表选项"
 msgid "Playlist type"
 msgstr "播放列表类型"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "播放列表"
 
@@ -4068,12 +4068,12 @@ msgstr "正在查询设备..."
 msgid "Queue Manager"
 msgstr "队列管理器"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "将选定曲目加入队列"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "加入队列"
 
@@ -4464,7 +4464,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "搜索"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr "搜索"
@@ -4489,7 +4489,7 @@ msgstr "搜索 Subsonic"
 msgid "Search automatically"
 msgstr "自动搜索"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "搜索专辑"
 
@@ -4502,7 +4502,7 @@ msgstr "搜索专辑封面..."
 msgid "Search for anything"
 msgstr "搜索一切"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "搜索艺术家"
 
@@ -4627,7 +4627,7 @@ msgstr "服务器详情"
 msgid "Service offline"
 msgstr "服务离线"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "将 %1 设置为 %2..."
@@ -4707,7 +4707,7 @@ msgstr "显示漂亮的 OSD"
 msgid "Show above status bar"
 msgstr "在状态栏之上显示"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "显示所有歌曲"
 
@@ -4727,12 +4727,12 @@ msgstr "显示分频器"
 msgid "Show fullsize..."
 msgstr "显示完整尺寸..."
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "在文件管理器中打开..."
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "在媒体库中显示"
 
@@ -4744,11 +4744,11 @@ msgstr "在群星中显示"
 msgid "Show moodbar"
 msgstr "显示心情指示条"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "只显示重复"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "只显示未加标签的"
 
@@ -4840,7 +4840,7 @@ msgstr "跳过计数"
 msgid "Skip forwards in playlist"
 msgstr "在播放列表中前进"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "跳过所选择的曲目"
 
@@ -4848,7 +4848,7 @@ msgstr "跳过所选择的曲目"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "跳过曲目"
 
@@ -4880,7 +4880,7 @@ msgstr "慢摇滚"
 msgid "Song Information"
 msgstr "曲目信息"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "曲目信息"
 
@@ -5001,7 +5001,7 @@ msgstr "播放完每个曲目后停止"
 msgid "Stop after every track"
 msgstr "播放每个曲目前停止"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "在此曲目后停止"
 
@@ -5169,7 +5169,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr "Subsonic 服务器的试用期已过。请捐助来获得许可文件。详情请访问 subsonic.org 。"
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5211,7 +5211,7 @@ msgid ""
 "continue?"
 msgstr "将从设备中删除这些文件.确定删除吗?"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5313,7 +5313,7 @@ msgstr "切换漂亮的 OSD"
 msgid "Toggle fullscreen"
 msgstr "切换全屏"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "切换队列状态"
 
@@ -5451,11 +5451,11 @@ msgstr "未知错误"
 msgid "Unset cover"
 msgstr "撤销封面"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr "取消略过的选定曲目"
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr "取消掠过曲目"
 
@@ -5792,7 +5792,7 @@ msgid ""
 "well?"
 msgstr "您想要把此专辑的其它歌曲移动到 群星?"
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "您要立即做个全部重新扫描？"
 

--- a/src/translations/zh_TW.po
+++ b/src/translations/zh_TW.po
@@ -10,7 +10,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Clementine Music Player\n"
-"PO-Revision-Date: 2021-01-12 11:57+0000\n"
+"PO-Revision-Date: 2021-01-26 23:47+0000\n"
 "Last-Translator: John Maguire <john.maguire@gmail.com>\n"
 "Language-Team: Chinese (Taiwan) (http://www.transifex.com/davidsansome/clementine/language/zh_TW/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -164,19 +164,19 @@ msgstr ""
 msgid "%filename%"
 msgstr "%檔案名稱%"
 
-#: transcoder/transcodedialog.cpp:216
+#: transcoder/transcodedialog.cpp:214
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n failed"
 msgstr "%n 失敗"
 
-#: transcoder/transcodedialog.cpp:211
+#: transcoder/transcodedialog.cpp:209
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n finished"
 msgstr "%n 完成的"
 
-#: transcoder/transcodedialog.cpp:205
+#: transcoder/transcodedialog.cpp:203
 #, c-format, qt-plural-format
 msgctxt ""
 msgid "%n remaining"
@@ -194,7 +194,7 @@ msgstr "中間(&C)"
 msgid "&Custom"
 msgstr "自訂(&C)"
 
-#: ../bin/src/ui_mainwindow.h:784
+#: ../bin/src/ui_mainwindow.h:796
 msgid "&Extras"
 msgstr "外掛程式(&E)"
 
@@ -202,7 +202,7 @@ msgstr "外掛程式(&E)"
 msgid "&Grouping"
 msgstr "群組(&G)"
 
-#: ../bin/src/ui_mainwindow.h:783
+#: ../bin/src/ui_mainwindow.h:795
 msgid "&Help"
 msgstr "幫助(&H)"
 
@@ -227,7 +227,7 @@ msgstr "鎖定評分(&L)"
 msgid "&Lyrics"
 msgstr "歌詞(L)"
 
-#: ../bin/src/ui_mainwindow.h:781
+#: ../bin/src/ui_mainwindow.h:793
 msgid "&Music"
 msgstr "音樂(&M)"
 
@@ -235,15 +235,15 @@ msgstr "音樂(&M)"
 msgid "&None"
 msgstr "無(&N)"
 
-#: ../bin/src/ui_mainwindow.h:782
+#: ../bin/src/ui_mainwindow.h:794
 msgid "&Playlist"
 msgstr "播放清單(&P)"
 
-#: ../bin/src/ui_mainwindow.h:723
+#: ../bin/src/ui_mainwindow.h:728
 msgid "&Quit"
 msgstr "結束(&Q)"
 
-#: ../bin/src/ui_mainwindow.h:748
+#: ../bin/src/ui_mainwindow.h:753
 msgid "&Repeat mode"
 msgstr "循環播放模式(&R)"
 
@@ -251,7 +251,7 @@ msgstr "循環播放模式(&R)"
 msgid "&Right"
 msgstr "右邊(&R)"
 
-#: ../bin/src/ui_mainwindow.h:747
+#: ../bin/src/ui_mainwindow.h:752
 msgid "&Shuffle mode"
 msgstr "隨機播放模式(&S)"
 
@@ -259,7 +259,7 @@ msgstr "隨機播放模式(&S)"
 msgid "&Stretch columns to fit window"
 msgstr "將列伸展至視窗邊界(&S)"
 
-#: ../bin/src/ui_mainwindow.h:785
+#: ../bin/src/ui_mainwindow.h:797
 msgid "&Tools"
 msgstr "工具(&T)"
 
@@ -448,11 +448,11 @@ msgstr "取消"
 msgid "About %1"
 msgstr "關於 %1"
 
-#: ../bin/src/ui_mainwindow.h:735
+#: ../bin/src/ui_mainwindow.h:740
 msgid "About Clementine..."
 msgstr "關於 Clementine…"
 
-#: ../bin/src/ui_mainwindow.h:762
+#: ../bin/src/ui_mainwindow.h:767
 msgid "About Qt..."
 msgstr "關於 Qt…"
 
@@ -512,32 +512,32 @@ msgstr "加入其它的網路串流"
 msgid "Add directory..."
 msgstr "加入目錄…"
 
-#: ui/mainwindow.cpp:2149
+#: ui/mainwindow.cpp:2172
 msgid "Add file"
 msgstr "加入檔案"
 
-#: ../bin/src/ui_mainwindow.h:771
+#: ../bin/src/ui_mainwindow.h:776
 msgid "Add file to transcoder"
 msgstr "加入檔案以便轉碼"
 
-#: ../bin/src/ui_mainwindow.h:769
+#: ../bin/src/ui_mainwindow.h:774
 msgid "Add file(s) to transcoder"
 msgstr "加入檔案以便轉碼"
 
-#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:737
+#: ../bin/src/ui_transcodedialog.h:218 ../bin/src/ui_mainwindow.h:742
 msgid "Add file..."
 msgstr "加入檔案…"
 
-#: transcoder/transcodedialog.cpp:226
+#: transcoder/transcodedialog.cpp:224
 msgid "Add files to transcode"
 msgstr "加入檔案以轉碼"
 
-#: transcoder/transcodedialog.cpp:309 ui/mainwindow.cpp:2176
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "加入資料夾"
 
-#: ../bin/src/ui_mainwindow.h:752
+#: ../bin/src/ui_mainwindow.h:757
 msgid "Add folder..."
 msgstr "加入資料夾…"
 
@@ -549,7 +549,7 @@ msgstr "新增資料夾…"
 msgid "Add podcast"
 msgstr "加入 Podcast"
 
-#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:767
+#: internet/podcasts/podcastservice.cpp:421 ../bin/src/ui_mainwindow.h:772
 msgid "Add podcast..."
 msgstr "加入 Podcast…"
 
@@ -625,7 +625,7 @@ msgstr "加入歌曲音軌標籤"
 msgid "Add song year tag"
 msgstr "加入歌曲年份標籤"
 
-#: ../bin/src/ui_mainwindow.h:738
+#: ../bin/src/ui_mainwindow.h:743
 msgid "Add stream..."
 msgstr "加入網路串流…"
 
@@ -637,7 +637,7 @@ msgstr "新增至 Spotify 播放清單"
 msgid "Add to Spotify starred"
 msgstr "新增至 Spotify 打星列表"
 
-#: ui/mainwindow.cpp:1950
+#: ui/mainwindow.cpp:1973
 msgid "Add to another playlist"
 msgstr "加入到其他播放清單"
 
@@ -731,7 +731,7 @@ msgstr "全部顯示"
 msgid "All Files (*)"
 msgstr "所有檔案 (*)"
 
-#: ../bin/src/ui_mainwindow.h:743
+#: ../bin/src/ui_mainwindow.h:748
 msgctxt "Label for button to enable/disable Hypnotoad background sound."
 msgid "All Glory to the Hypnotoad!"
 msgstr "榮耀終歸大蟾蜍！"
@@ -1122,7 +1122,7 @@ msgstr "檢查是否有新的片斷內容"
 msgid "Check for updates"
 msgstr "檢查更新"
 
-#: ui/mainwindow.cpp:841
+#: ui/mainwindow.cpp:851
 msgid "Check for updates..."
 msgstr "檢查更新…"
 
@@ -1171,18 +1171,18 @@ msgstr "古典"
 msgid "Cleaning up"
 msgstr "清除"
 
-#: transcoder/transcodedialog.cpp:63 widgets/lineedit.cpp:42
+#: transcoder/transcodedialog.cpp:64 widgets/lineedit.cpp:42
 #: ../bin/src/ui_queuemanager.h:155
 msgid "Clear"
 msgstr "清除"
 
-#: ../bin/src/ui_mainwindow.h:726 ../bin/src/ui_mainwindow.h:728
+#: ../bin/src/ui_mainwindow.h:731 ../bin/src/ui_mainwindow.h:733
 msgid "Clear playlist"
 msgstr "清除播放清單"
 
 #: smartplaylists/searchtermwidget.cpp:374
 #: visualisations/visualisationcontainer.cpp:224
-#: ../bin/src/ui_mainwindow.h:718 ../bin/src/ui_visualisationoverlay.h:182
+#: ../bin/src/ui_mainwindow.h:723 ../bin/src/ui_visualisationoverlay.h:182
 msgid "Clementine"
 msgstr "Clementine"
 
@@ -1327,7 +1327,7 @@ msgstr "評論"
 msgid "Complete tags automatically"
 msgstr "標籤完全自動分類"
 
-#: ../bin/src/ui_mainwindow.h:765
+#: ../bin/src/ui_mainwindow.h:770
 msgid "Complete tags automatically..."
 msgstr "標籤完全自動分類…"
 
@@ -1362,7 +1362,7 @@ msgstr "設定 Subsonic…"
 msgid "Configure global search..."
 msgstr "設定全域搜尋…"
 
-#: ui/mainwindow.cpp:672
+#: ui/mainwindow.cpp:682
 msgid "Configure library..."
 msgstr "設定媒體櫃"
 
@@ -1405,7 +1405,7 @@ msgid ""
 "Connection timed out, check server URL. Example: http://localhost:4040/"
 msgstr "連線逾時，請檢查伺服器網址。\n例如: http://localhost:4040/"
 
-#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:746
+#: ../bin/src/ui_console.h:128 ../bin/src/ui_mainwindow.h:751
 msgid "Console"
 msgstr "終端機"
 
@@ -1434,11 +1434,11 @@ msgid "Copy to clipboard"
 msgstr "複製到剪貼簿"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:732 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "複製到裝置…"
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:722
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "複製到媒體櫃"
@@ -1481,14 +1481,14 @@ msgstr "無法登入 Last.fm，請再試一次。"
 msgid "Couldn't create playlist"
 msgstr "無法建立播放清單"
 
-#: transcoder/transcoder.cpp:428
+#: transcoder/transcoder.cpp:434
 #, qt-format
 msgid ""
 "Couldn't find a muxer for %1, check you have the correct GStreamer plugins "
 "installed"
 msgstr "無法為%1找到混合器，請確認已正確安裝 GStreamer 外掛。"
 
-#: transcoder/transcoder.cpp:421
+#: transcoder/transcoder.cpp:427
 #, qt-format
 msgid ""
 "Couldn't find an encoder for %1, check you have the correct GStreamer "
@@ -1503,7 +1503,7 @@ msgstr "無法開啟輸出檔 %1"
 #: internet/core/cloudfileservice.cpp:103
 #: internet/googledrive/googledriveservice.cpp:231
 #: ../bin/src/ui_albumcovermanager.h:220
-#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:741
+#: ../bin/src/ui_albumcoversearcher.h:104 ../bin/src/ui_mainwindow.h:746
 msgid "Cover Manager"
 msgstr "封面管理員"
 
@@ -1656,7 +1656,7 @@ msgid "Delete downloaded data"
 msgstr "刪除下載的資料"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2530 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "刪除檔案"
 
@@ -1664,7 +1664,7 @@ msgstr "刪除檔案"
 msgid "Delete from device..."
 msgstr "從裝置中刪除…"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:735
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "從硬碟中刪除 …"
@@ -1697,11 +1697,11 @@ msgstr "檔案刪除中"
 msgid "Depth"
 msgstr "深度"
 
-#: ui/mainwindow.cpp:1863
+#: ui/mainwindow.cpp:1886
 msgid "Dequeue selected tracks"
 msgstr "將選取的音軌移出佇列中"
 
-#: ui/mainwindow.cpp:1861
+#: ui/mainwindow.cpp:1884
 msgid "Dequeue track"
 msgstr "將音軌移出佇列中"
 
@@ -1802,7 +1802,7 @@ msgstr "顯示選項"
 msgid "Display the on-screen-display"
 msgstr "顯示螢幕上的顯示"
 
-#: ../bin/src/ui_mainwindow.h:764
+#: ../bin/src/ui_mainwindow.h:769
 msgid "Do a full library rescan"
 msgstr "完整的重新掃描媒體櫃"
 
@@ -1981,12 +1981,12 @@ msgstr "動態隨機混合"
 msgid "Edit smart playlist..."
 msgstr "編輯智慧型播放清單…"
 
-#: ui/mainwindow.cpp:1913
+#: ui/mainwindow.cpp:1936
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "編輯「%1」標籤…"
 
-#: ../bin/src/ui_mainwindow.h:733
+#: ../bin/src/ui_mainwindow.h:738
 msgid "Edit tag..."
 msgstr "編輯標籤 …"
 
@@ -1999,7 +1999,7 @@ msgid "Edit track information"
 msgstr "編輯音軌資訊"
 
 #: library/libraryview.cpp:426 widgets/fileviewlist.cpp:52
-#: ../bin/src/ui_mainwindow.h:730
+#: ../bin/src/ui_mainwindow.h:735
 msgid "Edit track information..."
 msgstr "編輯音軌資訊…"
 
@@ -2107,7 +2107,7 @@ msgstr "整個收藏"
 msgid "Episode information"
 msgstr "本集資訊"
 
-#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:750
+#: ../bin/src/ui_equalizer.h:162 ../bin/src/ui_mainwindow.h:755
 msgid "Equalizer"
 msgstr "等化器"
 
@@ -2120,8 +2120,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "相當於 --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2205 ui/mainwindow.cpp:2483
-#: ui/mainwindow.cpp:2661
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
+#: ui/mainwindow.cpp:2684
 msgid "Error"
 msgstr "錯誤"
 
@@ -2156,7 +2156,7 @@ msgstr "錯誤載入 %1"
 msgid "Error loading di.fm playlist"
 msgstr "載入 di.fm 播放清單錯誤"
 
-#: transcoder/transcoder.cpp:393
+#: transcoder/transcoder.cpp:399
 #, qt-format
 msgid "Error processing %1: %2"
 msgstr "處理 %1 錯誤: %2"
@@ -2239,7 +2239,11 @@ msgstr "匯出完成"
 msgid "Exported %1 covers out of %2 (%3 skipped)"
 msgstr "從 %2 中匯出 %1 封面（略過 %3）"
 
-#: core/song.cpp:429 transcoder/transcoder.cpp:234
+#: ../bin/src/ui_mainwindow.h:790
+msgid "F9"
+msgstr ""
+
+#: core/song.cpp:429 transcoder/transcoder.cpp:240
 #: ../bin/src/ui_magnatunedownloaddialog.h:136
 #: ../bin/src/ui_magnatunesettingspage.h:170
 #: ../bin/src/ui_transcodersettingspage.h:176
@@ -2263,7 +2267,7 @@ msgstr "淡出"
 msgid "Fading duration"
 msgstr "淡出持續時間"
 
-#: ui/mainwindow.cpp:2206
+#: ui/mainwindow.cpp:2229
 msgid "Failed reading CD drive"
 msgstr "無法讀取 CD 光碟機"
 
@@ -2545,11 +2549,11 @@ msgstr "給它一個名字："
 msgid "Go"
 msgstr "前往"
 
-#: ../bin/src/ui_mainwindow.h:757
+#: ../bin/src/ui_mainwindow.h:762
 msgid "Go to next playlist tab"
 msgstr "到下一個播放清單分頁"
 
-#: ../bin/src/ui_mainwindow.h:758
+#: ../bin/src/ui_mainwindow.h:763
 msgid "Go to previous playlist tab"
 msgstr "到上一個播放清單分頁"
 
@@ -2882,7 +2886,7 @@ msgstr "Jamendo 資料庫"
 msgid "Jump to previous song right away"
 msgstr "立刻跳回上一首歌"
 
-#: ../bin/src/ui_mainwindow.h:753
+#: ../bin/src/ui_mainwindow.h:758
 msgid "Jump to the currently playing track"
 msgstr "跳轉到目前播放的曲目"
 
@@ -2906,7 +2910,7 @@ msgstr "視窗關閉後依然在背景執行"
 msgid "Keep the original files"
 msgstr "保留原本的檔案"
 
-#: ../bin/src/ui_mainwindow.h:745
+#: ../bin/src/ui_mainwindow.h:750
 msgctxt "Label for buton to enable/disable kittens in the now playing widget"
 msgid "Kittens"
 msgstr "小貓喵喵"
@@ -2998,7 +3002,7 @@ msgstr "媒體櫃"
 msgid "Library advanced grouping"
 msgstr "進階媒體櫃歸類"
 
-#: ui/mainwindow.cpp:2793
+#: ui/mainwindow.cpp:2816
 msgid "Library rescan notice"
 msgstr "媒體櫃重新掃描通知"
 
@@ -3038,7 +3042,7 @@ msgstr "從磁碟載入封面…"
 msgid "Load playlist"
 msgstr "載入播放清單"
 
-#: ../bin/src/ui_mainwindow.h:756
+#: ../bin/src/ui_mainwindow.h:761
 msgid "Load playlist..."
 msgstr "載入播放清單…"
 
@@ -3099,11 +3103,15 @@ msgstr "登入"
 msgid "Login failed"
 msgstr "登入失敗"
 
+#: ../bin/src/ui_transcodelogdialog.h:107
+msgid "Logs"
+msgstr ""
+
 #: ../bin/src/ui_transcoderoptionsaac.h:136
 msgid "Long term prediction profile (LTP)"
 msgstr "長時期預測規格 (LTP)"
 
-#: ../bin/src/ui_mainwindow.h:725
+#: ../bin/src/ui_mainwindow.h:730
 msgid "Love"
 msgstr "喜愛"
 
@@ -3138,11 +3146,11 @@ msgstr "歌詞來自 %1"
 msgid "Lyrics from the tag"
 msgstr "標籤中的歌詞"
 
-#: transcoder/transcoder.cpp:236
+#: transcoder/transcoder.cpp:242
 msgid "M4A AAC"
 msgstr "M4A AAC"
 
-#: core/song.cpp:435 transcoder/transcoder.cpp:239
+#: core/song.cpp:435 transcoder/transcoder.cpp:245
 #: ../bin/src/ui_transcodersettingspage.h:174
 msgid "MP3"
 msgstr "MP3"
@@ -3184,7 +3192,7 @@ msgstr "主規格 (MAIN)"
 msgid "Make it so!"
 msgstr "搞定它！"
 
-#: ../bin/src/ui_mainwindow.h:744
+#: ../bin/src/ui_mainwindow.h:749
 msgctxt "Label for button to enable/disable Enterprise background sound."
 msgid "Make it so!"
 msgstr "搞定它！"
@@ -3322,7 +3330,7 @@ msgstr "掛載點"
 msgid "Move down"
 msgstr "下移"
 
-#: ui/mainwindow.cpp:725 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "移到媒體櫃…"
 
@@ -3331,7 +3339,7 @@ msgstr "移到媒體櫃…"
 msgid "Move up"
 msgstr "上移"
 
-#: transcoder/transcodedialog.cpp:228 ui/mainwindow.cpp:2151
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
 msgid "Music"
 msgstr "音樂"
 
@@ -3344,7 +3352,7 @@ msgid "Music extensions remotely visible"
 msgstr ""
 
 #: core/globalshortcuts.cpp:65 wiimotedev/wiimotesettingspage.cpp:114
-#: ../bin/src/ui_mainwindow.h:763
+#: ../bin/src/ui_mainwindow.h:768
 msgid "Mute"
 msgstr "靜音"
 
@@ -3393,7 +3401,7 @@ msgstr "永不開始播放"
 msgid "New folder"
 msgstr "新資料夾"
 
-#: ui/mainwindow.cpp:1967 ../bin/src/ui_mainwindow.h:754
+#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "新增播放清單"
 
@@ -3421,8 +3429,12 @@ msgstr "最新的音軌"
 msgid "Next"
 msgstr "下一個"
 
+#: ../bin/src/ui_mainwindow.h:785
+msgid "Next album"
+msgstr ""
+
 #: core/globalshortcuts.cpp:59 wiimotedev/wiimotesettingspage.cpp:105
-#: ../bin/src/ui_mainwindow.h:722
+#: ../bin/src/ui_mainwindow.h:727
 msgid "Next track"
 msgstr "下一首"
 
@@ -3460,7 +3472,7 @@ msgstr "無短區塊"
 msgid "None"
 msgstr "沒有"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2484 ui/mainwindow.cpp:2662
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "所選歌曲沒有適合複製到裝置的"
 
@@ -3545,19 +3557,19 @@ msgstr "關"
 msgid "Ogg FLAC"
 msgstr "Ogg FLAC"
 
-#: transcoder/transcoder.cpp:245
+#: transcoder/transcoder.cpp:251
 msgid "Ogg Flac"
 msgstr "Ogg Flac"
 
-#: core/song.cpp:443 transcoder/transcoder.cpp:251
+#: core/song.cpp:443 transcoder/transcoder.cpp:257
 msgid "Ogg Opus"
 msgstr "Ogg Opus"
 
-#: core/song.cpp:439 transcoder/transcoder.cpp:248
+#: core/song.cpp:439 transcoder/transcoder.cpp:254
 msgid "Ogg Speex"
 msgstr "Ogg Speex"
 
-#: core/song.cpp:441 transcoder/transcoder.cpp:242
+#: core/song.cpp:441 transcoder/transcoder.cpp:248
 #: ../bin/src/ui_magnatunedownloaddialog.h:135
 #: ../bin/src/ui_magnatunesettingspage.h:169
 msgid "Ogg Vorbis"
@@ -3601,7 +3613,7 @@ msgstr "透明度"
 msgid "Open %1 in browser"
 msgstr "在瀏覽器中開啟 %1"
 
-#: ../bin/src/ui_mainwindow.h:740
+#: ../bin/src/ui_mainwindow.h:745
 msgid "Open &audio CD..."
 msgstr "開啟音樂光碟(&A)…"
 
@@ -3613,7 +3625,7 @@ msgstr "開啟 OPML 檔案"
 msgid "Open OPML file..."
 msgstr "開啟 OPML 檔案…"
 
-#: transcoder/transcodedialog.cpp:243
+#: transcoder/transcodedialog.cpp:241
 msgid "Open a directory to import music from"
 msgstr "選擇目錄以從內匯入音樂"
 
@@ -3621,7 +3633,7 @@ msgstr "選擇目錄以從內匯入音樂"
 msgid "Open device"
 msgstr "開啟裝置"
 
-#: ../bin/src/ui_mainwindow.h:739
+#: ../bin/src/ui_mainwindow.h:744
 msgid "Open file..."
 msgstr "開啟檔案…"
 
@@ -3675,7 +3687,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "組織檔案"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:728
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
 msgid "Organise files..."
 msgstr "組織檔案…"
 
@@ -3759,7 +3771,7 @@ msgstr "派對"
 msgid "Password"
 msgstr "密碼"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1170 ui/mainwindow.cpp:1758
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "暫停"
@@ -3783,6 +3795,10 @@ msgstr "演出者"
 msgid "Pipeline"
 msgstr ""
 
+#: ../bin/src/ui_transcodelogdialog.h:106
+msgid "Pipelines"
+msgstr ""
+
 #: ../bin/src/ui_albumcoverexport.h:214
 msgid "Pixel"
 msgstr "像素"
@@ -3791,10 +3807,10 @@ msgstr "像素"
 msgid "Plain sidebar"
 msgstr "樸素的側邊欄"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:689 ui/mainwindow.cpp:1134
-#: ui/mainwindow.cpp:1155 ui/mainwindow.cpp:1762 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
+#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
-#: ../bin/src/ui_mainwindow.h:720
+#: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
 msgstr "播放"
 
@@ -3815,11 +3831,11 @@ msgstr "停止的話就開始播放，播放中的就暫停"
 msgid "Play if there is nothing already playing"
 msgstr "播放如果沒有歌曲是正在播放中"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1874
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
 msgid "Play next"
 msgstr "播放下一首"
 
-#: ui/mainwindow.cpp:1872
+#: ui/mainwindow.cpp:1895
 msgid "Play selected tracks next"
 msgstr "下 一首播放選取的音軌"
 
@@ -3918,7 +3934,7 @@ msgstr "偏好設定"
 msgid "Preferences"
 msgstr "偏好設定"
 
-#: ../bin/src/ui_mainwindow.h:734
+#: ../bin/src/ui_mainwindow.h:739
 msgid "Preferences..."
 msgstr "偏好設定…"
 
@@ -3978,7 +3994,7 @@ msgid "Previous"
 msgstr "往前"
 
 #: core/globalshortcuts.cpp:61 wiimotedev/wiimotesettingspage.cpp:107
-#: ../bin/src/ui_mainwindow.h:719
+#: ../bin/src/ui_mainwindow.h:724
 msgid "Previous track"
 msgstr "上一首歌曲"
 
@@ -4036,16 +4052,16 @@ msgstr "品質"
 msgid "Querying device..."
 msgstr "查詢裝置…"
 
-#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:761
+#: ../bin/src/ui_queuemanager.h:137 ../bin/src/ui_mainwindow.h:766
 msgid "Queue Manager"
 msgstr "佇列管理員"
 
-#: ui/mainwindow.cpp:1867
+#: ui/mainwindow.cpp:1890
 msgid "Queue selected tracks"
 msgstr "將選取的歌曲加入佇列中"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1865
+#: ui/mainwindow.cpp:1888
 msgid "Queue track"
 msgstr "將歌曲加入佇列中"
 
@@ -4061,7 +4077,7 @@ msgstr "廣播 (為所有歌曲取得相同音量)"
 msgid "Rain"
 msgstr "下雨"
 
-#: ../bin/src/ui_mainwindow.h:742
+#: ../bin/src/ui_mainwindow.h:747
 msgctxt "Label for button to enable/disable rain background sound."
 msgid "Rain"
 msgstr "下雨"
@@ -4173,7 +4189,7 @@ msgstr "刪除功能"
 msgid "Remove current song from playlist"
 msgstr "從播放清單中移除目前的歌曲"
 
-#: ../bin/src/ui_mainwindow.h:768
+#: ../bin/src/ui_mainwindow.h:773
 msgid "Remove duplicates from playlist"
 msgstr "從播放清單中移除重複的歌曲"
 
@@ -4181,7 +4197,7 @@ msgstr "從播放清單中移除重複的歌曲"
 msgid "Remove folder"
 msgstr "移除資料夾"
 
-#: ../bin/src/ui_mainwindow.h:749 internet/spotify/spotifyservice.cpp:684
+#: ../bin/src/ui_mainwindow.h:754 internet/spotify/spotifyservice.cpp:684
 msgid "Remove from playlist"
 msgstr "從播放清單移除"
 
@@ -4193,7 +4209,7 @@ msgstr "移除播放清單"
 msgid "Remove playlists"
 msgstr "移除播放清單"
 
-#: ../bin/src/ui_mainwindow.h:774
+#: ../bin/src/ui_mainwindow.h:779
 msgid "Remove unavailable tracks from playlist"
 msgstr "從播放清單中移除無法讀取的歌曲"
 
@@ -4205,7 +4221,7 @@ msgstr "變更播放清單名稱"
 msgid "Rename playlist..."
 msgstr "重新命名播放清單"
 
-#: ../bin/src/ui_mainwindow.h:731
+#: ../bin/src/ui_mainwindow.h:736
 msgid "Renumber tracks in this order..."
 msgstr "按此順序重新為歌曲編號…"
 
@@ -4296,7 +4312,7 @@ msgstr "轉拷"
 msgid "Rip CD"
 msgstr "轉拷 CD"
 
-#: ../bin/src/ui_mainwindow.h:773
+#: ../bin/src/ui_mainwindow.h:778
 msgid "Rip audio CD"
 msgstr "轉拷音樂光碟"
 
@@ -4374,7 +4390,7 @@ msgctxt "Title of the playlist save dialog."
 msgid "Save playlist"
 msgstr "儲存播放清單"
 
-#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:755
+#: playlist/playlisttabbar.cpp:60 ../bin/src/ui_mainwindow.h:760
 msgid "Save playlist..."
 msgstr "儲存播放清單"
 
@@ -4461,7 +4477,7 @@ msgstr "搜尋 Subsonic"
 msgid "Search automatically"
 msgstr "自動搜尋"
 
-#: ui/mainwindow.cpp:709
+#: ui/mainwindow.cpp:719
 msgid "Search for album"
 msgstr "搜尋專輯"
 
@@ -4474,7 +4490,7 @@ msgstr "搜尋專輯封面…"
 msgid "Search for anything"
 msgstr "搜尋任何東西"
 
-#: ui/mainwindow.cpp:706
+#: ui/mainwindow.cpp:716
 msgid "Search for artist"
 msgstr "搜尋演出者"
 
@@ -4599,7 +4615,7 @@ msgstr "伺服器詳細內容"
 msgid "Service offline"
 msgstr "服務離線"
 
-#: ui/mainwindow.cpp:1912
+#: ui/mainwindow.cpp:1935
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "設定 %1 到「%2」…"
@@ -4608,7 +4624,7 @@ msgstr "設定 %1 到「%2」…"
 msgid "Set the volume to <value> percent"
 msgstr "設定音量到百分之<value>"
 
-#: ../bin/src/ui_mainwindow.h:732
+#: ../bin/src/ui_mainwindow.h:737
 msgid "Set value for all selected tracks..."
 msgstr "為所有選擇的歌曲設定音量…"
 
@@ -4679,7 +4695,7 @@ msgstr "顯示漂亮的螢幕顯示"
 msgid "Show above status bar"
 msgstr "顯示在狀態欄上方"
 
-#: ui/mainwindow.cpp:656
+#: ui/mainwindow.cpp:666
 msgid "Show all songs"
 msgstr "顯示所有歌曲"
 
@@ -4699,12 +4715,12 @@ msgstr "顯示分隔線"
 msgid "Show fullsize..."
 msgstr "全螢幕…"
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "在檔案瀏覽器顯示…"
 
-#: ui/mainwindow.cpp:740
+#: ui/mainwindow.cpp:750
 msgid "Show in library..."
 msgstr "在媒體櫃中顯示"
 
@@ -4716,15 +4732,15 @@ msgstr "顯示各演出者"
 msgid "Show moodbar"
 msgstr "顯示情境時間軸"
 
-#: ui/mainwindow.cpp:658
+#: ui/mainwindow.cpp:668
 msgid "Show only duplicates"
 msgstr "只顯示重複的"
 
-#: ui/mainwindow.cpp:660
+#: ui/mainwindow.cpp:670
 msgid "Show only untagged"
 msgstr "只顯示未標記的"
 
-#: ../bin/src/ui_mainwindow.h:778
+#: ../bin/src/ui_mainwindow.h:783
 msgid "Show or hide the sidebar"
 msgstr "顯示或隱藏側邊欄"
 
@@ -4732,7 +4748,7 @@ msgstr "顯示或隱藏側邊欄"
 msgid "Show search suggestions"
 msgstr "顯示搜尋建議"
 
-#: ../bin/src/ui_mainwindow.h:776
+#: ../bin/src/ui_mainwindow.h:781
 msgid "Show sidebar"
 msgstr "顯示側邊欄"
 
@@ -4768,7 +4784,7 @@ msgstr "隨機播放專輯"
 msgid "Shuffle all"
 msgstr "隨機播放所有歌曲"
 
-#: ../bin/src/ui_mainwindow.h:736
+#: ../bin/src/ui_mainwindow.h:741
 msgid "Shuffle playlist"
 msgstr "隨機排列播放清單"
 
@@ -4812,11 +4828,15 @@ msgstr "略過計數"
 msgid "Skip forwards in playlist"
 msgstr "跳至播放清單最後頭"
 
-#: ui/mainwindow.cpp:1883
+#: ui/mainwindow.cpp:1906
 msgid "Skip selected tracks"
 msgstr "跳過選取的曲目"
 
-#: ui/mainwindow.cpp:1881
+#: ../bin/src/ui_mainwindow.h:787
+msgid "Skip to the next album"
+msgstr ""
+
+#: ui/mainwindow.cpp:1904
 msgid "Skip track"
 msgstr "跳過曲目"
 
@@ -4933,7 +4953,7 @@ msgstr "開始轉拷"
 msgid "Start the playlist currently playing"
 msgstr "開始播放目前播放清單"
 
-#: transcoder/transcodedialog.cpp:92
+#: transcoder/transcodedialog.cpp:93
 msgid "Start transcoding"
 msgstr "開始轉碼"
 
@@ -4943,7 +4963,7 @@ msgid ""
 "list"
 msgstr "開始在上面的搜尋欄內輸入一些東西，以填滿搜尋結果清單"
 
-#: transcoder/transcoder.cpp:400
+#: transcoder/transcoder.cpp:406
 #, qt-format
 msgid "Starting %1"
 msgstr "標記星號 %1"
@@ -4953,7 +4973,7 @@ msgid "Starting..."
 msgstr "開啟…"
 
 #: core/globalshortcuts.cpp:55 wiimotedev/wiimotesettingspage.cpp:109
-#: ../bin/src/ui_mainwindow.h:721
+#: ../bin/src/ui_mainwindow.h:726
 msgid "Stop"
 msgstr "停止"
 
@@ -4969,7 +4989,7 @@ msgstr "在每首歌播完後停止"
 msgid "Stop after every track"
 msgstr "在每首歌播完後停止"
 
-#: ui/mainwindow.cpp:693 ../bin/src/ui_mainwindow.h:724
+#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "在這首歌之後停止"
 
@@ -5137,7 +5157,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2784
+#: ui/mainwindow.cpp:2807
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5179,7 +5199,7 @@ msgid ""
 "continue?"
 msgstr "這些檔案將從裝置上被移除，你確定你要繼續？"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2531 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5281,11 +5301,11 @@ msgstr "拖曳漂亮的螢幕顯示"
 msgid "Toggle fullscreen"
 msgstr "切換全螢幕模式"
 
-#: ui/mainwindow.cpp:1869
+#: ui/mainwindow.cpp:1892
 msgid "Toggle queue status"
 msgstr "切換佇列狀態"
 
-#: ../bin/src/ui_mainwindow.h:766
+#: ../bin/src/ui_mainwindow.h:771
 msgid "Toggle scrobbling"
 msgstr "切換 scrobbling"
 
@@ -5330,19 +5350,19 @@ msgstr "曲目(&K)"
 msgid "Track"
 msgstr "歌曲"
 
-#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:751
+#: ../bin/src/ui_transcodedialog.h:213 ../bin/src/ui_mainwindow.h:756
 msgid "Transcode Music"
 msgstr "音樂轉碼"
 
-#: ../bin/src/ui_transcodelogdialog.h:62
-msgid "Transcoder Log"
-msgstr "轉碼日誌"
+#: ../bin/src/ui_transcodelogdialog.h:105
+msgid "Transcoder Details"
+msgstr ""
 
 #: ../bin/src/ui_transcodersettingspage.h:172
 msgid "Transcoding"
 msgstr "轉碼"
 
-#: transcoder/transcoder.cpp:320
+#: transcoder/transcoder.cpp:326
 #, qt-format
 msgid "Transcoding %1 files using %2 threads"
 msgstr "轉碼 %1 個檔案使用 %2 個進程"
@@ -5419,11 +5439,11 @@ msgstr "不明的錯誤"
 msgid "Unset cover"
 msgstr "未設置封面"
 
-#: ui/mainwindow.cpp:1879
+#: ui/mainwindow.cpp:1902
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1877
+#: ui/mainwindow.cpp:1900
 msgid "Unskip track"
 msgstr ""
 
@@ -5440,7 +5460,7 @@ msgstr ""
 msgid "Update all podcasts"
 msgstr "更新全部的 podcasts"
 
-#: ../bin/src/ui_mainwindow.h:759
+#: ../bin/src/ui_mainwindow.h:764
 msgid "Update changed library folders"
 msgstr "更新改變的媒體櫃資料夾"
 
@@ -5601,7 +5621,7 @@ msgstr "版本 %1"
 msgid "View"
 msgstr "檢視"
 
-#: ../bin/src/ui_mainwindow.h:775
+#: ../bin/src/ui_mainwindow.h:780
 msgid "View Stream Details"
 msgstr ""
 
@@ -5609,7 +5629,7 @@ msgstr ""
 msgid "Visualization mode"
 msgstr "視覺化模式"
 
-#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:760
+#: ui/dbusscreensaver.cpp:33 ../bin/src/ui_mainwindow.h:765
 msgid "Visualizations"
 msgstr "視覺化"
 
@@ -5650,7 +5670,7 @@ msgid ""
 "also affect the performance of hardware decoders."
 msgstr ""
 
-#: core/song.cpp:447 transcoder/transcoder.cpp:257
+#: core/song.cpp:447 transcoder/transcoder.cpp:263
 msgid "Wav"
 msgstr "Wav"
 
@@ -5746,7 +5766,7 @@ msgstr "Windows Media 40k"
 msgid "Windows Media 64k"
 msgstr "Windows Media 64k"
 
-#: core/song.cpp:427 transcoder/transcoder.cpp:254
+#: core/song.cpp:427 transcoder/transcoder.cpp:260
 msgid "Windows Media audio"
 msgstr "Windows Media 音訊"
 
@@ -5760,7 +5780,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2791
+#: ui/mainwindow.cpp:2814
 msgid "Would you like to run a full rescan right now?"
 msgstr "您想要立刻執行完整的重新掃描嗎？"
 

--- a/src/translations/zh_TW.po
+++ b/src/translations/zh_TW.po
@@ -512,7 +512,7 @@ msgstr "加入其它的網路串流"
 msgid "Add directory..."
 msgstr "加入目錄…"
 
-#: ui/mainwindow.cpp:2172
+#: ui/mainwindow.cpp:2169
 msgid "Add file"
 msgstr "加入檔案"
 
@@ -532,7 +532,7 @@ msgstr "加入檔案…"
 msgid "Add files to transcode"
 msgstr "加入檔案以轉碼"
 
-#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2199
+#: transcoder/transcodedialog.cpp:307 ui/mainwindow.cpp:2196
 #: ripper/ripcddialog.cpp:202
 msgid "Add folder"
 msgstr "加入資料夾"
@@ -637,7 +637,7 @@ msgstr "新增至 Spotify 播放清單"
 msgid "Add to Spotify starred"
 msgstr "新增至 Spotify 打星列表"
 
-#: ui/mainwindow.cpp:1973
+#: ui/mainwindow.cpp:1970
 msgid "Add to another playlist"
 msgstr "加入到其他播放清單"
 
@@ -859,7 +859,7 @@ msgstr "確定要將歌曲統計數據寫入所有媒體櫃中的音樂檔案嗎
 msgid "Artist"
 msgstr "演出者"
 
-#: ui/mainwindow.cpp:290
+#: ui/mainwindow.cpp:289
 msgid "Artist info"
 msgstr "演出者"
 
@@ -1122,7 +1122,7 @@ msgstr "檢查是否有新的片斷內容"
 msgid "Check for updates"
 msgstr "檢查更新"
 
-#: ui/mainwindow.cpp:851
+#: ui/mainwindow.cpp:850
 msgid "Check for updates..."
 msgstr "檢查更新…"
 
@@ -1362,7 +1362,7 @@ msgstr "設定 Subsonic…"
 msgid "Configure global search..."
 msgstr "設定全域搜尋…"
 
-#: ui/mainwindow.cpp:682
+#: ui/mainwindow.cpp:681
 msgid "Configure library..."
 msgstr "設定媒體櫃"
 
@@ -1434,11 +1434,11 @@ msgid "Copy to clipboard"
 msgstr "複製到剪貼簿"
 
 #: library/libraryview.cpp:418 internet/podcasts/podcastservice.cpp:444
-#: ui/mainwindow.cpp:742 widgets/fileviewlist.cpp:46
+#: ui/mainwindow.cpp:741 widgets/fileviewlist.cpp:46
 msgid "Copy to device..."
 msgstr "複製到裝置…"
 
-#: devices/deviceview.cpp:222 ui/mainwindow.cpp:732
+#: devices/deviceview.cpp:222 ui/mainwindow.cpp:731
 #: widgets/fileviewlist.cpp:41
 msgid "Copy to library..."
 msgstr "複製到媒體櫃"
@@ -1656,7 +1656,7 @@ msgid "Delete downloaded data"
 msgstr "刪除下載的資料"
 
 #: devices/deviceview.cpp:396 library/libraryview.cpp:677
-#: ui/mainwindow.cpp:2553 widgets/fileview.cpp:189
+#: ui/mainwindow.cpp:2550 widgets/fileview.cpp:189
 msgid "Delete files"
 msgstr "刪除檔案"
 
@@ -1664,7 +1664,7 @@ msgstr "刪除檔案"
 msgid "Delete from device..."
 msgstr "從裝置中刪除…"
 
-#: library/libraryview.cpp:421 ui/mainwindow.cpp:745
+#: library/libraryview.cpp:421 ui/mainwindow.cpp:744
 #: widgets/fileviewlist.cpp:48
 msgid "Delete from disk..."
 msgstr "從硬碟中刪除 …"
@@ -1697,11 +1697,11 @@ msgstr "檔案刪除中"
 msgid "Depth"
 msgstr "深度"
 
-#: ui/mainwindow.cpp:1886
+#: ui/mainwindow.cpp:1883
 msgid "Dequeue selected tracks"
 msgstr "將選取的音軌移出佇列中"
 
-#: ui/mainwindow.cpp:1884
+#: ui/mainwindow.cpp:1881
 msgid "Dequeue track"
 msgstr "將音軌移出佇列中"
 
@@ -1730,7 +1730,7 @@ msgstr "裝置名稱"
 msgid "Device properties..."
 msgstr "裝置屬性…"
 
-#: ui/mainwindow.cpp:283
+#: ui/mainwindow.cpp:282
 msgid "Devices"
 msgstr "裝置"
 
@@ -1981,7 +1981,7 @@ msgstr "動態隨機混合"
 msgid "Edit smart playlist..."
 msgstr "編輯智慧型播放清單…"
 
-#: ui/mainwindow.cpp:1936
+#: ui/mainwindow.cpp:1933
 #, qt-format
 msgid "Edit tag \"%1\"..."
 msgstr "編輯「%1」標籤…"
@@ -2120,8 +2120,8 @@ msgid "Equivalent to --log-levels *:3"
 msgstr "相當於 --log-levels *:3"
 
 #: internet/magnatune/magnatunedownloaddialog.cpp:249
-#: library/libraryview.cpp:671 ui/mainwindow.cpp:2228 ui/mainwindow.cpp:2506
-#: ui/mainwindow.cpp:2684
+#: library/libraryview.cpp:671 ui/mainwindow.cpp:2225 ui/mainwindow.cpp:2503
+#: ui/mainwindow.cpp:2681
 msgid "Error"
 msgstr "錯誤"
 
@@ -2267,7 +2267,7 @@ msgstr "淡出"
 msgid "Fading duration"
 msgstr "淡出持續時間"
 
-#: ui/mainwindow.cpp:2229
+#: ui/mainwindow.cpp:2226
 msgid "Failed reading CD drive"
 msgstr "無法讀取 CD 光碟機"
 
@@ -2390,7 +2390,7 @@ msgstr "檔案型態"
 msgid "Filename"
 msgstr "檔名"
 
-#: ui/mainwindow.cpp:273
+#: ui/mainwindow.cpp:272
 msgid "Files"
 msgstr "檔案"
 
@@ -2805,7 +2805,7 @@ msgstr "已安裝"
 msgid "Integrity check"
 msgstr "完整性檢查"
 
-#: ui/mainwindow.cpp:279
+#: ui/mainwindow.cpp:278
 msgid "Internet"
 msgstr "網路"
 
@@ -2993,7 +2993,7 @@ msgstr "左"
 msgid "Length"
 msgstr "長度"
 
-#: ui/mainwindow.cpp:255 ui/mainwindow.cpp:270
+#: ui/mainwindow.cpp:254 ui/mainwindow.cpp:269
 #: ../bin/src/ui_seafilesettingspage.h:177
 msgid "Library"
 msgstr "媒體櫃"
@@ -3002,7 +3002,7 @@ msgstr "媒體櫃"
 msgid "Library advanced grouping"
 msgstr "進階媒體櫃歸類"
 
-#: ui/mainwindow.cpp:2816
+#: ui/mainwindow.cpp:2813
 msgid "Library rescan notice"
 msgstr "媒體櫃重新掃描通知"
 
@@ -3330,7 +3330,7 @@ msgstr "掛載點"
 msgid "Move down"
 msgstr "下移"
 
-#: ui/mainwindow.cpp:735 widgets/fileviewlist.cpp:43
+#: ui/mainwindow.cpp:734 widgets/fileviewlist.cpp:43
 msgid "Move to library..."
 msgstr "移到媒體櫃…"
 
@@ -3339,7 +3339,7 @@ msgstr "移到媒體櫃…"
 msgid "Move up"
 msgstr "上移"
 
-#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2174
+#: transcoder/transcodedialog.cpp:226 ui/mainwindow.cpp:2171
 msgid "Music"
 msgstr "音樂"
 
@@ -3401,7 +3401,7 @@ msgstr "永不開始播放"
 msgid "New folder"
 msgstr "新資料夾"
 
-#: ui/mainwindow.cpp:1990 ../bin/src/ui_mainwindow.h:759
+#: ui/mainwindow.cpp:1987 ../bin/src/ui_mainwindow.h:759
 msgid "New playlist"
 msgstr "新增播放清單"
 
@@ -3472,7 +3472,7 @@ msgstr "無短區塊"
 msgid "None"
 msgstr "沒有"
 
-#: library/libraryview.cpp:672 ui/mainwindow.cpp:2507 ui/mainwindow.cpp:2685
+#: library/libraryview.cpp:672 ui/mainwindow.cpp:2504 ui/mainwindow.cpp:2682
 msgid "None of the selected songs were suitable for copying to a device"
 msgstr "所選歌曲沒有適合複製到裝置的"
 
@@ -3687,7 +3687,7 @@ msgstr "Opus"
 msgid "Organise Files"
 msgstr "組織檔案"
 
-#: library/libraryview.cpp:415 ui/mainwindow.cpp:738
+#: library/libraryview.cpp:415 ui/mainwindow.cpp:737
 msgid "Organise files..."
 msgstr "組織檔案…"
 
@@ -3771,7 +3771,7 @@ msgstr "派對"
 msgid "Password"
 msgstr "密碼"
 
-#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1193 ui/mainwindow.cpp:1781
+#: core/globalshortcuts.cpp:52 ui/mainwindow.cpp:1190 ui/mainwindow.cpp:1778
 #: ui/qtsystemtrayicon.cpp:185 wiimotedev/wiimotesettingspage.cpp:115
 msgid "Pause"
 msgstr "暫停"
@@ -3807,8 +3807,8 @@ msgstr "像素"
 msgid "Plain sidebar"
 msgstr "樸素的側邊欄"
 
-#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:699 ui/mainwindow.cpp:1157
-#: ui/mainwindow.cpp:1178 ui/mainwindow.cpp:1785 ui/qtsystemtrayicon.cpp:173
+#: core/globalshortcuts.cpp:51 ui/mainwindow.cpp:698 ui/mainwindow.cpp:1154
+#: ui/mainwindow.cpp:1175 ui/mainwindow.cpp:1782 ui/qtsystemtrayicon.cpp:173
 #: ui/qtsystemtrayicon.cpp:199 wiimotedev/wiimotesettingspage.cpp:108
 #: ../bin/src/ui_mainwindow.h:725
 msgid "Play"
@@ -3831,11 +3831,11 @@ msgstr "停止的話就開始播放，播放中的就暫停"
 msgid "Play if there is nothing already playing"
 msgstr "播放如果沒有歌曲是正在播放中"
 
-#: library/libraryview.cpp:395 ui/mainwindow.cpp:1897
+#: library/libraryview.cpp:395 ui/mainwindow.cpp:1894
 msgid "Play next"
 msgstr "播放下一首"
 
-#: ui/mainwindow.cpp:1895
+#: ui/mainwindow.cpp:1892
 msgid "Play selected tracks next"
 msgstr "下 一首播放選取的音軌"
 
@@ -3874,7 +3874,7 @@ msgstr "播放清單選擇"
 msgid "Playlist type"
 msgstr "播放清單類型"
 
-#: ui/mainwindow.cpp:276
+#: ui/mainwindow.cpp:275
 msgid "Playlists"
 msgstr "播放清單"
 
@@ -4056,12 +4056,12 @@ msgstr "查詢裝置…"
 msgid "Queue Manager"
 msgstr "佇列管理員"
 
-#: ui/mainwindow.cpp:1890
+#: ui/mainwindow.cpp:1887
 msgid "Queue selected tracks"
 msgstr "將選取的歌曲加入佇列中"
 
 #: globalsearch/globalsearchview.cpp:464 library/libraryview.cpp:392
-#: ui/mainwindow.cpp:1888
+#: ui/mainwindow.cpp:1885
 msgid "Queue track"
 msgstr "將歌曲加入佇列中"
 
@@ -4452,7 +4452,7 @@ msgstr "Seafile"
 msgid "Search"
 msgstr "搜尋"
 
-#: ui/mainwindow.cpp:267 ../bin/src/ui_globalsearchsettingspage.h:141
+#: ui/mainwindow.cpp:266 ../bin/src/ui_globalsearchsettingspage.h:141
 msgctxt "Global search settings dialog title."
 msgid "Search"
 msgstr " 搜尋"
@@ -4477,7 +4477,7 @@ msgstr "搜尋 Subsonic"
 msgid "Search automatically"
 msgstr "自動搜尋"
 
-#: ui/mainwindow.cpp:719
+#: ui/mainwindow.cpp:718
 msgid "Search for album"
 msgstr "搜尋專輯"
 
@@ -4490,7 +4490,7 @@ msgstr "搜尋專輯封面…"
 msgid "Search for anything"
 msgstr "搜尋任何東西"
 
-#: ui/mainwindow.cpp:716
+#: ui/mainwindow.cpp:715
 msgid "Search for artist"
 msgstr "搜尋演出者"
 
@@ -4615,7 +4615,7 @@ msgstr "伺服器詳細內容"
 msgid "Service offline"
 msgstr "服務離線"
 
-#: ui/mainwindow.cpp:1935
+#: ui/mainwindow.cpp:1932
 #, qt-format
 msgid "Set %1 to \"%2\"..."
 msgstr "設定 %1 到「%2」…"
@@ -4695,7 +4695,7 @@ msgstr "顯示漂亮的螢幕顯示"
 msgid "Show above status bar"
 msgstr "顯示在狀態欄上方"
 
-#: ui/mainwindow.cpp:666
+#: ui/mainwindow.cpp:665
 msgid "Show all songs"
 msgstr "顯示所有歌曲"
 
@@ -4715,12 +4715,12 @@ msgstr "顯示分隔線"
 msgid "Show fullsize..."
 msgstr "全螢幕…"
 
-#: library/libraryview.cpp:432 ui/mainwindow.cpp:748
+#: library/libraryview.cpp:432 ui/mainwindow.cpp:747
 #: widgets/fileviewlist.cpp:54
 msgid "Show in file browser..."
 msgstr "在檔案瀏覽器顯示…"
 
-#: ui/mainwindow.cpp:750
+#: ui/mainwindow.cpp:749
 msgid "Show in library..."
 msgstr "在媒體櫃中顯示"
 
@@ -4732,11 +4732,11 @@ msgstr "顯示各演出者"
 msgid "Show moodbar"
 msgstr "顯示情境時間軸"
 
-#: ui/mainwindow.cpp:668
+#: ui/mainwindow.cpp:667
 msgid "Show only duplicates"
 msgstr "只顯示重複的"
 
-#: ui/mainwindow.cpp:670
+#: ui/mainwindow.cpp:669
 msgid "Show only untagged"
 msgstr "只顯示未標記的"
 
@@ -4828,7 +4828,7 @@ msgstr "略過計數"
 msgid "Skip forwards in playlist"
 msgstr "跳至播放清單最後頭"
 
-#: ui/mainwindow.cpp:1906
+#: ui/mainwindow.cpp:1903
 msgid "Skip selected tracks"
 msgstr "跳過選取的曲目"
 
@@ -4836,7 +4836,7 @@ msgstr "跳過選取的曲目"
 msgid "Skip to the next album"
 msgstr ""
 
-#: ui/mainwindow.cpp:1904
+#: ui/mainwindow.cpp:1901
 msgid "Skip track"
 msgstr "跳過曲目"
 
@@ -4868,7 +4868,7 @@ msgstr "比較輕柔的搖滾樂"
 msgid "Song Information"
 msgstr "歌曲資訊"
 
-#: ui/mainwindow.cpp:287
+#: ui/mainwindow.cpp:286
 msgid "Song info"
 msgstr "歌曲"
 
@@ -4989,7 +4989,7 @@ msgstr "在每首歌播完後停止"
 msgid "Stop after every track"
 msgstr "在每首歌播完後停止"
 
-#: ui/mainwindow.cpp:703 ../bin/src/ui_mainwindow.h:729
+#: ui/mainwindow.cpp:702 ../bin/src/ui_mainwindow.h:729
 msgid "Stop after this track"
 msgstr "在這首歌之後停止"
 
@@ -5157,7 +5157,7 @@ msgid ""
 "license key. Visit subsonic.org for details."
 msgstr ""
 
-#: ui/mainwindow.cpp:2807
+#: ui/mainwindow.cpp:2804
 msgid ""
 "The version of Clementine you've just updated to requires a full library "
 "rescan because of the new features listed below:"
@@ -5199,7 +5199,7 @@ msgid ""
 "continue?"
 msgstr "這些檔案將從裝置上被移除，你確定你要繼續？"
 
-#: library/libraryview.cpp:678 ui/mainwindow.cpp:2554 widgets/fileview.cpp:190
+#: library/libraryview.cpp:678 ui/mainwindow.cpp:2551 widgets/fileview.cpp:190
 msgid ""
 "These files will be permanently deleted from disk, are you sure you want to "
 "continue?"
@@ -5301,7 +5301,7 @@ msgstr "拖曳漂亮的螢幕顯示"
 msgid "Toggle fullscreen"
 msgstr "切換全螢幕模式"
 
-#: ui/mainwindow.cpp:1892
+#: ui/mainwindow.cpp:1889
 msgid "Toggle queue status"
 msgstr "切換佇列狀態"
 
@@ -5439,11 +5439,11 @@ msgstr "不明的錯誤"
 msgid "Unset cover"
 msgstr "未設置封面"
 
-#: ui/mainwindow.cpp:1902
+#: ui/mainwindow.cpp:1899
 msgid "Unskip selected tracks"
 msgstr ""
 
-#: ui/mainwindow.cpp:1900
+#: ui/mainwindow.cpp:1897
 msgid "Unskip track"
 msgstr ""
 
@@ -5780,7 +5780,7 @@ msgid ""
 "well?"
 msgstr ""
 
-#: ui/mainwindow.cpp:2814
+#: ui/mainwindow.cpp:2811
 msgid "Would you like to run a full rescan right now?"
 msgstr "您想要立刻執行完整的重新掃描嗎？"
 

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -154,7 +154,6 @@ void qt_mac_set_dock_menu(QMenu*);
 
 const char* MainWindow::kSettingsGroup = "MainWindow";
 const char* MainWindow::kAllFilesFilterSpec = QT_TR_NOOP("All Files (*)");
-const char* MainWindow::kShowDebugConsoleKey = "CLEMENTINE_DEBUG_CONSOLE";
 
 namespace {
 const int kTrackSliderUpdateTimeMs = 500;
@@ -942,9 +941,7 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
           SLOT(EnableKittens(bool)));
   connect(ui_->action_kittens, SIGNAL(toggled(bool)), app_->network_remote(),
           SLOT(EnableKittens(bool)));
-  QString showConsole =
-      QProcessEnvironment::systemEnvironment().value(kShowDebugConsoleKey, "0");
-  if (showConsole == "1")
+  if (app->DebugFeaturesEnabled())
     connect(ui_->action_console, SIGNAL(triggered()), SLOT(ShowConsole()));
   else
     ui_->action_console->setVisible(false);

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2126,8 +2126,7 @@ void MainWindow::SelectionSetValue() {
         app_->playlist_manager()->current()->proxy()->mapToSource(index);
     int row = source_index.row();
     Song song = app_->playlist_manager()->current()->item_at(row)->Metadata();
-    qLog(Debug) << "MainWindow: SelectionSetValue: song: " << row << " value: " <<  column_value;
-    
+
     if (Playlist::set_column_value(song, column, column_value)) {
       TagReaderReply* reply =
           TagReaderClient::Instance()->SaveFile(song.url().toLocalFile(), song);
@@ -2146,8 +2145,6 @@ void MainWindow::EditValue() {
   // Edit the last column that was right-clicked on.  If nothing's ever been
   // right clicked then look for the first editable column.
   int column = playlist_menu_index_.column();
-
-  qLog(Debug) << "MainWindow: EditValue: column: "  <<  column;
   if (column == -1) {
     for (int i = 0; i < ui_->playlist->view()->model()->columnCount(); ++i) {
       if (ui_->playlist->view()->isColumnHidden(i)) continue;
@@ -2156,7 +2153,7 @@ void MainWindow::EditValue() {
       break;
     }
   }
-  qLog(Debug) << "MainWindow: EditValue: column: "  <<  column;
+
   ui_->playlist->view()->edit(current.sibling(current.row(), column));
 }
 
@@ -2510,11 +2507,9 @@ void MainWindow::CopyFilesToDevice(const QList<QUrl>& urls) {
 
 void MainWindow::EditFileTags(const QList<QUrl>& urls) {
   SongList songs;
-  
   for (const QUrl& url : urls) {
     Song song;
     song.set_url(url);
-    qLog(Debug) << "MainWindow: EditFileTags: url: "  <<  url;
     song.set_valid(true);
     song.set_filetype(Song::Type_Mpeg);
     songs << song;

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2126,7 +2126,8 @@ void MainWindow::SelectionSetValue() {
         app_->playlist_manager()->current()->proxy()->mapToSource(index);
     int row = source_index.row();
     Song song = app_->playlist_manager()->current()->item_at(row)->Metadata();
-
+    qLog(Debug) << "MainWindow: SelectionSetValue: song: " << row << " value: " <<  column_value;
+    
     if (Playlist::set_column_value(song, column, column_value)) {
       TagReaderReply* reply =
           TagReaderClient::Instance()->SaveFile(song.url().toLocalFile(), song);
@@ -2145,6 +2146,8 @@ void MainWindow::EditValue() {
   // Edit the last column that was right-clicked on.  If nothing's ever been
   // right clicked then look for the first editable column.
   int column = playlist_menu_index_.column();
+
+  qLog(Debug) << "MainWindow: EditValue: column: "  <<  column;
   if (column == -1) {
     for (int i = 0; i < ui_->playlist->view()->model()->columnCount(); ++i) {
       if (ui_->playlist->view()->isColumnHidden(i)) continue;
@@ -2153,7 +2156,7 @@ void MainWindow::EditValue() {
       break;
     }
   }
-
+  qLog(Debug) << "MainWindow: EditValue: column: "  <<  column;
   ui_->playlist->view()->edit(current.sibling(current.row(), column));
 }
 
@@ -2507,9 +2510,11 @@ void MainWindow::CopyFilesToDevice(const QList<QUrl>& urls) {
 
 void MainWindow::EditFileTags(const QList<QUrl>& urls) {
   SongList songs;
+  
   for (const QUrl& url : urls) {
     Song song;
     song.set_url(url);
+    qLog(Debug) << "MainWindow: EditFileTags: url: "  <<  url;
     song.set_valid(true);
     song.set_filetype(Song::Type_Mpeg);
     songs << song;

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -98,7 +98,6 @@ class MainWindow : public QMainWindow, public PlatformInterface {
 
   static const char* kSettingsGroup;
   static const char* kAllFilesFilterSpec;
-  static const char* kShowDebugConsoleKey;
 
   // Don't change the values
   enum StartupBehaviour {

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -155,6 +155,7 @@ class MainWindow : public QMainWindow, public PlatformInterface {
 
   void NewDebugConsole(Console* console);
  private slots:
+  void SetNextAlbumEnabled(PlaylistSequence::RepeatMode mode);
   void FilePathChanged(const QString& path);
 
   void SaveSettings(QSettings* settings);

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -199,11 +199,20 @@
                 </item>
                 <item>
                  <widget class="QToolButton" name="forward_button">
+                  <property name="minimumSize">
+                   <size>
+                    <width>42</width>
+                    <height>29</height>
+                   </size>
+                  </property>
                   <property name="iconSize">
                    <size>
                     <width>22</width>
                     <height>22</height>
                    </size>
+                  </property>
+                  <property name="popupMode">
+                   <enum>QToolButton::MenuButtonPopup</enum>
                   </property>
                   <property name="autoRaise">
                    <bool>true</bool>
@@ -477,7 +486,7 @@
      <x>0</x>
      <y>0</y>
      <width>1131</width>
-     <height>23</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_music">
@@ -943,6 +952,17 @@
    </property>
    <property name="toolTip">
     <string>Show or hide the sidebar</string>
+   </property>
+  </action>
+  <action name="action_next_album">
+   <property name="text">
+    <string>Next album</string>
+   </property>
+   <property name="toolTip">
+    <string>Skip to the next album</string>
+   </property>
+   <property name="shortcut">
+    <string>F9</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
When using Apple Mp4 tags the 'tmpo' property which normally is translated to BPM is not fetched from audio file metadata.
This change adds this feature without fixing other problems, e.g. when changing tags within clementine existing but unchanged tags become deranged. I strongly suggest to change taglib interface in a way kid3 is using (explicit adding/removing tags).
The minor change within utilities is just to  avoid searching for a file within huge direcories as simply showing directory without positioning or at least highlighting is unuseable.