### PR TITLE
MusicBrainzClient: Log message for malformed XML in reply

### DIFF
--- a/src/musicbrainz/musicbrainzclient.cpp
+++ b/src/musicbrainz/musicbrainzclient.cpp
@@ -164,6 +164,10 @@ void MusicBrainzClient::DiscIdRequestFinished(const QString& discid,
       break;
     }
   }
+  if (reader.hasError()) {
+    qLog(Error) << "Received a reply from musicbrainz.org for" << discid
+                << " but the XML was not well-formed.";
+  }
 
   // If we parsed a year, copy it to the tracks.
   if (year > 0) {


### PR DESCRIPTION
Simple change to at least log misbehaving musicbrainz replies so they don't fly entirely under the radar, see #7027 