### PR TITLE
Fix rescan in case where library directory was recreated 

### DIFF
--- a/src/library/directory.h
+++ b/src/library/directory.h
@@ -31,6 +31,9 @@ struct Directory {
     return path == other.path && id == other.id;
   }
 
+  const QString& GetPath() const { return path; }
+  int GetId() const { return id; }
+
   QString path;
   int id;
 };
@@ -41,6 +44,10 @@ Q_DECLARE_METATYPE(DirectoryList)
 
 struct Subdirectory {
   Subdirectory() : directory_id(-1), mtime(0) {}
+
+  int GetDirectoryId() const { return directory_id; }
+  const QString& GetPath() const { return path; }
+  uint GetMtime() const { return mtime; }
 
   int directory_id;
   QString path;


### PR DESCRIPTION
If a root library directory is deleted and recreated, it is not detected since inotify would need to watch the parent directory. On rescan, if the subdirectory list for a directory is empty, re-add the library's root directory.

Also added accessor methods for Directory and Subdirectory members, but currently only using them in new code for this change.

This issue was reported on the mailing list. Unsure if this problem exists on Windows or Mac.