### PR TITLE
dbus: Fix annotation deprecation warnings

### DIFF
--- a/src/dbus/org.freedesktop.DBus.ObjectManager.xml
+++ b/src/dbus/org.freedesktop.DBus.ObjectManager.xml
@@ -4,12 +4,12 @@
   <interface name="org.freedesktop.DBus.ObjectManager">
     <method name="GetManagedObjects">
       <arg name="objects" type="a{oa{sa{sv}}}" direction="out"/>
-      <annotation name="com.trolltech.QtDBus.QtTypeName.Out0" value="ManagedObjectList"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="ManagedObjectList"/>
     </method>
     <signal name="InterfacesAdded">
       <arg name="object" type="o"/>
       <arg name="interfaces" type="a{sa{sv}}"/>
-      <annotation name="com.trolltech.QtDBus.QtTypeName.In1" value="InterfacesAndProperties"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="InterfacesAndProperties"/>
     </signal>
     <signal name="InterfacesRemoved">
       <arg type="o" name="object_path"/>

--- a/src/dbus/org.freedesktop.UDisks2.Drive.xml
+++ b/src/dbus/org.freedesktop.UDisks2.Drive.xml
@@ -4,7 +4,7 @@
   <interface name="org.freedesktop.UDisks2.Drive">
     <method name="Eject">
       <arg type="a{sv}" name="options" direction="in"/>
-      <annotation name="com.trolltech.QtDBus.QtTypeName.In0" value="QVariantMap"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap"/>
     </method>
     <property type="s" name="Vendor" access="read"/>
     <property type="s" name="Model" access="read"/>

--- a/src/dbus/org.freedesktop.UDisks2.Filesystem.xml
+++ b/src/dbus/org.freedesktop.UDisks2.Filesystem.xml
@@ -4,15 +4,15 @@
   <interface name="org.freedesktop.UDisks2.Filesystem">
     <method name="Mount">
       <arg type="a{sv}" name="options" direction="in"/>
-      <annotation name="com.trolltech.QtDBus.QtTypeName.In0" value="QVariantMap"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap"/>
       <arg type="s" name="mount_path" direction="out"/>
     </method>
     <method name="Unmount">
       <arg type="a{sv}" name="options" direction="in"/>
-      <annotation name="com.trolltech.QtDBus.QtTypeName.In0" value="QVariantMap"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap"/>
     </method>
     <property type="aay" name="MountPoints" access="read">
-      <annotation name="com.trolltech.QtDBus.QtTypeName" value="QList&lt;QByteArray&gt;"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName" value="QList&lt;QByteArray&gt;"/>
     </property>
   </interface>
 </node>


### PR DESCRIPTION
The com.trolltech was renamed to org.qtproject. The code generation tool
still handles the old name, but prints a deprecation error.

Reference: https://bugreports.qt.io/browse/QTBUG-23274