### PR TITLE
Add window icon under Linux/Wayland

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -391,7 +391,7 @@ int main(int argc, char* argv[]) {
 // Set the name of the app desktop file as per the freedesktop specifications
 // This is needed on Wayland for the main window to show the correct icon
 #if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
-    QGuiApplication::setDesktopFileName("clementine");
+  QGuiApplication::setDesktopFileName("clementine");
 #endif
 
   // Resources

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -388,6 +388,12 @@ int main(int argc, char* argv[]) {
   }
 #endif
 
+// Set the name of the app desktop file as per the freedesktop specifications
+// This is needed on Wayland for the main window to show the correct icon
+#if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
+    QGuiApplication::setDesktopFileName("clementine");
+#endif
+
   // Resources
   Q_INIT_RESOURCE(data);
 #ifdef HAVE_TRANSLATIONS


### PR DESCRIPTION
Wayland is a new protocol used under Linux used as an alternative to the old X11.
Windowing systems under Wayland won't use the window icons defined inside the application, instead they require the application to define an associated "desktop file" and load the icon defined in that file.
This is quite easy under Qt using [QGuiApplication::setDesktopFileName()](https://doc.qt.io/qt-5/qguiapplication.html#desktopFileName-prop)
This PR adds the needed method call.
Before:
![Screenshot_20210312_144719](https://user-images.githubusercontent.com/1631111/110949527-fe274a00-8342-11eb-9e8a-20bc36ab9eab.png)
After:
![Screenshot_20210312_144924](https://user-images.githubusercontent.com/1631111/110949545-01223a80-8343-11eb-98c0-1d8f500db712.png)

