### PR TITLE
dbus: Fix signal arg annotations

### DIFF
--- a/src/dbus/org.freedesktop.DBus.ObjectManager.xml
+++ b/src/dbus/org.freedesktop.DBus.ObjectManager.xml
@@ -8,8 +8,8 @@
     </method>
     <signal name="InterfacesAdded">
       <arg name="object" type="o"/>
-      <arg name="interfaces" type="a{sa{sv}}" direction="in"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="InterfacesAndProperties"/>
+      <arg name="interfaces" type="a{sa{sv}}"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="InterfacesAndProperties"/>
     </signal>
     <signal name="InterfacesRemoved">
       <arg type="o" name="object_path"/>

--- a/src/dbus/org.mpris.MediaPlayer2.Playlists.xml
+++ b/src/dbus/org.mpris.MediaPlayer2.Playlists.xml
@@ -20,8 +20,8 @@
 			<annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="MprisPlaylistList"/>
 		</method>
 		<signal name='PlaylistChanged'>
-			<arg direction='in' name='Playlist' type='(oss)' />
-			<annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="MprisPlaylist" />
+			<arg name='Playlist' type='(oss)' />
+			<annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="MprisPlaylist" />
 		</signal>
 		<annotation name="org.qtproject.QtDBus.QtTypeName" value="MaybePlaylist" />
 	</interface>

--- a/src/dbus/org.mpris.MediaPlayer2.TrackList.xml
+++ b/src/dbus/org.mpris.MediaPlayer2.TrackList.xml
@@ -24,8 +24,8 @@
 			<arg name='CurrentTrack' type='o'/>
 		</signal>
 		<signal name='TrackAdded'>
-			<arg direction='in' name='Metadata' type='a{sv}'/>
-			<annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="TrackMetadata"/>
+			<arg name='Metadata' type='a{sv}'/>
+			<annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="TrackMetadata"/>
 			<arg name='AfterTrack' type='o'/>
 		</signal>
 		<signal name='TrackRemoved'>
@@ -33,8 +33,8 @@
 		</signal>
 		<signal name='TrackMetadataChanged'>
 			<arg name='TrackId' type='o'/>
-			<arg direction='in' name='Metadata' type='a{sv}'/>
-			<annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="TrackMetadata"/>
+			<arg name='Metadata' type='a{sv}'/>
+			<annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="TrackMetadata"/>
 		</signal>
 		<property name='Tracks' type='ao' access='read'/>
 		<property name='CanEditTracks' type='b' access='read'/>


### PR DESCRIPTION
An earlier change attempted to fix qdbusxml2cpp parsing errors by adding
directions to arguments. However, signal arguments are always out and it
was the annotations that were incorrect.

Fixes: f17b79a10 (dbus: Fix qdbusxml2cpp unknown type warnings., 2021-04-19)
Reference: https://dbus.freedesktop.org/doc/dbus-specification.html