### PR TITLE
protobuf: Fix namespace conflict

### DIFF
--- a/ext/clementine-spotifyblob/spotifyclient.h
+++ b/ext/clementine-spotifyblob/spotifyclient.h
@@ -35,7 +35,7 @@ class QTimer;
 class MediaPipeline;
 class ResponseMessage;
 
-class SpotifyClient : public AbstractMessageHandler<pb::spotify::Message> {
+class SpotifyClient : public AbstractMessageHandler<cpb::spotify::Message> {
   Q_OBJECT
 
  public:
@@ -48,7 +48,7 @@ class SpotifyClient : public AbstractMessageHandler<pb::spotify::Message> {
   void Init(quint16 port);
 
  protected:
-  void MessageArrived(const pb::spotify::Message& message);
+  void MessageArrived(const cpb::spotify::Message& message);
   void DeviceClosed();
 
  private slots:
@@ -56,7 +56,7 @@ class SpotifyClient : public AbstractMessageHandler<pb::spotify::Message> {
 
  private:
   void SendLoginCompleted(bool success, const QString& error,
-                          pb::spotify::LoginResponse_Error error_code);
+                          cpb::spotify::LoginResponse_Error error_code);
   void SendPlaybackError(const QString& error);
   void SendSearchResponse(sp_search* result);
 
@@ -118,40 +118,40 @@ class SpotifyClient : public AbstractMessageHandler<pb::spotify::Message> {
       ToplistBrowseComplete(sp_toplistbrowse* result, void* userdata);
 
   // Request handlers.
-  void Login(const pb::spotify::LoginRequest& req);
-  void Search(const pb::spotify::SearchRequest& req);
-  void LoadPlaylist(const pb::spotify::LoadPlaylistRequest& req);
-  void SyncPlaylist(const pb::spotify::SyncPlaylistRequest& req);
-  void AddTracksToPlaylist(const pb::spotify::AddTracksToPlaylistRequest& req);
+  void Login(const cpb::spotify::LoginRequest& req);
+  void Search(const cpb::spotify::SearchRequest& req);
+  void LoadPlaylist(const cpb::spotify::LoadPlaylistRequest& req);
+  void SyncPlaylist(const cpb::spotify::SyncPlaylistRequest& req);
+  void AddTracksToPlaylist(const cpb::spotify::AddTracksToPlaylistRequest& req);
   void RemoveTracksFromPlaylist(
-      const pb::spotify::RemoveTracksFromPlaylistRequest& req);
-  void StartPlayback(const pb::spotify::PlaybackRequest& req);
+      const cpb::spotify::RemoveTracksFromPlaylistRequest& req);
+  void StartPlayback(const cpb::spotify::PlaybackRequest& req);
   void Seek(qint64 offset_nsec);
   void LoadImage(const QString& id_b64);
   void BrowseAlbum(const QString& uri);
-  void BrowseToplist(const pb::spotify::BrowseToplistRequest& req);
-  void SetPlaybackSettings(const pb::spotify::PlaybackSettings& req);
-  void SetPaused(const pb::spotify::PauseRequest& req);
+  void BrowseToplist(const cpb::spotify::BrowseToplistRequest& req);
+  void SetPlaybackSettings(const cpb::spotify::PlaybackSettings& req);
+  void SetPaused(const cpb::spotify::PauseRequest& req);
 
   void SendPlaylistList();
 
-  void ConvertTrack(sp_track* track, pb::spotify::Track* pb);
-  void ConvertAlbum(sp_album* album, pb::spotify::Track* pb);
-  void ConvertAlbumBrowse(sp_albumbrowse* browse, pb::spotify::Track* pb);
+  void ConvertTrack(sp_track* track, cpb::spotify::Track* pb);
+  void ConvertAlbum(sp_album* album, cpb::spotify::Track* pb);
+  void ConvertAlbumBrowse(sp_albumbrowse* browse, cpb::spotify::Track* pb);
 
   // Gets the appropriate sp_playlist* but does not load it.
-  sp_playlist* GetPlaylist(pb::spotify::PlaylistType type, int user_index);
+  sp_playlist* GetPlaylist(cpb::spotify::PlaylistType type, int user_index);
 
  private:
   struct PendingLoadPlaylist {
-    pb::spotify::LoadPlaylistRequest request_;
+    cpb::spotify::LoadPlaylistRequest request_;
     sp_playlist* playlist_;
     QList<sp_track*> tracks_;
     bool offline_sync;
   };
 
   struct PendingPlaybackRequest {
-    pb::spotify::PlaybackRequest request_;
+    cpb::spotify::PlaybackRequest request_;
     sp_link* link_;
     sp_track* track_;
 
@@ -170,7 +170,7 @@ class SpotifyClient : public AbstractMessageHandler<pb::spotify::Message> {
   void TryPlaybackAgain(const PendingPlaybackRequest& req);
   void TryImageAgain(sp_image* image);
   int GetDownloadProgress(sp_playlist* playlist);
-  void SendDownloadProgress(pb::spotify::PlaylistType type, int index,
+  void SendDownloadProgress(cpb::spotify::PlaylistType type, int index,
                             int download_progress);
 
   QByteArray api_key_;
@@ -190,9 +190,9 @@ class SpotifyClient : public AbstractMessageHandler<pb::spotify::Message> {
   QList<PendingPlaybackRequest> pending_playback_requests_;
   QList<PendingImageRequest> pending_image_requests_;
   QMap<sp_image*, int> image_callbacks_registered_;
-  QMap<sp_search*, pb::spotify::SearchRequest> pending_searches_;
+  QMap<sp_search*, cpb::spotify::SearchRequest> pending_searches_;
   QMap<sp_albumbrowse*, QString> pending_album_browses_;
-  QMap<sp_toplistbrowse*, pb::spotify::BrowseToplistRequest>
+  QMap<sp_toplistbrowse*, cpb::spotify::BrowseToplistRequest>
       pending_toplist_browses_;
 
   QMap<sp_search*, QList<sp_albumbrowse*>> pending_search_album_browses_;

--- a/ext/clementine-tagreader/tagreaderworker.cpp
+++ b/ext/clementine-tagreader/tagreaderworker.cpp
@@ -25,10 +25,10 @@
 #include <QUrl>
 
 TagReaderWorker::TagReaderWorker(QIODevice* socket, QObject* parent)
-    : AbstractMessageHandler<pb::tagreader::Message>(socket, parent) {}
+    : AbstractMessageHandler<cpb::tagreader::Message>(socket, parent) {}
 
-void TagReaderWorker::MessageArrived(const pb::tagreader::Message& message) {
-  pb::tagreader::Message reply;
+void TagReaderWorker::MessageArrived(const cpb::tagreader::Message& message) {
+  cpb::tagreader::Message reply;
 
 #if 0
   // Crash every few requests
@@ -68,7 +68,7 @@ void TagReaderWorker::MessageArrived(const pb::tagreader::Message& message) {
                                                          data.size());
   } else if (message.has_read_cloud_file_request()) {
 #ifdef HAVE_GOOGLE_DRIVE
-    const pb::tagreader::ReadCloudFileRequest& req =
+    const cpb::tagreader::ReadCloudFileRequest& req =
         message.read_cloud_file_request();
     if (!tag_reader_.ReadCloudFile(
             QUrl::fromEncoded(QByteArray(req.download_url().data(),
@@ -86,7 +86,7 @@ void TagReaderWorker::MessageArrived(const pb::tagreader::Message& message) {
 }
 
 void TagReaderWorker::DeviceClosed() {
-  AbstractMessageHandler<pb::tagreader::Message>::DeviceClosed();
+  AbstractMessageHandler<cpb::tagreader::Message>::DeviceClosed();
 
   qApp->exit();
 }

--- a/ext/clementine-tagreader/tagreaderworker.h
+++ b/ext/clementine-tagreader/tagreaderworker.h
@@ -23,12 +23,12 @@
 #include "tagreadermessages.pb.h"
 #include "core/messagehandler.h"
 
-class TagReaderWorker : public AbstractMessageHandler<pb::tagreader::Message> {
+class TagReaderWorker : public AbstractMessageHandler<cpb::tagreader::Message> {
  public:
   TagReaderWorker(QIODevice* socket, QObject* parent = NULL);
 
  protected:
-  void MessageArrived(const pb::tagreader::Message& message);
+  void MessageArrived(const cpb::tagreader::Message& message);
   void DeviceClosed();
 
  private:

--- a/ext/libclementine-remote/remotecontrolmessages.proto
+++ b/ext/libclementine-remote/remotecontrolmessages.proto
@@ -20,7 +20,7 @@
 
 syntax = "proto2";
 
-package pb.remote;
+package cpb.remote;
 
 // The supported message types
 enum MsgType {

--- a/ext/libclementine-spotifyblob/spotifymessages.proto
+++ b/ext/libclementine-spotifyblob/spotifymessages.proto
@@ -20,7 +20,7 @@
 
 syntax = "proto2";
 
-package pb.spotify;
+package cpb.spotify;
 
 message LoginRequest {
   required string username = 1;

--- a/ext/libclementine-tagreader/gmereader.cpp
+++ b/ext/libclementine-tagreader/gmereader.cpp
@@ -20,7 +20,7 @@ bool GME::IsSupportedFormat(const QFileInfo& file_info) {
 }
 
 void GME::ReadFile(const QFileInfo& file_info,
-                   pb::tagreader::SongMetadata* song_info) {
+                   cpb::tagreader::SongMetadata* song_info) {
   if (file_info.completeSuffix().endsWith("spc"))
     SPC::Read(file_info, song_info);
   if (file_info.completeSuffix().endsWith("vgm"))
@@ -28,7 +28,7 @@ void GME::ReadFile(const QFileInfo& file_info,
 }
 
 void GME::SPC::Read(const QFileInfo& file_info,
-                    pb::tagreader::SongMetadata* song_info) {
+                    cpb::tagreader::SongMetadata* song_info) {
   QFile file(file_info.filePath());
   if (!file.open(QIODevice::ReadOnly)) return;
 
@@ -137,7 +137,7 @@ void GME::SPC::Read(const QFileInfo& file_info,
   }
 
   song_info->set_valid(true);
-  song_info->set_type(pb::tagreader::SongMetadata_Type_SPC);
+  song_info->set_type(cpb::tagreader::SongMetadata_Type_SPC);
 }
 
 qint16 GME::SPC::GetNextMemAddressAlign32bit(qint16 input) {
@@ -157,7 +157,7 @@ quint64 GME::SPC::ConvertSPCStringToNum(const QByteArray& arr) {
 }
 
 void GME::VGM::Read(const QFileInfo& file_info,
-                    pb::tagreader::SongMetadata* song_info) {
+                    cpb::tagreader::SongMetadata* song_info) {
   QFile file(file_info.filePath());
   if (!file.open(QIODevice::ReadOnly)) return;
 
@@ -206,7 +206,7 @@ void GME::VGM::Read(const QFileInfo& file_info,
   song_info->set_year(strings[8].left(4).toInt());
   song_info->set_length_nanosec(length * kNsecPerMsec);
   song_info->set_valid(true);
-  song_info->set_type(pb::tagreader::SongMetadata_Type_VGM);
+  song_info->set_type(cpb::tagreader::SongMetadata_Type_VGM);
 }
 
 bool GME::VGM::GetPlaybackLength(const QByteArray& sample_count_bytes,

--- a/ext/libclementine-tagreader/gmereader.h
+++ b/ext/libclementine-tagreader/gmereader.h
@@ -10,7 +10,7 @@ class QByteArray;
 namespace GME {
 bool IsSupportedFormat(const QFileInfo& file_info);
 void ReadFile(const QFileInfo& file_info,
-              pb::tagreader::SongMetadata* song_info);
+              cpb::tagreader::SongMetadata* song_info);
 
 namespace SPC {
 /* SPC SPEC:
@@ -42,7 +42,7 @@ enum xID6_ID { SongName = 0x01, GameName = 0x02, ArtistName = 0x03 };
 
 enum xID6_TYPE { Length = 0x0, String = 0x1, Integer = 0x4 };
 
-void Read(const QFileInfo& file_info, pb::tagreader::SongMetadata* song_info);
+void Read(const QFileInfo& file_info, cpb::tagreader::SongMetadata* song_info);
 qint16 GetNextMemAddressAlign32bit(qint16 input);
 quint64 ConvertSPCStringToNum(const QByteArray& arr);
 }  // namespace SPC
@@ -58,7 +58,7 @@ const int LOOP_SAMPLE_COUNT = 0x20;
 const int SAMPLE_TIMEBASE = 44100;
 const int GST_GME_LOOP_TIME_MS = 8000;
 
-void Read(const QFileInfo& file_info, pb::tagreader::SongMetadata* song_info);
+void Read(const QFileInfo& file_info, cpb::tagreader::SongMetadata* song_info);
 /* Takes in two QByteArrays, expected to be 4 bytes long. Desired length
  * is returned via output parameter out_length. Returns false on error. */
 bool GetPlaybackLength(const QByteArray& sample_count_bytes,

--- a/ext/libclementine-tagreader/tagreader.cpp
+++ b/ext/libclementine-tagreader/tagreader.cpp
@@ -143,7 +143,7 @@ QString ReplaceUnderscoresWithSpaces(const QString& s) {
 
 }  // namespace
 
-void TagReader::GuessArtistAndTitle(pb::tagreader::SongMetadata* song) const {
+void TagReader::GuessArtistAndTitle(cpb::tagreader::SongMetadata* song) const {
   QString artist = QString::fromStdString(song->artist());
   QString title = QString::fromStdString(song->title());
   const QString bn = QString::fromStdString(song->basefilename());
@@ -171,7 +171,7 @@ void TagReader::GuessArtistAndTitle(pb::tagreader::SongMetadata* song) const {
 }
 
 void TagReader::GuessAlbum(const QFileInfo& info,
-                           pb::tagreader::SongMetadata* song) const {
+                           cpb::tagreader::SongMetadata* song) const {
   QString album = QString::fromStdString(song->album());
   if (!album.isEmpty()) return;
   const QString str_dir = info.absoluteDir().absolutePath();
@@ -191,7 +191,7 @@ TagReader::TagReader()
     : factory_(new TagLibFileRefFactory), kEmbeddedCover("(embedded)") {}
 
 void TagReader::ReadFile(const QString& filename,
-                         pb::tagreader::SongMetadata* song) const {
+                         cpb::tagreader::SongMetadata* song) const {
   const QByteArray url(QUrl::fromLocalFile(filename).toEncoded());
   const QFileInfo info(filename);
 
@@ -674,7 +674,7 @@ void TagReader::Decode(const QString& tag, const QTextCodec* codec,
 }
 
 void TagReader::ParseFMPSFrame(const QString& name, const QString& value,
-                               pb::tagreader::SongMetadata* song) const {
+                               cpb::tagreader::SongMetadata* song) const {
   qLog(Debug) << "Parsing FMPSFrame" << name << ", " << value;
   FMPSParser parser;
   if (!parser.Parse(value) || parser.is_empty()) return;
@@ -717,7 +717,7 @@ void TagReader::ParseFMPSFrame(const QString& name, const QString& value,
 void TagReader::ParseOggTag(const TagLib::Ogg::FieldListMap& map,
                             const QTextCodec* codec, QString* disc,
                             QString* compilation,
-                            pb::tagreader::SongMetadata* song) const {
+                            cpb::tagreader::SongMetadata* song) const {
   if (!map["COMPOSER"].isEmpty())
     Decode(map["COMPOSER"].front(), codec, song->mutable_composer());
   if (!map["PERFORMER"].isEmpty())
@@ -774,7 +774,7 @@ void TagReader::ParseOggTag(const TagLib::Ogg::FieldListMap& map,
 
 void TagReader::SetVorbisComments(
     TagLib::Ogg::XiphComment* vorbis_comments,
-    const pb::tagreader::SongMetadata& song) const {
+    const cpb::tagreader::SongMetadata& song) const {
   vorbis_comments->addField("COMPOSER",
                             StdStringToTaglibString(song.composer()), true);
   vorbis_comments->addField("PERFORMER",
@@ -810,7 +810,7 @@ void TagReader::SetVorbisComments(
 
 void TagReader::SetFMPSStatisticsVorbisComments(
     TagLib::Ogg::XiphComment* vorbis_comments,
-    const pb::tagreader::SongMetadata& song) const {
+    const cpb::tagreader::SongMetadata& song) const {
   if (song.playcount())
     vorbis_comments->addField("FMPS_PLAYCOUNT",
                               TagLib::String::number(song.playcount()), true);
@@ -822,54 +822,54 @@ void TagReader::SetFMPSStatisticsVorbisComments(
 
 void TagReader::SetFMPSRatingVorbisComments(
     TagLib::Ogg::XiphComment* vorbis_comments,
-    const pb::tagreader::SongMetadata& song) const {
+    const cpb::tagreader::SongMetadata& song) const {
   vorbis_comments->addField(
       "FMPS_RATING", QStringToTaglibString(QString::number(song.rating())),
       true);
 }
 
-pb::tagreader::SongMetadata_Type TagReader::GuessFileType(
+cpb::tagreader::SongMetadata_Type TagReader::GuessFileType(
     TagLib::FileRef* fileref) const {
 #ifdef TAGLIB_WITH_ASF
   if (dynamic_cast<TagLib::ASF::File*>(fileref->file()))
-    return pb::tagreader::SongMetadata_Type_ASF;
+    return cpb::tagreader::SongMetadata_Type_ASF;
 #endif
   if (dynamic_cast<TagLib::FLAC::File*>(fileref->file()))
-    return pb::tagreader::SongMetadata_Type_FLAC;
+    return cpb::tagreader::SongMetadata_Type_FLAC;
 #ifdef TAGLIB_WITH_MP4
   if (dynamic_cast<TagLib::MP4::File*>(fileref->file()))
-    return pb::tagreader::SongMetadata_Type_MP4;
+    return cpb::tagreader::SongMetadata_Type_MP4;
 #endif
   if (dynamic_cast<TagLib::MPC::File*>(fileref->file()))
-    return pb::tagreader::SongMetadata_Type_MPC;
+    return cpb::tagreader::SongMetadata_Type_MPC;
   if (dynamic_cast<TagLib::MPEG::File*>(fileref->file()))
-    return pb::tagreader::SongMetadata_Type_MPEG;
+    return cpb::tagreader::SongMetadata_Type_MPEG;
   if (dynamic_cast<TagLib::Ogg::FLAC::File*>(fileref->file()))
-    return pb::tagreader::SongMetadata_Type_OGGFLAC;
+    return cpb::tagreader::SongMetadata_Type_OGGFLAC;
   if (dynamic_cast<TagLib::Ogg::Speex::File*>(fileref->file()))
-    return pb::tagreader::SongMetadata_Type_OGGSPEEX;
+    return cpb::tagreader::SongMetadata_Type_OGGSPEEX;
   if (dynamic_cast<TagLib::Ogg::Vorbis::File*>(fileref->file()))
-    return pb::tagreader::SongMetadata_Type_OGGVORBIS;
+    return cpb::tagreader::SongMetadata_Type_OGGVORBIS;
 #ifdef TAGLIB_HAS_OPUS
   if (dynamic_cast<TagLib::Ogg::Opus::File*>(fileref->file()))
-    return pb::tagreader::SongMetadata_Type_OGGOPUS;
+    return cpb::tagreader::SongMetadata_Type_OGGOPUS;
 #endif
   if (dynamic_cast<TagLib::RIFF::AIFF::File*>(fileref->file()))
-    return pb::tagreader::SongMetadata_Type_AIFF;
+    return cpb::tagreader::SongMetadata_Type_AIFF;
   if (dynamic_cast<TagLib::RIFF::WAV::File*>(fileref->file()))
-    return pb::tagreader::SongMetadata_Type_WAV;
+    return cpb::tagreader::SongMetadata_Type_WAV;
   if (dynamic_cast<TagLib::TrueAudio::File*>(fileref->file()))
-    return pb::tagreader::SongMetadata_Type_TRUEAUDIO;
+    return cpb::tagreader::SongMetadata_Type_TRUEAUDIO;
   if (dynamic_cast<TagLib::WavPack::File*>(fileref->file()))
-    return pb::tagreader::SongMetadata_Type_WAVPACK;
+    return cpb::tagreader::SongMetadata_Type_WAVPACK;
   if (dynamic_cast<TagLib::APE::File*>(fileref->file()))
-    return pb::tagreader::SongMetadata_Type_APE;
+    return cpb::tagreader::SongMetadata_Type_APE;
 
-  return pb::tagreader::SongMetadata_Type_UNKNOWN;
+  return cpb::tagreader::SongMetadata_Type_UNKNOWN;
 }
 
 bool TagReader::SaveFile(const QString& filename,
-                         const pb::tagreader::SongMetadata& song) const {
+                         const cpb::tagreader::SongMetadata& song) const {
   if (filename.isNull()) return false;
 
   qLog(Debug) << "Saving tags to" << filename;
@@ -986,7 +986,7 @@ bool TagReader::SaveFile(const QString& filename,
 }
 
 bool TagReader::SaveSongStatisticsToFile(
-    const QString& filename, const pb::tagreader::SongMetadata& song) const {
+    const QString& filename, const cpb::tagreader::SongMetadata& song) const {
   if (filename.isNull()) return false;
 
   qLog(Debug) << "Saving song statistics tags to" << filename;
@@ -1083,7 +1083,7 @@ bool TagReader::SaveSongStatisticsToFile(
 }
 
 bool TagReader::SaveSongRatingToFile(
-    const QString& filename, const pb::tagreader::SongMetadata& song) const {
+    const QString& filename, const cpb::tagreader::SongMetadata& song) const {
   if (filename.isNull()) return false;
 
   qLog(Debug) << "Saving song rating tags to" << filename;
@@ -1427,7 +1427,7 @@ QByteArray TagReader::LoadEmbeddedArt(const QString& filename) const {
 bool TagReader::ReadCloudFile(const QUrl& download_url, const QString& title,
                               int size, const QString& mime_type,
                               const QString& authorisation_header,
-                              pb::tagreader::SongMetadata* song) const {
+                              cpb::tagreader::SongMetadata* song) const {
   qLog(Debug) << "Loading tags from" << title;
 
   std::unique_ptr<CloudStream> stream(
@@ -1488,7 +1488,7 @@ bool TagReader::ReadCloudFile(const QUrl& download_url, const QString& title,
       song->set_year(tag->tag()->year());
     }
 
-    song->set_type(pb::tagreader::SongMetadata_Type_STREAM);
+    song->set_type(cpb::tagreader::SongMetadata_Type_STREAM);
 
     if (tag->audioProperties()) {
       song->set_length_nanosec(tag->audioProperties()->length() * kNsecPerSec);

--- a/ext/libclementine-tagreader/tagreader.h
+++ b/ext/libclementine-tagreader/tagreader.h
@@ -57,16 +57,16 @@ class TagReader {
   TagReader();
 
   void ReadFile(const QString& filename,
-                pb::tagreader::SongMetadata* song) const;
+                cpb::tagreader::SongMetadata* song) const;
   bool SaveFile(const QString& filename,
-                const pb::tagreader::SongMetadata& song) const;
+                const cpb::tagreader::SongMetadata& song) const;
   // Returns false if something went wrong; returns true otherwise (might
   // returns true if the file exists but nothing has been written inside because
   // statistics tag format is not supported for this kind of file)
   bool SaveSongStatisticsToFile(const QString& filename,
-                                const pb::tagreader::SongMetadata& song) const;
+                                const cpb::tagreader::SongMetadata& song) const;
   bool SaveSongRatingToFile(const QString& filename,
-                            const pb::tagreader::SongMetadata& song) const;
+                            const cpb::tagreader::SongMetadata& song) const;
 
   bool IsMediaFile(const QString& filename) const;
   QByteArray LoadEmbeddedArt(const QString& filename) const;
@@ -74,7 +74,7 @@ class TagReader {
 #ifdef HAVE_GOOGLE_DRIVE
   bool ReadCloudFile(const QUrl& download_url, const QString& title, int size,
                      const QString& mime_type, const QString& access_token,
-                     pb::tagreader::SongMetadata* song) const;
+                     cpb::tagreader::SongMetadata* song) const;
 #endif  // HAVE_GOOGLE_DRIVE
 
   static void Decode(const TagLib::String& tag, const QTextCodec* codec,
@@ -83,23 +83,23 @@ class TagReader {
                      std::string* output);
 
   void ParseFMPSFrame(const QString& name, const QString& value,
-                      pb::tagreader::SongMetadata* song) const;
+                      cpb::tagreader::SongMetadata* song) const;
   void ParseOggTag(const TagLib::Ogg::FieldListMap& map,
                    const QTextCodec* codec, QString* disc, QString* compilation,
-                   pb::tagreader::SongMetadata* song) const;
+                   cpb::tagreader::SongMetadata* song) const;
   void SetVorbisComments(TagLib::Ogg::XiphComment* vorbis_comments,
-                         const pb::tagreader::SongMetadata& song) const;
+                         const cpb::tagreader::SongMetadata& song) const;
   void SetFMPSStatisticsVorbisComments(
       TagLib::Ogg::XiphComment* vorbis_comments,
-      const pb::tagreader::SongMetadata& song) const;
+      const cpb::tagreader::SongMetadata& song) const;
   void SetFMPSRatingVorbisComments(
       TagLib::Ogg::XiphComment* vorbis_comments,
-      const pb::tagreader::SongMetadata& song) const;
+      const cpb::tagreader::SongMetadata& song) const;
 
-  void GuessArtistAndTitle(pb::tagreader::SongMetadata* song) const;
-  void GuessAlbum(const QFileInfo &info, pb::tagreader::SongMetadata* song) const;
+  void GuessArtistAndTitle(cpb::tagreader::SongMetadata* song) const;
+  void GuessAlbum(const QFileInfo &info, cpb::tagreader::SongMetadata* song) const;
 
-  pb::tagreader::SongMetadata_Type GuessFileType(
+  cpb::tagreader::SongMetadata_Type GuessFileType(
       TagLib::FileRef* fileref) const;
 
   void SetUserTextFrame(const QString& description, const QString& value,

--- a/ext/libclementine-tagreader/tagreadermessages.proto
+++ b/ext/libclementine-tagreader/tagreadermessages.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package pb.tagreader;
+package cpb.tagreader;
 
 message SongMetadata {
   enum Type {

--- a/src/core/song.cpp
+++ b/src/core/song.cpp
@@ -526,7 +526,7 @@ QString Song::Decode(const QString& tag, const QTextCodec* codec) {
   return codec->toUnicode(tag.toUtf8());
 }
 
-void Song::InitFromProtobuf(const pb::tagreader::SongMetadata& pb) {
+void Song::InitFromProtobuf(const cpb::tagreader::SongMetadata& pb) {
   d->init_from_file_ = true;
   d->valid_ = pb.valid();
   d->title_ = QStringFromStdString(pb.title());
@@ -575,7 +575,7 @@ void Song::InitFromProtobuf(const pb::tagreader::SongMetadata& pb) {
   InitArtManual();
 }
 
-void Song::ToProtobuf(pb::tagreader::SongMetadata* pb) const {
+void Song::ToProtobuf(cpb::tagreader::SongMetadata* pb) const {
   const QByteArray url(d->url_.toEncoded());
 
   pb->set_valid(d->valid_);
@@ -610,7 +610,7 @@ void Song::ToProtobuf(pb::tagreader::SongMetadata* pb) const {
   pb->set_filesize(d->filesize_);
   pb->set_suspicious_tags(d->suspicious_tags_);
   pb->set_art_automatic(DataCommaSizeFromQString(d->art_automatic_));
-  pb->set_type(static_cast<pb::tagreader::SongMetadata_Type>(d->filetype_));
+  pb->set_type(static_cast<cpb::tagreader::SongMetadata_Type>(d->filetype_));
 }
 
 void Song::InitFromQuery(const SqlRow& q, bool reliable_metadata, int col) {

--- a/src/core/song.h
+++ b/src/core/song.h
@@ -37,11 +37,11 @@
 #include "config.h"
 #include "engines/engine_fwd.h"
 
-namespace pb {
+namespace cpb {
 namespace tagreader {
 class SongMetadata;
 }  // namespace tagreader
-}  // namespace pb
+}  // namespace cpb
 
 class QSqlQuery;
 class QUrl;
@@ -123,7 +123,7 @@ class Song {
             qint64 length_nanosec);
   void Init(const QString& title, const QString& artist, const QString& album,
             qint64 beginning, qint64 end);
-  void InitFromProtobuf(const pb::tagreader::SongMetadata& pb);
+  void InitFromProtobuf(const cpb::tagreader::SongMetadata& pb);
   void InitFromQuery(const SqlRow& query, bool reliable_metadata, int col = 0);
   void InitFromFilePartial(
       const QString& filename);  // Just store the filename: incomplete but fast
@@ -159,7 +159,7 @@ class Song {
   void ToLastFM(lastfm::Track* track, bool prefer_album_artist) const;
 #endif
   void ToXesam(QVariantMap* map) const;
-  void ToProtobuf(pb::tagreader::SongMetadata* pb) const;
+  void ToProtobuf(cpb::tagreader::SongMetadata* pb) const;
 
   // Simple accessors
   bool is_valid() const;

--- a/src/core/tagreaderclient.cpp
+++ b/src/core/tagreaderclient.cpp
@@ -58,8 +58,8 @@ void TagReaderClient::WorkerFailedToStart() {
 }
 
 TagReaderReply* TagReaderClient::ReadFile(const QString& filename) {
-  pb::tagreader::Message message;
-  pb::tagreader::ReadFileRequest* req = message.mutable_read_file_request();
+  cpb::tagreader::Message message;
+  cpb::tagreader::ReadFileRequest* req = message.mutable_read_file_request();
 
   req->set_filename(DataCommaSizeFromQString(filename));
 
@@ -68,8 +68,8 @@ TagReaderReply* TagReaderClient::ReadFile(const QString& filename) {
 
 TagReaderReply* TagReaderClient::SaveFile(const QString& filename,
                                           const Song& metadata) {
-  pb::tagreader::Message message;
-  pb::tagreader::SaveFileRequest* req = message.mutable_save_file_request();
+  cpb::tagreader::Message message;
+  cpb::tagreader::SaveFileRequest* req = message.mutable_save_file_request();
 
   req->set_filename(DataCommaSizeFromQString(filename));
   metadata.ToProtobuf(req->mutable_metadata());
@@ -78,8 +78,8 @@ TagReaderReply* TagReaderClient::SaveFile(const QString& filename,
 }
 
 TagReaderReply* TagReaderClient::UpdateSongStatistics(const Song& metadata) {
-  pb::tagreader::Message message;
-  pb::tagreader::SaveSongStatisticsToFileRequest* req =
+  cpb::tagreader::Message message;
+  cpb::tagreader::SaveSongStatisticsToFileRequest* req =
       message.mutable_save_song_statistics_to_file_request();
 
   req->set_filename(DataCommaSizeFromQString(metadata.url().toLocalFile()));
@@ -96,8 +96,8 @@ void TagReaderClient::UpdateSongsStatistics(const SongList& songs) {
 }
 
 TagReaderReply* TagReaderClient::UpdateSongRating(const Song& metadata) {
-  pb::tagreader::Message message;
-  pb::tagreader::SaveSongRatingToFileRequest* req =
+  cpb::tagreader::Message message;
+  cpb::tagreader::SaveSongRatingToFileRequest* req =
       message.mutable_save_song_rating_to_file_request();
 
   req->set_filename(DataCommaSizeFromQString(metadata.url().toLocalFile()));
@@ -114,8 +114,8 @@ void TagReaderClient::UpdateSongsRating(const SongList& songs) {
 }
 
 TagReaderReply* TagReaderClient::IsMediaFile(const QString& filename) {
-  pb::tagreader::Message message;
-  pb::tagreader::IsMediaFileRequest* req =
+  cpb::tagreader::Message message;
+  cpb::tagreader::IsMediaFileRequest* req =
       message.mutable_is_media_file_request();
 
   req->set_filename(DataCommaSizeFromQString(filename));
@@ -124,8 +124,8 @@ TagReaderReply* TagReaderClient::IsMediaFile(const QString& filename) {
 }
 
 TagReaderReply* TagReaderClient::LoadEmbeddedArt(const QString& filename) {
-  pb::tagreader::Message message;
-  pb::tagreader::LoadEmbeddedArtRequest* req =
+  cpb::tagreader::Message message;
+  cpb::tagreader::LoadEmbeddedArtRequest* req =
       message.mutable_load_embedded_art_request();
 
   req->set_filename(DataCommaSizeFromQString(filename));
@@ -136,8 +136,8 @@ TagReaderReply* TagReaderClient::LoadEmbeddedArt(const QString& filename) {
 TagReaderReply* TagReaderClient::ReadCloudFile(
     const QUrl& download_url, const QString& title, int size,
     const QString& mime_type, const QString& authorisation_header) {
-  pb::tagreader::Message message;
-  pb::tagreader::ReadCloudFileRequest* req =
+  cpb::tagreader::Message message;
+  cpb::tagreader::ReadCloudFileRequest* req =
       message.mutable_read_cloud_file_request();
 
   const QString url_string = download_url.toEncoded();

--- a/src/core/tagreaderclient.h
+++ b/src/core/tagreaderclient.h
@@ -37,7 +37,7 @@ class TagReaderClient : public QObject {
  public:
   explicit TagReaderClient(QObject* parent = nullptr);
 
-  typedef AbstractMessageHandler<pb::tagreader::Message> HandlerType;
+  typedef AbstractMessageHandler<cpb::tagreader::Message> HandlerType;
   typedef HandlerType::ReplyType ReplyType;
 
   static const char* kWorkerExecutableName;
@@ -78,7 +78,7 @@ class TagReaderClient : public QObject {
   static TagReaderClient* sInstance;
 
   WorkerPool<HandlerType>* worker_pool_;
-  QList<pb::tagreader::Message> message_queue_;
+  QList<cpb::tagreader::Message> message_queue_;
 };
 
 typedef TagReaderClient::ReplyType TagReaderReply;

--- a/src/globalsearch/spotifysearchprovider.cpp
+++ b/src/globalsearch/spotifysearchprovider.cpp
@@ -49,16 +49,16 @@ SpotifyServer* SpotifySearchProvider::server() {
   if (!service_->IsBlobInstalled()) return nullptr;
 
   server_ = service_->server();
-  connect(server_, SIGNAL(SearchResults(pb::spotify::SearchResponse)),
-          SLOT(SearchFinishedSlot(pb::spotify::SearchResponse)));
+  connect(server_, SIGNAL(SearchResults(cpb::spotify::SearchResponse)),
+          SLOT(SearchFinishedSlot(cpb::spotify::SearchResponse)));
   connect(server_, SIGNAL(ImageLoaded(QString, QImage)),
           SLOT(ArtLoadedSlot(QString, QImage)));
   connect(server_, SIGNAL(destroyed()), SLOT(ServerDestroyed()));
-  connect(server_, SIGNAL(StarredLoaded(pb::spotify::LoadPlaylistResponse)),
-          SLOT(SuggestionsLoaded(pb::spotify::LoadPlaylistResponse)));
+  connect(server_, SIGNAL(StarredLoaded(cpb::spotify::LoadPlaylistResponse)),
+          SLOT(SuggestionsLoaded(cpb::spotify::LoadPlaylistResponse)));
   connect(server_,
-          SIGNAL(ToplistBrowseResults(pb::spotify::BrowseToplistResponse)),
-          SLOT(SuggestionsLoaded(pb::spotify::BrowseToplistResponse)));
+          SIGNAL(ToplistBrowseResults(cpb::spotify::BrowseToplistResponse)),
+          SLOT(SuggestionsLoaded(cpb::spotify::BrowseToplistResponse)));
 
   return server_;
 }
@@ -82,7 +82,7 @@ void SpotifySearchProvider::SearchAsync(int id, const QString& query) {
 }
 
 void SpotifySearchProvider::SearchFinishedSlot(
-    const pb::spotify::SearchResponse& response) {
+    const cpb::spotify::SearchResponse& response) {
   QString query_string = QString::fromUtf8(response.request().query().c_str());
   QMap<QString, PendingState>::iterator it = queries_.find(query_string);
   if (it == queries_.end()) return;
@@ -107,7 +107,7 @@ void SpotifySearchProvider::SearchFinishedSlot(
   ResultList ret;
 
   for (int i = 0; i < response.album_size(); ++i) {
-    const pb::spotify::Album& album = response.album(i);
+    const cpb::spotify::Album& album = response.album(i);
 
     QHash<QString, int> artist_count;
     QString majority_artist;
@@ -153,7 +153,7 @@ void SpotifySearchProvider::SearchFinishedSlot(
   }
 
   for (int i = 0; i < response.result_size(); ++i) {
-    const pb::spotify::Track& track = response.result(i);
+    const cpb::spotify::Track& track = response.result(i);
 
     // Check this track/album against tracks we've already seen
     // in the album results, and skip if it's a duplicate
@@ -211,7 +211,7 @@ void SpotifySearchProvider::ShowConfig() {
 }
 
 void SpotifySearchProvider::AddSuggestionFromTrack(
-    const pb::spotify::Track& track) {
+    const cpb::spotify::Track& track) {
   if (!track.title().empty()) {
     suggestions_.insert(QString::fromUtf8(track.title().c_str()));
   }
@@ -226,7 +226,7 @@ void SpotifySearchProvider::AddSuggestionFromTrack(
 }
 
 void SpotifySearchProvider::AddSuggestionFromAlbum(
-    const pb::spotify::Album& album) {
+    const cpb::spotify::Album& album) {
   AddSuggestionFromTrack(album.metadata());
   for (int i = 0; i < album.track_size(); ++i) {
     AddSuggestionFromTrack(album.track(i));
@@ -234,14 +234,14 @@ void SpotifySearchProvider::AddSuggestionFromAlbum(
 }
 
 void SpotifySearchProvider::SuggestionsLoaded(
-    const pb::spotify::LoadPlaylistResponse& playlist) {
+    const cpb::spotify::LoadPlaylistResponse& playlist) {
   for (int i = 0; i < playlist.track_size(); ++i) {
     AddSuggestionFromTrack(playlist.track(i));
   }
 }
 
 void SpotifySearchProvider::SuggestionsLoaded(
-    const pb::spotify::BrowseToplistResponse& response) {
+    const cpb::spotify::BrowseToplistResponse& response) {
   for (int i = 0; i < response.track_size(); ++i) {
     AddSuggestionFromTrack(response.track(i));
   }

--- a/src/globalsearch/spotifysearchprovider.h
+++ b/src/globalsearch/spotifysearchprovider.h
@@ -41,17 +41,17 @@ class SpotifySearchProvider : public SearchProvider {
 
  private slots:
   void ServerDestroyed();
-  void SearchFinishedSlot(const pb::spotify::SearchResponse& response);
+  void SearchFinishedSlot(const cpb::spotify::SearchResponse& response);
   void ArtLoadedSlot(const QString& id, const QImage& image);
-  void SuggestionsLoaded(const pb::spotify::LoadPlaylistResponse& response);
-  void SuggestionsLoaded(const pb::spotify::BrowseToplistResponse& response);
+  void SuggestionsLoaded(const cpb::spotify::LoadPlaylistResponse& response);
+  void SuggestionsLoaded(const cpb::spotify::BrowseToplistResponse& response);
 
  private:
   SpotifyServer* server();
 
   void LoadSuggestions();
-  void AddSuggestionFromTrack(const pb::spotify::Track& track);
-  void AddSuggestionFromAlbum(const pb::spotify::Album& album);
+  void AddSuggestionFromTrack(const cpb::spotify::Track& track);
+  void AddSuggestionFromAlbum(const cpb::spotify::Album& album);
 
  private:
   SpotifyServer* server_;

--- a/src/internet/core/cloudfileservice.cpp
+++ b/src/internet/core/cloudfileservice.cpp
@@ -192,14 +192,14 @@ void CloudFileService::ReadTagsFinished(TagReaderClient::ReplyType* reply,
                                    indexing_task_max_);
   }
 
-  const pb::tagreader::ReadCloudFileResponse& message =
+  const cpb::tagreader::ReadCloudFileResponse& message =
       reply->message().read_cloud_file_response();
   if (!message.has_metadata() || !message.metadata().filesize()) {
     qLog(Debug) << "Failed to tag:" << metadata.url();
     return;
   }
 
-  pb::tagreader::SongMetadata metadata_pb;
+  cpb::tagreader::SongMetadata metadata_pb;
   metadata.ToProtobuf(&metadata_pb);
   metadata_pb.MergeFrom(message.metadata());
 

--- a/src/internet/spotify/spotifyserver.h
+++ b/src/internet/spotify/spotifyserver.h
@@ -31,7 +31,7 @@
 class QTcpServer;
 class QTcpSocket;
 
-class SpotifyServer : public AbstractMessageHandler<pb::spotify::Message> {
+class SpotifyServer : public AbstractMessageHandler<cpb::spotify::Message> {
   Q_OBJECT
 
  public:
@@ -39,7 +39,7 @@ class SpotifyServer : public AbstractMessageHandler<pb::spotify::Message> {
 
   void Init();
   void Login(const QString& username, const QString& password,
-             pb::spotify::Bitrate bitrate, bool volume_normalisation);
+             cpb::spotify::Bitrate bitrate, bool volume_normalisation);
 
   void LoadStarred();
   void SyncStarred();
@@ -56,7 +56,7 @@ class SpotifyServer : public AbstractMessageHandler<pb::spotify::Message> {
   void Search(const QString& text, int limit, int limit_album = 0);
   void LoadImage(const QString& id);
   void AlbumBrowse(const QString& uri);
-  void SetPlaybackSettings(pb::spotify::Bitrate bitrate,
+  void SetPlaybackSettings(cpb::spotify::Bitrate bitrate,
                            bool volume_normalisation);
   void LoadToplist();
   void SetPaused(const bool paused);
@@ -69,43 +69,44 @@ class SpotifyServer : public AbstractMessageHandler<pb::spotify::Message> {
 
  signals:
   void LoginCompleted(bool success, const QString& error,
-                      pb::spotify::LoginResponse_Error error_code);
-  void PlaylistsUpdated(const pb::spotify::Playlists& playlists);
+                      cpb::spotify::LoginResponse_Error error_code);
+  void PlaylistsUpdated(const cpb::spotify::Playlists& playlists);
 
-  void StarredLoaded(const pb::spotify::LoadPlaylistResponse& response);
-  void InboxLoaded(const pb::spotify::LoadPlaylistResponse& response);
-  void UserPlaylistLoaded(const pb::spotify::LoadPlaylistResponse& response);
+  void StarredLoaded(const cpb::spotify::LoadPlaylistResponse& response);
+  void InboxLoaded(const cpb::spotify::LoadPlaylistResponse& response);
+  void UserPlaylistLoaded(const cpb::spotify::LoadPlaylistResponse& response);
   void PlaybackError(const QString& message);
-  void SearchResults(const pb::spotify::SearchResponse& response);
+  void SearchResults(const cpb::spotify::SearchResponse& response);
   void ImageLoaded(const QString& id, const QImage& image);
-  void SyncPlaylistProgress(const pb::spotify::SyncPlaylistProgress& progress);
-  void AlbumBrowseResults(const pb::spotify::BrowseAlbumResponse& response);
-  void ToplistBrowseResults(const pb::spotify::BrowseToplistResponse& response);
+  void SyncPlaylistProgress(const cpb::spotify::SyncPlaylistProgress& progress);
+  void AlbumBrowseResults(const cpb::spotify::BrowseAlbumResponse& response);
+  void ToplistBrowseResults(
+      const cpb::spotify::BrowseToplistResponse& response);
 
  protected:
-  void MessageArrived(const pb::spotify::Message& message);
+  void MessageArrived(const cpb::spotify::Message& message);
 
  private slots:
   void NewConnection();
 
  private:
-  void LoadPlaylist(pb::spotify::PlaylistType type, int index = -1);
-  void SyncPlaylist(pb::spotify::PlaylistType type, int index, bool offline);
-  void AddSongsToPlaylist(const pb::spotify::PlaylistType playlist_type,
+  void LoadPlaylist(cpb::spotify::PlaylistType type, int index = -1);
+  void SyncPlaylist(cpb::spotify::PlaylistType type, int index, bool offline);
+  void AddSongsToPlaylist(const cpb::spotify::PlaylistType playlist_type,
                           const QList<QUrl>& songs_urls,
                           // Used iff type is user_playlist
                           int playlist_index = -1);
-  void RemoveSongsFromPlaylist(const pb::spotify::PlaylistType playlist_type,
+  void RemoveSongsFromPlaylist(const cpb::spotify::PlaylistType playlist_type,
                                const QList<int>& songs_indices_to_remove,
                                // Used iff type is user_playlist
                                int playlist_index = -1);
-  void SendOrQueueMessage(const pb::spotify::Message& message);
+  void SendOrQueueMessage(const cpb::spotify::Message& message);
 
   QTcpServer* server_;
   bool logged_in_;
 
-  QList<pb::spotify::Message> queued_login_messages_;
-  QList<pb::spotify::Message> queued_messages_;
+  QList<cpb::spotify::Message> queued_login_messages_;
+  QList<cpb::spotify::Message> queued_messages_;
 };
 
 #endif  // INTERNET_SPOTIFY_SPOTIFYSERVER_H_

--- a/src/internet/spotify/spotifyservice.h
+++ b/src/internet/spotify/spotifyservice.h
@@ -93,7 +93,7 @@ class SpotifyService : public InternetService {
   LoginState login_state() const { return login_state_; }
   bool IsLoggedIn() const { return login_state_ == LoginState_LoggedIn; }
 
-  static void SongFromProtobuf(const pb::spotify::Track& track, Song* song);
+  static void SongFromProtobuf(const cpb::spotify::Track& track, Song* song);
 
  signals:
   void BlobStateChanged();
@@ -109,9 +109,9 @@ class SpotifyService : public InternetService {
   void StartBlobProcess();
   void FillPlaylist(
       QStandardItem* item,
-      const google::protobuf::RepeatedPtrField<pb::spotify::Track>& tracks);
+      const google::protobuf::RepeatedPtrField<cpb::spotify::Track>& tracks);
   void FillPlaylist(QStandardItem* item,
-                    const pb::spotify::LoadPlaylistResponse& response);
+                    const cpb::spotify::LoadPlaylistResponse& response);
   void AddSongsToUserPlaylist(int playlist_index,
                               const QList<QUrl>& songs_urls);
   void AddSongsToStarred(const QList<QUrl>& songs_urls);
@@ -123,26 +123,26 @@ class SpotifyService : public InternetService {
   void InitSearch();
   void ClearSearchResults();
   QStandardItem* PlaylistBySpotifyIndex(int index) const;
-  bool DoPlaylistsDiffer(const pb::spotify::Playlists& response) const;
+  bool DoPlaylistsDiffer(const cpb::spotify::Playlists& response) const;
 
  private slots:
   void EnsureServerCreated(const QString& username = QString(),
                            const QString& password = QString());
   void BlobProcessError(QProcess::ProcessError error);
   void LoginCompleted(bool success, const QString& error,
-                      pb::spotify::LoginResponse_Error error_code);
+                      cpb::spotify::LoginResponse_Error error_code);
   void AddCurrentSongToUserPlaylist(QAction* action);
   void AddCurrentSongToStarredPlaylist();
   void RemoveSongsFromUserPlaylist(int playlist_index,
                                    const QList<int>& songs_indices_to_remove);
   void RemoveSongsFromStarred(const QList<int>& songs_indices_to_remove);
-  void PlaylistsUpdated(const pb::spotify::Playlists& response);
-  void InboxLoaded(const pb::spotify::LoadPlaylistResponse& response);
-  void StarredLoaded(const pb::spotify::LoadPlaylistResponse& response);
-  void UserPlaylistLoaded(const pb::spotify::LoadPlaylistResponse& response);
-  void SearchResults(const pb::spotify::SearchResponse& response);
-  void SyncPlaylistProgress(const pb::spotify::SyncPlaylistProgress& progress);
-  void ToplistLoaded(const pb::spotify::BrowseToplistResponse& response);
+  void PlaylistsUpdated(const cpb::spotify::Playlists& response);
+  void InboxLoaded(const cpb::spotify::LoadPlaylistResponse& response);
+  void StarredLoaded(const cpb::spotify::LoadPlaylistResponse& response);
+  void UserPlaylistLoaded(const cpb::spotify::LoadPlaylistResponse& response);
+  void SearchResults(const cpb::spotify::SearchResponse& response);
+  void SyncPlaylistProgress(const cpb::spotify::SyncPlaylistProgress& progress);
+  void ToplistLoaded(const cpb::spotify::BrowseToplistResponse& response);
   void GetCurrentSongUrlToShare() const;
   void GetCurrentPlaylistUrlToShare() const;
 
@@ -188,7 +188,7 @@ class SpotifyService : public InternetService {
   QMap<int, int> playlist_sync_ids_;
 
   LoginState login_state_;
-  pb::spotify::Bitrate bitrate_;
+  cpb::spotify::Bitrate bitrate_;
   bool volume_normalisation_;
 };
 

--- a/src/internet/spotify/spotifysettingspage.cpp
+++ b/src/internet/spotify/spotifysettingspage.cpp
@@ -59,9 +59,9 @@ SpotifySettingsPage::SpotifySettingsPage(SettingsDialog* dialog)
   ui_->login_state->AddCredentialField(ui_->password);
   ui_->login_state->AddCredentialGroup(ui_->account_group);
 
-  ui_->bitrate->addItem("96 " + tr("kbps"), pb::spotify::Bitrate96k);
-  ui_->bitrate->addItem("160 " + tr("kbps"), pb::spotify::Bitrate160k);
-  ui_->bitrate->addItem("320 " + tr("kbps"), pb::spotify::Bitrate320k);
+  ui_->bitrate->addItem("96 " + tr("kbps"), cpb::spotify::Bitrate96k);
+  ui_->bitrate->addItem("160 " + tr("kbps"), cpb::spotify::Bitrate160k);
+  ui_->bitrate->addItem("320 " + tr("kbps"), cpb::spotify::Bitrate320k);
 
   BlobStateChanged();
 }
@@ -108,7 +108,7 @@ void SpotifySettingsPage::Load() {
   validated_ = false;
 
   ui_->bitrate->setCurrentIndex(ui_->bitrate->findData(
-      s.value("bitrate", pb::spotify::Bitrate320k).toInt()));
+      s.value("bitrate", cpb::spotify::Bitrate320k).toInt()));
   ui_->volume_normalisation->setChecked(
       s.value("volume_normalisation", false).toBool());
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -191,7 +191,7 @@ void ParseAProto() {
       "304c6f756e67652e6d786dba012a28414c42554d2920476f74616e2050726f6a65637"
       "4202d20416d6269656e74204c6f756e67652e6d786dc001c7a7efd104c801bad685e4"
       "04d001eeca32");
-  pb::tagreader::Message message;
+  cpb::tagreader::Message message;
   message.ParseFromArray(data.constData(), data.size());
 }
 

--- a/src/networkremote/incomingdataparser.cpp
+++ b/src/networkremote/incomingdataparser.cpp
@@ -107,112 +107,112 @@ void IncomingDataParser::ReloadSettings() {
 
 bool IncomingDataParser::close_connection() { return close_connection_; }
 
-void IncomingDataParser::Parse(const pb::remote::Message& msg) {
+void IncomingDataParser::Parse(const cpb::remote::Message& msg) {
   close_connection_ = false;
   RemoteClient* client = qobject_cast<RemoteClient*>(sender());
 
   // Now check what's to do
   switch (msg.type()) {
-    case pb::remote::CONNECT:
+    case cpb::remote::CONNECT:
       ClientConnect(msg, client);
       break;
-    case pb::remote::DISCONNECT:
+    case cpb::remote::DISCONNECT:
       close_connection_ = true;
       break;
-    case pb::remote::REQUEST_PLAYLISTS:
+    case cpb::remote::REQUEST_PLAYLISTS:
       SendPlaylists(msg);
       break;
-    case pb::remote::REQUEST_PLAYLIST_SONGS:
+    case cpb::remote::REQUEST_PLAYLIST_SONGS:
       GetPlaylistSongs(msg);
       break;
-    case pb::remote::SET_VOLUME:
+    case cpb::remote::SET_VOLUME:
       emit SetVolume(msg.request_set_volume().volume());
       break;
-    case pb::remote::PLAY:
+    case cpb::remote::PLAY:
       emit Play();
       break;
-    case pb::remote::PLAYPAUSE:
+    case cpb::remote::PLAYPAUSE:
       emit PlayPause();
       break;
-    case pb::remote::PAUSE:
+    case cpb::remote::PAUSE:
       emit Pause();
       break;
-    case pb::remote::STOP:
+    case cpb::remote::STOP:
       emit Stop();
       break;
-    case pb::remote::STOP_AFTER:
+    case cpb::remote::STOP_AFTER:
       emit StopAfterCurrent();
       break;
-    case pb::remote::NEXT:
+    case cpb::remote::NEXT:
       emit Next();
       break;
-    case pb::remote::PREVIOUS:
+    case cpb::remote::PREVIOUS:
       emit Previous();
       break;
-    case pb::remote::CHANGE_SONG:
+    case cpb::remote::CHANGE_SONG:
       ChangeSong(msg);
       break;
-    case pb::remote::SHUFFLE_PLAYLIST:
+    case cpb::remote::SHUFFLE_PLAYLIST:
       emit ShuffleCurrent();
       break;
-    case pb::remote::REPEAT:
+    case cpb::remote::REPEAT:
       SetRepeatMode(msg.repeat());
       break;
-    case pb::remote::SHUFFLE:
+    case cpb::remote::SHUFFLE:
       SetShuffleMode(msg.shuffle());
       break;
-    case pb::remote::SET_TRACK_POSITION:
+    case cpb::remote::SET_TRACK_POSITION:
       emit SeekTo(msg.request_set_track_position().position());
       break;
-    case pb::remote::INSERT_URLS:
+    case cpb::remote::INSERT_URLS:
       InsertUrls(msg);
       break;
-    case pb::remote::REMOVE_SONGS:
+    case cpb::remote::REMOVE_SONGS:
       RemoveSongs(msg);
       break;
-    case pb::remote::OPEN_PLAYLIST:
+    case cpb::remote::OPEN_PLAYLIST:
       OpenPlaylist(msg);
       break;
-    case pb::remote::CLOSE_PLAYLIST:
+    case cpb::remote::CLOSE_PLAYLIST:
       ClosePlaylist(msg);
       break;
-    case pb::remote::UPDATE_PLAYLIST:
+    case cpb::remote::UPDATE_PLAYLIST:
       UpdatePlaylist(msg);
       break;
-    case pb::remote::LOVE:
+    case cpb::remote::LOVE:
       emit Love();
       break;
-    case pb::remote::BAN:
+    case cpb::remote::BAN:
       emit Ban();
       break;
-    case pb::remote::GET_LYRICS:
+    case cpb::remote::GET_LYRICS:
       emit GetLyrics();
       break;
-    case pb::remote::DOWNLOAD_SONGS:
+    case cpb::remote::DOWNLOAD_SONGS:
       client->song_sender()->SendSongs(msg.request_download_songs());
       break;
-    case pb::remote::SONG_OFFER_RESPONSE:
+    case cpb::remote::SONG_OFFER_RESPONSE:
       client->song_sender()->ResponseSongOffer(
           msg.response_song_offer().accepted());
       break;
-    case pb::remote::GET_LIBRARY:
+    case cpb::remote::GET_LIBRARY:
       emit SendLibrary(client);
       break;
-    case pb::remote::RATE_SONG:
+    case cpb::remote::RATE_SONG:
       RateSong(msg);
       break;
-    case pb::remote::GLOBAL_SEARCH:
+    case cpb::remote::GLOBAL_SEARCH:
       GlobalSearch(client, msg);
       break;
-    case pb::remote::REQUEST_FILES:
+    case cpb::remote::REQUEST_FILES:
       emit SendListFiles(
           QString::fromStdString(msg.request_list_files().relative_path()),
           client);
       break;
-    case pb::remote::APPEND_FILES:
+    case cpb::remote::APPEND_FILES:
       AppendFilesToPlaylist(msg);
       break;
-    case pb::remote::REQUEST_SAVED_RADIOS:
+    case cpb::remote::REQUEST_SAVED_RADIOS:
       emit SendSavedRadios(client);
       break;
 
@@ -221,13 +221,13 @@ void IncomingDataParser::Parse(const pb::remote::Message& msg) {
   }
 }
 
-void IncomingDataParser::GetPlaylistSongs(const pb::remote::Message& msg) {
+void IncomingDataParser::GetPlaylistSongs(const cpb::remote::Message& msg) {
   emit SendPlaylistSongs(msg.request_playlist_songs().id());
 }
 
-void IncomingDataParser::ChangeSong(const pb::remote::Message& msg) {
+void IncomingDataParser::ChangeSong(const cpb::remote::Message& msg) {
   // Get the first entry and check if there is a song
-  const pb::remote::RequestChangeSong& request = msg.request_change_song();
+  const cpb::remote::RequestChangeSong& request = msg.request_change_song();
 
   // Check if we need to change the playlist
   if (request.playlist_id() != app_->playlist_manager()->active_id()) {
@@ -251,18 +251,18 @@ void IncomingDataParser::ChangeSong(const pb::remote::Message& msg) {
   }
 }
 
-void IncomingDataParser::SetRepeatMode(const pb::remote::Repeat& repeat) {
+void IncomingDataParser::SetRepeatMode(const cpb::remote::Repeat& repeat) {
   switch (repeat.repeat_mode()) {
-    case pb::remote::Repeat_Off:
+    case cpb::remote::Repeat_Off:
       emit SetRepeatMode(PlaylistSequence::Repeat_Off);
       break;
-    case pb::remote::Repeat_Track:
+    case cpb::remote::Repeat_Track:
       emit SetRepeatMode(PlaylistSequence::Repeat_Track);
       break;
-    case pb::remote::Repeat_Album:
+    case cpb::remote::Repeat_Album:
       emit SetRepeatMode(PlaylistSequence::Repeat_Album);
       break;
-    case pb::remote::Repeat_Playlist:
+    case cpb::remote::Repeat_Playlist:
       emit SetRepeatMode(PlaylistSequence::Repeat_Playlist);
       break;
     default:
@@ -270,18 +270,18 @@ void IncomingDataParser::SetRepeatMode(const pb::remote::Repeat& repeat) {
   }
 }
 
-void IncomingDataParser::SetShuffleMode(const pb::remote::Shuffle& shuffle) {
+void IncomingDataParser::SetShuffleMode(const cpb::remote::Shuffle& shuffle) {
   switch (shuffle.shuffle_mode()) {
-    case pb::remote::Shuffle_Off:
+    case cpb::remote::Shuffle_Off:
       emit SetShuffleMode(PlaylistSequence::Shuffle_Off);
       break;
-    case pb::remote::Shuffle_All:
+    case cpb::remote::Shuffle_All:
       emit SetShuffleMode(PlaylistSequence::Shuffle_All);
       break;
-    case pb::remote::Shuffle_InsideAlbum:
+    case cpb::remote::Shuffle_InsideAlbum:
       emit SetShuffleMode(PlaylistSequence::Shuffle_InsideAlbum);
       break;
-    case pb::remote::Shuffle_Albums:
+    case cpb::remote::Shuffle_Albums:
       emit SetShuffleMode(PlaylistSequence::Shuffle_Albums);
       break;
     default:
@@ -289,8 +289,8 @@ void IncomingDataParser::SetShuffleMode(const pb::remote::Shuffle& shuffle) {
   }
 }
 
-void IncomingDataParser::InsertUrls(const pb::remote::Message& msg) {
-  const pb::remote::RequestInsertUrls& request = msg.request_insert_urls();
+void IncomingDataParser::InsertUrls(const cpb::remote::Message& msg) {
+  const cpb::remote::RequestInsertUrls& request = msg.request_insert_urls();
   int playlist_id = request.playlist_id();
 
   // Insert plain urls without metadata
@@ -328,8 +328,8 @@ void IncomingDataParser::InsertUrls(const pb::remote::Message& msg) {
   }
 }
 
-void IncomingDataParser::RemoveSongs(const pb::remote::Message& msg) {
-  const pb::remote::RequestRemoveSongs& request = msg.request_remove_songs();
+void IncomingDataParser::RemoveSongs(const cpb::remote::Message& msg) {
+  const cpb::remote::RequestRemoveSongs& request = msg.request_remove_songs();
 
   // Extract urls
   QList<int> songs;
@@ -341,7 +341,7 @@ void IncomingDataParser::RemoveSongs(const pb::remote::Message& msg) {
   emit RemoveSongs(request.playlist_id(), songs);
 }
 
-void IncomingDataParser::ClientConnect(const pb::remote::Message& msg,
+void IncomingDataParser::ClientConnect(const cpb::remote::Message& msg,
                                        RemoteClient* client) {
   // Always sned the Clementine infos
   emit SendClementineInfo();
@@ -357,7 +357,7 @@ void IncomingDataParser::ClientConnect(const pb::remote::Message& msg,
   }
 }
 
-void IncomingDataParser::SendPlaylists(const pb::remote::Message& msg) {
+void IncomingDataParser::SendPlaylists(const cpb::remote::Message& msg) {
   if (!msg.has_request_playlists() ||
       !msg.request_playlists().include_closed()) {
     emit SendAllActivePlaylists();
@@ -366,16 +366,16 @@ void IncomingDataParser::SendPlaylists(const pb::remote::Message& msg) {
   }
 }
 
-void IncomingDataParser::OpenPlaylist(const pb::remote::Message& msg) {
+void IncomingDataParser::OpenPlaylist(const cpb::remote::Message& msg) {
   emit Open(msg.request_open_playlist().playlist_id());
 }
 
-void IncomingDataParser::ClosePlaylist(const pb::remote::Message& msg) {
+void IncomingDataParser::ClosePlaylist(const cpb::remote::Message& msg) {
   emit Close(msg.request_close_playlist().playlist_id());
 }
 
-void IncomingDataParser::UpdatePlaylist(const pb::remote::Message& msg) {
-  const pb::remote::RequestUpdatePlaylist& req_update =
+void IncomingDataParser::UpdatePlaylist(const cpb::remote::Message& msg) {
+  const cpb::remote::RequestUpdatePlaylist& req_update =
       msg.request_update_playlist();
   if (req_update.has_create_new_playlist() &&
       req_update.create_new_playlist()) {
@@ -396,19 +396,19 @@ void IncomingDataParser::UpdatePlaylist(const pb::remote::Message& msg) {
     emit Favorite(req_update.playlist_id(), req_update.favorite());
 }
 
-void IncomingDataParser::RateSong(const pb::remote::Message& msg) {
+void IncomingDataParser::RateSong(const cpb::remote::Message& msg) {
   double rating = (double)msg.request_rate_song().rating();
   emit RateCurrentSong(rating);
 }
 
 void IncomingDataParser::GlobalSearch(RemoteClient* client,
-                                      const pb::remote::Message& msg) {
+                                      const cpb::remote::Message& msg) {
   emit DoGlobalSearch(QStringFromStdString(msg.request_global_search().query()),
                       client);
 }
 
 Song IncomingDataParser::CreateSongFromProtobuf(
-    const pb::remote::SongMetadata& pb) {
+    const cpb::remote::SongMetadata& pb) {
   Song song;
   song.Init(QStringFromStdString(pb.title()), QStringFromStdString(pb.artist()),
             QStringFromStdString(pb.album()), pb.length() * kNsecPerSec);
@@ -429,7 +429,8 @@ Song IncomingDataParser::CreateSongFromProtobuf(
   return song;
 }
 
-void IncomingDataParser::AppendFilesToPlaylist(const pb::remote::Message& msg) {
+void IncomingDataParser::AppendFilesToPlaylist(
+    const cpb::remote::Message& msg) {
   if (files_root_folder_.isEmpty()) {  // should never happen...
     qLog(Warning) << "Remote root dir is not set although receiving "
                      "APPEND_FILES request...";
@@ -441,7 +442,8 @@ void IncomingDataParser::AppendFilesToPlaylist(const pb::remote::Message& msg) {
     return;
   }
 
-  const pb::remote::RequestAppendFiles& req_append = msg.request_append_files();
+  const cpb::remote::RequestAppendFiles& req_append =
+      msg.request_append_files();
   QString relative_path = QString::fromStdString(req_append.relative_path());
   if (relative_path.startsWith("/")) relative_path.remove(0, 1);
 

--- a/src/networkremote/incomingdataparser.h
+++ b/src/networkremote/incomingdataparser.h
@@ -20,7 +20,7 @@ class IncomingDataParser : public QObject {
   }
 
  public slots:
-  void Parse(const pb::remote::Message& msg);
+  void Parse(const cpb::remote::Message& msg);
   void ReloadSettings();
 
  signals:
@@ -75,22 +75,22 @@ class IncomingDataParser : public QObject {
   MainWindow::PlaylistAddBehaviour doubleclick_playlist_addmode_;
   QString files_root_folder_;
 
-  void GetPlaylistSongs(const pb::remote::Message& msg);
-  void ChangeSong(const pb::remote::Message& msg);
-  void SetRepeatMode(const pb::remote::Repeat& repeat);
-  void SetShuffleMode(const pb::remote::Shuffle& shuffle);
-  void InsertUrls(const pb::remote::Message& msg);
-  void RemoveSongs(const pb::remote::Message& msg);
-  void ClientConnect(const pb::remote::Message& msg, RemoteClient* client);
-  void SendPlaylists(const pb::remote::Message& msg);
-  void OpenPlaylist(const pb::remote::Message& msg);
-  void ClosePlaylist(const pb::remote::Message& msg);
-  void UpdatePlaylist(const pb::remote::Message& msg);
-  void RateSong(const pb::remote::Message& msg);
-  void GlobalSearch(RemoteClient* client, const pb::remote::Message& msg);
-  void AppendFilesToPlaylist(const pb::remote::Message& msg);
+  void GetPlaylistSongs(const cpb::remote::Message& msg);
+  void ChangeSong(const cpb::remote::Message& msg);
+  void SetRepeatMode(const cpb::remote::Repeat& repeat);
+  void SetShuffleMode(const cpb::remote::Shuffle& shuffle);
+  void InsertUrls(const cpb::remote::Message& msg);
+  void RemoveSongs(const cpb::remote::Message& msg);
+  void ClientConnect(const cpb::remote::Message& msg, RemoteClient* client);
+  void SendPlaylists(const cpb::remote::Message& msg);
+  void OpenPlaylist(const cpb::remote::Message& msg);
+  void ClosePlaylist(const cpb::remote::Message& msg);
+  void UpdatePlaylist(const cpb::remote::Message& msg);
+  void RateSong(const cpb::remote::Message& msg);
+  void GlobalSearch(RemoteClient* client, const cpb::remote::Message& msg);
+  void AppendFilesToPlaylist(const cpb::remote::Message& msg);
 
-  Song CreateSongFromProtobuf(const pb::remote::SongMetadata& pb);
+  Song CreateSongFromProtobuf(const cpb::remote::SongMetadata& pb);
 };
 
 #endif  // INCOMINGDATAPARSER_H

--- a/src/networkremote/networkremote.cpp
+++ b/src/networkremote/networkremote.cpp
@@ -234,8 +234,8 @@ void NetworkRemote::CreateRemoteClient(QTcpSocket* client_socket) {
     outgoing_data_creator_->SetAllowDownloads(client->allow_downloads());
 
     // Connect the signal to parse data
-    connect(client, SIGNAL(Parse(pb::remote::Message)),
-            incoming_data_parser_.get(), SLOT(Parse(pb::remote::Message)));
+    connect(client, SIGNAL(Parse(cpb::remote::Message)),
+            incoming_data_parser_.get(), SLOT(Parse(cpb::remote::Message)));
   }
 }
 

--- a/src/networkremote/outgoingdatacreator.cpp
+++ b/src/networkremote/outgoingdatacreator.cpp
@@ -147,7 +147,7 @@ SongInfoProvider* OutgoingDataCreator::ProviderByName(
   return nullptr;
 }
 
-void OutgoingDataCreator::SendDataToClients(pb::remote::Message* msg) {
+void OutgoingDataCreator::SendDataToClients(cpb::remote::Message* msg) {
   // Check if we have clients to send data to
   if (clients_->empty()) {
     return;
@@ -175,11 +175,11 @@ void OutgoingDataCreator::SendDataToClients(pb::remote::Message* msg) {
 
 void OutgoingDataCreator::SendClementineInfo() {
   // Create the general message and set the message type
-  pb::remote::Message msg;
-  msg.set_type(pb::remote::INFO);
+  cpb::remote::Message msg;
+  msg.set_type(cpb::remote::INFO);
 
   // Now add the message specific data
-  pb::remote::ResponseClementineInfo* info =
+  cpb::remote::ResponseClementineInfo* info =
       msg.mutable_response_clementine_info();
   SetEngineState(info);
 
@@ -196,20 +196,20 @@ void OutgoingDataCreator::SendClementineInfo() {
 }
 
 void OutgoingDataCreator::SetEngineState(
-    pb::remote::ResponseClementineInfo* msg) {
+    cpb::remote::ResponseClementineInfo* msg) {
   switch (app_->player()->GetState()) {
     case Engine::Idle:
-      msg->set_state(pb::remote::Idle);
+      msg->set_state(cpb::remote::Idle);
       break;
     case Engine::Error:
     case Engine::Empty:
-      msg->set_state(pb::remote::Empty);
+      msg->set_state(cpb::remote::Empty);
       break;
     case Engine::Playing:
-      msg->set_state(pb::remote::Playing);
+      msg->set_state(cpb::remote::Playing);
       break;
     case Engine::Paused:
-      msg->set_state(pb::remote::Paused);
+      msg->set_state(cpb::remote::Paused);
       break;
   }
 }
@@ -220,10 +220,10 @@ void OutgoingDataCreator::SendAllPlaylists() {
   int active_playlist = playlist_manager->active_id();
 
   // Create message
-  pb::remote::Message msg;
-  msg.set_type(pb::remote::PLAYLISTS);
+  cpb::remote::Message msg;
+  msg.set_type(cpb::remote::PLAYLISTS);
 
-  pb::remote::ResponsePlaylists* playlists = msg.mutable_response_playlists();
+  cpb::remote::ResponsePlaylists* playlists = msg.mutable_response_playlists();
   playlists->set_include_closed(true);
 
   // Get all playlists, even ones that are hidden in the UI.
@@ -234,7 +234,7 @@ void OutgoingDataCreator::SendAllPlaylists() {
         playlist_open ? playlist_manager->playlist(p.id)->rowCount() : 0;
 
     // Create a new playlist
-    pb::remote::Playlist* playlist = playlists->add_playlist();
+    cpb::remote::Playlist* playlist = playlists->add_playlist();
     playlist->set_name(DataCommaSizeFromQString(p.name));
     playlist->set_id(p.id);
     playlist->set_active((p.id == active_playlist));
@@ -252,10 +252,10 @@ void OutgoingDataCreator::SendAllActivePlaylists() {
   int active_playlist = app_->playlist_manager()->active_id();
 
   // Create message
-  pb::remote::Message msg;
-  msg.set_type(pb::remote::PLAYLISTS);
+  cpb::remote::Message msg;
+  msg.set_type(cpb::remote::PLAYLISTS);
 
-  pb::remote::ResponsePlaylists* playlists = msg.mutable_response_playlists();
+  cpb::remote::ResponsePlaylists* playlists = msg.mutable_response_playlists();
 
   QListIterator<Playlist*> it(app_playlists);
   while (it.hasNext()) {
@@ -264,7 +264,7 @@ void OutgoingDataCreator::SendAllActivePlaylists() {
     QString playlist_name = app_->playlist_manager()->GetPlaylistName(p->id());
 
     // Create a new playlist
-    pb::remote::Playlist* playlist = playlists->add_playlist();
+    cpb::remote::Playlist* playlist = playlists->add_playlist();
     playlist->set_name(DataCommaSizeFromQString(playlist_name));
     playlist->set_id(p->id());
     playlist->set_active((p->id() == active_playlist));
@@ -281,8 +281,8 @@ void OutgoingDataCreator::ActiveChanged(Playlist* playlist) {
   SendPlaylistSongs(playlist->id());
 
   // Send the changed message after sending the playlist songs
-  pb::remote::Message msg;
-  msg.set_type(pb::remote::ACTIVE_PLAYLIST_CHANGED);
+  cpb::remote::Message msg;
+  msg.set_type(cpb::remote::ACTIVE_PLAYLIST_CHANGED);
   msg.mutable_response_active_changed()->set_id(playlist->id());
   SendDataToClients(&msg);
 }
@@ -335,8 +335,8 @@ void OutgoingDataCreator::SendFirstData(bool send_playlist_songs) {
   SendRepeatMode(app_->playlist_manager()->sequence()->repeat_mode());
 
   // We send all first data
-  pb::remote::Message msg;
-  msg.set_type(pb::remote::FIRST_DATA_SENT_COMPLETE);
+  cpb::remote::Message msg;
+  msg.set_type(cpb::remote::FIRST_DATA_SENT_COMPLETE);
   SendDataToClients(&msg);
 }
 
@@ -355,8 +355,8 @@ void OutgoingDataCreator::CurrentSongChanged(const Song& song,
 
 void OutgoingDataCreator::SendSongMetadata() {
   // Create the message
-  pb::remote::Message msg;
-  msg.set_type(pb::remote::CURRENT_METAINFO);
+  cpb::remote::Message msg;
+  msg.set_type(cpb::remote::CURRENT_METAINFO);
 
   // If there is no song, create an empty node, otherwise fill it with data
   int i = app_->playlist_manager()->active()->current_row();
@@ -368,7 +368,7 @@ void OutgoingDataCreator::SendSongMetadata() {
 
 void OutgoingDataCreator::CreateSong(const Song& song, const QImage& art,
                                      const int index,
-                                     pb::remote::SongMetadata* song_metadata) {
+                                     cpb::remote::SongMetadata* song_metadata) {
   if (song.is_valid()) {
     song_metadata->set_id(song.id());
     song_metadata->set_index(index);
@@ -394,7 +394,7 @@ void OutgoingDataCreator::CreateSong(const Song& song, const QImage& art,
         DataCommaSizeFromQString(song.art_automatic()));
     song_metadata->set_art_manual(DataCommaSizeFromQString(song.art_manual()));
     song_metadata->set_type(
-        static_cast<::pb::remote::SongMetadata_Type>(song.filetype()));
+        static_cast<::cpb::remote::SongMetadata_Type>(song.filetype()));
 
     // Append coverart
     if (!art.isNull()) {
@@ -420,8 +420,8 @@ void OutgoingDataCreator::CreateSong(const Song& song, const QImage& art,
 
 void OutgoingDataCreator::VolumeChanged(int volume) {
   // Create the message
-  pb::remote::Message msg;
-  msg.set_type(pb::remote::SET_VOLUME);
+  cpb::remote::Message msg;
+  msg.set_type(cpb::remote::SET_VOLUME);
   msg.mutable_request_set_volume()->set_volume(volume);
   SendDataToClients(&msg);
 }
@@ -435,15 +435,15 @@ void OutgoingDataCreator::SendPlaylistSongs(int id) {
   }
 
   // Create the message and the playlist
-  pb::remote::Message msg;
-  msg.set_type(pb::remote::PLAYLIST_SONGS);
+  cpb::remote::Message msg;
+  msg.set_type(cpb::remote::PLAYLIST_SONGS);
 
   // Create the Response message
-  pb::remote::ResponsePlaylistSongs* pb_response_playlist_songs =
+  cpb::remote::ResponsePlaylistSongs* pb_response_playlist_songs =
       msg.mutable_response_playlist_songs();
 
   // Create a new playlist
-  pb::remote::Playlist* pb_playlist =
+  cpb::remote::Playlist* pb_playlist =
       pb_response_playlist_songs->mutable_requested_playlist();
   pb_playlist->set_id(id);
 
@@ -454,7 +454,8 @@ void OutgoingDataCreator::SendPlaylistSongs(int id) {
   QImage null_img;
   while (it.hasNext()) {
     Song song = it.next();
-    pb::remote::SongMetadata* pb_song = pb_response_playlist_songs->add_songs();
+    cpb::remote::SongMetadata* pb_song =
+        pb_response_playlist_songs->add_songs();
     CreateSong(song, null_img, index, pb_song);
     ++index;
   }
@@ -475,23 +476,23 @@ void OutgoingDataCreator::StateChanged(Engine::State state) {
   }
   last_state_ = state;
 
-  pb::remote::Message msg;
+  cpb::remote::Message msg;
 
   switch (state) {
     case Engine::Playing:
-      msg.set_type(pb::remote::PLAY);
+      msg.set_type(cpb::remote::PLAY);
       track_position_timer_->start(1000);
       break;
     case Engine::Paused:
-      msg.set_type(pb::remote::PAUSE);
+      msg.set_type(cpb::remote::PAUSE);
       track_position_timer_->stop();
       break;
     case Engine::Empty:
-      msg.set_type(pb::remote::STOP);  // Empty is called when player stopped
+      msg.set_type(cpb::remote::STOP);  // Empty is called when player stopped
       track_position_timer_->stop();
       break;
     default:
-      msg.set_type(pb::remote::STOP);
+      msg.set_type(cpb::remote::STOP);
       track_position_timer_->stop();
       break;
   };
@@ -500,27 +501,27 @@ void OutgoingDataCreator::StateChanged(Engine::State state) {
 }
 
 void OutgoingDataCreator::SendRepeatMode(PlaylistSequence::RepeatMode mode) {
-  pb::remote::Message msg;
-  msg.set_type(pb::remote::REPEAT);
+  cpb::remote::Message msg;
+  msg.set_type(cpb::remote::REPEAT);
 
   switch (mode) {
     case PlaylistSequence::Repeat_Off:
-      msg.mutable_repeat()->set_repeat_mode(pb::remote::Repeat_Off);
+      msg.mutable_repeat()->set_repeat_mode(cpb::remote::Repeat_Off);
       break;
     case PlaylistSequence::Repeat_Track:
-      msg.mutable_repeat()->set_repeat_mode(pb::remote::Repeat_Track);
+      msg.mutable_repeat()->set_repeat_mode(cpb::remote::Repeat_Track);
       break;
     case PlaylistSequence::Repeat_Album:
-      msg.mutable_repeat()->set_repeat_mode(pb::remote::Repeat_Album);
+      msg.mutable_repeat()->set_repeat_mode(cpb::remote::Repeat_Album);
       break;
     case PlaylistSequence::Repeat_Playlist:
-      msg.mutable_repeat()->set_repeat_mode(pb::remote::Repeat_Playlist);
+      msg.mutable_repeat()->set_repeat_mode(cpb::remote::Repeat_Playlist);
       break;
     case PlaylistSequence::Repeat_OneByOne:
-      msg.mutable_repeat()->set_repeat_mode(pb::remote::Repeat_OneByOne);
+      msg.mutable_repeat()->set_repeat_mode(cpb::remote::Repeat_OneByOne);
       break;
     case PlaylistSequence::Repeat_Intro:
-      msg.mutable_repeat()->set_repeat_mode(pb::remote::Repeat_Intro);
+      msg.mutable_repeat()->set_repeat_mode(cpb::remote::Repeat_Intro);
       break;
   }
 
@@ -528,21 +529,21 @@ void OutgoingDataCreator::SendRepeatMode(PlaylistSequence::RepeatMode mode) {
 }
 
 void OutgoingDataCreator::SendShuffleMode(PlaylistSequence::ShuffleMode mode) {
-  pb::remote::Message msg;
-  msg.set_type(pb::remote::SHUFFLE);
+  cpb::remote::Message msg;
+  msg.set_type(cpb::remote::SHUFFLE);
 
   switch (mode) {
     case PlaylistSequence::Shuffle_Off:
-      msg.mutable_shuffle()->set_shuffle_mode(pb::remote::Shuffle_Off);
+      msg.mutable_shuffle()->set_shuffle_mode(cpb::remote::Shuffle_Off);
       break;
     case PlaylistSequence::Shuffle_All:
-      msg.mutable_shuffle()->set_shuffle_mode(pb::remote::Shuffle_All);
+      msg.mutable_shuffle()->set_shuffle_mode(cpb::remote::Shuffle_All);
       break;
     case PlaylistSequence::Shuffle_InsideAlbum:
-      msg.mutable_shuffle()->set_shuffle_mode(pb::remote::Shuffle_InsideAlbum);
+      msg.mutable_shuffle()->set_shuffle_mode(cpb::remote::Shuffle_InsideAlbum);
       break;
     case PlaylistSequence::Shuffle_Albums:
-      msg.mutable_shuffle()->set_shuffle_mode(pb::remote::Shuffle_Albums);
+      msg.mutable_shuffle()->set_shuffle_mode(cpb::remote::Shuffle_Albums);
       break;
   }
 
@@ -550,14 +551,14 @@ void OutgoingDataCreator::SendShuffleMode(PlaylistSequence::ShuffleMode mode) {
 }
 
 void OutgoingDataCreator::SendKeepAlive() {
-  pb::remote::Message msg;
-  msg.set_type(pb::remote::KEEP_ALIVE);
+  cpb::remote::Message msg;
+  msg.set_type(cpb::remote::KEEP_ALIVE);
   SendDataToClients(&msg);
 }
 
 void OutgoingDataCreator::UpdateTrackPosition() {
-  pb::remote::Message msg;
-  msg.set_type(pb::remote::UPDATE_TRACK_POSITION);
+  cpb::remote::Message msg;
+  msg.set_type(cpb::remote::UPDATE_TRACK_POSITION);
 
   qint64 position_nanosec = app_->player()->engine()->position_nanosec();
   int position = static_cast<int>(
@@ -574,10 +575,10 @@ void OutgoingDataCreator::UpdateTrackPosition() {
 }
 
 void OutgoingDataCreator::DisconnectAllClients() {
-  pb::remote::Message msg;
-  msg.set_type(pb::remote::DISCONNECT);
+  cpb::remote::Message msg;
+  msg.set_type(cpb::remote::DISCONNECT);
   msg.mutable_response_disconnect()->set_reason_disconnect(
-      pb::remote::Server_Shutdown);
+      cpb::remote::Server_Shutdown);
   SendDataToClients(&msg);
 }
 
@@ -585,9 +586,9 @@ void OutgoingDataCreator::GetLyrics() { fetcher_->FetchInfo(current_song_); }
 
 void OutgoingDataCreator::SendLyrics(int id,
                                      const SongInfoFetcher::Result& result) {
-  pb::remote::Message msg;
-  msg.set_type(pb::remote::LYRICS);
-  pb::remote::ResponseLyrics* response = msg.mutable_response_lyrics();
+  cpb::remote::Message msg;
+  msg.set_type(cpb::remote::LYRICS);
+  cpb::remote::ResponseLyrics* response = msg.mutable_response_lyrics();
 
   for (const CollapsibleInfoPane::Data& data : result.info_) {
     // If the size is zero, do not send the provider
@@ -595,7 +596,7 @@ void OutgoingDataCreator::SendLyrics(int id,
         qobject_cast<UltimateLyricsLyric*>(data.content_object_);
     if (editor->toPlainText().length() == 0) continue;
 
-    pb::remote::Lyric* lyric = response->mutable_lyrics()->Add();
+    cpb::remote::Lyric* lyric = response->mutable_lyrics()->Add();
 
     lyric->set_id(DataCommaSizeFromQString(data.id_));
     lyric->set_title(DataCommaSizeFromQString(data.title_));
@@ -636,10 +637,10 @@ void OutgoingDataCreator::SendLibrary(RemoteClient* client) {
   file.open(QIODevice::ReadOnly);
 
   QByteArray data;
-  pb::remote::Message msg;
-  pb::remote::ResponseLibraryChunk* chunk =
+  cpb::remote::Message msg;
+  cpb::remote::ResponseLibraryChunk* chunk =
       msg.mutable_response_library_chunk();
-  msg.set_type(pb::remote::LIBRARY_CHUNK);
+  msg.set_type(cpb::remote::LIBRARY_CHUNK);
 
   // Calculate the number of chunks
   int chunk_count = qRound((file.size() / kFileChunkSize) + 0.5);
@@ -687,14 +688,14 @@ void OutgoingDataCreator::DoGlobalSearch(const QString& query,
   global_search_result_map_.insert(id, request);
 
   // Send status message
-  pb::remote::Message msg;
-  pb::remote::ResponseGlobalSearchStatus* status =
+  cpb::remote::Message msg;
+  cpb::remote::ResponseGlobalSearchStatus* status =
       msg.mutable_response_global_search_status();
 
-  msg.set_type(pb::remote::GLOBAL_SEARCH_STATUS);
+  msg.set_type(cpb::remote::GLOBAL_SEARCH_STATUS);
   status->set_id(id);
   status->set_query(DataCommaSizeFromQString(query));
-  status->set_status(pb::remote::GlobalSearchStarted);
+  status->set_status(cpb::remote::GlobalSearchStarted);
 
   client->SendData(&msg);
 
@@ -709,11 +710,11 @@ void OutgoingDataCreator::ResultsAvailable(
   RemoteClient* client = search_request.client_;
   QImage null_img;
 
-  pb::remote::Message msg;
-  pb::remote::ResponseGlobalSearch* response =
+  cpb::remote::Message msg;
+  cpb::remote::ResponseGlobalSearch* response =
       msg.mutable_response_global_search();
 
-  msg.set_type(pb::remote::GLOBAL_SEARCH_RESULT);
+  msg.set_type(cpb::remote::GLOBAL_SEARCH_RESULT);
   response->set_id(search_request.id_);
   response->set_query(DataCommaSizeFromQString(search_request.query_));
   response->set_search_provider(
@@ -728,7 +729,7 @@ void OutgoingDataCreator::ResultsAvailable(
   response->set_search_provider_icon(byte_array.constData(), byte_array.size());
 
   for (const SearchProvider::Result& result : results) {
-    pb::remote::SongMetadata* pb_song = response->add_song_metadata();
+    cpb::remote::SongMetadata* pb_song = response->add_song_metadata();
     CreateSong(result.metadata_, null_img, 0, pb_song);
   }
 
@@ -744,14 +745,14 @@ void OutgoingDataCreator::SearchFinished(int id) {
   GlobalSearchRequest req = global_search_result_map_.take(id);
 
   // Send status message
-  pb::remote::Message msg;
-  pb::remote::ResponseGlobalSearchStatus* status =
+  cpb::remote::Message msg;
+  cpb::remote::ResponseGlobalSearchStatus* status =
       msg.mutable_response_global_search_status();
 
-  msg.set_type(pb::remote::GLOBAL_SEARCH_STATUS);
+  msg.set_type(cpb::remote::GLOBAL_SEARCH_STATUS);
   status->set_id(req.id_);
   status->set_query(DataCommaSizeFromQString(req.query_));
-  status->set_status(pb::remote::GlobalSearchFinished);
+  status->set_status(cpb::remote::GlobalSearchFinished);
 
   req.client_->SendData(&msg);
 
@@ -760,32 +761,32 @@ void OutgoingDataCreator::SearchFinished(int id) {
 
 void OutgoingDataCreator::SendListFiles(QString relative_path,
                                         RemoteClient* client) {
-  pb::remote::Message msg;
-  msg.set_type(pb::remote::LIST_FILES);
-  pb::remote::ResponseListFiles* files = msg.mutable_response_list_files();
+  cpb::remote::Message msg;
+  msg.set_type(cpb::remote::LIST_FILES);
+  cpb::remote::ResponseListFiles* files = msg.mutable_response_list_files();
   // Security checks
   if (files_root_folder_.isEmpty()) {
-    files->set_error(pb::remote::ResponseListFiles::ROOT_DIR_NOT_SET);
+    files->set_error(cpb::remote::ResponseListFiles::ROOT_DIR_NOT_SET);
     SendDataToClients(&msg);
     return;
   }
 
   QDir root_dir(files_root_folder_);
   if (!root_dir.exists())
-    files->set_error(pb::remote::ResponseListFiles::ROOT_DIR_NOT_SET);
+    files->set_error(cpb::remote::ResponseListFiles::ROOT_DIR_NOT_SET);
   else if (relative_path.startsWith("..") || relative_path.startsWith("./.."))
-    files->set_error(pb::remote::ResponseListFiles::DIR_NOT_ACCESSIBLE);
+    files->set_error(cpb::remote::ResponseListFiles::DIR_NOT_ACCESSIBLE);
   else {
     if (relative_path.startsWith("/")) relative_path.remove(0, 1);
 
     QFileInfo fi_folder(root_dir, relative_path);
     if (!fi_folder.exists())
-      files->set_error(pb::remote::ResponseListFiles::DIR_NOT_EXIST);
+      files->set_error(cpb::remote::ResponseListFiles::DIR_NOT_EXIST);
     else if (!fi_folder.isDir())
-      files->set_error(pb::remote::ResponseListFiles::DIR_NOT_EXIST);
+      files->set_error(cpb::remote::ResponseListFiles::DIR_NOT_EXIST);
     else if (root_dir.relativeFilePath(fi_folder.absoluteFilePath())
                  .startsWith("../"))
-      files->set_error(pb::remote::ResponseListFiles::DIR_NOT_ACCESSIBLE);
+      files->set_error(cpb::remote::ResponseListFiles::DIR_NOT_ACCESSIBLE);
     else {
       files->set_relative_path(
           root_dir.relativeFilePath(fi_folder.absoluteFilePath())
@@ -796,7 +797,7 @@ void OutgoingDataCreator::SendListFiles(QString relative_path,
 
       for (const QFileInfo& fi : dir.entryInfoList()) {
         if (fi.isDir() || files_music_extensions_.contains(fi.suffix())) {
-          pb::remote::FileMetadata* pb_file = files->add_files();
+          cpb::remote::FileMetadata* pb_file = files->add_files();
           pb_file->set_is_dir(fi.isDir());
           pb_file->set_filename(fi.fileName().toStdString());
         }
@@ -807,16 +808,16 @@ void OutgoingDataCreator::SendListFiles(QString relative_path,
 }
 
 void OutgoingDataCreator::SendSavedRadios(RemoteClient* client) {
-  pb::remote::Message msg;
-  msg.set_type(pb::remote::REQUEST_SAVED_RADIOS);
+  cpb::remote::Message msg;
+  msg.set_type(cpb::remote::REQUEST_SAVED_RADIOS);
 
   SavedRadio* radio_service = static_cast<SavedRadio*>(
       InternetModel::ServiceByName(SavedRadio::kServiceName));
   if (radio_service) {
-    pb::remote::ResponseSavedRadios* radios =
+    cpb::remote::ResponseSavedRadios* radios =
         msg.mutable_response_saved_radios();
     for (const auto& stream : radio_service->Streams()) {
-      pb::remote::Stream* pb_stream = radios->add_streams();
+      cpb::remote::Stream* pb_stream = radios->add_streams();
       pb_stream->set_name(stream.name_.toStdString());
       pb_stream->set_url(stream.url_.toString().toStdString());
       if (!stream.url_logo_.isEmpty())

--- a/src/networkremote/outgoingdatacreator.h
+++ b/src/networkremote/outgoingdatacreator.h
@@ -57,7 +57,7 @@ class OutgoingDataCreator : public QObject {
     allow_downloads_ = allow_downloads;
   }
   static void CreateSong(const Song& song, const QImage& art, const int index,
-                         pb::remote::SongMetadata* song_metadata);
+                         cpb::remote::SongMetadata* song_metadata);
 
  public slots:
   void SendClementineInfo();
@@ -116,8 +116,8 @@ class OutgoingDataCreator : public QObject {
 
   QMap<int, GlobalSearchRequest> global_search_result_map_;
 
-  void SendDataToClients(pb::remote::Message* msg);
-  void SetEngineState(pb::remote::ResponseClementineInfo* msg);
+  void SendDataToClients(cpb::remote::Message* msg);
+  void SetEngineState(cpb::remote::ResponseClementineInfo* msg);
   void CheckEnabledProviders();
   SongInfoProvider* ProviderByName(const QString& name) const;
 };

--- a/src/networkremote/remoteclient.cpp
+++ b/src/networkremote/remoteclient.cpp
@@ -103,33 +103,33 @@ void RemoteClient::IncomingData() {
 }
 
 void RemoteClient::ParseMessage(const QByteArray& data) {
-  pb::remote::Message msg;
+  cpb::remote::Message msg;
   if (!msg.ParseFromArray(data.constData(), data.size())) {
     qLog(Info) << "Couldn't parse data";
     return;
   }
 
-  if (msg.type() == pb::remote::CONNECT && use_auth_code_) {
+  if (msg.type() == cpb::remote::CONNECT && use_auth_code_) {
     if (msg.request_connect().auth_code() != auth_code_) {
-      DisconnectClient(pb::remote::Wrong_Auth_Code);
+      DisconnectClient(cpb::remote::Wrong_Auth_Code);
       return;
     } else {
       authenticated_ = true;
     }
   }
 
-  if (msg.type() == pb::remote::CONNECT) {
+  if (msg.type() == cpb::remote::CONNECT) {
     setDownloader(msg.request_connect().downloader());
     qDebug() << "Downloader" << downloader_;
   }
 
   // Check if downloads are allowed
-  if (msg.type() == pb::remote::DOWNLOAD_SONGS && !allow_downloads_) {
-    DisconnectClient(pb::remote::Download_Forbidden);
+  if (msg.type() == cpb::remote::DOWNLOAD_SONGS && !allow_downloads_) {
+    DisconnectClient(cpb::remote::Download_Forbidden);
     return;
   }
 
-  if (msg.type() == pb::remote::DISCONNECT) {
+  if (msg.type() == cpb::remote::DISCONNECT) {
     client_->abort();
     qDebug() << "Client disconnected";
     return;
@@ -137,7 +137,7 @@ void RemoteClient::ParseMessage(const QByteArray& data) {
 
   // Check if the client has sent the correct auth code
   if (!authenticated_) {
-    DisconnectClient(pb::remote::Not_Authenticated);
+    DisconnectClient(cpb::remote::Not_Authenticated);
     return;
   }
 
@@ -145,9 +145,9 @@ void RemoteClient::ParseMessage(const QByteArray& data) {
   emit Parse(msg);
 }
 
-void RemoteClient::DisconnectClient(pb::remote::ReasonDisconnect reason) {
-  pb::remote::Message msg;
-  msg.set_type(pb::remote::DISCONNECT);
+void RemoteClient::DisconnectClient(cpb::remote::ReasonDisconnect reason) {
+  cpb::remote::Message msg;
+  msg.set_type(cpb::remote::DISCONNECT);
 
   msg.mutable_response_disconnect()->set_reason_disconnect(reason);
   SendDataToClient(&msg);
@@ -158,7 +158,7 @@ void RemoteClient::DisconnectClient(pb::remote::ReasonDisconnect reason) {
 }
 
 // Sends data to client without check if authenticated
-void RemoteClient::SendDataToClient(pb::remote::Message* msg) {
+void RemoteClient::SendDataToClient(cpb::remote::Message* msg) {
   // Set the default version
   msg->set_version(msg->default_instance().version());
 
@@ -185,7 +185,7 @@ void RemoteClient::SendDataToClient(pb::remote::Message* msg) {
   }
 }
 
-void RemoteClient::SendData(pb::remote::Message* msg) {
+void RemoteClient::SendData(cpb::remote::Message* msg) {
   // Check if client is authenticated before sending the data
   if (authenticated_) {
     SendDataToClient(msg);

--- a/src/networkremote/remoteclient.h
+++ b/src/networkremote/remoteclient.h
@@ -14,11 +14,11 @@ class RemoteClient : public QObject {
   ~RemoteClient();
 
   // This method checks if client is authenticated before sending the data
-  void SendData(pb::remote::Message* msg);
+  void SendData(cpb::remote::Message* msg);
   QAbstractSocket::SocketState State();
   void setDownloader(bool downloader);
   bool isDownloader() { return downloader_; }
-  void DisconnectClient(pb::remote::ReasonDisconnect reason);
+  void DisconnectClient(cpb::remote::ReasonDisconnect reason);
 
   SongSender* song_sender() { return song_sender_; }
   const QString& files_root_folder() const { return files_root_folder_; }
@@ -31,13 +31,13 @@ class RemoteClient : public QObject {
   void IncomingData();
 
  signals:
-  void Parse(const pb::remote::Message& msg);
+  void Parse(const cpb::remote::Message& msg);
 
  private:
   void ParseMessage(const QByteArray& data);
 
   // Sends data to client without check if authenticated
-  void SendDataToClient(pb::remote::Message* msg);
+  void SendDataToClient(cpb::remote::Message* msg);
 
   Application* app_;
 

--- a/src/networkremote/songsender.cpp
+++ b/src/networkremote/songsender.cpp
@@ -68,29 +68,29 @@ SongSender::~SongSender() {
   transcoder_->Cancel();
 }
 
-void SongSender::SendSongs(const pb::remote::RequestDownloadSongs& request) {
+void SongSender::SendSongs(const cpb::remote::RequestDownloadSongs& request) {
   Song current_song;
   if (app_->player()->GetCurrentItem()) {
     current_song = app_->player()->GetCurrentItem()->Metadata();
   }
 
   switch (request.download_item()) {
-    case pb::remote::CurrentItem: {
+    case cpb::remote::CurrentItem: {
       if (current_song.is_valid()) {
         DownloadItem item(current_song, 1, 1);
         download_queue_.append(item);
       }
       break;
     }
-    case pb::remote::ItemAlbum:
+    case cpb::remote::ItemAlbum:
       if (current_song.is_valid()) {
         SendAlbum(current_song);
       }
       break;
-    case pb::remote::APlaylist:
+    case cpb::remote::APlaylist:
       SendPlaylist(request);
       break;
-    case pb::remote::Urls:
+    case cpb::remote::Urls:
       SendUrls(request);
       break;
     default:
@@ -140,10 +140,10 @@ void SongSender::TranscodeJobComplete(const QString& input,
 
 void SongSender::SendTranscoderStatus() {
   // Send a message to the remote that we are converting files
-  pb::remote::Message msg;
-  msg.set_type(pb::remote::TRANSCODING_FILES);
+  cpb::remote::Message msg;
+  msg.set_type(cpb::remote::TRANSCODING_FILES);
 
-  pb::remote::ResponseTranscoderStatus* status =
+  cpb::remote::ResponseTranscoderStatus* status =
       msg.mutable_response_transcoder_status();
   status->set_processed(transcoder_map_.count());
   status->set_total(total_transcode_);
@@ -162,10 +162,10 @@ void SongSender::StartTransfer() {
 }
 
 void SongSender::SendTotalFileSize() {
-  pb::remote::Message msg;
-  msg.set_type(pb::remote::DOWNLOAD_TOTAL_SIZE);
+  cpb::remote::Message msg;
+  msg.set_type(cpb::remote::DOWNLOAD_TOTAL_SIZE);
 
-  pb::remote::ResponseDownloadTotalSize* response =
+  cpb::remote::ResponseDownloadTotalSize* response =
       msg.mutable_response_download_total_size();
 
   response->set_file_count(download_queue_.size());
@@ -187,16 +187,16 @@ void SongSender::SendTotalFileSize() {
 }
 
 void SongSender::OfferNextSong() {
-  pb::remote::Message msg;
+  cpb::remote::Message msg;
 
   if (download_queue_.isEmpty()) {
-    msg.set_type(pb::remote::DOWNLOAD_QUEUE_EMPTY);
+    msg.set_type(cpb::remote::DOWNLOAD_QUEUE_EMPTY);
   } else {
     // Get the item and send the single song
     DownloadItem item = download_queue_.head();
 
-    msg.set_type(pb::remote::SONG_FILE_CHUNK);
-    pb::remote::ResponseSongFileChunk* chunk =
+    msg.set_type(cpb::remote::SONG_FILE_CHUNK);
+    cpb::remote::ResponseSongFileChunk* chunk =
         msg.mutable_response_song_file_chunk();
 
     // Open the file
@@ -248,10 +248,10 @@ void SongSender::SendSingleSong(DownloadItem download_item) {
   file.open(QIODevice::ReadOnly);
 
   QByteArray data;
-  pb::remote::Message msg;
-  pb::remote::ResponseSongFileChunk* chunk =
+  cpb::remote::Message msg;
+  cpb::remote::ResponseSongFileChunk* chunk =
       msg.mutable_response_song_file_chunk();
-  msg.set_type(pb::remote::SONG_FILE_CHUNK);
+  msg.set_type(cpb::remote::SONG_FILE_CHUNK);
 
   QImage null_image;
 
@@ -276,7 +276,7 @@ void SongSender::SendSingleSong(DownloadItem download_item) {
     // what file it receives.
     if (chunk_number == 1) {
       int i = app_->playlist_manager()->active()->current_row();
-      pb::remote::SongMetadata* song_metadata =
+      cpb::remote::SongMetadata* song_metadata =
           msg.mutable_response_song_file_chunk()->mutable_song_metadata();
       OutgoingDataCreator::CreateSong(download_item.song_, null_image, i,
                                       song_metadata);
@@ -322,7 +322,8 @@ void SongSender::SendAlbum(const Song& song) {
   }
 }
 
-void SongSender::SendPlaylist(const pb::remote::RequestDownloadSongs& request) {
+void SongSender::SendPlaylist(
+    const cpb::remote::RequestDownloadSongs& request) {
   int playlist_id = request.playlist_id();
   Playlist* playlist = app_->playlist_manager()->playlist(playlist_id);
   if (!playlist) {
@@ -353,7 +354,7 @@ void SongSender::SendPlaylist(const pb::remote::RequestDownloadSongs& request) {
   }
 }
 
-void SongSender::SendUrls(const pb::remote::RequestDownloadSongs& request) {
+void SongSender::SendUrls(const cpb::remote::RequestDownloadSongs& request) {
   SongList song_list;
 
   // First gather all valid songs

--- a/src/networkremote/songsender.h
+++ b/src/networkremote/songsender.h
@@ -30,7 +30,7 @@ class SongSender : public QObject {
   static const quint32 kFileChunkSize;
 
  public slots:
-  void SendSongs(const pb::remote::RequestDownloadSongs& request);
+  void SendSongs(const cpb::remote::RequestDownloadSongs& request);
   void ResponseSongOffer(bool accepted);
 
  private slots:
@@ -52,8 +52,8 @@ class SongSender : public QObject {
 
   void SendSingleSong(DownloadItem download_item);
   void SendAlbum(const Song& song);
-  void SendPlaylist(const pb::remote::RequestDownloadSongs& request);
-  void SendUrls(const pb::remote::RequestDownloadSongs& request);
+  void SendPlaylist(const cpb::remote::RequestDownloadSongs& request);
+  void SendUrls(const cpb::remote::RequestDownloadSongs& request);
   void OfferNextSong();
   void SendTotalFileSize();
   void TranscodeLosslessFiles();

--- a/tests/song_test.cpp
+++ b/tests/song_test.cpp
@@ -45,7 +45,7 @@ class SongTest : public ::testing::Test {
   static Song ReadSongFromFile(const QString& filename) {
     TagReader tag_reader;
     Song song;
-    ::pb::tagreader::SongMetadata pb_song;
+    ::cpb::tagreader::SongMetadata pb_song;
 
     // We need to init protobuf object from a Song object, to have default
     // values initialized correctly. For example, Song's rating is -1 by
@@ -59,7 +59,7 @@ class SongTest : public ::testing::Test {
 
   static void WriteSongToFile(const Song& song, const QString& filename) {
     TagReader tag_reader;
-    ::pb::tagreader::SongMetadata pb_song;
+    ::cpb::tagreader::SongMetadata pb_song;
     song.ToProtobuf(&pb_song);
     tag_reader.SaveFile(filename, pb_song);
   }
@@ -67,14 +67,14 @@ class SongTest : public ::testing::Test {
   static void WriteSongStatisticsToFile(const Song& song,
                                         const QString& filename) {
     TagReader tag_reader;
-    ::pb::tagreader::SongMetadata pb_song;
+    ::cpb::tagreader::SongMetadata pb_song;
     song.ToProtobuf(&pb_song);
     tag_reader.SaveSongStatisticsToFile(filename, pb_song);
   }
 
   static void WriteSongRatingToFile(const Song& song, const QString& filename) {
     TagReader tag_reader;
-    ::pb::tagreader::SongMetadata pb_song;
+    ::cpb::tagreader::SongMetadata pb_song;
     song.ToProtobuf(&pb_song);
     tag_reader.SaveSongRatingToFile(filename, pb_song);
   }


### PR DESCRIPTION
Protobuf 3.15 adds a namespace alias for "pb" that conflicts with
Clementine's. Modify Clementine to use "cpb".

Patch provided by @ahesford

Reference: https://github.com/protocolbuffers/protobuf/blob/5c028d6cf42e426d47f5baa6ea3f0f5c86b97beb/src/google/protobuf/port.h#L44

Fixes #6926
