### PR TITLE
Add splash

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -361,6 +361,7 @@ set(SOURCES
   ui/screensaver.cpp
   ui/settingsdialog.cpp
   ui/settingspage.cpp
+  ui/splash.cpp
   ui/standarditemiconloader.cpp
   ui/streamdetailsdialog.cpp
   ui/systemtrayicon.cpp

--- a/src/core/application.cpp
+++ b/src/core/application.cpp
@@ -252,6 +252,10 @@ void Application::MoveToThread(QObject* object, QThread* thread) {
 
 void Application::AddError(const QString& message) { emit ErrorAdded(message); }
 
+void Application::Starting() {
+  qLog(Debug) << "Application starting";
+}
+
 QString Application::language_without_region() const {
   const int underscore = language_name_.indexOf('_');
   if (underscore != -1) {

--- a/src/core/application.cpp
+++ b/src/core/application.cpp
@@ -54,6 +54,7 @@
 #include "networkremote/networkremotehelper.h"
 #include "playlist/playlistbackend.h"
 #include "playlist/playlistmanager.h"
+#include "ui/splash.h"
 
 #ifdef HAVE_LIBLASTFM
 #include "covers/lastfmcoverprovider.h"
@@ -203,6 +204,12 @@ class ApplicationImpl {
 Application::Application(QObject* parent)
     : QObject(parent), p_(new ApplicationImpl(this)) {
   setObjectName("Clementine Application");
+
+  // Show the splash
+  splash_.reset(new Splash());
+  splash_->show();
+  QCoreApplication::processEvents();
+
   // This must be before library_->Init();
   // In the constructor the helper waits for the signal
   // PlaylistManagerInitialized
@@ -254,6 +261,11 @@ void Application::AddError(const QString& message) { emit ErrorAdded(message); }
 
 void Application::Starting() {
   qLog(Debug) << "Application starting";
+
+  // Hide the splash
+  if (splash_) {
+    splash_.reset();
+  }
 }
 
 QString Application::language_without_region() const {

--- a/src/core/application.h
+++ b/src/core/application.h
@@ -114,6 +114,7 @@ class Application : public QObject {
   void MoveToThread(QObject* object, QThread* thread);
 
  public slots:
+  void Starting();
   void AddError(const QString& message);
   void ReloadSettings();
   void OpenSettingsDialogAtPage(SettingsDialog::Page page);

--- a/src/core/application.h
+++ b/src/core/application.h
@@ -55,6 +55,7 @@ class PodcastDeleter;
 class PodcastDownloader;
 class PodcastUpdater;
 class Scrobbler;
+class Splash;
 class TagReaderClient;
 class TaskManager;
 
@@ -133,6 +134,7 @@ class Application : public QObject {
  private:
   QString language_name_;
   std::unique_ptr<ApplicationImpl> p_;
+  std::unique_ptr<Splash> splash_;
   QList<QThread*> threads_;
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -460,6 +460,10 @@ int main(int argc, char* argv[]) {
   QObject::connect(&a, SIGNAL(messageReceived(QString)), &w,
                    SLOT(CommandlineOptionsReceived(QString)));
 
+  // Use a queued connection so the invokation occurs after the application
+  // loop starts.
+  QMetaObject::invokeMethod(&app, "Starting", Qt::QueuedConnection);
+
   int ret = a.exec();
 
   return ret;

--- a/src/ui/splash.cpp
+++ b/src/ui/splash.cpp
@@ -1,0 +1,22 @@
+/* This file is part of Clementine.
+   Copyright 2021, Jim Broadus <jbroadus@gmail.com>
+
+   Clementine is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Clementine is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "splash.h"
+
+#include <QPixmap>
+
+Splash::Splash() : QSplashScreen(QPixmap(":/icon.png")) {}

--- a/src/ui/splash.h
+++ b/src/ui/splash.h
@@ -1,0 +1,28 @@
+/* This file is part of Clementine.
+   Copyright 2021, Jim Broadus <jbroadus@gmail.com>
+
+   Clementine is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Clementine is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef SPLASH_H
+#define SPLASH_H
+
+#include <QSplashScreen>
+
+class Splash : public QSplashScreen {
+ public:
+  Splash();
+};
+
+#endif  // SPLASH_H


### PR DESCRIPTION
Since initialization on first startup or during a database schema update can take several seconds, show a splash screen. In the initial implementation, this is just a small Clementine logo.

The benefit of instantiating the splash in the Application class rather than in main is that it could eventually show status messages during startup. However, this implementation does not use the QSplashScreen::finish mechanism that would synchronize the hiding of the splash screen with the showing of the main window.
