### PR TITLE
libclementine-common: Use positive numbers for worker ids.

### DIFF
--- a/ext/libclementine-common/core/workerpool.h
+++ b/ext/libclementine-common/core/workerpool.h
@@ -278,7 +278,7 @@ void WorkerPool<HandlerType>::StartOneWorker(Worker* worker) {
     const int unique_number = qrand() ^ ((int)(quint64(this) & 0xFFFFFFFF));
 #else
     // The global generator is securely seeded.
-    const int unique_number = QRandomGenerator::global()->generate();
+    const unsigned int unique_number = QRandomGenerator::global()->generate();
 #endif
     const QString name =
         QString("%1_%2").arg(local_server_name_).arg(unique_number);


### PR DESCRIPTION
QRandomGenerator::generate() returns an unbounded int32, while the legacy
qrand method always returned a positive number. When generating a tag
reader ID with QRandomGenerator, cast the random value to an unsigned so
that it is formatted as a positive number in the name.

Note that most usages of QRandomGenrator in the codebase use bounded()
instead of generate(), and should work as expected.