### PR TITLE
settings: Make the internet header selectable

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -363,6 +363,7 @@ set(SOURCES
   ui/playbacksettingspage.cpp
   ui/qtsystemtrayicon.cpp
   ui/screensaver.cpp
+  ui/settingscategory.cpp
   ui/settingsdialog.cpp
   ui/settingspage.cpp
   ui/splash.cpp
@@ -659,6 +660,7 @@ set(HEADERS
   ui/organiseerrordialog.h
   ui/playbacksettingspage.h
   ui/qtsystemtrayicon.h
+  ui/settingscategory.h
   ui/settingsdialog.h
   ui/settingspage.h
   ui/standarditemiconloader.h

--- a/src/ui/settingscategory.cpp
+++ b/src/ui/settingscategory.cpp
@@ -1,0 +1,25 @@
+/* This file is part of Clementine.
+   Copyright 2021, Jim Broadus <jbroadus@gmail.com>
+
+   Clementine is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Clementine is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "settingscategory.h"
+
+SettingsCategory::SettingsCategory(const QString& name, SettingsDialog* dialog)
+    : dialog_(dialog) {
+  setText(0, name);
+  setData(0, SettingsDialog::Role_IsSeparator, true);
+  setFlags(Qt::ItemIsEnabled);
+}

--- a/src/ui/settingscategory.cpp
+++ b/src/ui/settingscategory.cpp
@@ -17,9 +17,20 @@
 
 #include "settingscategory.h"
 
+#include "settingspage.h"
+
 SettingsCategory::SettingsCategory(const QString& name, SettingsDialog* dialog)
     : dialog_(dialog) {
   setText(0, name);
   setData(0, SettingsDialog::Role_IsSeparator, true);
   setFlags(Qt::ItemIsEnabled);
+}
+
+SettingsCategory::SettingsCategory(SettingsDialog::Page id, SettingsPage* page,
+                                   SettingsDialog* dialog)
+    : dialog_(dialog) {
+  setText(0, page->windowTitle());
+  setData(0, SettingsDialog::Role_IsSeparator, true);
+  setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
+  dialog->AddPageToStack(id, page, this);
 }

--- a/src/ui/settingscategory.h
+++ b/src/ui/settingscategory.h
@@ -1,0 +1,33 @@
+/* This file is part of Clementine.
+   Copyright 2021, Jim Broadus <jbroadus@gmail.com>
+
+   Clementine is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Clementine is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef SETTINGSCATEGORY_H
+#define SETTINGSCATEGORY_H
+
+#include <QTreeWidgetItem>
+
+#include "settingsdialog.h"
+
+class SettingsCategory : public QTreeWidgetItem {
+ public:
+  SettingsCategory(const QString& name, SettingsDialog* dialog);
+
+ protected:
+  SettingsDialog* dialog_;
+};
+
+#endif  // SETTINGSCATEGORY_H

--- a/src/ui/settingscategory.h
+++ b/src/ui/settingscategory.h
@@ -22,9 +22,13 @@
 
 #include "settingsdialog.h"
 
+class SettingsPage;
+
 class SettingsCategory : public QTreeWidgetItem {
  public:
   SettingsCategory(const QString& name, SettingsDialog* dialog);
+  SettingsCategory(SettingsDialog::Page id, SettingsPage* page,
+                   SettingsDialog* dialog);
 
  protected:
   SettingsDialog* dialog_;

--- a/src/ui/settingsdialog.cpp
+++ b/src/ui/settingsdialog.cpp
@@ -114,7 +114,8 @@ void SettingsItemDelegate::paint(QPainter* painter,
 
   if (is_separator) {
     GroupedIconView::DrawHeader(painter, option.rect, option.font,
-                                option.palette, index.data().toString(), false);
+                                option.palette, index.data().toString(),
+                                option.state & QStyle::State_Selected);
   } else {
     QStyledItemDelegate::paint(painter, option, index);
   }
@@ -168,11 +169,10 @@ SettingsDialog::SettingsDialog(Application* app, BackgroundStreams* streams,
           SIGNAL(NotificationPreview(OSD::Behaviour, QString, QString)),
           SIGNAL(NotificationPreview(OSD::Behaviour, QString, QString)));
 
-  AddPage(Page_InternetShow, new InternetShowSettingsPage(this), iface);
-
   // Internet providers
+  InternetShowSettingsPage* internet_page = new InternetShowSettingsPage(this);
   SettingsCategory* providers =
-      new SettingsCategory(tr("Internet providers"), this);
+      new SettingsCategory(Page_InternetShow, internet_page, this);
   AddCategory(providers);
 
 #ifdef HAVE_LIBLASTFM
@@ -254,6 +254,11 @@ void SettingsDialog::AddPage(Page id, SettingsPage* page,
 
   parent->addChild(item);
 
+  AddPageToStack(id, page, item);
+}
+
+void SettingsDialog::AddPageToStack(Page id, SettingsPage* page,
+                                    QTreeWidgetItem* item) {
   // Create a scroll area containing the page
   QScrollArea* area = new QScrollArea;
   area->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
@@ -345,7 +350,8 @@ void SettingsDialog::CurrentItemChanged(QTreeWidgetItem* item) {
   for (const PageData& data : pages_.values()) {
     if (data.item_ == item) {
       ui_->stacked_widget->setCurrentWidget(data.scroll_area_);
-      break;
+      return;
     }
   }
+  qLog(Debug) << "Didn't find page for item!";
 }

--- a/src/ui/settingsdialog.cpp
+++ b/src/ui/settingsdialog.cpp
@@ -114,7 +114,7 @@ void SettingsItemDelegate::paint(QPainter* painter,
 
   if (is_separator) {
     GroupedIconView::DrawHeader(painter, option.rect, option.font,
-                                option.palette, index.data().toString());
+                                option.palette, index.data().toString(), false);
   } else {
     QStyledItemDelegate::paint(painter, option, index);
   }

--- a/src/ui/settingsdialog.cpp
+++ b/src/ui/settingsdialog.cpp
@@ -44,6 +44,7 @@
 #include "notificationssettingspage.h"
 #include "playbacksettingspage.h"
 #include "playlist/playlistview.h"
+#include "settingscategory.h"
 #include "songinfo/songinfosettingspage.h"
 #include "transcoder/transcodersettingspage.h"
 #include "ui_settingsdialog.h"
@@ -134,8 +135,8 @@ SettingsDialog::SettingsDialog(Application* app, BackgroundStreams* streams,
   ui_->setupUi(this);
   ui_->list->setItemDelegate(new SettingsItemDelegate(this));
 
-  QTreeWidgetItem* general = AddCategory(tr("General"));
-
+  SettingsCategory* general = new SettingsCategory(tr("General"), this);
+  AddCategory(general);
   AddPage(Page_Playback, new PlaybackSettingsPage(this), general);
   AddPage(Page_Behaviour, new BehaviourSettingsPage(this), general);
   AddPage(Page_Library, new LibrarySettingsPage(this), general);
@@ -153,7 +154,8 @@ SettingsDialog::SettingsDialog(Application* app, BackgroundStreams* streams,
 #endif
 
   // User interface
-  QTreeWidgetItem* iface = AddCategory(tr("User interface"));
+  SettingsCategory* iface = new SettingsCategory(tr("User interface"), this);
+  AddCategory(iface);
   AddPage(Page_GlobalShortcuts, new GlobalShortcutsSettingsPage(this), iface);
   AddPage(Page_GlobalSearch, new GlobalSearchSettingsPage(this), iface);
   AddPage(Page_Appearance, new AppearanceSettingsPage(this), iface);
@@ -169,7 +171,9 @@ SettingsDialog::SettingsDialog(Application* app, BackgroundStreams* streams,
   AddPage(Page_InternetShow, new InternetShowSettingsPage(this), iface);
 
   // Internet providers
-  QTreeWidgetItem* providers = AddCategory(tr("Internet providers"));
+  SettingsCategory* providers =
+      new SettingsCategory(tr("Internet providers"), this);
+  AddCategory(providers);
 
 #ifdef HAVE_LIBLASTFM
   AddPage(Page_Lastfm, new LastFMSettingsPage(this), providers);
@@ -228,16 +232,10 @@ SettingsDialog::SettingsDialog(Application* app, BackgroundStreams* streams,
 
 SettingsDialog::~SettingsDialog() { delete ui_; }
 
-QTreeWidgetItem* SettingsDialog::AddCategory(const QString& name) {
-  QTreeWidgetItem* item = new QTreeWidgetItem;
-  item->setText(0, name);
-  item->setData(0, Role_IsSeparator, true);
-  item->setFlags(Qt::ItemIsEnabled);
-
-  ui_->list->invisibleRootItem()->addChild(item);
-  item->setExpanded(true);
-
-  return item;
+void SettingsDialog::AddCategory(SettingsCategory* category) {
+  ui_->list->invisibleRootItem()->addChild(category);
+  // This must not be called before it's added to the parent.
+  category->setExpanded(true);
 }
 
 void SettingsDialog::AddPage(Page id, SettingsPage* page,

--- a/src/ui/settingsdialog.h
+++ b/src/ui/settingsdialog.h
@@ -137,6 +137,10 @@ class SettingsDialog : public QDialog {
   void AddPage(Page id, SettingsPage* page, QTreeWidgetItem* parent = nullptr);
 
  private:
+  friend class SettingsCategory;
+  void AddPageToStack(Page id, SettingsPage* page, QTreeWidgetItem* item);
+
+ private:
   Application* app_;
   LibraryDirectoryModel* model_;
   GlobalShortcuts* manager_;

--- a/src/ui/settingsdialog.h
+++ b/src/ui/settingsdialog.h
@@ -49,6 +49,8 @@ class SettingsItemDelegate : public QStyledItemDelegate {
              const QModelIndex& index) const;
 };
 
+class SettingsCategory;
+
 class SettingsDialog : public QDialog {
   Q_OBJECT
 
@@ -131,7 +133,7 @@ class SettingsDialog : public QDialog {
     SettingsPage* page_;
   };
 
-  QTreeWidgetItem* AddCategory(const QString& name);
+  void AddCategory(SettingsCategory* category);
   void AddPage(Page id, SettingsPage* page, QTreeWidgetItem* parent = nullptr);
 
  private:

--- a/src/widgets/groupediconview.cpp
+++ b/src/widgets/groupediconview.cpp
@@ -65,13 +65,17 @@ int GroupedIconView::header_height() const { return default_header_height_; }
 
 void GroupedIconView::DrawHeader(QPainter* painter, const QRect& rect,
                                  const QFont& font, const QPalette& palette,
-                                 const QString& text) {
+                                 const QString& text, bool selected) {
   painter->save();
 
   // Bold font
   QFont bold_font(font);
   bold_font.setBold(true);
   QFontMetrics metrics(bold_font);
+
+  if (selected) {
+    painter->fillRect(rect, palette.highlight());
+  }
 
   QRect text_rect(rect);
   text_rect.setHeight(metrics.height());
@@ -291,7 +295,8 @@ void GroupedIconView::paintEvent(QPaintEvent* e) {
     DrawHeader(&painter,
                header_rect.translated(-horizontalOffset(), -verticalOffset()),
                font(), palette(),
-               model()->index(header.first_row, 0).data(Role_Group).toString());
+               model()->index(header.first_row, 0).data(Role_Group).toString(),
+               false);
   }
 }
 

--- a/src/widgets/groupediconview.h
+++ b/src/widgets/groupediconview.h
@@ -64,7 +64,7 @@ class GroupedIconView : public QListView {
 
   static void DrawHeader(QPainter* painter, const QRect& rect,
                          const QFont& font, const QPalette& palette,
-                         const QString& text);
+                         const QString& text, bool selected);
 
  protected:
   virtual int header_height() const;


### PR DESCRIPTION
Make the "Internet services" tab the internet providers category header instead of a tab under "User Interface".
