### PR TITLE
Generalize debug feature check

### DIFF
--- a/src/core/application.cpp
+++ b/src/core/application.cpp
@@ -69,8 +69,16 @@ bool Application::kIsPortable = false;
 const char* Application::kLegacyPortableDataDir = "data";
 const char* Application::kDefaultPortableDataDir = "clementine-data";
 const char* Application::kPortableDataDir = nullptr;
+const char* Application::kDebugFeaturesKey = "CLEMENTINE_DEBUG";
 const QStringList Application::kDefaultMusicExtensionsAllowedRemotely = {
     "aac", "alac", "flac", "m3u", "m4a", "mp3", "ogg", "wav", "wmv"};
+
+// Use CLEMENTINE_DEBUG=1 to enable debug features.
+bool Application::DebugFeaturesEnabled() {
+  QString showConsole =
+      QProcessEnvironment::systemEnvironment().value(kDebugFeaturesKey, "0");
+  return (showConsole == "1");
+}
 
 class ApplicationImpl {
  public:

--- a/src/core/application.h
+++ b/src/core/application.h
@@ -67,7 +67,9 @@ class Application : public QObject {
   static const char* kLegacyPortableDataDir;
   static const char* kDefaultPortableDataDir;
   static const QStringList kDefaultMusicExtensionsAllowedRemotely;
+  static const char* kDebugFeaturesKey;
   static bool IsPortable() { return kIsPortable; }
+  static bool DebugFeaturesEnabled();
 
   explicit Application(QObject* parent = nullptr);
   ~Application();

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -154,7 +154,6 @@ void qt_mac_set_dock_menu(QMenu*);
 
 const char* MainWindow::kSettingsGroup = "MainWindow";
 const char* MainWindow::kAllFilesFilterSpec = QT_TR_NOOP("All Files (*)");
-const char* MainWindow::kShowDebugConsoleKey = "CLEMENTINE_DEBUG_CONSOLE";
 
 namespace {
 const int kTrackSliderUpdateTimeMs = 500;
@@ -942,9 +941,7 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
           SLOT(EnableKittens(bool)));
   connect(ui_->action_kittens, SIGNAL(toggled(bool)), app_->network_remote(),
           SLOT(EnableKittens(bool)));
-  QString showConsole =
-      QProcessEnvironment::systemEnvironment().value(kShowDebugConsoleKey, "0");
-  if (showConsole == "1")
+  if (app->DebugFeaturesEnabled())
     connect(ui_->action_console, SIGNAL(triggered()), SLOT(ShowConsole()));
   else
     ui_->action_console->setVisible(false);

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -98,7 +98,6 @@ class MainWindow : public QMainWindow, public PlatformInterface {
 
   static const char* kSettingsGroup;
   static const char* kAllFilesFilterSpec;
-  static const char* kShowDebugConsoleKey;
 
   // Don't change the values
   enum StartupBehaviour {


### PR DESCRIPTION
Move check for debug console to Application and use environment variable CLEMENTINE_DEBUG instead of CLEMENTINE_DEBUG_CONSOLE.

I doubt anybody else is currently using the debug console. And if they are, they're probably reading commit messages as well.