### PR TITLE
Add InternetSettingsCategory class

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -173,6 +173,7 @@ set(SOURCES
   internet/core/internetmodel.cpp
   internet/core/internetplaylistitem.cpp
   internet/core/internetservice.cpp
+  internet/core/internetsettingscategory.cpp
   internet/core/internetshowsettingspage.cpp
   internet/core/internetview.cpp
   internet/core/internetviewcontainer.cpp

--- a/src/internet/core/internetsettingscategory.cpp
+++ b/src/internet/core/internetsettingscategory.cpp
@@ -17,8 +17,89 @@
 
 #include "internetsettingscategory.h"
 
+#include "internet/digitally/digitallyimportedsettingspage.h"
+#include "internet/magnatune/magnatunesettingspage.h"
+#include "internet/podcasts/podcastsettingspage.h"
+#include "internet/radiobrowser/radiobrowsersettingspage.h"
+#include "internet/subsonic/subsonicsettingspage.h"
 #include "internetshowsettingspage.h"
+
+#ifdef HAVE_LIBLASTFM
+#include "internet/lastfm/lastfmsettingspage.h"
+#endif
+
+#ifdef HAVE_GOOGLE_DRIVE
+#include "internet/googledrive/googledrivesettingspage.h"
+#endif
+
+#ifdef HAVE_DROPBOX
+#include "internet/dropbox/dropboxsettingspage.h"
+#endif
+
+#ifdef HAVE_BOX
+#include "internet/box/boxsettingspage.h"
+#endif
+
+#ifdef HAVE_SKYDRIVE
+#include "internet/skydrive/skydrivesettingspage.h"
+#endif
+
+#ifdef HAVE_SEAFILE
+#include "internet/seafile/seafilesettingspage.h"
+#endif
+
+#ifdef HAVE_SPOTIFY
+#include "internet/spotify/spotifysettingspage.h"
+#endif
 
 InternetSettingsCategory::InternetSettingsCategory(SettingsDialog* dialog)
     : SettingsCategory(SettingsDialog::Page_InternetShow,
-                       new InternetShowSettingsPage(dialog), dialog) {}
+                       new InternetShowSettingsPage(dialog), dialog) {
+  AddChildren();
+}
+
+void InternetSettingsCategory::AddChildren() {
+#ifdef HAVE_LIBLASTFM
+  AddPage(SettingsDialog::Page_Lastfm, new LastFMSettingsPage(dialog_));
+#endif
+
+#ifdef HAVE_GOOGLE_DRIVE
+  AddPage(SettingsDialog::Page_GoogleDrive,
+          new GoogleDriveSettingsPage(dialog_));
+#endif
+
+#ifdef HAVE_DROPBOX
+  AddPage(SettingsDialog::Page_Dropbox, new DropboxSettingsPage(dialog_));
+#endif
+
+#ifdef HAVE_BOX
+  AddPage(SettingsDialog::Page_Box, new BoxSettingsPage(dialog_));
+#endif
+
+#ifdef HAVE_SKYDRIVE
+  AddPage(SettingsDialog::Page_Skydrive, new SkydriveSettingsPage(dialog_));
+#endif
+
+#ifdef HAVE_SPOTIFY
+  AddPage(SettingsDialog::Page_Spotify, new SpotifySettingsPage(dialog_));
+#endif
+
+#ifdef HAVE_SEAFILE
+  AddPage(SettingsDialog::Page_Seafile, new SeafileSettingsPage(dialog_));
+#endif
+
+#ifdef HAVE_AMAZON_CLOUD_DRIVE
+  AddPage(SettingsDialog::Page_AmazonCloudDrive,
+          new AmazonSettingsPage(dialog_));
+#endif
+
+  AddPage(SettingsDialog::Page_Magnatune, new MagnatuneSettingsPage(dialog_));
+  AddPage(SettingsDialog::Page_DigitallyImported,
+          new DigitallyImportedSettingsPage(dialog_));
+  AddPage(SettingsDialog::Page_Subsonic, new SubsonicSettingsPage(dialog_));
+  AddPage(SettingsDialog::Page_Podcasts, new PodcastSettingsPage(dialog_));
+  AddPage(SettingsDialog::Page_RadioBrowser,
+          new RadioBrowserSettingsPage(dialog_));
+
+  sortChildren(0, Qt::AscendingOrder);
+}

--- a/src/internet/core/internetsettingscategory.cpp
+++ b/src/internet/core/internetsettingscategory.cpp
@@ -1,0 +1,24 @@
+/* This file is part of Clementine.
+   Copyright 2021, Jim Broadus <jbroadus@gmail.com>
+
+   Clementine is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Clementine is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "internetsettingscategory.h"
+
+#include "internetshowsettingspage.h"
+
+InternetSettingsCategory::InternetSettingsCategory(SettingsDialog* dialog)
+    : SettingsCategory(SettingsDialog::Page_InternetShow,
+                       new InternetShowSettingsPage(dialog), dialog) {}

--- a/src/internet/core/internetsettingscategory.h
+++ b/src/internet/core/internetsettingscategory.h
@@ -23,6 +23,9 @@
 class InternetSettingsCategory : public SettingsCategory {
  public:
   InternetSettingsCategory(SettingsDialog* dialog);
+
+ private:
+  void AddChildren();
 };
 
 #endif  // INTERNETSETTINGSCATEGORY_H

--- a/src/internet/core/internetsettingscategory.h
+++ b/src/internet/core/internetsettingscategory.h
@@ -1,0 +1,28 @@
+/* This file is part of Clementine.
+   Copyright 2021, Jim Broadus <jbroadus@gmail.com>
+
+   Clementine is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Clementine is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef INTERNETSETTINGSCATEGORY_H
+#define INTERNETSETTINGSCATEGORY_H
+
+#include "ui/settingscategory.h"
+
+class InternetSettingsCategory : public SettingsCategory {
+ public:
+  InternetSettingsCategory(SettingsDialog* dialog);
+};
+
+#endif  // INTERNETSETTINGSCATEGORY_H

--- a/src/ui/settingsdialog.cpp
+++ b/src/ui/settingsdialog.cpp
@@ -32,11 +32,6 @@
 #include "globalshortcutssettingspage.h"
 #include "iconloader.h"
 #include "internet/core/internetsettingscategory.h"
-#include "internet/digitally/digitallyimportedsettingspage.h"
-#include "internet/magnatune/magnatunesettingspage.h"
-#include "internet/podcasts/podcastsettingspage.h"
-#include "internet/radiobrowser/radiobrowsersettingspage.h"
-#include "internet/subsonic/subsonicsettingspage.h"
 #include "library/librarysettingspage.h"
 #include "mainwindow.h"
 #include "networkproxysettingspage.h"
@@ -51,36 +46,8 @@
 #include "widgets/groupediconview.h"
 #include "widgets/osdpretty.h"
 
-#ifdef HAVE_LIBLASTFM
-#include "internet/lastfm/lastfmsettingspage.h"
-#endif
-
 #ifdef HAVE_WIIMOTEDEV
 #include "wiimotedev/wiimotesettingspage.h"
-#endif
-
-#ifdef HAVE_GOOGLE_DRIVE
-#include "internet/googledrive/googledrivesettingspage.h"
-#endif
-
-#ifdef HAVE_DROPBOX
-#include "internet/dropbox/dropboxsettingspage.h"
-#endif
-
-#ifdef HAVE_BOX
-#include "internet/box/boxsettingspage.h"
-#endif
-
-#ifdef HAVE_SKYDRIVE
-#include "internet/skydrive/skydrivesettingspage.h"
-#endif
-
-#ifdef HAVE_SEAFILE
-#include "internet/seafile/seafilesettingspage.h"
-#endif
-
-#ifdef HAVE_SPOTIFY
-#include "internet/spotify/spotifysettingspage.h"
 #endif
 
 #include <QAbstractButton>
@@ -169,50 +136,8 @@ SettingsDialog::SettingsDialog(Application* app, BackgroundStreams* streams,
           SIGNAL(NotificationPreview(OSD::Behaviour, QString, QString)),
           SIGNAL(NotificationPreview(OSD::Behaviour, QString, QString)));
 
-  // Internet providers
-  SettingsCategory* providers = new InternetSettingsCategory(this);
-  AddCategory(providers);
-
-#ifdef HAVE_LIBLASTFM
-  providers->AddPage(Page_Lastfm, new LastFMSettingsPage(this));
-#endif
-
-#ifdef HAVE_GOOGLE_DRIVE
-  providers->AddPage(Page_GoogleDrive, new GoogleDriveSettingsPage(this));
-#endif
-
-#ifdef HAVE_DROPBOX
-  providers->AddPage(Page_Dropbox, new DropboxSettingsPage(this));
-#endif
-
-#ifdef HAVE_BOX
-  providers->AddPage(Page_Box, new BoxSettingsPage(this));
-#endif
-
-#ifdef HAVE_SKYDRIVE
-  providers->AddPage(Page_Skydrive, new SkydriveSettingsPage(this));
-#endif
-
-#ifdef HAVE_SPOTIFY
-  providers->AddPage(Page_Spotify, new SpotifySettingsPage(this));
-#endif
-
-#ifdef HAVE_SEAFILE
-  providers->AddPage(Page_Seafile, new SeafileSettingsPage(this));
-#endif
-
-#ifdef HAVE_AMAZON_CLOUD_DRIVE
-  providers->AddPage(Page_AmazonCloudDrive, new AmazonSettingsPage(this));
-#endif
-
-  providers->AddPage(Page_Magnatune, new MagnatuneSettingsPage(this));
-  providers->AddPage(Page_DigitallyImported,
-                     new DigitallyImportedSettingsPage(this));
-  providers->AddPage(Page_Subsonic, new SubsonicSettingsPage(this));
-  providers->AddPage(Page_Podcasts, new PodcastSettingsPage(this));
-  providers->AddPage(Page_RadioBrowser, new RadioBrowserSettingsPage(this));
-
-  providers->sortChildren(0, Qt::AscendingOrder);
+  // Internet services category
+  AddCategory(new InternetSettingsCategory(this));
 
   // List box
   connect(ui_->list,

--- a/src/ui/settingsdialog.cpp
+++ b/src/ui/settingsdialog.cpp
@@ -31,7 +31,7 @@
 #include "globalsearch/globalsearchsettingspage.h"
 #include "globalshortcutssettingspage.h"
 #include "iconloader.h"
-#include "internet/core/internetshowsettingspage.h"
+#include "internet/core/internetsettingscategory.h"
 #include "internet/digitally/digitallyimportedsettingspage.h"
 #include "internet/magnatune/magnatunesettingspage.h"
 #include "internet/podcasts/podcastsettingspage.h"
@@ -170,9 +170,7 @@ SettingsDialog::SettingsDialog(Application* app, BackgroundStreams* streams,
           SIGNAL(NotificationPreview(OSD::Behaviour, QString, QString)));
 
   // Internet providers
-  InternetShowSettingsPage* internet_page = new InternetShowSettingsPage(this);
-  SettingsCategory* providers =
-      new SettingsCategory(Page_InternetShow, internet_page, this);
+  SettingsCategory* providers = new InternetSettingsCategory(this);
   AddCategory(providers);
 
 #ifdef HAVE_LIBLASTFM


### PR DESCRIPTION
Create a InternetSettingsCategory class and create all internet provider settings pages here.This consolidates most of the knowledge of internet settings pages in the internet subdirectory. The exception is the master page enumeration in the settings dialog.