### PR TITLE
Show encode options for correct element

### DIFF
--- a/src/transcoder/transcoder.cpp
+++ b/src/transcoder/transcoder.cpp
@@ -190,6 +190,12 @@ GstElement* Transcoder::CreateElementForMimeType(const QString& element_type,
   }
 }
 
+QString Transcoder::GetEncoderFactoryForMimeType(const QString& mime_type) {
+  SuitableElement best =
+      FindBestElementForMimeType("Codec/Encoder/Audio", mime_type);
+  return best.name_;
+}
+
 Transcoder::JobFinishedEvent::JobFinishedEvent(JobState* state, bool success)
     : QEvent(QEvent::Type(sEventType)), state_(state), success_(success) {}
 

--- a/src/transcoder/transcoder.h
+++ b/src/transcoder/transcoder.h
@@ -29,6 +29,8 @@
 #include "core/song.h"
 #include "engines/gstpipelinebase.h"
 
+struct SuitableElement;
+
 struct TranscoderPreset {
   TranscoderPreset() : type_(Song::Type_Unknown) {}
   TranscoderPreset(Song::FileType type, const QString& name,
@@ -134,6 +136,9 @@ class Transcoder : public QObject {
                                        const QString& mime_type,
                                        GstElement* bin = nullptr);
   void SetElementProperties(const QString& name, GObject* element);
+
+  static SuitableElement FindBestElementForMimeType(const QString& element_type,
+                                                    const QString& mime_type);
 
   static void NewPadCallback(GstElement*, GstPad* pad, gpointer data);
   static GstBusSyncReply BusCallbackSync(GstBus*, GstMessage* msg,

--- a/src/transcoder/transcoder.h
+++ b/src/transcoder/transcoder.h
@@ -71,6 +71,7 @@ class Transcoder : public QObject {
   void Cancel();
   void DumpGraph(int id);
 
+  static QString GetEncoderFactoryForMimeType(const QString& mime_type);
  signals:
   void JobComplete(const QString& input, const QString& output, bool success);
   void LogLine(const QString& message);

--- a/src/transcoder/transcoderoptionsdialog.ui
+++ b/src/transcoder/transcoderoptionsdialog.ui
@@ -25,6 +25,12 @@
      <property name="alignment">
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
      </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="openExternalLinks">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
In transcode audio format options, determine which gstreamer encoder element will be used to encode the chosen audio format. Show an error message if the element isn't know to the settings dialog.

Current behavior shows settings for faac when MP4 is selected, but that is not available in base Fedora and Debian/Ubuntu distros. A follow-up change will add options pages for the fdkaacenc and voaacenc.