### PR TITLE
Provide user feedback in options error condition 

### DIFF
--- a/src/ripper/ripcddialog.cpp
+++ b/src/ripper/ripcddialog.cpp
@@ -186,7 +186,7 @@ void RipCDDialog::Options() {
   TranscoderPreset preset = ui_->format->itemData(ui_->format->currentIndex())
                                 .value<TranscoderPreset>();
 
-  TranscoderOptionsDialog dialog(preset.type_, this);
+  TranscoderOptionsDialog dialog(preset, this);
   if (dialog.is_valid()) {
     dialog.exec();
   }

--- a/src/ripper/ripcddialog.cpp
+++ b/src/ripper/ripcddialog.cpp
@@ -187,9 +187,7 @@ void RipCDDialog::Options() {
                                 .value<TranscoderPreset>();
 
   TranscoderOptionsDialog dialog(preset, this);
-  if (dialog.is_valid()) {
-    dialog.exec();
-  }
+  dialog.exec();
 }
 
 // Adds a folder to the destination box.

--- a/src/transcoder/transcodedialog.cpp
+++ b/src/transcoder/transcodedialog.cpp
@@ -314,9 +314,7 @@ void TranscodeDialog::Options() {
                                 .value<TranscoderPreset>();
 
   TranscoderOptionsDialog dialog(preset, this);
-  if (dialog.is_valid()) {
-    dialog.exec();
-  }
+  dialog.exec();
 }
 
 // Adds a folder to the destination box.

--- a/src/transcoder/transcodedialog.cpp
+++ b/src/transcoder/transcodedialog.cpp
@@ -313,7 +313,7 @@ void TranscodeDialog::Options() {
   TranscoderPreset preset = ui_->format->itemData(ui_->format->currentIndex())
                                 .value<TranscoderPreset>();
 
-  TranscoderOptionsDialog dialog(preset.type_, this);
+  TranscoderOptionsDialog dialog(preset, this);
   if (dialog.is_valid()) {
     dialog.exec();
   }

--- a/src/transcoder/transcoderoptionsdialog.cpp
+++ b/src/transcoder/transcoderoptionsdialog.cpp
@@ -56,11 +56,15 @@ TranscoderOptionsDialog::TranscoderOptionsDialog(const TranscoderPreset& preset,
       options_ = new TranscoderOptionsWma(this);
       break;
     default:
+      ui_->errorMessage->setText(
+          tr("Unknown encoder type: %1").arg(preset.name_));
       break;
   }
 
   if (options_) {
-    setWindowTitle(windowTitle() + " - " + Song::TextForFiletype(preset.type_));
+    ui_->errorMessage->setVisible(false);
+    setWindowTitle(tr("Transcoding options - %1")
+                       .arg(Song::TextForFiletype(preset.type_)));
     options_->layout()->setContentsMargins(0, 0, 0, 0);
     ui_->verticalLayout->insertWidget(0, options_);
     resize(width(), minimumHeight());

--- a/src/transcoder/transcoderoptionsdialog.cpp
+++ b/src/transcoder/transcoderoptionsdialog.cpp
@@ -17,6 +17,7 @@
 
 #include "transcoderoptionsdialog.h"
 
+#include "transcoder.h"
 #include "transcoderoptionsaac.h"
 #include "transcoderoptionsflac.h"
 #include "transcoderoptionsmp3.h"
@@ -26,12 +27,12 @@
 #include "transcoderoptionswma.h"
 #include "ui_transcoderoptionsdialog.h"
 
-TranscoderOptionsDialog::TranscoderOptionsDialog(Song::FileType type,
+TranscoderOptionsDialog::TranscoderOptionsDialog(const TranscoderPreset& preset,
                                                  QWidget* parent)
     : QDialog(parent), ui_(new Ui_TranscoderOptionsDialog), options_(nullptr) {
   ui_->setupUi(this);
 
-  switch (type) {
+  switch (preset.type_) {
     case Song::Type_Flac:
     case Song::Type_OggFlac:
       options_ = new TranscoderOptionsFlac(this);
@@ -59,7 +60,7 @@ TranscoderOptionsDialog::TranscoderOptionsDialog(Song::FileType type,
   }
 
   if (options_) {
-    setWindowTitle(windowTitle() + " - " + Song::TextForFiletype(type));
+    setWindowTitle(windowTitle() + " - " + Song::TextForFiletype(preset.type_));
     options_->layout()->setContentsMargins(0, 0, 0, 0);
     ui_->verticalLayout->insertWidget(0, options_);
     resize(width(), minimumHeight());

--- a/src/transcoder/transcoderoptionsdialog.h
+++ b/src/transcoder/transcoderoptionsdialog.h
@@ -20,16 +20,17 @@
 
 #include <QDialog>
 
-#include "core/song.h"
 #include "transcoderoptionsinterface.h"
 
 class Ui_TranscoderOptionsDialog;
+struct TranscoderPreset;
 
 class TranscoderOptionsDialog : public QDialog {
   Q_OBJECT
 
  public:
-  TranscoderOptionsDialog(Song::FileType type, QWidget* parent = nullptr);
+  TranscoderOptionsDialog(const TranscoderPreset& preset,
+                          QWidget* parent = nullptr);
   ~TranscoderOptionsDialog();
 
   bool is_valid() const { return options_; }

--- a/src/transcoder/transcoderoptionsdialog.h
+++ b/src/transcoder/transcoderoptionsdialog.h
@@ -33,8 +33,6 @@ class TranscoderOptionsDialog : public QDialog {
                           QWidget* parent = nullptr);
   ~TranscoderOptionsDialog();
 
-  bool is_valid() const { return options_; }
-
   void accept();
 
   void set_settings_postfix(const QString& settings_postfix);

--- a/src/transcoder/transcoderoptionsdialog.ui
+++ b/src/transcoder/transcoderoptionsdialog.ui
@@ -15,6 +15,19 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <widget class="QLabel" name="errorMessage">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>Error</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>

--- a/src/ui/networkremotesettingspage.cpp
+++ b/src/ui/networkremotesettingspage.cpp
@@ -204,7 +204,7 @@ void NetworkRemoteSettingsPage::Options() {
   TranscoderPreset preset = ui_->format->itemData(ui_->format->currentIndex())
                                 .value<TranscoderPreset>();
 
-  TranscoderOptionsDialog dialog(preset.type_, this);
+  TranscoderOptionsDialog dialog(preset, this);
   dialog.set_settings_postfix(NetworkRemote::kTranscoderSettingPostfix);
   if (dialog.is_valid()) {
     dialog.exec();

--- a/src/ui/networkremotesettingspage.cpp
+++ b/src/ui/networkremotesettingspage.cpp
@@ -206,7 +206,5 @@ void NetworkRemoteSettingsPage::Options() {
 
   TranscoderOptionsDialog dialog(preset, this);
   dialog.set_settings_postfix(NetworkRemote::kTranscoderSettingPostfix);
-  if (dialog.is_valid()) {
-    dialog.exec();
-  }
+  dialog.exec();
 }


### PR DESCRIPTION
Remove condition that allows no dialog to be displayed when user selects
options for transcoding. Display the dialog with an error message
instead. This also applies to the transcode options dialog in the
ripping and network remote settings.

This should not occur in current scenarios, but it's groundwork another fix.