### PR TITLE
playbacksettings: Don't try to load empty icons

### DIFF
--- a/src/ui/playbacksettingspage.cpp
+++ b/src/ui/playbacksettingspage.cpp
@@ -63,12 +63,14 @@ void PlaybackSettingsPage::Load() {
 
   ui_->gst_output->clear();
   for (const GstEngine::OutputDetails& output : engine->GetOutputsList()) {
-    // Strip components off the icon name until we find one.
-    QStringList components = output.icon_name.split("-");
     QIcon icon;
-    while (icon.isNull() && !components.isEmpty()) {
-      icon = IconLoader::Load(components.join("-"), IconLoader::Base);
-      components.removeLast();
+    if (!output.icon_name.isEmpty()) {
+      // Strip components off the icon name until we find one.
+      QStringList components = output.icon_name.split("-");
+      while (icon.isNull() && !components.isEmpty()) {
+        icon = IconLoader::Load(components.join("-"), IconLoader::Base);
+        components.removeLast();
+      }
     }
 
     ui_->gst_output->addItem(icon, output.description,


### PR DESCRIPTION
When populating output options, don't attempt to load an icon if that
field is empty. This cuts some log noise.