### PR TITLE
Remove unneeded policies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 project(clementine)
 
 cmake_minimum_required(VERSION 3.0.0)
-cmake_policy(SET CMP0011 OLD)
 cmake_policy(SET CMP0053 OLD)
 
 include(CheckCXXCompilerFlag)

--- a/cmake/Summary.cmake
+++ b/cmake/Summary.cmake
@@ -1,5 +1,3 @@
-cmake_policy(SET CMP0012 NEW)
-
 set(summary_willbuild "")
 set(summary_willnotbuild "")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,7 +52,6 @@ if(HAVE_SPOTIFY)
   include_directories(${CMAKE_BINARY_DIR}/ext/libclementine-spotifyblob)
 endif(HAVE_SPOTIFY)
 
-cmake_policy(SET CMP0011 NEW)
 include(../cmake/ParseArguments.cmake)
 
 if(HAVE_TRANSLATIONS)


### PR DESCRIPTION
Remove CMP0011 OLD policy. This policy allowed included files and modules to affect policy in the parent scope. Besides the top level, 3rdparty/libprojectm is the only place where old policy is set.

Remove CMP0012 NEW policy. This policy is already enabled by default. This may have originally been a typo since it was added in the same commit where CMP0011 was set to OLD in the top-level cmake file (b63d1cf).

Reference: https://cmake.org/cmake/help/latest/policy/CMP0011.html
