### PR TITLE
Fix cover art query for Subsonic-based Funkwhale servers

### DIFF
--- a/src/internet/subsonic/subsonicservice.cpp
+++ b/src/internet/subsonic/subsonicservice.cpp
@@ -599,6 +599,7 @@ Song SubsonicService::ReadSong(QXmlStreamReader& reader) {
   song.set_year(reader.attributes().value("year").toString().toInt());
   song.set_genre(reader.attributes().value("genre").toString());
   qint64 length = reader.attributes().value("duration").toString().toInt();
+  QString cover_art_id = reader.attributes().value("coverArt").toString();
   length *= kNsecPerSec;
   song.set_length_nanosec(length);
   QUrl url = QUrl(QString("subsonic://"));
@@ -608,7 +609,7 @@ Song SubsonicService::ReadSong(QXmlStreamReader& reader) {
 
   QUrl cover_url = BuildRequestUrl("getCoverArt");
   QUrlQuery cover_url_query(cover_url.query());
-  cover_url_query.addQueryItem("id", id);
+  cover_url_query.addQueryItem("id", cover_art_id);
   cover_url.setQuery(cover_url_query);
   song.set_art_automatic(cover_url.toEncoded());
 


### PR DESCRIPTION
Background: Funkwhale is a music streaming server which implements the Subsonic API. It can be used as a source in Clementine by adding it as a Subsonic server.

When using a Subsonic as a source, Clementine will pull album art from the Subsonic server using the API. With standard Subsonic servers, this works fine. With Funkwhale, it does not work. See this comment on steps I went through to debug the issue: https://github.com/clementine-player/Clementine/issues/6565#issuecomment-786139065 and the cause/solution of the issue.

Subsonic's API supports looking up cover arts on the `getCoverArt` endpoint using the song ID, but it also provides an explicit cover art ID which can also be used to look up the song. This cover art ID is provided in the `coverArt` attribute from the `getAlbum`, which Clementine already reads from when retrieving the album/song list. This change uses the explicit `coverArt` ID rather than the song ID for cover art lookups.

This fixes cover art for Funkwhale servers using the Subsonic API, and remains compatible with the vanilla Subsonic server implementation of the API.

Change can be tested with the demo Funkwhale server https://demo.funkwhale.audio/ in Clementine using username demo and password demo.