### PR TITLE
Use correct URL in SongChangeRequestProcessed

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -70,10 +70,10 @@ Player::Player(Application* app, QObject* parent)
 
   connect(engine_.get(), SIGNAL(Error(QString)), SIGNAL(Error(QString)));
 
-  connect(engine_.get(), SIGNAL(ValidSongRequested(QUrl)),
-          SLOT(ValidSongRequested(QUrl)));
-  connect(engine_.get(), SIGNAL(InvalidSongRequested(QUrl)),
-          SLOT(InvalidSongRequested(QUrl)));
+  connect(engine_.get(), SIGNAL(ValidMediaRequested(MediaPlaybackRequest)),
+          SLOT(ValidMediaRequested(MediaPlaybackRequest)));
+  connect(engine_.get(), SIGNAL(InvalidMediaRequested(MediaPlaybackRequest)),
+          SLOT(InvalidMediaRequested(MediaPlaybackRequest)));
 }
 
 Player::~Player() {}
@@ -669,13 +669,13 @@ void Player::TrackAboutToEnd() {
 
 void Player::IntroPointReached() { NextInternal(Engine::Intro); }
 
-void Player::ValidSongRequested(const QUrl& url) {
-  emit SongChangeRequestProcessed(url, true);
+void Player::ValidMediaRequested(const MediaPlaybackRequest& req) {
+  emit SongChangeRequestProcessed(req.url_, true);
 }
 
-void Player::InvalidSongRequested(const QUrl& url) {
+void Player::InvalidMediaRequested(const MediaPlaybackRequest& req) {
   // first send the notification to others...
-  emit SongChangeRequestProcessed(url, false);
+  emit SongChangeRequestProcessed(req.url_, false);
   // ... and now when our listeners have completed their processing of the
   // current item we can change the current item by skipping to the next song
 

--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -670,12 +670,12 @@ void Player::TrackAboutToEnd() {
 void Player::IntroPointReached() { NextInternal(Engine::Intro); }
 
 void Player::ValidMediaRequested(const MediaPlaybackRequest& req) {
-  emit SongChangeRequestProcessed(req.url_, true);
+  emit SongChangeRequestProcessed(req.RequestUrl(), true);
 }
 
 void Player::InvalidMediaRequested(const MediaPlaybackRequest& req) {
   // first send the notification to others...
-  emit SongChangeRequestProcessed(req.url_, false);
+  emit SongChangeRequestProcessed(req.RequestUrl(), false);
   // ... and now when our listeners have completed their processing of the
   // current item we can change the current item by skipping to the next song
 

--- a/src/core/player.h
+++ b/src/core/player.h
@@ -40,6 +40,7 @@
 #include "playlist/playlistitem.h"
 
 class Application;
+class MediaPlaybackRequest;
 class Scrobbler;
 
 class PlayerInterface : public QObject {
@@ -191,8 +192,8 @@ class Player : public PlayerInterface {
   void PlayPlaylistInternal(Engine::TrackChangeFlags,
                             const QString& playlistName);
 
-  void ValidSongRequested(const QUrl&);
-  void InvalidSongRequested(const QUrl&);
+  void ValidMediaRequested(const MediaPlaybackRequest&);
+  void InvalidMediaRequested(const MediaPlaybackRequest&);
 
   void UrlHandlerDestroyed(QObject* object);
   void HandleLoadResult(const UrlHandler::LoadResult& result);

--- a/src/engines/enginebase.h
+++ b/src/engines/enginebase.h
@@ -116,11 +116,11 @@ class Base : public QObject {
   void StatusText(const QString&);
   void Error(const QString&);
 
-  // Emitted when Engine was unable to play a song with the given QUrl.
-  void InvalidSongRequested(const QUrl&);
+  // Emitted when Engine was unable to play a request.
+  void InvalidMediaRequested(const MediaPlaybackRequest&);
   // Emitted when Engine successfully started playing a song with the
-  // given QUrl.
-  void ValidSongRequested(const QUrl&);
+  // given request.
+  void ValidMediaRequested(const MediaPlaybackRequest&);
 
   void MetaData(const Engine::SimpleMetaBundle&);
 

--- a/src/engines/gstengine.cpp
+++ b/src/engines/gstengine.cpp
@@ -522,8 +522,8 @@ void GstEngine::PlayDone(QFuture<GstStateChangeReturn> future,
   }
 
   emit StateChanged(Engine::Playing);
-  // we've successfully started playing a media stream with this url
-  emit ValidSongRequested(playback_req_.url_);
+  // we've successfully started playing this request
+  emit ValidMediaRequested(playback_req_);
 }
 
 void GstEngine::Stop(bool stop_after) {
@@ -727,8 +727,8 @@ void GstEngine::HandlePipelineError(int pipeline_id, const QString& message,
 
   BufferingFinished();
   emit StateChanged(Engine::Error);
-  // unable to play media stream with this url
-  emit InvalidSongRequested(playback_req_.url_);
+  // Unable to play this media request
+  emit InvalidMediaRequested(playback_req_);
 
   // TODO: the types of errors listed below won't be shown to user - they will
   // get logged and the current song will be skipped; instead of maintaining

--- a/src/engines/playbackrequest.h
+++ b/src/engines/playbackrequest.h
@@ -23,9 +23,17 @@
 
 class MediaPlaybackRequest {
  public:
-  MediaPlaybackRequest(const QUrl& url) : url_(url) {}
+  // For local songs and raw streams, the request and media URLs are the same.
+  MediaPlaybackRequest(const QUrl& url) : request_url_(url), url_(url) {}
+  MediaPlaybackRequest(const QUrl& request_url, const QUrl& media_url)
+      : request_url_(request_url), url_(media_url) {}
   MediaPlaybackRequest() {}
 
+  const QUrl& RequestUrl() const { return request_url_; }
+  const QUrl& MediaUrl() const { return url_; }
+  void SetMediaUrl(const QUrl& url) { url_ = url; }
+
+  QUrl request_url_;
   QUrl url_;
 
   typedef QMap<QByteArray, QByteArray> HeaderList;


### PR DESCRIPTION
Use the request URL rather than the media URL when emitting the SongChangeRequestProcessed signal. The request URL is the URL that the PlaylistManager, which is the only consumer of this signal, knows about. However, in the current cases, the url is only checked by the playlist when the URLs should be the same.