### PR TITLE
Detecting media change in CD ripper dialog.

### DIFF
--- a/src/ripper/ripcddialog.cpp
+++ b/src/ripper/ripcddialog.cpp
@@ -60,7 +60,6 @@ RipCDDialog::RipCDDialog(QWidget* parent)
       loader_(new CddaSongLoader(QUrl(), this)),
       mediaChangedWatchingThread_(*this),
       mutex_() {
-
   QMutexLocker l(&mutex_);
   // Init
   ui_->setupUi(this);
@@ -138,7 +137,8 @@ RipCDDialog::RipCDDialog(QWidget* parent)
 }
 
 RipCDDialog::~RipCDDialog() {
-  QMutexLocker l(&mutex_);  // ensure now one is holding a lock on the mutex when destroying..
+  QMutexLocker l(&mutex_);  // ensure now one is holding a lock on the mutex
+                            // when destroying..
 }
 
 bool RipCDDialog::CheckCDIOIsValid() { return ripper_->CheckCDIOIsValid(); }
@@ -344,8 +344,9 @@ void RipCDDialog::ResetDialog() {
   ui_->discLineEdit->clear();
 }
 
-RipCDDialog::MediaChangedPollingThread::MediaChangedPollingThread(RipCDDialog& dialog)
-  : QThread(&dialog), dialog_(dialog) { }
+RipCDDialog::MediaChangedPollingThread::MediaChangedPollingThread(
+    RipCDDialog& dialog)
+    : QThread(&dialog), dialog_(dialog) {}
 
 RipCDDialog::MediaChangedPollingThread::~MediaChangedPollingThread() {
   requestInterruption();
@@ -354,13 +355,13 @@ RipCDDialog::MediaChangedPollingThread::~MediaChangedPollingThread() {
 
 void RipCDDialog::MediaChangedPollingThread::run() {
   while (!isInterruptionRequested()) {
-      if (dialog_.ripper_->MediaChanged()) {
-        qLog(Debug) << "media changed!";
-        dialog_.ResetDialog();
-        if (dialog_.CheckCDIOIsValid()) {
-          dialog_.loader_->LoadSongs();
-        }
+    if (dialog_.ripper_->MediaChanged()) {
+      qLog(Debug) << "media changed!";
+      dialog_.ResetDialog();
+      if (dialog_.CheckCDIOIsValid()) {
+        dialog_.loader_->LoadSongs();
       }
+    }
     msleep(500);
   }
 }

--- a/src/ripper/ripcddialog.cpp
+++ b/src/ripper/ripcddialog.cpp
@@ -58,9 +58,7 @@ RipCDDialog::RipCDDialog(QWidget* parent)
       ripper_(new Ripper(this)),
       working_(false),
       loader_(new CddaSongLoader(QUrl(), this)),
-      mutex_(),
       media_changed_timer_() {
-  QMutexLocker l(&mutex_);
   // Init
   ui_->setupUi(this);
 
@@ -136,10 +134,7 @@ RipCDDialog::RipCDDialog(QWidget* parent)
   media_changed_timer_.start(500, this);
 }
 
-RipCDDialog::~RipCDDialog() {
-  QMutexLocker l(&mutex_);  // ensure noone is holding a lock on the mutex
-                            // when destroying..
-}
+RipCDDialog::~RipCDDialog() {}
 
 bool RipCDDialog::CheckCDIOIsValid() { return ripper_->CheckCDIOIsValid(); }
 
@@ -266,7 +261,6 @@ void RipCDDialog::UpdateProgressBar(int progress) {
 }
 
 void RipCDDialog::BuildTrackListTable(const SongList& songs) {
-  QMutexLocker l(&mutex_);
   checkboxes_.clear();
   track_names_.clear();
 
@@ -292,7 +286,6 @@ void RipCDDialog::BuildTrackListTable(const SongList& songs) {
 
 void RipCDDialog::AddAlbumMetadataFromMusicBrainz(const SongList& songs) {
   Q_ASSERT(songs.length() > 0);
-  QMutexLocker l(&mutex_);
 
   const Song& song = songs.first();
   ui_->albumLineEdit->setText(song.album());
@@ -335,7 +328,6 @@ QString RipCDDialog::ParseFileFormatString(const QString& file_format,
 }
 
 void RipCDDialog::ResetDialog() {
-  QMutexLocker l(&mutex_);
   ui_->tableWidget->setRowCount(0);
   ui_->albumLineEdit->clear();
   ui_->artistLineEdit->clear();

--- a/src/ripper/ripcddialog.cpp
+++ b/src/ripper/ripcddialog.cpp
@@ -24,6 +24,7 @@
 #include <QLineEdit>
 #include <QMessageBox>
 #include <QSettings>
+#include <QTimer>
 #include <QUrl>
 #include <algorithm>
 
@@ -130,8 +131,9 @@ RipCDDialog::RipCDDialog(QWidget* parent)
     }
   }
 
-  // Start thread for polling
-  media_changed_timer_.start(500, this);
+  // Start timer for polling
+  connect(&media_changed_timer_, SIGNAL(timeout()), SLOT(CheckMediaChanged()));
+  media_changed_timer_.start(500);
 }
 
 RipCDDialog::~RipCDDialog() {}
@@ -336,9 +338,8 @@ void RipCDDialog::ResetDialog() {
   ui_->discLineEdit->clear();
 }
 
-void RipCDDialog::timerEvent(QTimerEvent* e) {
+void RipCDDialog::CheckMediaChanged() {
   if (ripper_->MediaChanged()) {
-    qLog(Debug) << "media changed!";
     ResetDialog();
     if (CheckCDIOIsValid()) {
       loader_->LoadSongs();

--- a/src/ripper/ripcddialog.h
+++ b/src/ripper/ripcddialog.h
@@ -18,7 +18,6 @@
 #ifndef SRC_RIPPER_RIPCDDIALOG_H_
 #define SRC_RIPPER_RIPCDDIALOG_H_
 
-#include <QBasicTimer>
 #include <QDialog>
 #include <QFile>
 #include <memory>
@@ -26,6 +25,7 @@
 #include "core/song.h"
 #include "core/tagreaderclient.h"
 
+class QTimer;
 class QCheckBox;
 class QCloseEvent;
 class QLineEdit;
@@ -46,7 +46,6 @@ class RipCDDialog : public QDialog {
  protected:
   void closeEvent(QCloseEvent* event);
   void showEvent(QShowEvent* event);
-  void timerEvent(QTimerEvent* e);
 
  private slots:
   void ClickedRipButton();
@@ -61,6 +60,7 @@ class RipCDDialog : public QDialog {
   void UpdateProgressBar(int progress);
   void BuildTrackListTable(const SongList& songs);
   void AddAlbumMetadataFromMusicBrainz(const SongList& songs);
+  void CheckMediaChanged();
 
  private:
   static const char* kSettingsGroup;
@@ -85,6 +85,6 @@ class RipCDDialog : public QDialog {
   Ripper* ripper_;
   bool working_;
   CddaSongLoader* loader_;
-  QBasicTimer media_changed_timer_;
+  QTimer media_changed_timer_;
 };
 #endif  // SRC_RIPPER_RIPCDDIALOG_H_

--- a/src/ripper/ripcddialog.h
+++ b/src/ripper/ripcddialog.h
@@ -85,7 +85,6 @@ class RipCDDialog : public QDialog {
   Ripper* ripper_;
   bool working_;
   CddaSongLoader* loader_;
-  QMutex mutex_;  // mutex to control access to track list/metadata updates
   QBasicTimer media_changed_timer_;
 };
 #endif  // SRC_RIPPER_RIPCDDIALOG_H_

--- a/src/ripper/ripcddialog.h
+++ b/src/ripper/ripcddialog.h
@@ -18,9 +18,9 @@
 #ifndef SRC_RIPPER_RIPCDDIALOG_H_
 #define SRC_RIPPER_RIPCDDIALOG_H_
 
+#include <QBasicTimer>
 #include <QDialog>
 #include <QFile>
-#include <QThread>
 #include <memory>
 
 #include "core/song.h"
@@ -46,6 +46,7 @@ class RipCDDialog : public QDialog {
  protected:
   void closeEvent(QCloseEvent* event);
   void showEvent(QShowEvent* event);
+  void timerEvent(QTimerEvent* e);
 
  private slots:
   void ClickedRipButton();
@@ -74,20 +75,6 @@ class RipCDDialog : public QDialog {
   void SetWorking(bool working);
   void ResetDialog();
 
-  void MediaChangedPoller();
-
-  class MediaChangedPollingThread : public QThread {
-   public:
-    MediaChangedPollingThread(RipCDDialog& dialog);
-    ~MediaChangedPollingThread() override;
-
-   protected:
-    void run() override;
-
-   private:
-    RipCDDialog& dialog_;
-  };
-
   QList<QCheckBox*> checkboxes_;
   QList<QLineEdit*> track_names_;
   QString last_add_dir_;
@@ -98,7 +85,7 @@ class RipCDDialog : public QDialog {
   Ripper* ripper_;
   bool working_;
   CddaSongLoader* loader_;
-  MediaChangedPollingThread mediaChangedWatchingThread_;
   QMutex mutex_;  // mutex to control access to track list/metadata updates
+  QBasicTimer media_changed_timer_;
 };
 #endif  // SRC_RIPPER_RIPCDDIALOG_H_

--- a/src/ripper/ripcddialog.h
+++ b/src/ripper/ripcddialog.h
@@ -20,6 +20,7 @@
 
 #include <QDialog>
 #include <QFile>
+#include <QThread>
 #include <memory>
 
 #include "core/song.h"
@@ -73,6 +74,21 @@ class RipCDDialog : public QDialog {
   void SetWorking(bool working);
   void ResetDialog();
 
+  void MediaChangedPoller();
+
+  class MediaChangedPollingThread : public QThread {
+
+  public:
+    MediaChangedPollingThread(RipCDDialog& dialog);
+    ~MediaChangedPollingThread() override;
+
+  protected:
+    void run() override;
+
+  private:
+    RipCDDialog& dialog_;
+  };
+
   QList<QCheckBox*> checkboxes_;
   QList<QLineEdit*> track_names_;
   QString last_add_dir_;
@@ -83,5 +99,7 @@ class RipCDDialog : public QDialog {
   Ripper* ripper_;
   bool working_;
   CddaSongLoader* loader_;
+  MediaChangedPollingThread mediaChangedWatchingThread_;
+  QMutex mutex_;  // mutex to control access to track list/metadata updates
 };
 #endif  // SRC_RIPPER_RIPCDDIALOG_H_

--- a/src/ripper/ripcddialog.h
+++ b/src/ripper/ripcddialog.h
@@ -77,15 +77,14 @@ class RipCDDialog : public QDialog {
   void MediaChangedPoller();
 
   class MediaChangedPollingThread : public QThread {
-
-  public:
+   public:
     MediaChangedPollingThread(RipCDDialog& dialog);
     ~MediaChangedPollingThread() override;
 
-  protected:
+   protected:
     void run() override;
 
-  private:
+   private:
     RipCDDialog& dialog_;
   };
 

--- a/src/ripper/ripper.h
+++ b/src/ripper/ripper.h
@@ -128,6 +128,7 @@ class Ripper : public QObject {
   int files_tagged_;
   QList<TrackInformation> tracks_;
   AlbumInformation album_;
+  mutable QMutex cdio_mutex_;
 };
 
 #endif  // SRC_RIPPER_RIPPER_H_


### PR DESCRIPTION
Closes #7023. I essentially added a thread to `RipCDDialog` that periodically polls `Ripper::MediaChanged()` and issues a reloading of track list / metadata if the return value is `true`.

Added a mutex that controls access to data updates in `RipCDDialog` to avoid potential race conditions from media changes and musicbrainz metadata responses (not sure if those could really happen, but figured I'd rather be on the safe side).