### PR TITLE
playlist: Fix queued item painting

### DIFF
--- a/src/playlist/playlistdelegates.cpp
+++ b/src/playlist/playlistdelegates.cpp
@@ -69,19 +69,16 @@ void QueuedItemDelegate::paint(QPainter* painter,
       opacity /= kQueueOpacitySteps;
       opacity *= 1.0 - kQueueOpacityLowerBound;
       opacity += kQueueOpacityLowerBound;
-      painter->setOpacity(opacity);
 
       DrawBox(painter, option.rect, option.font, QString::number(queue_pos + 1),
-              kQueueBoxLength);
-
-      painter->setOpacity(1.0);
+              kQueueBoxLength, opacity);
     }
   }
 }
 
 void QueuedItemDelegate::DrawBox(QPainter* painter, const QRect& line_rect,
                                  const QFont& font, const QString& text,
-                                 int width) const {
+                                 int width, float opacity) const {
   QFont smaller = font;
   smaller.setPointSize(smaller.pointSize() - 1);
   smaller.setBold(true);
@@ -101,6 +98,11 @@ void QueuedItemDelegate::DrawBox(QPainter* painter, const QRect& line_rect,
   gradient.setColorAt(0.0, kQueueBoxGradientColor1);
   gradient.setColorAt(1.0, kQueueBoxGradientColor2);
 
+  // Push painter state
+  painter->save();
+
+  painter->setOpacity(opacity);
+
   // Turn on antialiasing
   painter->setRenderHint(QPainter::Antialiasing);
 
@@ -114,6 +116,9 @@ void QueuedItemDelegate::DrawBox(QPainter* painter, const QRect& line_rect,
   painter->setFont(smaller);
   painter->drawText(rect, Qt::AlignCenter, text);
   painter->translate(-0.5, -0.5);
+
+  // Pop painter state
+  painter->restore();
 }
 
 int QueuedItemDelegate::queue_indicator_size(const QModelIndex& index) const {

--- a/src/playlist/playlistdelegates.h
+++ b/src/playlist/playlistdelegates.h
@@ -37,7 +37,7 @@ class QueuedItemDelegate : public QStyledItemDelegate {
   void paint(QPainter* painter, const QStyleOptionViewItem& option,
              const QModelIndex& index) const;
   void DrawBox(QPainter* painter, const QRect& line_rect, const QFont& font,
-               const QString& text, int width = -1) const;
+               const QString& text, int width = -1, float opacity = 1.0) const;
 
   int queue_indicator_size(const QModelIndex& index) const;
 


### PR DESCRIPTION
QueuedItemDelegate::DrawBox leaves the painter in a state that can cause
artifacts. Specifically, there are cases where the item text is not
visible. To fix this, push the painter state before making changes and
pop it after drawing.

This appears to be a very old issue: #2207