### PR TITLE
Add transcoder options widgets for fdkaacenc and voaacenc

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -325,6 +325,7 @@ set(SOURCES
   transcoder/transcoderoptionsmp3.cpp
   transcoder/transcoderoptionsopus.cpp
   transcoder/transcoderoptionsspeex.cpp
+  transcoder/transcoderoptionsvoaac.cpp
   transcoder/transcoderoptionsvorbis.cpp
   transcoder/transcoderoptionswma.cpp
   transcoder/transcodersettingspage.cpp
@@ -754,6 +755,7 @@ set(UI
   transcoder/transcoderoptionsmp3.ui
   transcoder/transcoderoptionsopus.ui
   transcoder/transcoderoptionsspeex.ui
+  transcoder/transcoderoptionsvoaac.ui
   transcoder/transcoderoptionsvorbis.ui
   transcoder/transcoderoptionswma.ui
   transcoder/transcodersettingspage.ui

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -320,6 +320,7 @@ set(SOURCES
   transcoder/transcoderoptionsaac.cpp
   transcoder/transcoderoptionsdialog.cpp
   transcoder/transcoderoptionserror.cpp
+  transcoder/transcoderoptionsfdkaac.cpp
   transcoder/transcoderoptionsflac.cpp
   transcoder/transcoderoptionsmp3.cpp
   transcoder/transcoderoptionsopus.cpp
@@ -618,6 +619,7 @@ set(HEADERS
   transcoder/transcoder.h
   transcoder/transcoderoptionsdialog.h
   transcoder/transcoderoptionsmp3.h
+  transcoder/transcoderoptionsfdkaac.h
   transcoder/transcoderoptionsflac.h
   transcoder/transcodersettingspage.h
 
@@ -747,6 +749,7 @@ set(UI
   transcoder/transcoderoptionsaac.ui
   transcoder/transcoderoptionsdialog.ui
   transcoder/transcoderoptionserror.ui
+  transcoder/transcoderoptionsfdkaac.ui
   transcoder/transcoderoptionsflac.ui
   transcoder/transcoderoptionsmp3.ui
   transcoder/transcoderoptionsopus.ui

--- a/src/transcoder/transcoderoptionsdialog.cpp
+++ b/src/transcoder/transcoderoptionsdialog.cpp
@@ -22,6 +22,7 @@
 #include "transcoder.h"
 #include "transcoderoptionsaac.h"
 #include "transcoderoptionserror.h"
+#include "transcoderoptionsfdkaac.h"
 #include "transcoderoptionsflac.h"
 #include "transcoderoptionsmp3.h"
 #include "transcoderoptionsopus.h"
@@ -78,6 +79,8 @@ TranscoderOptionsInterface* TranscoderOptionsDialog::MakeOptionsPage(
     return new TranscoderOptionsFlac(parent);
   } else if (element == "faac") {
     return new TranscoderOptionsAAC(parent);
+  } else if (element == "fdkaacenc") {
+    return new TranscoderOptionsFDKAAC(parent);
   } else if (element == "lamemp3enc") {
     return new TranscoderOptionsMP3(parent);
   } else if (element == "vorbisenc") {

--- a/src/transcoder/transcoderoptionsdialog.cpp
+++ b/src/transcoder/transcoderoptionsdialog.cpp
@@ -27,6 +27,7 @@
 #include "transcoderoptionsmp3.h"
 #include "transcoderoptionsopus.h"
 #include "transcoderoptionsspeex.h"
+#include "transcoderoptionsvoaac.h"
 #include "transcoderoptionsvorbis.h"
 #include "transcoderoptionswma.h"
 #include "ui_transcoderoptionsdialog.h"
@@ -81,6 +82,8 @@ TranscoderOptionsInterface* TranscoderOptionsDialog::MakeOptionsPage(
     return new TranscoderOptionsAAC(parent);
   } else if (element == "fdkaacenc") {
     return new TranscoderOptionsFDKAAC(parent);
+  } else if (element == "voaacenc") {
+    return new TranscoderOptionsVOAAC(parent);
   } else if (element == "lamemp3enc") {
     return new TranscoderOptionsMP3(parent);
   } else if (element == "vorbisenc") {

--- a/src/transcoder/transcoderoptionsfdkaac.cpp
+++ b/src/transcoder/transcoderoptionsfdkaac.cpp
@@ -1,0 +1,69 @@
+/* This file is part of Clementine.
+   Copyright 2021, Jim Broadus <jbroadus@gmail.com>
+
+   Clementine is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Clementine is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*
+ Settings for the fdkaacenc gstreamer element.
+ https://gstreamer.freedesktop.org/documentation/fdkaac/fdkaacenc.html
+*/
+
+#include "transcoderoptionsfdkaac.h"
+
+#include <QSettings>
+
+#include "ui_transcoderoptionsfdkaac.h"
+
+const char* TranscoderOptionsFDKAAC::kSettingsGroup = "Transcoder/fdkaacenc";
+
+TranscoderOptionsFDKAAC::TranscoderOptionsFDKAAC(QWidget* parent)
+    : TranscoderOptionsInterface(parent), ui_(new Ui_TranscoderOptionsFDKAAC) {
+  ui_->setupUi(this);
+  connect(ui_->target_radio, SIGNAL(toggled(bool)),
+          SLOT(TargetBitrateToggle(bool)));
+}
+
+TranscoderOptionsFDKAAC::~TranscoderOptionsFDKAAC() { delete ui_; }
+
+void TranscoderOptionsFDKAAC::Load() {
+  QSettings s;
+  s.beginGroup(kSettingsGroup + settings_postfix_);
+
+  // If bitrate is set to 0 (default), then bitrate is detemined by sample rate
+  // and channel count.
+  int bitrate = s.value("bitrate", 0).toInt();
+  if (bitrate == 0) {
+    ui_->auto_radio->setChecked(true);
+    ui_->bitrate_group->setEnabled(false);
+  } else {
+    ui_->target_radio->setChecked(true);
+    ui_->bitrate_slider->setValue(bitrate / 1000);
+  }
+}
+
+void TranscoderOptionsFDKAAC::Save() {
+  QSettings s;
+  s.beginGroup(kSettingsGroup + settings_postfix_);
+
+  if (ui_->target_radio->isChecked()) {
+    s.setValue("bitrate", ui_->bitrate_slider->value() * 1000);
+  } else {
+    s.setValue("bitrate", 0);
+  }
+}
+
+void TranscoderOptionsFDKAAC::TargetBitrateToggle(bool checked) {
+  ui_->bitrate_group->setEnabled(checked);
+}

--- a/src/transcoder/transcoderoptionsfdkaac.h
+++ b/src/transcoder/transcoderoptionsfdkaac.h
@@ -1,0 +1,44 @@
+/* This file is part of Clementine.
+   Copyright 2021, Jim Broadus <jbroadus@gmail.com>
+
+   Clementine is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Clementine is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef TRANSCODEROPTIONSFDKAAC_H
+#define TRANSCODEROPTIONSFDKAAC_H
+
+#include "transcoderoptionsinterface.h"
+
+class Ui_TranscoderOptionsFDKAAC;
+
+class TranscoderOptionsFDKAAC : public TranscoderOptionsInterface {
+  Q_OBJECT
+
+ public:
+  TranscoderOptionsFDKAAC(QWidget* parent = nullptr);
+  ~TranscoderOptionsFDKAAC();
+
+  void Load();
+  void Save();
+
+ private slots:
+  void TargetBitrateToggle(bool checked);
+
+ private:
+  static const char* kSettingsGroup;
+
+  Ui_TranscoderOptionsFDKAAC* ui_;
+};
+
+#endif  // TRANSCODEROPTIONSFDKAAC_H

--- a/src/transcoder/transcoderoptionsfdkaac.ui
+++ b/src/transcoder/transcoderoptionsfdkaac.ui
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TranscoderOptionsFDKAAC</class>
+ <widget class="QWidget" name="TranscoderOptionsFDKAAC">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>480</width>
+    <height>344</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Bitrate</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QRadioButton" name="auto_radio">
+        <property name="text">
+         <string>Automatically determine based on sample rate.</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="target_radio">
+        <property name="text">
+         <string>Set target rate</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="bitrate_group">
+        <property name="title">
+         <string/>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QSpinBox" name="bitrate_spinbox">
+           <property name="suffix">
+            <string> kbps</string>
+           </property>
+           <property name="minimum">
+            <number>8</number>
+           </property>
+           <property name="maximum">
+            <number>320</number>
+           </property>
+           <property name="singleStep">
+            <number>8</number>
+           </property>
+           <property name="value">
+            <number>128</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSlider" name="bitrate_slider">
+           <property name="minimum">
+            <number>8</number>
+           </property>
+           <property name="maximum">
+            <number>320</number>
+           </property>
+           <property name="value">
+            <number>128</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>bitrate_slider</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>bitrate_spinbox</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>170</x>
+     <y>29</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>445</x>
+     <y>24</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>bitrate_spinbox</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>bitrate_slider</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>407</x>
+     <y>18</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>191</x>
+     <y>29</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/transcoder/transcoderoptionsvoaac.cpp
+++ b/src/transcoder/transcoderoptionsvoaac.cpp
@@ -1,0 +1,50 @@
+/* This file is part of Clementine.
+   Copyright 2021, Jim Broadus <jbroadus@gmail.com>
+
+   Clementine is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Clementine is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*
+ Settings for the voaacenc gstreamer element.
+ https://gstreamer.freedesktop.org/documentation/voaacenc/index.html
+*/
+
+#include "transcoderoptionsvoaac.h"
+
+#include <QSettings>
+
+#include "ui_transcoderoptionsvoaac.h"
+
+const char* TranscoderOptionsVOAAC::kSettingsGroup = "Transcoder/voaacenc";
+
+TranscoderOptionsVOAAC::TranscoderOptionsVOAAC(QWidget* parent)
+    : TranscoderOptionsInterface(parent), ui_(new Ui_TranscoderOptionsVOAAC) {
+  ui_->setupUi(this);
+}
+
+TranscoderOptionsVOAAC::~TranscoderOptionsVOAAC() { delete ui_; }
+
+void TranscoderOptionsVOAAC::Load() {
+  QSettings s;
+  s.beginGroup(kSettingsGroup + settings_postfix_);
+
+  ui_->bitrate_slider->setValue(s.value("bitrate", 128000).toInt() / 1000);
+}
+
+void TranscoderOptionsVOAAC::Save() {
+  QSettings s;
+  s.beginGroup(kSettingsGroup + settings_postfix_);
+
+  s.setValue("bitrate", ui_->bitrate_slider->value() * 1000);
+}

--- a/src/transcoder/transcoderoptionsvoaac.h
+++ b/src/transcoder/transcoderoptionsvoaac.h
@@ -1,0 +1,39 @@
+/* This file is part of Clementine.
+   Copyright 2021, Jim Broadus <jbroadus@gmail.com>
+
+   Clementine is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Clementine is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef TRANSCODEROPTIONSVOAAC_H
+#define TRANSCODEROPTIONSVOAAC_H
+
+#include "transcoderoptionsinterface.h"
+
+class Ui_TranscoderOptionsVOAAC;
+
+class TranscoderOptionsVOAAC : public TranscoderOptionsInterface {
+ public:
+  TranscoderOptionsVOAAC(QWidget* parent = nullptr);
+  ~TranscoderOptionsVOAAC();
+
+  void Load();
+  void Save();
+
+ private:
+  static const char* kSettingsGroup;
+
+  Ui_TranscoderOptionsVOAAC* ui_;
+};
+
+#endif  // TRANSCODEROPTIONSVOAAC_H

--- a/src/transcoder/transcoderoptionsvoaac.ui
+++ b/src/transcoder/transcoderoptionsvoaac.ui
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TranscoderOptionsVOAAC</class>
+ <widget class="QWidget" name="TranscoderOptionsVOAAC">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>480</width>
+    <height>344</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QFormLayout" name="formLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="bitrate_label">
+     <property name="text">
+      <string>Bitrate</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <layout class="QHBoxLayout" name="bitrate_layout">
+     <item>
+      <widget class="QSlider" name="bitrate_slider">
+       <property name="minimum">
+        <number>8</number>
+       </property>
+       <property name="maximum">
+        <number>320</number>
+       </property>
+       <property name="value">
+        <number>128</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="bitrate_spinbox">
+       <property name="suffix">
+        <string> kbps</string>
+       </property>
+       <property name="minimum">
+        <number>8</number>
+       </property>
+       <property name="maximum">
+        <number>320</number>
+       </property>
+       <property name="singleStep">
+        <number>8</number>
+       </property>
+       <property name="value">
+        <number>128</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>bitrate_slider</tabstop>
+  <tabstop>bitrate_spinbox</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>bitrate_slider</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>bitrate_spinbox</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>170</x>
+     <y>29</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>445</x>
+     <y>24</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>bitrate_spinbox</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>bitrate_slider</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>407</x>
+     <y>18</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>191</x>
+     <y>29</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
These are the aac encoder elements available in vanilla Fedora and Debian/Ubuntu distros.

https://gstreamer.freedesktop.org/documentation/fdkaac/fdkaacenc.html
https://gstreamer.freedesktop.org/documentation/voaacenc/index.html

Base class options aren't included in these or any of the other options widgets. If those are deemed necessary at any point, a new widget could be added and embedded in the other options pages.