### PR TITLE
Replace qrand usage with QRandomGenerator

### DIFF
--- a/ext/clementine-tagreader/main.cpp
+++ b/ext/clementine-tagreader/main.cpp
@@ -39,10 +39,13 @@ int main(int argc, char** argv) {
     return 1;
   }
 
+// Use QRandomGenerator starting in 5.10.
+#if (QT_VERSION < QT_VERSION_CHECK(5, 10, 0))
   // Seed random number generator
   timeval time;
   gettimeofday(&time, nullptr);
   qsrand((time.tv_sec * 1000) + (time.tv_usec / 1000));
+#endif
 
   logging::Init();
   qLog(Info) << "TagReader worker connecting to" << args[1];

--- a/ext/libclementine-common/core/closure.cpp
+++ b/ext/libclementine-common/core/closure.cpp
@@ -19,6 +19,10 @@
 
 #include "core/timeconstants.h"
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+#include <QRandomGenerator>
+#endif
+
 namespace _detail {
 
 ClosureBase::ClosureBase(ObjectHelper* helper) : helper_(helper) {}
@@ -67,6 +71,11 @@ void DoAfter(QObject* receiver, const char* slot, int msec) {
 }
 
 void DoInAMinuteOrSo(QObject* receiver, const char* slot) {
+  // qrand is deprecated in 5.15
+#if (QT_VERSION < QT_VERSION_CHECK(5, 10, 0))
   int msec = (60 + (qrand() % 60)) * kMsecPerSec;
+#else
+  int msec = QRandomGenerator::global()->bounded(60, 120) * kMsecPerSec;
+#endif
   DoAfter(receiver, slot, msec);
 }

--- a/ext/libclementine-common/core/workerpool.h
+++ b/ext/libclementine-common/core/workerpool.h
@@ -29,6 +29,10 @@
 #include <QQueue>
 #include <QThread>
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+#include <QRandomGenerator>
+#endif
+
 #include "clementine-config.h"
 #include "core/closure.h"
 #include "core/logging.h"
@@ -270,7 +274,12 @@ void WorkerPool<HandlerType>::StartOneWorker(Worker* worker) {
 
   // Create a server, find an unused name and start listening
   forever {
+#if (QT_VERSION < QT_VERSION_CHECK(5, 10, 0))
     const int unique_number = qrand() ^ ((int)(quint64(this) & 0xFFFFFFFF));
+#else
+    // The global generator is securely seeded.
+    const int unique_number = QRandomGenerator::global()->generate();
+#endif
     const QString name =
         QString("%1_%2").arg(local_server_name_).arg(unique_number);
 

--- a/src/core/crashreporting.cpp
+++ b/src/core/crashreporting.cpp
@@ -30,6 +30,10 @@
 #include <QUrl>
 #include <QtDebug>
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+#include <QRandomGenerator>
+#endif
+
 #include "config.h"
 #include "core/logging.h"
 
@@ -158,7 +162,13 @@ void CrashSender::RedirectFinished() {
   // Find a boundary that doesn't exist in the file
   QByteArray boundary;
   forever {
+#if (QT_VERSION < QT_VERSION_CHECK(5, 10, 0))
     boundary = "--------------" + QString::number(qrand(), 16).toAscii();
+#else
+    boundary =
+        "--------------" +
+        QString::number(QRandomGenerator::global()->generate(), 16).toAscii();
+#endif
     if (!file_data.contains(boundary)) {
       break;
     }

--- a/src/core/utilities.cpp
+++ b/src/core/utilities.cpp
@@ -52,6 +52,10 @@
 #include "core/logging.h"
 #include "core/timeconstants.h"
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+#include <QRandomGenerator>
+#endif
+
 #if defined(Q_OS_UNIX)
 #include <sys/statvfs.h>
 #elif defined(Q_OS_WIN32)
@@ -533,7 +537,11 @@ bool IsMouseEventInWidget(const QMouseEvent* e, const QWidget* widget) {
 
 quint16 PickUnusedPort() {
   forever {
+#if (QT_VERSION < QT_VERSION_CHECK(5, 10, 0))
     const quint16 port = 49152 + qrand() % 16384;
+#else
+    const quint16 port = QRandomGenerator::global()->bounded(49152, 65536);
+#endif
 
     QTcpServer server;
     if (server.listen(QHostAddress::Any, port)) {

--- a/src/globalsearch/librarysearchprovider.cpp
+++ b/src/globalsearch/librarysearchprovider.cpp
@@ -19,6 +19,10 @@
 
 #include <QStack>
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+#include <QRandomGenerator>
+#endif
+
 #include "core/logging.h"
 #include "covers/albumcoverloader.h"
 #include "library/librarybackend.h"
@@ -100,7 +104,11 @@ QStringList LibrarySearchProvider::GetSuggestions(int count) {
     LibraryQuery q;
     q.SetColumnSpec("artist, album");
     q.SetIncludeUnavailable(true);
+#if (QT_VERSION < QT_VERSION_CHECK(5, 10, 0))
     q.AddWhere("ROWID", qrand() % largest_rowid);
+#else
+    q.AddWhere("ROWID", QRandomGenerator::global()->bounded(largest_rowid));
+#endif
     q.SetLimit(1);
 
     if (!backend_->ExecQuery(&q) || !q.Next()) {
@@ -111,7 +119,11 @@ QStringList LibrarySearchProvider::GetSuggestions(int count) {
     const QString album = q.Value(1).toString();
 
     if (!artist.isEmpty() && !album.isEmpty())
+#if (QT_VERSION < QT_VERSION_CHECK(5, 10, 0))
       ret << ((qrand() % 2 == 0) ? artist : album);
+#else
+      ret << (QRandomGenerator::global()->bounded(2) == 0 ? artist : album);
+#endif
     else if (!artist.isEmpty())
       ret << artist;
     else if (!album.isEmpty())

--- a/src/globalsearch/simplesearchprovider.cpp
+++ b/src/globalsearch/simplesearchprovider.cpp
@@ -20,6 +20,10 @@
 #include "core/logging.h"
 #include "playlist/songmimedata.h"
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+#include <QRandomGenerator>
+#endif
+
 const int SimpleSearchProvider::kDefaultResultLimit = 6;
 
 SimpleSearchProvider::Item::Item(const QString& title, const QUrl& url,
@@ -109,7 +113,12 @@ QStringList SimpleSearchProvider::GetSuggestions(int count) {
       break;
     }
 
+#if (QT_VERSION < QT_VERSION_CHECK(5, 10, 0))
     const Item& item = items_[qrand() % items_.count()];
+#else
+    const Item& item =
+        items_[QRandomGenerator::global()->bounded(items_.count())];
+#endif
     if (!item.keyword_.isEmpty()) ret << item.keyword_;
     if (!item.metadata_.title().isEmpty()) ret << item.metadata_.title();
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -321,8 +321,13 @@ int main(int argc, char* argv[]) {
 
   // Seed the random number generators.
   time_t t = time(nullptr);
+  // rand is still used in 3rdParty
   srand(t);
+#if (QT_VERSION < QT_VERSION_CHECK(5, 10, 0))
+  // Deprecated in 1.15. Starting in 5.10, QRandomGenerator::global provides a
+  // securely seeded PRNG.
   qsrand(t);
+#endif
 
   IncreaseFDLimit();
 

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -34,6 +34,10 @@
 #include <memory>
 #include <unordered_map>
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+#include <QRandomGenerator>
+#endif
+
 #include "core/application.h"
 #include "core/closure.h"
 #include "core/logging.h"
@@ -2032,8 +2036,11 @@ void Playlist::Shuffle() {
 
   const int count = items_.count();
   for (int i = begin; i < count; ++i) {
-    int new_pos = i + (rand() % (count - i));
-
+#if (QT_VERSION < QT_VERSION_CHECK(5, 10, 0))
+    int new_pos = i + (qrand() % (count - i));
+#else
+    int new_pos = QRandomGenerator::global()->bounded(i, count);
+#endif
     std::swap(new_items[i], new_items[new_pos]);
   }
 

--- a/src/ui/networkremotesettingspage.cpp
+++ b/src/ui/networkremotesettingspage.cpp
@@ -25,6 +25,10 @@
 #include <QUrl>
 #include <algorithm>
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+#include <QRandomGenerator>
+#endif
+
 #include "core/application.h"
 #include "networkremote/networkremote.h"
 #include "networkremote/networkremotehelper.h"
@@ -106,7 +110,13 @@ void NetworkRemoteSettingsPage::Load() {
 
   // Auth Code, 5 digits
   ui_->use_auth_code->setChecked(s.value("use_auth_code", false).toBool());
+#if (QT_VERSION < QT_VERSION_CHECK(5, 10, 0))
   ui_->auth_code->setValue(s.value("auth_code", qrand() % 100000).toInt());
+#else
+  ui_->auth_code->setValue(
+      s.value("auth_code", QRandomGenerator::global()->bounded(100000))
+          .toInt());
+#endif
 
   ui_->allow_downloads->setChecked(s.value("allow_downloads", false).toBool());
   ui_->convert_lossless->setChecked(

--- a/src/visualisations/projectmvisualisation.cpp
+++ b/src/visualisations/projectmvisualisation.cpp
@@ -34,6 +34,10 @@
 #include "projectmpresetmodel.h"
 #include "visualisationcontainer.h"
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+#include <QRandomGenerator>
+#endif
+
 #ifdef USE_SYSTEM_PROJECTM
 #include <libprojectM/projectM.hpp>
 #else
@@ -125,7 +129,13 @@ void ProjectMVisualisation::InitProjectM() {
 
   // Start at a random preset.
   if (projectm_->getPlaylistSize() > 0) {
-    projectm_->selectPreset(qrand() % projectm_->getPlaylistSize(), true);
+#if (QT_VERSION < QT_VERSION_CHECK(5, 10, 0))
+    int selection = qrand() % projectm_->getPlaylistSize();
+#else
+    int selection =
+        QRandomGenerator::global()->bounded(projectm_->getPlaylistSize());
+#endif
+    projectm_->selectPreset(selection, true);
   }
 
   if (font_path.isNull()) {


### PR DESCRIPTION
QRandomGenerator was introduced in 5.10 and qrand has since been
deprecated. QRandomGenerator::global() returns a global instance that
has been securely seeded. QRandomGenerator provides methods that
generate values within ranges, so taking a modulus of the result isn't
necessary.