### PR TITLE
utilities: Add common method for bug report URL generation

### DIFF
--- a/src/core/utilities.cpp
+++ b/src/core/utilities.cpp
@@ -40,6 +40,7 @@
 #include <QTcpServer>
 #include <QTemporaryFile>
 #include <QUrl>
+#include <QUrlQuery>
 #include <QWidget>
 #include <QXmlStreamReader>
 #include <QtDebug>
@@ -767,6 +768,16 @@ QString ScrubUrlQueries(const QString& str) {
   QRegExp rx("((?:http|https)://\\S*\\?)\\S*");
   // QString::replace is non const, so operate on a copy.
   return QString(str).replace(rx, "\\1 (query removed)");
+}
+
+QString MakeBugReportUrl(const QString& title) {
+  // Example:
+  // https://github.com/clementine-player/Clementine/issues/new?title=New%20bug
+  QUrl url("https://github.com/clementine-player/Clementine/issues/new");
+  QUrlQuery query;
+  query.addQueryItem("title", title);
+  url.setQuery(query);
+  return url.toString(QUrl::FullyEncoded);
 }
 
 }  // namespace Utilities

--- a/src/core/utilities.h
+++ b/src/core/utilities.h
@@ -166,6 +166,10 @@ QString SystemLanguageName();
 
 // Scrub messages for to remove queries, which may include auth info, from URLs.
 QString ScrubUrlQueries(const QString& str);
+
+// Return URL for user bug a user bug report.
+QString MakeBugReportUrl(const QString& title);
+
 }  // namespace Utilities
 
 class ScopedWCharArray {

--- a/src/internet/podcasts/podcastparser.cpp
+++ b/src/internet/podcasts/podcastparser.cpp
@@ -214,13 +214,10 @@ void PodcastParser::ParseItem(QXmlStreamReader* reader, Podcast* ret) const {
           QString date = reader->readElementText();
           episode.set_publication_date(Utilities::ParseRFC822DateTime(date));
           if (!episode.publication_date().isValid()) {
-            qLog(Error) << "Unable to parse date:" << date
-                        << "Please submit it to "
-                        << "https://github.com/clementine-player/Clementine/"
-                           "issues/new?title=" +
-                               QUrl::toPercentEncoding(
-                                   QString("[podcast] Unable to parse date: %1")
-                                       .arg(date));
+            qLog(Error)
+                << "Unable to parse date:" << date << "Please submit it to "
+                << Utilities::MakeBugReportUrl(
+                       QString("[podcast] Unable to parse date: %1").arg(date));
           }
         } else if (name == "duration" && lower_namespace == kItunesNamespace) {
           // http://www.apple.com/itunes/podcasts/specs.html


### PR DESCRIPTION
Move code from PodcastParser::ParseItem for reuse.

Example:
Calling Utilities::MakeBugReportUrl("New bug") returns:
https://github.com/clementine-player/Clementine/issues/new?title=New%20bug