### PR TITLE
devices: Fix guessed icons in DeviceIcons

### DIFF
--- a/src/devices/devicelister.cpp
+++ b/src/devices/devicelister.cpp
@@ -19,7 +19,6 @@
 
 #include <QDir>
 #include <QFile>
-#include <QStringList>
 #include <QThread>
 #include <QtDebug>
 
@@ -171,8 +170,8 @@ bool DeviceLister::IsIpod(const QString& path) const {
          QFile::exists(path + "/iTunes/iTunes_Control");
 }
 
-QStringList DeviceLister::GuessIconForPath(const QString& path) {
-  QStringList ret;
+QVariantList DeviceLister::GuessIconForPath(const QString& path) {
+  QVariantList ret;
 
 #ifdef HAVE_LIBGPOD
   if (IsIpod(path)) {
@@ -200,9 +199,9 @@ QStringList DeviceLister::GuessIconForPath(const QString& path) {
   return ret;
 }
 
-QStringList DeviceLister::GuessIconForModel(const QString& vendor,
-                                            const QString& model) {
-  QStringList ret;
+QVariantList DeviceLister::GuessIconForModel(const QString& vendor,
+                                             const QString& model) {
+  QVariantList ret;
   if (vendor.startsWith("Google") && model.contains("Nexus")) {
     ret << "phone-google-nexus-one";
   }

--- a/src/devices/devicelister.h
+++ b/src/devices/devicelister.h
@@ -79,8 +79,8 @@ class DeviceLister : public QObject {
   QUrl MakeUrlFromLocalPath(const QString& path) const;
   bool IsIpod(const QString& path) const;
 
-  QStringList GuessIconForPath(const QString& path);
-  QStringList GuessIconForModel(const QString& vendor, const QString& model);
+  QVariantList GuessIconForPath(const QString& path);
+  QVariantList GuessIconForModel(const QString& vendor, const QString& model);
 
  protected:
   QThread* thread_;

--- a/src/devices/giolister.h
+++ b/src/devices/giolister.h
@@ -99,7 +99,7 @@ class GioLister : public DeviceLister {
     QString mount_path;
     QString mount_uri;
     QString mount_name;
-    QStringList mount_icon_names;
+    QVariantList mount_icon_names;
     QString mount_uuid;
     quint64 filesystem_size;
     quint64 filesystem_free;


### PR DESCRIPTION
In the initial implementation, DeviceLister::DeviceIcons returned a
string list and some listers would concatenate other lists to form that
list. When DeviceIcons was changed to return a variant list, that
logic wasn't changed in many places, so instead of appending, string
list variants are being added icon list.