### PR TITLE
errordialog: Don't clear messages on sponaneous events.

### DIFF
--- a/src/widgets/errordialog.cpp
+++ b/src/widgets/errordialog.cpp
@@ -17,6 +17,7 @@
 
 #include "errordialog.h"
 
+#include <QHideEvent>
 #include <QStyle>
 
 #include "ui_errordialog.h"
@@ -47,9 +48,11 @@ void ErrorDialog::ShowMessage(const QString& message) {
   activateWindow();
 }
 
-void ErrorDialog::hideEvent(QHideEvent*) {
-  current_messages_.clear();
-  UpdateContent();
+void ErrorDialog::hideEvent(QHideEvent* event) {
+  if (!event->spontaneous()) {
+    current_messages_.clear();
+    UpdateContent();
+  }
 }
 
 void ErrorDialog::UpdateContent() {


### PR DESCRIPTION
Don't clear the message dialog if a hide event is sent from the window
manager. These spontaneous events are sent when a window is minimized,
moved to a different screen, etc.