### PR TITLE
settings: Don't connect service-specific signals to every page

### DIFF
--- a/src/internet/core/internetshowsettingspage.h
+++ b/src/internet/core/internetshowsettingspage.h
@@ -20,6 +20,7 @@
 #define INTERNET_CORE_INTERNETSHOWSETTINGSPAGE_H_
 
 #include <QIcon>
+#include <memory>
 
 #include "ui/settingspage.h"
 #include "ui_internetshowsettingspage.h"

--- a/src/internet/radiobrowser/radiobrowsersettingspage.h
+++ b/src/internet/radiobrowser/radiobrowsersettingspage.h
@@ -18,6 +18,8 @@
 #ifndef INTERNET_RADIOBROWSER_RADIOBROWSERSETTINGSPAGE_H_
 #define INTERNET_RADIOBROWSER_RADIOBROWSERSETTINGSPAGE_H_
 
+#include <memory>
+
 #include "radiobrowserservice.h"
 #include "ui/settingspage.h"
 #include "ui_radiobrowsersettingspage.h"

--- a/src/internet/seafile/seafilesettingspage.h
+++ b/src/internet/seafile/seafilesettingspage.h
@@ -21,6 +21,7 @@
 
 #include <QModelIndex>
 #include <QWidget>
+#include <memory>
 
 #include "ui/settingspage.h"
 

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -3061,6 +3061,7 @@ void MainWindow::ScrobbleError(int value) {
 
 void MainWindow::HandleNotificationPreview(OSD::Behaviour type, QString line1,
                                            QString line2) {
+  qLog(Debug) << "Handling notification preview";
   if (!app_->playlist_manager()->current()->GetAllSongs().isEmpty()) {
     // Show a preview notification for the first song in the current playlist
     osd_->ShowPreview(

--- a/src/ui/notificationssettingspage.h
+++ b/src/ui/notificationssettingspage.h
@@ -19,6 +19,7 @@
 #define NOTIFICATIONSSETTINGSPAGE_H
 
 #include "settingspage.h"
+#include "widgets/osd.h"
 
 class Ui_NotificationsSettingsPage;
 
@@ -35,6 +36,9 @@ class NotificationsSettingsPage : public SettingsPage {
  protected:
   void hideEvent(QHideEvent*);
   void showEvent(QShowEvent*);
+
+ signals:
+  void NotificationPreview(OSD::Behaviour, QString, QString);
 
  private slots:
   void NotificationTypeChanged();

--- a/src/ui/settingsdialog.cpp
+++ b/src/ui/settingsdialog.cpp
@@ -146,7 +146,10 @@ SettingsDialog::SettingsDialog(Application* app, BackgroundStreams* streams,
   AddPage(Page_NetworkRemote, new NetworkRemoteSettingsPage(this), general);
 
 #ifdef HAVE_WIIMOTEDEV
-  AddPage(Page_Wiimotedev, new WiimoteSettingsPage(this), general);
+  WiimoteSettingsPage* wii_page = new WiimoteSettingsPage(this);
+  AddPage(Page_Wiimotedev, wii_page, general);
+  connect(wii_page, SIGNAL(SetWiimotedevInterfaceActived(bool)),
+          SIGNAL(SetWiimotedevInterfaceActived(bool)));
 #endif
 
   // User interface
@@ -155,7 +158,14 @@ SettingsDialog::SettingsDialog(Application* app, BackgroundStreams* streams,
   AddPage(Page_GlobalSearch, new GlobalSearchSettingsPage(this), iface);
   AddPage(Page_Appearance, new AppearanceSettingsPage(this), iface);
   AddPage(Page_SongInformation, new SongInfoSettingsPage(this), iface);
-  AddPage(Page_Notifications, new NotificationsSettingsPage(this), iface);
+
+  NotificationsSettingsPage* notification_page =
+      new NotificationsSettingsPage(this);
+  AddPage(Page_Notifications, notification_page, iface);
+  connect(notification_page,
+          SIGNAL(NotificationPreview(OSD::Behaviour, QString, QString)),
+          SIGNAL(NotificationPreview(OSD::Behaviour, QString, QString)));
+
   AddPage(Page_InternetShow, new InternetShowSettingsPage(this), iface);
 
   // Internet providers
@@ -233,12 +243,6 @@ QTreeWidgetItem* SettingsDialog::AddCategory(const QString& name) {
 void SettingsDialog::AddPage(Page id, SettingsPage* page,
                              QTreeWidgetItem* parent) {
   if (!parent) parent = ui_->list->invisibleRootItem();
-
-  // Connect page's signals to the settings dialog's signals
-  connect(page, SIGNAL(NotificationPreview(OSD::Behaviour, QString, QString)),
-          SIGNAL(NotificationPreview(OSD::Behaviour, QString, QString)));
-  connect(page, SIGNAL(SetWiimotedevInterfaceActived(bool)),
-          SIGNAL(SetWiimotedevInterfaceActived(bool)));
 
   // Create the list item
   QTreeWidgetItem* item = new QTreeWidgetItem;

--- a/src/ui/settingspage.h
+++ b/src/ui/settingspage.h
@@ -20,8 +20,6 @@
 
 #include <QWidget>
 
-#include "widgets/osd.h"
-
 class SettingsDialog;
 
 class SettingsPage : public QWidget {
@@ -44,10 +42,6 @@ class SettingsPage : public QWidget {
 
   // The dialog that this page belongs to.
   SettingsDialog* dialog() const { return dialog_; }
-
- signals:
-  void NotificationPreview(OSD::Behaviour, QString, QString);
-  void SetWiimotedevInterfaceActived(bool);
 
  protected:
   void showEvent(QShowEvent* event);

--- a/src/wiimotedev/shortcuts.cpp
+++ b/src/wiimotedev/shortcuts.cpp
@@ -19,6 +19,7 @@
 
 #include <QSettings>
 
+#include "core/logging.h"
 #include "wiimotedev/consts.h"
 
 const char* WiimotedevShortcuts::kActionsGroup = "WiimotedevActions";
@@ -56,6 +57,8 @@ WiimotedevShortcuts::WiimotedevShortcuts(OSD* osd, QWidget* window,
 }
 
 void WiimotedevShortcuts::SetWiimotedevInterfaceActived(bool actived) {
+  qLog(Debug) << "Wiimote interface activated" << actived;
+
   if (!QDBusConnection::systemBus().isConnected()) return;
 
   // http://code.google.com/p/clementine-player/issues/detail?id=670


### PR DESCRIPTION
Wii and notifications signals are currently connected for every settings page. Move the signals from the base SettingsPage class into the derived classes and connect the signals for only those objects.