### PR TITLE
build: Don't reset cflags in moodbar cmake

### DIFF
--- a/gst/moodbar/CMakeLists.txt
+++ b/gst/moodbar/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.11)
 
-set(CMAKE_C_FLAGS "-Wall")
-set(CMAKE_CXX_FLAGS "-Woverloaded-virtual -Wall --std=c++0x")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Woverloaded-virtual -Wall --std=c++0x")
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 


### PR DESCRIPTION
Append CMAKE_CXX_FLAGS and CMAKE_C_FLAGS instead of setting. Setting the
variables causes breakage in cross-compiled systems where sysroots and
machine types are set.