### PR TITLE
Fix smart playlist search terms

### DIFF
--- a/src/smartplaylists/searchterm.cpp
+++ b/src/smartplaylists/searchterm.cpp
@@ -23,6 +23,13 @@
 
 namespace smart_playlists {
 
+const char* kEscClause = " ESCAPE '#'";
+
+// Replace % and _ with #% and #_
+static QString Escape(QString term) {
+  return term.replace(QRegExp("([%_#])"), "#\\1");
+}
+
 SearchTerm::SearchTerm() : field_(Field_Title), operator_(Op_Equals) {}
 
 SearchTerm::SearchTerm(Field field, Operator op, const QVariant& value)
@@ -87,16 +94,16 @@ QString SearchTerm::ToSql() const {
 
   switch (operator_) {
     case Op_Contains:
-      return col + " LIKE '%" + value + "%'";
+      return col + " LIKE '%" + Escape(value) + "%'" + kEscClause;
     case Op_NotContains:
-      return col + " NOT LIKE '%" + value + "%'";
+      return col + " NOT LIKE '%" + Escape(value) + "%'" + kEscClause;
     case Op_StartsWith:
-      return col + " LIKE '" + value + "%'";
+      return col + " LIKE '" + Escape(value) + "%'" + kEscClause;
     case Op_EndsWith:
-      return col + " LIKE '%" + value + "'";
+      return col + " LIKE '%" + Escape(value) + "'" + kEscClause;
     case Op_Equals:
       if (TypeOf(field_) == Type_Text)
-        return col + " LIKE '" + value + "'";
+        return col + " LIKE '" + Escape(value) + "'" + kEscClause;
       else if (TypeOf(field_) == Type_Rating || TypeOf(field_) == Type_Date ||
                TypeOf(field_) == Type_Time)
         return col + " = " + value;

--- a/src/smartplaylists/searchterm.cpp
+++ b/src/smartplaylists/searchterm.cpp
@@ -74,8 +74,10 @@ QString SearchTerm::ToSql() const {
   }
 
   // File paths need some extra processing since they are stored as
-  // encoded urls in the database.
+  // encoded urls in the database. In some versions of sqlite, the
+  // LIKE function doesn't handle the blob form, so cast it to TEXT.
   if (field_ == Field_Filepath) {
+    col = "CAST (" + col + " AS TEXT)";
     if (operator_ == Op_StartsWith || operator_ == Op_Equals) {
       value = QUrl::fromLocalFile(value).toEncoded();
     } else {


### PR DESCRIPTION
- Cast filename to TEXT in queries
In some versions/builds of sqlite, the LIKE function doesn't match blobs.
- Escape pattern characters in search term
When using the LIKE function, use \ as an escape character and prepend that to occurrences of the pattern characters _ and % in the search term.

Fix for #6958