### PR TITLE
Fix onedrive

### DIFF
--- a/ext/libclementine-tagreader/cloudstream.cpp
+++ b/ext/libclementine-tagreader/cloudstream.cpp
@@ -113,6 +113,8 @@ TagLib::ByteVector CloudStream::readBlock(ulong length) {
                        QString("bytes=%1-%2").arg(start).arg(end).toUtf8());
   request.setAttribute(QNetworkRequest::CacheLoadControlAttribute,
                        QNetworkRequest::AlwaysNetwork);
+  // TODO: Use RedirectPolicyAttribute after baseline moves to Qt 5.9.
+  request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
 
   QNetworkReply* reply = network_->get(request);
   connect(reply, SIGNAL(sslErrors(QList<QSslError>)),

--- a/src/internet/core/oauthenticator.cpp
+++ b/src/internet/core/oauthenticator.cpp
@@ -102,15 +102,17 @@ QByteArray OAuthenticator::ParseHttpRequest(const QByteArray& request) const {
 }
 
 void OAuthenticator::RequestAccessToken(const QByteArray& code,
-                                        const QUrl& url) {
+                                        const QUrl& redirect_url) {
   typedef QPair<QString, QString> Param;
   QList<Param> parameters;
   parameters << Param("code", code) << Param("client_id", client_id_)
-             << Param("client_secret", client_secret_)
              << Param("grant_type", "authorization_code")
              // Even though we don't use this URI anymore, it must match the
              // original one.
-             << Param("redirect_uri", url.toString());
+             << Param("redirect_uri", redirect_url.toString());
+  if (!client_secret_.isEmpty()) {
+    parameters << Param("client_secret", client_secret_);
+  }
 
   QStringList params;
   for (const Param& p : parameters) {

--- a/src/internet/core/oauthenticator.h
+++ b/src/internet/core/oauthenticator.h
@@ -74,7 +74,7 @@ class OAuthenticator : public QObject {
   static const char* kRemoteURL;
 
   QByteArray ParseHttpRequest(const QByteArray& request) const;
-  void RequestAccessToken(const QByteArray& code, const QUrl& url);
+  void RequestAccessToken(const QByteArray& code, const QUrl& redirect_url);
   void SetExpiryTime(int expires_in_seconds);
 
   NetworkAccessManager network_;

--- a/src/internet/skydrive/skydriveservice.cpp
+++ b/src/internet/skydrive/skydriveservice.cpp
@@ -110,8 +110,11 @@ void SkydriveService::AddAuthorizationHeader(QNetworkRequest* request) {
 
 void SkydriveService::FetchUserInfoFinished(QNetworkReply* reply) {
   reply->deleteLater();
-  QJsonObject json_response =
-      QJsonDocument::fromBinaryData(reply->readAll()).object();
+
+  QJsonDocument document = ParseJsonReply(reply);
+  if (document.isNull()) return;
+
+  QJsonObject json_response = document.object();
 
   QString name = json_response["name"].toString();
   if (!name.isEmpty()) {
@@ -137,8 +140,11 @@ void SkydriveService::ListFiles(const QString& folder) {
 
 void SkydriveService::ListFilesFinished(QNetworkReply* reply) {
   reply->deleteLater();
-  QJsonObject json_response =
-      QJsonDocument::fromBinaryData(reply->readAll()).object();
+
+  QJsonDocument document = ParseJsonReply(reply);
+  if (document.isNull()) return;
+
+  QJsonObject json_response = document.object();
 
   QJsonArray files = json_response["data"].toArray();
   for (const QJsonValue& f : files) {
@@ -179,8 +185,11 @@ QUrl SkydriveService::GetStreamingUrlFromSongId(const QString& file_id) {
   std::unique_ptr<QNetworkReply> reply(network_->get(request));
   WaitForSignal(reply.get(), SIGNAL(finished()));
 
-  QJsonObject json_response =
-      QJsonDocument::fromBinaryData(reply.get()->readAll()).object();
+  QJsonDocument document = ParseJsonReply(reply.get());
+  if (document.isNull()) return QUrl();
+
+  QJsonObject json_response = document.object();
+
   return QUrl(json_response["source"].toString());
 }
 

--- a/src/internet/skydrive/skydriveservice.cpp
+++ b/src/internet/skydrive/skydriveservice.cpp
@@ -36,14 +36,16 @@ namespace {
 
 static const char* kServiceId = "skydrive";
 
-static const char* kClientId = "0000000040111F16";
-static const char* kClientSecret = "w2ClguSX0jG56cBl1CeUniypTBRjXt2Z";
+static const char* kClientId = "905def38-34d2-4e32-8ba7-c37bcc329047";
+static const char* kClientSecret = "";
 
+// https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow
 static const char* kOAuthEndpoint =
-    "https://login.live.com/oauth20_authorize.srf";
+    "https://login.microsoftonline.com/common/oauth2/v2.0/authorize";
 static const char* kOAuthTokenEndpoint =
-    "https://login.live.com/oauth20_token.srf";
-static const char* kOAuthScope = "wl.basic wl.skydrive wl.offline_access";
+    "https://login.microsoftonline.com/common/oauth2/v2.0/token";
+static const char* kOAuthScope =
+    "User.Read Files.Read Files.Read.All offline_access";
 
 static const char* kLiveUserInfo = "https://apis.live.net/v5.0/me";
 static const char* kSkydriveBase = "https://apis.live.net/v5.0/";
@@ -51,7 +53,7 @@ static const char* kSkydriveBase = "https://apis.live.net/v5.0/";
 }  // namespace
 
 const char* SkydriveService::kServiceName = "OneDrive";
-const char* SkydriveService::kSettingsGroup = "Skydrive";
+const char* SkydriveService::kSettingsGroup = "OneDrive";
 
 SkydriveService::SkydriveService(Application* app, InternetModel* parent)
     : CloudFileService(app, parent, kServiceName, kServiceId,
@@ -73,7 +75,7 @@ QString SkydriveService::refresh_token() const {
 
 void SkydriveService::Connect() {
   OAuthenticator* oauth = new OAuthenticator(
-      kClientId, kClientSecret, OAuthenticator::RedirectStyle::REMOTE, this);
+      kClientId, kClientSecret, OAuthenticator::RedirectStyle::LOCALHOST, this);
   if (!refresh_token().isEmpty()) {
     oauth->RefreshAuthorisation(kOAuthTokenEndpoint, refresh_token());
   } else {

--- a/src/internet/skydrive/skydriveservice.h
+++ b/src/internet/skydrive/skydriveservice.h
@@ -40,6 +40,8 @@ class SkydriveService : public CloudFileService {
   virtual bool has_credentials() const;
   QUrl GetStreamingUrlFromSongId(const QString& song_id);
 
+  QString GetScheme() const { return "onedrive"; }
+
  public slots:
   virtual void Connect();
   void ForgetCredentials();
@@ -53,10 +55,16 @@ class SkydriveService : public CloudFileService {
   void Connected();
 
  private:
+  friend class SkydriveUrlHandler;
+  QByteArray GetAuthHeader() const;
+
+ private:
   QString refresh_token() const;
   void AddAuthorizationHeader(QNetworkRequest* request);
+  void FetchUserInfo();
   void ListFiles(const QString& folder);
   void EnsureConnected();
+  QUrl ItemUrl(const QString& id, const QString& path);
 
   QString access_token_;
   QDateTime expiry_time_;

--- a/src/internet/skydrive/skydriveurlhandler.cpp
+++ b/src/internet/skydrive/skydriveurlhandler.cpp
@@ -27,5 +27,9 @@ SkydriveUrlHandler::SkydriveUrlHandler(SkydriveService* service,
 UrlHandler::LoadResult SkydriveUrlHandler::StartLoading(const QUrl& url) {
   QString file_id(url.path());
   QUrl real_url = service_->GetStreamingUrlFromSongId(file_id);
-  return LoadResult(url, LoadResult::TrackAvailable, real_url);
+  LoadResult res(url, LoadResult::TrackAvailable, real_url);
+  res.auth_header_ = service_->GetAuthHeader();
+  return res;
 }
+
+QString SkydriveUrlHandler::scheme() const { return service_->GetScheme(); }

--- a/src/internet/skydrive/skydriveurlhandler.h
+++ b/src/internet/skydrive/skydriveurlhandler.h
@@ -31,7 +31,7 @@ class SkydriveUrlHandler : public UrlHandler {
   explicit SkydriveUrlHandler(SkydriveService* service,
                               QObject* parent = nullptr);
 
-  QString scheme() const { return "skydrive"; }
+  QString scheme() const;
   QIcon icon() const {
     return IconLoader::Load("skydrive", IconLoader::Provider);
   }


### PR DESCRIPTION
The live API was deprecated in 2018. This change implements basic
onedrive access using the MS graph API.

The URL scheme was also changed from skydrive to onedrive. This is based
on the assumption that existing playlists won't have compatible item
ids.

Known issues:
- Directories with over 200 items will be truncated.
- No mechanism for discovering changes at runtime.
- No mechanism for removing deleted items or rescanning.

Reference: https://docs.microsoft.com/en-us/onedrive/developer/rest-api/concepts/migrating-from-live-sdk?view=odsp-graph-online

