### PR TITLE
dbus: Fix qdbusxml2cpp unknown type warnings.

### DIFF
--- a/src/dbus/org.freedesktop.DBus.ObjectManager.xml
+++ b/src/dbus/org.freedesktop.DBus.ObjectManager.xml
@@ -8,7 +8,7 @@
     </method>
     <signal name="InterfacesAdded">
       <arg name="object" type="o"/>
-      <arg name="interfaces" type="a{sa{sv}}"/>
+      <arg name="interfaces" type="a{sa{sv}}" direction="in"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="InterfacesAndProperties"/>
     </signal>
     <signal name="InterfacesRemoved">

--- a/src/dbus/org.mpris.MediaPlayer2.Playlists.xml
+++ b/src/dbus/org.mpris.MediaPlayer2.Playlists.xml
@@ -20,7 +20,7 @@
 			<annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="MprisPlaylistList"/>
 		</method>
 		<signal name='PlaylistChanged'>
-			<arg name='Playlist' type='(oss)' />
+			<arg direction='in' name='Playlist' type='(oss)' />
 			<annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="MprisPlaylist" />
 		</signal>
 		<annotation name="org.qtproject.QtDBus.QtTypeName" value="MaybePlaylist" />

--- a/src/dbus/org.mpris.MediaPlayer2.TrackList.xml
+++ b/src/dbus/org.mpris.MediaPlayer2.TrackList.xml
@@ -5,8 +5,8 @@
 	<interface name='org.mpris.MediaPlayer2.TrackList'>
 		<method name='GetTracksMetadata'>
 			<arg direction='in' name='TrackIds' type='ao'/>
-      <arg direction='out' name='Metadata' type='aa{sv}'/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="TrackMetadata" />
+			<arg direction='out' name='Metadata' type='aa{sv}'/>
+			<annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="TrackMetadata" />
 		</method>
 		<method name='AddTrack'>
 			<arg direction='in' name='Uri' type='s'/>
@@ -24,8 +24,8 @@
 			<arg name='CurrentTrack' type='o'/>
 		</signal>
 		<signal name='TrackAdded'>
-      <arg name='Metadata' type='a{sv}'/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="TrackMetadata"/>
+			<arg direction='in' name='Metadata' type='a{sv}'/>
+			<annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="TrackMetadata"/>
 			<arg name='AfterTrack' type='o'/>
 		</signal>
 		<signal name='TrackRemoved'>
@@ -33,8 +33,8 @@
 		</signal>
 		<signal name='TrackMetadataChanged'>
 			<arg name='TrackId' type='o'/>
-      <arg name='Metadata' type='a{sv}'/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="TrackMetadata"/>
+			<arg direction='in' name='Metadata' type='a{sv}'/>
+			<annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="TrackMetadata"/>
 		</signal>
 		<property name='Tracks' type='ao' access='read'/>
 		<property name='CanEditTracks' type='b' access='read'/>


### PR DESCRIPTION
Add direction attributes to args where qdbusxml2cpp was looking for the incorrect annotation.