### PR TITLE
transcoder: Move option error into its own widget

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -319,6 +319,7 @@ set(SOURCES
   transcoder/transcoder.cpp
   transcoder/transcoderoptionsaac.cpp
   transcoder/transcoderoptionsdialog.cpp
+  transcoder/transcoderoptionserror.cpp
   transcoder/transcoderoptionsflac.cpp
   transcoder/transcoderoptionsmp3.cpp
   transcoder/transcoderoptionsopus.cpp
@@ -745,6 +746,7 @@ set(UI
   transcoder/transcodelogdialog.ui
   transcoder/transcoderoptionsaac.ui
   transcoder/transcoderoptionsdialog.ui
+  transcoder/transcoderoptionserror.ui
   transcoder/transcoderoptionsflac.ui
   transcoder/transcoderoptionsmp3.ui
   transcoder/transcoderoptionsopus.ui

--- a/src/transcoder/transcoderoptionsdialog.h
+++ b/src/transcoder/transcoderoptionsdialog.h
@@ -37,6 +37,9 @@ class TranscoderOptionsDialog : public QDialog {
 
   void set_settings_postfix(const QString& settings_postfix);
 
+  static TranscoderOptionsInterface* MakeOptionsPage(const QString& mime_type,
+                                                     QWidget* parent = nullptr);
+
  protected:
   void showEvent(QShowEvent* e);
 

--- a/src/transcoder/transcoderoptionsdialog.ui
+++ b/src/transcoder/transcoderoptionsdialog.ui
@@ -15,25 +15,6 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QLabel" name="errorMessage">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="text">
-      <string>Error</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-     <property name="openExternalLinks">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>

--- a/src/transcoder/transcoderoptionserror.cpp
+++ b/src/transcoder/transcoderoptionserror.cpp
@@ -1,0 +1,51 @@
+/* This file is part of Clementine.
+   Copyright 2021, Jim Broadus <jbroadus@gmail.com>
+
+   Clementine is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Clementine is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "transcoderoptionserror.h"
+
+#include "core/utilities.h"
+#include "transcoder.h"
+#include "ui_transcoderoptionserror.h"
+
+TranscoderOptionsError::TranscoderOptionsError(const QString& mime_type,
+                                               const QString& element,
+                                               QWidget* parent)
+    : TranscoderOptionsInterface(parent), ui_(new Ui_TranscoderOptionsError) {
+  ui_->setupUi(this);
+
+  if (mime_type.isEmpty()) {
+    // No codec for raw formats such as wav.
+    ui_->info->setText(tr("No settings available for this type."));
+  } else if (element.isEmpty()) {
+    // Didn't find a suitable element.
+    ui_->info->setText(tr("Could not find a suitable encoder element "
+                          "for <b>%1</b>.")
+                           .arg(mime_type));
+  } else {
+    // No settings page available for element.
+    QString url = Utilities::MakeBugReportUrl(
+        QString("transcoder settings: Unknown encoder element: ") + element);
+    ui_->info->setText(tr("No settings page available for encoder "
+                          "element <b>%1</b>. "
+                          "Please report this issue:<br>"
+                          "<a href=\"%2\">%2</a>")
+                           .arg(element)
+                           .arg(url));
+  }
+}
+
+TranscoderOptionsError::~TranscoderOptionsError() { delete ui_; }

--- a/src/transcoder/transcoderoptionserror.h
+++ b/src/transcoder/transcoderoptionserror.h
@@ -1,0 +1,38 @@
+/* This file is part of Clementine.
+   Copyright 2021, Jim Broadus <jbroadus@gmail.com>
+
+   Clementine is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Clementine is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef TRANSCODEROPTIONSERROR_H
+#define TRANSCODEROPTIONSERROR_H
+
+#include "transcoderoptionsinterface.h"
+
+class Ui_TranscoderOptionsError;
+
+class TranscoderOptionsError : public TranscoderOptionsInterface {
+ public:
+  TranscoderOptionsError(const QString& mime_type, const QString& element,
+                         QWidget* parent = nullptr);
+  ~TranscoderOptionsError();
+
+  void Load(){};
+  void Save(){};
+
+ private:
+  Ui_TranscoderOptionsError* ui_;
+};
+
+#endif  // TRANSCODEROPTIONSERROR_H

--- a/src/transcoder/transcoderoptionserror.ui
+++ b/src/transcoder/transcoderoptionserror.ui
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TranscoderOptionsError</class>
+ <widget class="QWidget" name="TranscoderOptionsError">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>102</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QFormLayout" name="formLayout">
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="info">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="openExternalLinks">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Create a TranscoderOptionsError class and ui that inherits from
TranscoderOptionsInterface. Use this to display options errors. Move
widget creation into a static method. These changes will allow use of
the same mechanism in the transcoder settings page.