### PR TITLE
Use qt sqlite3 driver by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -366,14 +366,20 @@ if(HAVE_VISUALISATIONS)
   endif(USE_SYSTEM_PROJECTM)
 endif(HAVE_VISUALISATIONS)
 
-
-# Build our copy of QSqlLiteDriver.
-# We do this because we can't guarantee that the driver shipped with Qt exposes the
-# raw sqlite3_ functions required for FTS support. This way we know that those symbols
-# exist at compile-time and that our code links to the same sqlite library as the
-# Qt driver.
-add_subdirectory(3rdparty/qsqlite)
-include_directories("3rdparty/qsqlite")
+# In qt5, FTS3 is enabled by default.
+# See: https://github.com/qt/qtbase/commit/ee69c935c0f7b4ad3747e369fc18373d31e2521b
+option(USE_SYSTEM_SQLITE_DRIVER "Use Qt's sqlite driver" ON)
+if (USE_SYSTEM_SQLITE_DRIVER)
+  find_library(SQLITE_LIBRARIES sqlite3 REQUIRED)
+else (USE_SYSTEM_SQLITE_DRIVER)
+  # Build our copy of QSqlLiteDriver.
+  # We do this because we can't guarantee that the driver shipped with Qt exposes the
+  # raw sqlite3_ functions required for FTS support. This way we know that those symbols
+  # exist at compile-time and that our code links to the same sqlite library as the
+  # Qt driver.
+  add_subdirectory(3rdparty/qsqlite)
+  include_directories("3rdparty/qsqlite")
+endif (USE_SYSTEM_SQLITE_DRIVER)
 
 # When/if upstream accepts our patches then these options can be used to link
 # to system installed qtsingleapplication instead.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1386,8 +1386,11 @@ else (APPLE)
   target_link_libraries(clementine_lib ${QXT_LIBRARIES})
 endif (APPLE)
 
-set(3RDPARTY_SQLITE_LIBRARY qsqlite)
-target_link_libraries(clementine_lib qsqlite)
+if (NOT USE_SYSTEM_SQLITE_DRIVER)
+  set(USE_QSQLITE_PLUGIN ON)
+  set(3RDPARTY_SQLITE_LIBRARY qsqlite)
+  target_link_libraries(clementine_lib qsqlite)
+endif (NOT USE_SYSTEM_SQLITE_DRIVER)
 
 if (WIN32)
   target_link_libraries(clementine_lib

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -53,6 +53,7 @@
 #cmakedefine USE_SYSTEM_PROJECTM
 #cmakedefine USE_SYSTEM_SHA2
 #cmakedefine USE_BUNDLE
+#cmakedefine USE_QSQLITE_PLUGIN
 
 #define USE_BUNDLE_DIR "${USE_BUNDLE_DIR}"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -95,9 +95,11 @@ QDBusArgument& operator<<(QDBusArgument& arg, const QImage& image);
 const QDBusArgument& operator>>(const QDBusArgument& arg, QImage& image);
 #endif
 
+#ifdef USE_QSQLITE_PLUGIN
 // Load sqlite plugin on windows and mac.
 #include <QtPlugin>
 Q_IMPORT_PLUGIN(QSQLiteDriverPlugin)
+#endif
 
 namespace {
 


### PR DESCRIPTION
The 3rdParty qsqlite plugin was kept to insure that fts3 support was
included. In qt5, the option was added by default, so it's unlikely
that there are distros that lack the support. A build option,
USE_SYSTEM_SQLITE_DRIVER, can be disabled to switch back to the 3rd
party driver.

Reference: https://github.com/qt/qtbase/commit/ee69c935c0f7b4ad3747e369fc18373d31e2521b