### PR TITLE
Mac: Fix exec search path 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,10 @@ add_definitions(${QT_DEFINITIONS})
 link_directories(${TAGLIB_LIBRARY_DIRS})
 link_directories(${GSTREAMER_LIBRARY_DIRS})
 
+# Top level headers and generated headers
+include_directories(${PROJECT_SOURCE_DIR}/include)
+include_directories(${PROJECT_BINARY_DIR}/include)
+
 include_directories(${Boost_INCLUDE_DIRS})
 include_directories(${TAGLIB_INCLUDE_DIRS})
 include_directories(${GSTREAMER_INCLUDE_DIRS})
@@ -474,6 +478,10 @@ endif(HAVE_SPOTIFY_BLOB)
 if(HAVE_MOODBAR)
   add_subdirectory(gst/moodbar)
 endif()
+
+# Global configuration
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/clementine-config.h.in
+               ${CMAKE_CURRENT_BINARY_DIR}/include/clementine-config.h)
 
 # Uninstall support
 configure_file(

--- a/ext/clementine-tagreader/tagreaderworker.h
+++ b/ext/clementine-tagreader/tagreaderworker.h
@@ -18,7 +18,7 @@
 #ifndef TAGREADERWORKER_H
 #define TAGREADERWORKER_H
 
-#include "config.h"
+#include "clementine-config.h"
 #include "tagreader.h"
 #include "tagreadermessages.pb.h"
 #include "core/messagehandler.h"

--- a/ext/libclementine-common/core/workerpool.h
+++ b/ext/libclementine-common/core/workerpool.h
@@ -29,6 +29,7 @@
 #include <QQueue>
 #include <QThread>
 
+#include "clementine-config.h"
 #include "core/closure.h"
 #include "core/logging.h"
 

--- a/ext/libclementine-tagreader/tagreader.h
+++ b/ext/libclementine-tagreader/tagreader.h
@@ -24,7 +24,7 @@
 #include <taglib/xiphcomment.h>
 #include <memory>
 
-#include "config.h"
+#include "clementine-config.h"
 #include "tagreadermessages.pb.h"
 
 class QString;

--- a/include/clementine-config.h.in
+++ b/include/clementine-config.h.in
@@ -14,8 +14,8 @@
    along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef CONFIG_H_IN
-#define CONFIG_H_IN
+#ifndef CLEMENTINE_CONFIG_H
+#define CLEMENTINE_CONFIG_H
 
 #define CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}"
 #define CMAKE_EXECUTABLE_SUFFIX "${CMAKE_EXECUTABLE_SUFFIX}"
@@ -56,4 +56,4 @@
 
 #define USE_BUNDLE_DIR "${USE_BUNDLE_DIR}"
 
-#endif  // CONFIG_H_IN
+#endif  //  CLEMENTINE_CONFIG_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1243,9 +1243,6 @@ optional_source(LINUX
   HEADERS core/ubuntuunityhack.h
 )
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in
-               ${CMAKE_CURRENT_BINARY_DIR}/config.h)
-
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version.h.in
                ${CMAKE_CURRENT_BINARY_DIR}/version.h)
 

--- a/src/config.h
+++ b/src/config.h
@@ -1,0 +1,24 @@
+/* This file is part of Clementine.
+
+   Clementine is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Clementine is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DEPRECATED_CONFIG_H
+#define DEPRECATED_CONFIG_H
+
+// Deprecated. Please include clementine-config.h directly.
+
+#include "clementine-config.h"
+
+#endif  // DEPRECATED_CONFIG_H


### PR DESCRIPTION
workerpool.h utilizes the MAC-specific USE_BUNDLE option, but the file didn't directly include the config header file. Cleanup change 341dc73 reordered some headers, so it was no longer included as a side-effect either.

This also moves /src/config.h to /include/clementine-config.h to remove dependencies of /ext on /src.
