### PR TITLE
Move context_menu_ to InternetService

### DIFF
--- a/src/internet/core/cloudfileservice.cpp
+++ b/src/internet/core/cloudfileservice.cpp
@@ -107,15 +107,6 @@ void CloudFileService::PopulateContextMenu() {
                            SLOT(ShowSettingsDialog()));
 }
 
-void CloudFileService::ShowContextMenu(const QPoint& global_pos) {
-  if (!context_menu_) {
-    context_menu_.reset(new QMenu);
-    PopulateContextMenu();
-  }
-  UpdateContextMenu();
-  context_menu_->popup(global_pos);
-}
-
 void CloudFileService::ShowCoverManager() {
   if (!cover_manager_) {
     cover_manager_.reset(new AlbumCoverManager(app_, library_backend_.get()));

--- a/src/internet/core/cloudfileservice.h
+++ b/src/internet/core/cloudfileservice.h
@@ -88,7 +88,6 @@ class CloudFileService : public InternetService {
   LibraryModel* library_model_;
   QSortFilterProxyModel* library_sort_model_;
 
-  std::unique_ptr<QMenu> context_menu_;
   std::unique_ptr<AlbumCoverManager> cover_manager_;
   PlaylistManager* playlist_manager_;
   TaskManager* task_manager_;

--- a/src/internet/core/cloudfileservice.h
+++ b/src/internet/core/cloudfileservice.h
@@ -45,7 +45,6 @@ class CloudFileService : public InternetService {
   // InternetService
   virtual QStandardItem* CreateRootItem();
   virtual void LazyPopulate(QStandardItem* item);
-  virtual void ShowContextMenu(const QPoint& point);
 
   virtual bool has_credentials() const = 0;
   bool is_indexing() const { return indexing_task_id_ != -1; }
@@ -68,9 +67,7 @@ class CloudFileService : public InternetService {
   void AbortReadTagsReplies();
 
   // Called once when context menu is created
-  virtual void PopulateContextMenu();
-  // Called every time context menu is shown
-  virtual void UpdateContextMenu(){};
+  virtual void PopulateContextMenu() override;
 
  protected slots:
   void ShowCoverManager();

--- a/src/internet/core/internetservice.cpp
+++ b/src/internet/core/internetservice.cpp
@@ -88,6 +88,15 @@ void InternetService::ShowUrlBox(const QString& title, const QString& url) {
   }
 }
 
+void InternetService::ShowContextMenu(const QPoint& global_pos) {
+  if (!context_menu_) {
+    context_menu_.reset(new QMenu);
+    PopulateContextMenu();
+  }
+  UpdateContextMenu();
+  context_menu_->popup(global_pos);
+}
+
 QList<QAction*> InternetService::GetPlaylistActions() {
   return QList<QAction*>() << GetAppendToPlaylistAction()
                            << GetReplacePlaylistAction()

--- a/src/internet/core/internetservice.h
+++ b/src/internet/core/internetservice.h
@@ -25,6 +25,7 @@
 
 #include <QAction>
 #include <QList>
+#include <QMenu>
 #include <QObject>
 #include <QUrl>
 
@@ -138,6 +139,7 @@ class InternetService : public QObject {
 
  protected:
   Application* app_;
+  std::unique_ptr<QMenu> context_menu_;
 
  private:
   InternetModel* model_;

--- a/src/internet/core/internetservice.h
+++ b/src/internet/core/internetservice.h
@@ -64,7 +64,8 @@ class InternetService : public QObject {
   virtual void LazyPopulate(QStandardItem* parent) = 0;
   virtual bool has_initial_load_settings() const { return false; }
   virtual void InitialLoadSettings() {}
-  virtual void ShowContextMenu(const QPoint& global_pos) {}
+  virtual void ShowContextMenu(const QPoint& global_pos);
+
   // Create a generator for smart playlists
   virtual smart_playlists::GeneratorPtr CreateGenerator(QStandardItem* item) {
     return smart_playlists::GeneratorPtr();
@@ -103,6 +104,11 @@ class InternetService : public QObject {
   void OpenInNewPlaylist();
 
  protected:
+  // Called once when context menu is created
+  virtual void PopulateContextMenu(){};
+  // Called every time context menu is shown
+  virtual void UpdateContextMenu(){};
+
   // Returns all the playlist insertion related QActions (see below).
   QList<QAction*> GetPlaylistActions();
 

--- a/src/internet/digitally/digitallyimportedservicebase.h
+++ b/src/internet/digitally/digitallyimportedservicebase.h
@@ -101,7 +101,6 @@ class DigitallyImportedServiceBase : public InternetService {
 
   QStandardItem* root_;
 
-  std::unique_ptr<QMenu> context_menu_;
   QStandardItem* context_item_;
 
   CachedList<DigitallyImportedClient::Channel> saved_channels_;

--- a/src/internet/icecast/icecastservice.cpp
+++ b/src/internet/icecast/icecastservice.cpp
@@ -55,7 +55,6 @@ const char* IcecastService::kHomepage = "http://dir.xiph.org/";
 IcecastService::IcecastService(Application* app, InternetModel* parent)
     : InternetService(kServiceName, app, parent, parent),
       network_(new NetworkAccessManager(this)),
-      context_menu_(nullptr),
       backend_(new IcecastBackend),
       model_(nullptr),
       filter_(new IcecastFilterWidget(0)) {
@@ -298,7 +297,7 @@ void IcecastService::ShowContextMenu(const QPoint& global_pos) {
 void IcecastService::EnsureMenuCreated() {
   if (context_menu_) return;
 
-  context_menu_ = new QMenu;
+  context_menu_.reset(new QMenu);
 
   context_menu_->addActions(GetPlaylistActions());
   context_menu_->addAction(IconLoader::Load("download", IconLoader::Base),

--- a/src/internet/icecast/icecastservice.h
+++ b/src/internet/icecast/icecastservice.h
@@ -73,7 +73,6 @@ class IcecastService : public InternetService {
 
   QStandardItem* root_;
   NetworkAccessManager* network_;
-  QMenu* context_menu_;
 
   std::shared_ptr<IcecastBackend> backend_;
   IcecastModel* model_;

--- a/src/internet/intergalacticfm/intergalacticfmservice.cpp
+++ b/src/internet/intergalacticfm/intergalacticfmservice.cpp
@@ -58,7 +58,6 @@ IntergalacticFMServiceBase::IntergalacticFMServiceBase(
       url_scheme_(name.toLower().remove(' ')),
       url_handler_(new IntergalacticFMUrlHandler(app, this, this)),
       root_(nullptr),
-      context_menu_(nullptr),
       network_(new NetworkAccessManager(this)),
       streams_(name, "streams", kStreamsCacheDurationSecs),
       name_(name),
@@ -73,9 +72,7 @@ IntergalacticFMServiceBase::IntergalacticFMServiceBase(
       new IntergalacticFMSearchProvider(this, app_, this));
 }
 
-IntergalacticFMServiceBase::~IntergalacticFMServiceBase() {
-  delete context_menu_;
-}
+IntergalacticFMServiceBase::~IntergalacticFMServiceBase() {}
 
 QStandardItem* IntergalacticFMServiceBase::CreateRootItem() {
   root_ = new QStandardItem(icon_, name_);
@@ -96,7 +93,7 @@ void IntergalacticFMServiceBase::LazyPopulate(QStandardItem* item) {
 
 void IntergalacticFMServiceBase::ShowContextMenu(const QPoint& global_pos) {
   if (!context_menu_) {
-    context_menu_ = new QMenu;
+    context_menu_.reset(new QMenu);
     context_menu_->addActions(GetPlaylistActions());
     context_menu_->addAction(IconLoader::Load("download", IconLoader::Base),
                              tr("Open %1 in browser").arg(homepage_url_.host()),

--- a/src/internet/intergalacticfm/intergalacticfmservice.h
+++ b/src/internet/intergalacticfm/intergalacticfmservice.h
@@ -91,7 +91,6 @@ class IntergalacticFMServiceBase : public InternetService {
   IntergalacticFMUrlHandler* url_handler_;
 
   QStandardItem* root_;
-  QMenu* context_menu_;
 
   QNetworkAccessManager* network_;
 

--- a/src/internet/internetradio/savedradio.cpp
+++ b/src/internet/internetradio/savedradio.cpp
@@ -37,16 +37,14 @@ const char* SavedRadio::kServiceName = "SavedRadio";
 const char* SavedRadio::kSettingsGroup = "SavedRadio";
 
 SavedRadio::SavedRadio(Application* app, InternetModel* parent)
-    : InternetService(kServiceName, app, parent, parent),
-      context_menu_(nullptr),
-      root_(nullptr) {
+    : InternetService(kServiceName, app, parent, parent), root_(nullptr) {
   LoadStreams();
 
   app_->global_search()->AddProvider(
       new SavedRadioSearchProvider(this, app_, this));
 }
 
-SavedRadio::~SavedRadio() { delete context_menu_; }
+SavedRadio::~SavedRadio() {}
 
 QStandardItem* SavedRadio::CreateRootItem() {
   root_ = new QStandardItem(
@@ -104,7 +102,7 @@ void SavedRadio::SaveStreams() {
 
 void SavedRadio::ShowContextMenu(const QPoint& global_pos) {
   if (!context_menu_) {
-    context_menu_ = new QMenu;
+    context_menu_.reset(new QMenu);
     context_menu_->addActions(GetPlaylistActions());
     remove_action_ = context_menu_->addAction(
         IconLoader::Load("list-remove", IconLoader::Base), tr("Remove"), this,

--- a/src/internet/internetradio/savedradio.h
+++ b/src/internet/internetradio/savedradio.h
@@ -81,7 +81,6 @@ class SavedRadio : public InternetService {
   void AddStreamToList(const Stream& stream, QStandardItem* parent);
 
  private:
-  QMenu* context_menu_;
   QStandardItem* root_;
 
   QAction* remove_action_;

--- a/src/internet/jamendo/jamendoservice.cpp
+++ b/src/internet/jamendo/jamendoservice.cpp
@@ -81,7 +81,6 @@ const int JamendoService::kApproxDatabaseSize = 450000;
 JamendoService::JamendoService(Application* app, InternetModel* parent)
     : InternetService(kServiceName, app, parent, parent),
       network_(new NetworkAccessManager(this)),
-      context_menu_(nullptr),
       library_backend_(nullptr),
       library_filter_(nullptr),
       library_model_(nullptr),
@@ -176,7 +175,7 @@ void JamendoService::UpdateTotalSongCount(int count) {
 void JamendoService::DownloadDirectory() {
   // don't ask if we're refreshing the database
   if (total_song_count_ == 0) {
-    if (QMessageBox::question(context_menu_, tr("Jamendo database"),
+    if (QMessageBox::question(nullptr, tr("Jamendo database"),
                               tr("This action will create a database which "
                                  "could be as big as 150 MB.\n"
                                  "Do you want to continue anyway?"),
@@ -414,7 +413,7 @@ void JamendoService::ParseDirectoryFinished() {
 void JamendoService::EnsureMenuCreated() {
   if (library_filter_) return;
 
-  context_menu_ = new QMenu;
+  context_menu_.reset(new QMenu);
   context_menu_->addActions(GetPlaylistActions());
   album_info_ = context_menu_->addAction(
       IconLoader::Load("view-media-lyrics", IconLoader::Base),

--- a/src/internet/jamendo/jamendoservice.h
+++ b/src/internet/jamendo/jamendoservice.h
@@ -104,8 +104,6 @@ class JamendoService : public InternetService {
  private:
   NetworkAccessManager* network_;
 
-  QMenu* context_menu_;
-
   QAction* album_info_;
   QAction* download_album_;
 

--- a/src/internet/magnatune/magnatuneservice.cpp
+++ b/src/internet/magnatune/magnatuneservice.cpp
@@ -74,7 +74,6 @@ const char* MagnatuneService::kDownloadUrl =
 MagnatuneService::MagnatuneService(Application* app, InternetModel* parent)
     : InternetService(kServiceName, app, parent, parent),
       url_handler_(new MagnatuneUrlHandler(this, this)),
-      context_menu_(nullptr),
       root_(nullptr),
       library_backend_(nullptr),
       library_model_(nullptr),
@@ -107,7 +106,7 @@ MagnatuneService::MagnatuneService(Application* app, InternetModel* parent)
       IconLoader::Load("magnatune", IconLoader::Provider), true, app_, this));
 }
 
-MagnatuneService::~MagnatuneService() { delete context_menu_; }
+MagnatuneService::~MagnatuneService() {}
 
 void MagnatuneService::ReloadSettings() {
   QSettings s;
@@ -272,7 +271,7 @@ QString MagnatuneService::ReadElementText(QXmlStreamReader& reader) {
 void MagnatuneService::EnsureMenuCreated() {
   if (context_menu_) return;
 
-  context_menu_ = new QMenu;
+  context_menu_.reset(new QMenu);
 
   context_menu_->addActions(GetPlaylistActions());
   download_ = context_menu_->addAction(

--- a/src/internet/magnatune/magnatuneservice.h
+++ b/src/internet/magnatune/magnatuneservice.h
@@ -109,7 +109,6 @@ class MagnatuneService : public InternetService {
  private:
   MagnatuneUrlHandler* url_handler_;
 
-  QMenu* context_menu_;
   QStandardItem* root_;
 
   QAction* download_;

--- a/src/internet/podcasts/podcastservice.cpp
+++ b/src/internet/podcasts/podcastservice.cpp
@@ -66,7 +66,6 @@ PodcastService::PodcastService(Application* app, InternetModel* parent)
       backend_(app->podcast_backend()),
       model_(new PodcastServiceModel(this)),
       proxy_(new PodcastSortProxyModel(this)),
-      context_menu_(nullptr),
       root_(nullptr),
       organise_dialog_(new OrganiseDialog(app_->task_manager())) {
   icon_loader_->SetModel(model_);
@@ -416,7 +415,7 @@ QStandardItem* PodcastService::CreatePodcastEpisodeItem(
 
 void PodcastService::ShowContextMenu(const QPoint& global_pos) {
   if (!context_menu_) {
-    context_menu_ = new QMenu;
+    context_menu_.reset(new QMenu);
     context_menu_->addAction(IconLoader::Load("list-add", IconLoader::Base),
                              tr("Add podcast..."), this, SLOT(AddPodcast()));
     context_menu_->addAction(IconLoader::Load("view-refresh", IconLoader::Base),

--- a/src/internet/podcasts/podcastservice.h
+++ b/src/internet/podcasts/podcastservice.h
@@ -146,7 +146,6 @@ class PodcastService : public InternetService {
   QStandardItemModel* model_;
   QSortFilterProxyModel* proxy_;
 
-  QMenu* context_menu_;
   QAction* update_selected_action_;
   QAction* remove_selected_action_;
   QAction* download_selected_action_;

--- a/src/internet/radiobrowser/radiobrowserservice.cpp
+++ b/src/internet/radiobrowser/radiobrowserservice.cpp
@@ -136,7 +136,6 @@ RadioBrowserService::RadioBrowserService(Application* app,
                                          InternetModel* parent)
     : InternetService(kServiceName, app, parent, parent),
       root_(nullptr),
-      context_menu_(nullptr),
       station_menu_(nullptr),
       add_to_saved_radio_action_(nullptr),
       network_(new NetworkAccessManager(this)),

--- a/src/internet/radiobrowser/radiobrowserservice.h
+++ b/src/internet/radiobrowser/radiobrowserservice.h
@@ -107,7 +107,6 @@ class RadioBrowserService : public InternetService {
 
  private:
   QStandardItem* root_;
-  std::unique_ptr<QMenu> context_menu_;
   std::unique_ptr<QMenu> station_menu_;
   std::unique_ptr<QAction> add_to_saved_radio_action_;
 

--- a/src/internet/somafm/somafmservice.cpp
+++ b/src/internet/somafm/somafmservice.cpp
@@ -60,7 +60,6 @@ SomaFMServiceBase::SomaFMServiceBase(Application* app, InternetModel* parent,
       url_scheme_(name.toLower().remove(' ')),
       url_handler_(new SomaFMUrlHandler(app, this, this)),
       root_(nullptr),
-      context_menu_(nullptr),
       network_(new NetworkAccessManager(this)),
       streams_(name, "streams", kStreamsCacheDurationSecs),
       name_(name),
@@ -75,7 +74,7 @@ SomaFMServiceBase::SomaFMServiceBase(Application* app, InternetModel* parent,
       new SomaFMSearchProvider(this, app_, this));
 }
 
-SomaFMServiceBase::~SomaFMServiceBase() { delete context_menu_; }
+SomaFMServiceBase::~SomaFMServiceBase() {}
 
 QStandardItem* SomaFMServiceBase::CreateRootItem() {
   root_ = new QStandardItem(icon_, name_);
@@ -96,7 +95,7 @@ void SomaFMServiceBase::LazyPopulate(QStandardItem* item) {
 
 void SomaFMServiceBase::ShowContextMenu(const QPoint& global_pos) {
   if (!context_menu_) {
-    context_menu_ = new QMenu;
+    context_menu_.reset(new QMenu);
     context_menu_->addActions(GetPlaylistActions());
     context_menu_->addAction(IconLoader::Load("download", IconLoader::Base),
                              tr("Open %1 in browser").arg(homepage_url_.host()),

--- a/src/internet/somafm/somafmservice.h
+++ b/src/internet/somafm/somafmservice.h
@@ -91,7 +91,6 @@ class SomaFMServiceBase : public InternetService {
   SomaFMUrlHandler* url_handler_;
 
   QStandardItem* root_;
-  QMenu* context_menu_;
 
   QNetworkAccessManager* network_;
 

--- a/src/internet/spotify/spotifyservice.cpp
+++ b/src/internet/spotify/spotifyservice.cpp
@@ -76,7 +76,6 @@ SpotifyService::SpotifyService(Application* app, InternetModel* parent)
       inbox_(nullptr),
       toplist_(nullptr),
       login_task_id_(0),
-      context_menu_(nullptr),
       playlist_context_menu_(nullptr),
       song_context_menu_(nullptr),
       playlist_sync_action_(nullptr),
@@ -661,7 +660,7 @@ QWidget* SpotifyService::HeaderWidget() const {
 void SpotifyService::EnsureMenuCreated() {
   if (context_menu_) return;
 
-  context_menu_ = new QMenu;
+  context_menu_.reset(new QMenu);
   context_menu_->addAction(GetNewShowConfigAction());
 
   playlist_context_menu_ = new QMenu;

--- a/src/internet/spotify/spotifyservice.h
+++ b/src/internet/spotify/spotifyservice.h
@@ -168,7 +168,6 @@ class SpotifyService : public InternetService {
   int login_task_id_;
   QString pending_search_;
 
-  QMenu* context_menu_;
   QMenu* playlist_context_menu_;
   QMenu* song_context_menu_;
   QAction* playlist_sync_action_;

--- a/src/internet/subsonic/subsonicservice.cpp
+++ b/src/internet/subsonic/subsonicservice.cpp
@@ -67,7 +67,6 @@ SubsonicService::SubsonicService(Application* app, InternetModel* parent)
       url_handler_(new SubsonicUrlHandler(this, this)),
       scanner_(new SubsonicLibraryScanner(this, this)),
       load_database_task_id_(0),
-      context_menu_(nullptr),
       root_(nullptr),
       library_backend_(nullptr),
       library_model_(nullptr),
@@ -137,7 +136,7 @@ SubsonicService::SubsonicService(Application* app, InternetModel* parent)
   connect(this, SIGNAL(LoginStateChanged(SubsonicService::LoginState)),
           SLOT(OnLoginStateChanged(SubsonicService::LoginState)));
 
-  context_menu_ = new QMenu;
+  context_menu_.reset(new QMenu);
   context_menu_->addActions(GetPlaylistActions());
   context_menu_->addSeparator();
   context_menu_->addAction(IconLoader::Load("view-refresh", IconLoader::Base),

--- a/src/internet/subsonic/subsonicservice.h
+++ b/src/internet/subsonic/subsonicservice.h
@@ -143,7 +143,6 @@ class SubsonicService : public InternetService {
   SubsonicLibraryScanner* scanner_;
   int load_database_task_id_;
 
-  QMenu* context_menu_;
   QStandardItem* root_;
 
   std::shared_ptr<LibraryBackend> library_backend_;


### PR DESCRIPTION
Every internet service has a context_menu_ member, so move it to the base InternetService class. Move the common ShowContextMenu method from CloudFileService as well. Other services can adopt this pattern gradually. When all services are migrated, we'll have the option to move to a Lazy pointer implementation.