### PR TITLE
Improved CD metadata loading

### DIFF
--- a/src/devices/cddasongloader.cpp
+++ b/src/devices/cddasongloader.cpp
@@ -49,6 +49,7 @@ QUrl CddaSongLoader::GetUrlFromTrack(int track_number) const {
 void CddaSongLoader::LoadSongs() {
   QtConcurrent::run(this, &CddaSongLoader::LoadSongsFromCdda);
 }
+
 void CddaSongLoader::LoadSongsFromCdda() {
   QMutexLocker locker(&mutex_load_);
   cdio_ = cdio_open(url_.path().toLocal8Bit().constData(), DRIVER_DEVICE);
@@ -155,6 +156,8 @@ void CddaSongLoader::LoadSongsFromCdda() {
           songs[i++].set_length_nanosec(duration);
         }
       }
+      g_list_free(entries);
+      gst_toc_unref(toc);
     }
     gst_message_unref(msg_toc);
   }
@@ -172,9 +175,10 @@ void CddaSongLoader::LoadSongsFromCdda() {
       emit MusicBrainzDiscIdLoaded(musicbrainz_discid);
 
       g_free(string_mb);
-      gst_message_unref(msg_tag);
-      gst_tag_list_free(tags);
     }
+
+    gst_message_unref(msg_tag);
+    gst_tag_list_free(tags);
   }
 
   gst_element_set_state(pipeline, GST_STATE_NULL);

--- a/src/devices/cddasongloader.cpp
+++ b/src/devices/cddasongloader.cpp
@@ -123,12 +123,12 @@ void CddaSongLoader::LoadSongsFromCdda() {
   GstMessage* msg = nullptr;
   GstMessage* msg_toc = nullptr;
   GstMessage* msg_tag = nullptr;
-  GstMessageType msg_filter = static_cast<GstMessageType>(GST_MESSAGE_TOC | GST_MESSAGE_TAG);
-  while ((msg = gst_bus_timed_pop_filtered(
-              GST_ELEMENT_BUS(pipeline), 10 * GST_SECOND,
-              msg_filter))) {
-
-    msg_filter = static_cast<GstMessageType>(static_cast<int>(msg_filter) ^ static_cast<int>(GST_MESSAGE_TYPE(msg)));
+  GstMessageType msg_filter =
+      static_cast<GstMessageType>(GST_MESSAGE_TOC | GST_MESSAGE_TAG);
+  while ((msg = gst_bus_timed_pop_filtered(GST_ELEMENT_BUS(pipeline),
+                                           10 * GST_SECOND, msg_filter))) {
+    msg_filter = static_cast<GstMessageType>(
+        static_cast<int>(msg_filter) ^ static_cast<int>(GST_MESSAGE_TYPE(msg)));
     if (GST_MESSAGE_TYPE(msg) == GST_MESSAGE_TOC) {
       if (msg_toc)
         gst_message_unref(msg_toc);  // Shouldn't happen, but just in case

--- a/src/devices/cddasongloader.cpp
+++ b/src/devices/cddasongloader.cpp
@@ -156,7 +156,6 @@ void CddaSongLoader::LoadSongsFromCdda() {
           songs[i++].set_length_nanosec(duration);
         }
       }
-      g_list_free(entries);
       gst_toc_unref(toc);
     }
     gst_message_unref(msg_toc);

--- a/src/devices/cddasongloader.cpp
+++ b/src/devices/cddasongloader.cpp
@@ -121,63 +121,54 @@ void CddaSongLoader::LoadSongsFromCdda() {
 
   // Get TOC and TAG messages
   GstMessage* msg = nullptr;
-  GstMessage* msg_toc = nullptr;
-  GstMessage* msg_tag = nullptr;
   GstMessageType msg_filter =
       static_cast<GstMessageType>(GST_MESSAGE_TOC | GST_MESSAGE_TAG);
-  while ((msg = gst_bus_timed_pop_filtered(GST_ELEMENT_BUS(pipeline),
+  while (msg_filter &&
+         (msg = gst_bus_timed_pop_filtered(GST_ELEMENT_BUS(pipeline),
                                            10 * GST_SECOND, msg_filter))) {
-    msg_filter = static_cast<GstMessageType>(
-        static_cast<int>(msg_filter) ^ static_cast<int>(GST_MESSAGE_TYPE(msg)));
     if (GST_MESSAGE_TYPE(msg) == GST_MESSAGE_TOC) {
-      if (msg_toc)
-        gst_message_unref(msg_toc);  // Shouldn't happen, but just in case
-      msg_toc = msg;
-    } else if (GST_MESSAGE_TYPE(msg) == GST_MESSAGE_TAG) {
-      if (msg_tag) gst_message_unref(msg_tag);
-      msg_tag = msg;
-    }
-  }
-
-  // Handle TOC message: get tracks duration
-  if (msg_toc) {
-    GstToc* toc;
-    gst_message_parse_toc(msg_toc, &toc, nullptr);
-    if (toc) {
-      GList* entries = gst_toc_get_entries(toc);
-      if (entries && songs.size() <= g_list_length(entries)) {
-        int i = 0;
-        for (GList* node = entries; node != nullptr; node = node->next) {
-          GstTocEntry* entry = static_cast<GstTocEntry*>(node->data);
-          quint64 duration = 0;
-          gint64 start, stop;
-          if (gst_toc_entry_get_start_stop_times(entry, &start, &stop))
-            duration = stop - start;
-          songs[i++].set_length_nanosec(duration);
+      // Handle TOC message: get tracks duration
+      GstToc* toc;
+      gst_message_parse_toc(msg, &toc, nullptr);
+      if (toc) {
+        GList* entries = gst_toc_get_entries(toc);
+        if (entries && songs.size() <= g_list_length(entries)) {
+          int i = 0;
+          for (GList* node = entries; node != nullptr; node = node->next) {
+            GstTocEntry* entry = static_cast<GstTocEntry*>(node->data);
+            quint64 duration = 0;
+            gint64 start, stop;
+            if (gst_toc_entry_get_start_stop_times(entry, &start, &stop))
+              duration = stop - start;
+            songs[i++].set_length_nanosec(duration);
+          }
+          gst_toc_unref(toc);
         }
+        msg_filter = static_cast<GstMessageType>(static_cast<int>(msg_filter) ^
+                                                 GST_MESSAGE_TOC);
       }
-      gst_toc_unref(toc);
+      emit SongsDurationLoaded(songs);
+
+    } else if (GST_MESSAGE_TYPE(msg) == GST_MESSAGE_TAG) {
+      // Handle TAG message: generate MusicBrainz DiscId
+
+      GstTagList* tags = nullptr;
+      gst_message_parse_tag(msg, &tags);
+      char* string_mb = nullptr;
+      if (gst_tag_list_get_string(tags, GST_TAG_CDDA_MUSICBRAINZ_DISCID,
+                                  &string_mb)) {
+        QString musicbrainz_discid(string_mb);
+        qLog(Info) << "MusicBrainz discid: " << musicbrainz_discid;
+        emit MusicBrainzDiscIdLoaded(musicbrainz_discid);
+
+        g_free(string_mb);
+
+        msg_filter = static_cast<GstMessageType>(static_cast<int>(msg_filter) ^
+                                                 GST_MESSAGE_TAG);
+      }
+      gst_tag_list_free(tags);
     }
-    gst_message_unref(msg_toc);
-  }
-  emit SongsDurationLoaded(songs);
-
-  // Handle TAG message: generate MusicBrainz DiscId
-  if (msg_tag) {
-    GstTagList* tags = nullptr;
-    gst_message_parse_tag(msg_tag, &tags);
-    char* string_mb = nullptr;
-    if (gst_tag_list_get_string(tags, GST_TAG_CDDA_MUSICBRAINZ_DISCID,
-                                &string_mb)) {
-      QString musicbrainz_discid(string_mb);
-      qLog(Info) << "MusicBrainz discid: " << musicbrainz_discid;
-      emit MusicBrainzDiscIdLoaded(musicbrainz_discid);
-
-      g_free(string_mb);
-    }
-
-    gst_message_unref(msg_tag);
-    gst_tag_list_free(tags);
+    gst_message_unref(msg);
   }
 
   gst_element_set_state(pipeline, GST_STATE_NULL);

--- a/src/devices/cddasongloader.cpp
+++ b/src/devices/cddasongloader.cpp
@@ -156,7 +156,7 @@ void CddaSongLoader::LoadSongsFromCdda() {
       char* string_mb = nullptr;
       if (gst_tag_list_get_string(tags, GST_TAG_CDDA_MUSICBRAINZ_DISCID,
                                   &string_mb)) {
-        QString musicbrainz_discid(string_mb);
+        QString musicbrainz_discid = QString::fromUtf8(string_mb);
         g_free(string_mb);
 
         qLog(Info) << "MusicBrainz discid: " << musicbrainz_discid;

--- a/src/devices/cddasongloader.cpp
+++ b/src/devices/cddasongloader.cpp
@@ -122,9 +122,12 @@ void CddaSongLoader::LoadSongsFromCdda() {
   GstMessage* msg = nullptr;
   GstMessage* msg_toc = nullptr;
   GstMessage* msg_tag = nullptr;
+  GstMessageType msg_filter = static_cast<GstMessageType>(GST_MESSAGE_TOC | GST_MESSAGE_TAG);
   while ((msg = gst_bus_timed_pop_filtered(
-              GST_ELEMENT_BUS(pipeline), 2 * GST_SECOND,
-              (GstMessageType)(GST_MESSAGE_TOC | GST_MESSAGE_TAG)))) {
+              GST_ELEMENT_BUS(pipeline), 10 * GST_SECOND,
+              msg_filter))) {
+
+    msg_filter = static_cast<GstMessageType>(static_cast<int>(msg_filter) ^ static_cast<int>(GST_MESSAGE_TYPE(msg)));
     if (GST_MESSAGE_TYPE(msg) == GST_MESSAGE_TOC) {
       if (msg_toc)
         gst_message_unref(msg_toc);  // Shouldn't happen, but just in case

--- a/src/devices/cddasongloader.cpp
+++ b/src/devices/cddasongloader.cpp
@@ -142,13 +142,12 @@ void CddaSongLoader::LoadSongsFromCdda() {
               duration = stop - start;
             songs[i++].set_length_nanosec(duration);
           }
-          gst_toc_unref(toc);
+          emit SongsDurationLoaded(songs);
+          msg_filter = static_cast<GstMessageType>(
+              static_cast<int>(msg_filter) ^ GST_MESSAGE_TOC);
         }
-        msg_filter = static_cast<GstMessageType>(static_cast<int>(msg_filter) ^
-                                                 GST_MESSAGE_TOC);
+        gst_toc_unref(toc);
       }
-      emit SongsDurationLoaded(songs);
-
     } else if (GST_MESSAGE_TYPE(msg) == GST_MESSAGE_TAG) {
       // Handle TAG message: generate MusicBrainz DiscId
 
@@ -158,11 +157,10 @@ void CddaSongLoader::LoadSongsFromCdda() {
       if (gst_tag_list_get_string(tags, GST_TAG_CDDA_MUSICBRAINZ_DISCID,
                                   &string_mb)) {
         QString musicbrainz_discid(string_mb);
-        qLog(Info) << "MusicBrainz discid: " << musicbrainz_discid;
-        emit MusicBrainzDiscIdLoaded(musicbrainz_discid);
-
         g_free(string_mb);
 
+        qLog(Info) << "MusicBrainz discid: " << musicbrainz_discid;
+        emit MusicBrainzDiscIdLoaded(musicbrainz_discid);
         msg_filter = static_cast<GstMessageType>(static_cast<int>(msg_filter) ^
                                                  GST_MESSAGE_TAG);
       }

--- a/src/musicbrainz/musicbrainzclient.cpp
+++ b/src/musicbrainz/musicbrainzclient.cpp
@@ -156,7 +156,7 @@ void MusicBrainzClient::DiscIdRequestFinished(const QString& discid,
             ret << track;
           }
         }
-        break; // stop after consuming one medium with correct discid!
+        break;  // stop after consuming one medium with correct discid!
       } else {
         Utilities::ConsumeCurrentElement(&reader);
       }

--- a/src/musicbrainz/musicbrainzclient.cpp
+++ b/src/musicbrainz/musicbrainzclient.cpp
@@ -156,6 +156,7 @@ void MusicBrainzClient::DiscIdRequestFinished(const QString& discid,
             ret << track;
           }
         }
+        break; // stop after consuming one medium with correct discid!
       } else {
         Utilities::ConsumeCurrentElement(&reader);
       }

--- a/src/ripper/ripcddialog.cpp
+++ b/src/ripper/ripcddialog.cpp
@@ -284,7 +284,8 @@ void RipCDDialog::UpdateTrackListTable(const SongList& songs) {
   if (track_names_.length() == songs.length()) {
     BuildTrackListTable(songs);
   } else {
-    qLog(Error) << "Number of tracks in metadata does not match number of songs on disc!";
+    qLog(Error) << "Number of tracks in metadata does not match number of "
+                   "songs on disc!";
   }
 }
 

--- a/src/ripper/ripcddialog.cpp
+++ b/src/ripper/ripcddialog.cpp
@@ -93,7 +93,7 @@ RipCDDialog::RipCDDialog(QWidget* parent)
   connect(loader_, SIGNAL(SongsDurationLoaded(SongList)),
           SLOT(BuildTrackListTable(SongList)));
   connect(loader_, SIGNAL(SongsMetadataLoaded(SongList)),
-          SLOT(BuildTrackListTable(SongList)));
+          SLOT(UpdateTrackListTable(SongList)));
   connect(loader_, SIGNAL(SongsMetadataLoaded(SongList)),
           SLOT(AddAlbumMetadataFromMusicBrainz(SongList)));
 
@@ -277,6 +277,14 @@ void RipCDDialog::BuildTrackListTable(const SongList& songs) {
     ui_->tableWidget->setCellWidget(current_row, kTrackDurationColumn,
                                     new QLabel(song.PrettyLength()));
     current_row++;
+  }
+}
+
+void RipCDDialog::UpdateTrackListTable(const SongList& songs) {
+  if (track_names_.length() == songs.length()) {
+    BuildTrackListTable(songs);
+  } else {
+    qLog(Error) << "Number of tracks in metadata does not match number of songs on disc!";
   }
 }
 

--- a/src/ripper/ripcddialog.h
+++ b/src/ripper/ripcddialog.h
@@ -57,7 +57,8 @@ class RipCDDialog : public QDialog {
   void Cancelled();
   void SetupProgressBarLimits(int min, int max);
   void UpdateProgressBar(int progress);
-  // Initializes track list table based on preliminary song list with durations but without metadata.
+  // Initializes track list table based on preliminary song list with durations
+  // but without metadata.
   void BuildTrackListTable(const SongList& songs);
   // Update track list based on metadata.
   void UpdateTrackListTable(const SongList& songs);

--- a/src/ripper/ripcddialog.h
+++ b/src/ripper/ripcddialog.h
@@ -57,7 +57,11 @@ class RipCDDialog : public QDialog {
   void Cancelled();
   void SetupProgressBarLimits(int min, int max);
   void UpdateProgressBar(int progress);
+  // Initializes track list table based on preliminary song list with durations but without metadata.
   void BuildTrackListTable(const SongList& songs);
+  // Update track list based on metadata.
+  void UpdateTrackListTable(const SongList& songs);
+  // Update album information with metadata.
   void AddAlbumMetadataFromMusicBrainz(const SongList& songs);
 
  private:


### PR DESCRIPTION
closes #7019 and closes #7020:
- For #7019: I increased the timeout for reading CD tags in `CddaSongLoader` and also made sure that waiting for messages stops after reading a TOC and a TAG message each, to ensure that no waiting until timeout happens after receiving messages.
- For #7020: If a MusicBrainz metadata requests returns an XML with several media with identical discid, MusicBrainzClient stops after parsing tracks from the first contained medium.
- Additional for #7020: As an additional safeguard, RipCDDialog will ignore a metadata update if the number of tracks contained does not match the number of tracks on the disc.

The solution for parsing the MusicBrainz metadata is not ideal: It implicitly assumes that the first medium contained in the API response is the correct one. The justificiation is that I assume that if identical discids happen, they will most likely correspond to remasters/different variants of the same record of the same artist. So even if the track list is wrong, it will probably be close enough and thus better than the default "Track x" naming.
However, long term it would be better to either let the user choose the correct track list, which would require an additional popup dialog, or read additional metadata from the disc (CD-text, if present) to disambiguate (based on my dabbling with it, I'm not sure if this is possible with gstreamer, though).