### PR TITLE
library: Add option to ignore files by extension

### DIFF
--- a/src/library/librarysettingspage.cpp
+++ b/src/library/librarysettingspage.cpp
@@ -98,6 +98,10 @@ void LibrarySettingsPage::Save() {
   QStringList filters = filter_text.split(',', QString::SkipEmptyParts);
   s.setValue("cover_art_patterns", filters);
 
+  QString skip_extensions = ui_->skip_extensions->text();
+  QStringList extensions = skip_extensions.split(',', QString::SkipEmptyParts);
+  s.setValue("skip_file_extensions", extensions);
+
   s.endGroup();
 
   s.beginGroup(LibraryBackend::kSettingsGroup);
@@ -138,6 +142,9 @@ void LibrarySettingsPage::Load() {
                                                                     << "cover")
                             .toStringList();
   ui_->cover_art_patterns->setText(filters.join(","));
+
+  QStringList extensions = s.value("skip_file_extensions").toStringList();
+  ui_->skip_extensions->setText(extensions.join(","));
 
   s.endGroup();
 

--- a/src/library/librarysettingspage.ui
+++ b/src/library/librarysettingspage.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>509</width>
-    <height>452</height>
+    <height>600</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -137,7 +137,17 @@
        </layout>
       </item>
       <item>
-       <widget class="QLabel" name="label_2">
+       <widget class="QLabel" name="skip_extensions_label">
+        <property name="text">
+         <string>Skip files with these extensions (comma separated, case insensitive)</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="skip_extensions"/>
+      </item>
+      <item>
+       <widget class="QLabel" name="cover_art_patterns_label">
         <property name="text">
          <string>Preferred album art filenames (comma separated)</string>
         </property>

--- a/src/library/librarywatcher.cpp
+++ b/src/library/librarywatcher.cpp
@@ -330,10 +330,12 @@ void LibraryWatcher::ScanSubdirectory(const QString& path,
       QString ext_part(ExtensionPart(child));
       QString dir_part(DirectoryPart(child));
 
-      if (sValidImages.contains(ext_part))
-        album_art[dir_part] << child;
-      else if (!child_info.isHidden())
-        files_on_disk << child;
+      if (!skip_file_extensions_.contains(ext_part)) {
+        if (sValidImages.contains(ext_part))
+          album_art[dir_part] << child;
+        else if (!child_info.isHidden())
+          files_on_disk << child;
+      }
     }
   }
 
@@ -830,6 +832,13 @@ void LibraryWatcher::ReloadSettings() {
   for (const QString& filter : filters) {
     QString s = filter.trimmed();
     if (!s.isEmpty()) best_image_filters_ << s;
+  }
+
+  skip_file_extensions_.clear();
+  QStringList extensions = s.value("skip_file_extensions").toStringList();
+  for (const QString& extension : extensions) {
+    QString s = extension.trimmed().toLower();
+    if (!s.isEmpty()) skip_file_extensions_ << s;
   }
 
   if (!monitor_ && was_monitoring_before) {

--- a/src/library/librarywatcher.h
+++ b/src/library/librarywatcher.h
@@ -217,6 +217,9 @@ class LibraryWatcher : public QObject {
    */
   QStringList best_image_filters_;
 
+  // List of file extensions that should be ingored during a scan.
+  QStringList skip_file_extensions_;
+
   bool scan_on_startup_;
   bool monitor_;
 


### PR DESCRIPTION
Add a new skip option in library settings that takes a comma separated list of file extensions. Skip files with the specified extensions when scanning the library.

Work-around for #6945