### PR TITLE
Fix: Transcoding for CD rips not starting.

### DIFF
--- a/src/ripper/ripper.cpp
+++ b/src/ripper/ripper.cpp
@@ -47,7 +47,6 @@ Ripper::Ripper(QObject* parent)
       files_tagged_(0) {
   cdio_ = cdio_open(NULL, DRIVER_UNKNOWN);
 
-  connect(this, SIGNAL(RippingComplete()), transcoder_, SLOT(Start()));
   connect(transcoder_, SIGNAL(JobComplete(QString, QString, bool)),
           SLOT(TranscodingJobComplete(QString, QString, bool)));
   connect(transcoder_, SIGNAL(AllJobsComplete()),
@@ -252,6 +251,7 @@ void Ripper::Rip() {
     transcoder_->AddJob(it->temporary_filename, it->preset,
                         it->transcoded_filename);
   }
+  transcoder_->Start();
   emit(RippingComplete());
 }
 


### PR DESCRIPTION
Fixes #7017 .

As `Transcoder::Start()` is no longer a slot, I removed the `connect` that invokes it once `Ripper` emits the `RippingComplete` signal and instead call `Transcoder::Start` directly. The alternative would be to reinstate `Transcoder::Start()` as a slot, which I decided against because it would be inconsistent with `Transcoder::Cancel()` which is never (and never was, apparently) used as a slot as well.