### PR TITLE
Add setting to disable guessing metadata based on filename.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -368,6 +368,7 @@ set(SOURCES
   ui/settingsdialog.cpp
   ui/settingspage.cpp
   ui/splash.cpp
+  ui/songmetadatasettingspage.cpp
   ui/standarditemiconloader.cpp
   ui/streamdetailsdialog.cpp
   ui/systemtrayicon.cpp
@@ -664,6 +665,7 @@ set(HEADERS
   ui/settingscategory.h
   ui/settingsdialog.h
   ui/settingspage.h
+  ui/songmetadatasettingspage.h
   ui/standarditemiconloader.h
   ui/streamdetailsdialog.h
   ui/systemtrayicon.h
@@ -796,6 +798,7 @@ set(UI
   ui/organiseerrordialog.ui
   ui/playbacksettingspage.ui
   ui/settingsdialog.ui
+  ui/songmetadatasettingspage.ui
   ui/streamdetailsdialog.ui
   ui/trackselectiondialog.ui
 

--- a/src/core/tagreaderclient.cpp
+++ b/src/core/tagreaderclient.cpp
@@ -58,6 +58,8 @@ TagReaderClient::~TagReaderClient() {}
 
 void TagReaderClient::Start() { worker_pool_->Start(); }
 
+void TagReaderClient::ReloadSettings() { path_parser_->ReloadSettings(); }
+
 void TagReaderClient::WorkerFailedToStart() {
   qLog(Error) << "The" << kWorkerExecutableName << "executable was not found"
               << "in the current directory or on the PATH.  Clementine will"

--- a/src/core/tagreaderclient.h
+++ b/src/core/tagreaderclient.h
@@ -47,6 +47,7 @@ class TagReaderClient : public QObject {
   static const char* kWorkerExecutableName;
 
   void Start();
+  void ReloadSettings();
 
   ReplyType* ReadFile(const QString& filename);
   ReplyType* SaveFile(const QString& filename, const Song& metadata);

--- a/src/ui/behavioursettingspage.cpp
+++ b/src/ui/behavioursettingspage.cpp
@@ -40,15 +40,6 @@ BehaviourSettingsPage::BehaviourSettingsPage(SettingsDialog* dialog)
   connect(ui_->b_show_tray_icon_, SIGNAL(toggled(bool)),
           SLOT(ShowTrayIconToggled(bool)));
 
-  connect(ui_->max_numprocs_tagclients, SIGNAL(valueChanged(int)),
-          SLOT(MaxNumProcsTagClientsChanged(int)));
-  ui_->max_numprocs_tagclients_value_label->setMinimumWidth(
-      QFontMetrics(ui_->max_numprocs_tagclients_value_label->font())
-          .width("WWW"));
-
-  // Limit max tag clients to number of CPU cores.
-  ui_->max_numprocs_tagclients->setMaximum(QThread::idealThreadCount());
-
   ui_->doubleclick_addmode->setItemData(0, MainWindow::AddBehaviour_Append);
   ui_->doubleclick_addmode->setItemData(1, MainWindow::AddBehaviour_Load);
   ui_->doubleclick_addmode->setItemData(2, MainWindow::AddBehaviour_OpenInNew);
@@ -181,12 +172,6 @@ void BehaviourSettingsPage::Load() {
           .toInt()));
   ui_->seek_step_sec->setValue(s.value("seek_step_sec", 10).toInt());
 
-  int max_numprocs_tagclients =
-      s.value("max_numprocs_tagclients", QThread::idealThreadCount()).toInt();
-  ui_->max_numprocs_tagclients->setValue(max_numprocs_tagclients);
-  ui_->max_numprocs_tagclients_value_label->setText(
-      QString::number(max_numprocs_tagclients));
-
   if (s.value("play_count_short_duration", false).toBool()) {
     ui_->b_play_count_short_duration->setChecked(true);
     ui_->b_play_count_normal_duration->setChecked(false);
@@ -298,7 +283,6 @@ void BehaviourSettingsPage::Save() {
   s.setValue("stop_play_if_fail", ui_->stop_play_if_fail_->isChecked());
   s.setValue("menu_previousmode", menu_previousmode);
   s.setValue("seek_step_sec", ui_->seek_step_sec->value());
-  s.setValue("max_numprocs_tagclients", ui_->max_numprocs_tagclients->value());
 
   if (ui_->b_play_count_short_duration->isChecked()) {
     s.setValue("play_count_short_duration", true);
@@ -336,8 +320,4 @@ void BehaviourSettingsPage::ShowTrayIconToggled(bool on) {
   ui_->b_keep_running_->setEnabled(on);
   ui_->b_keep_running_->setChecked(on);
   ui_->b_scroll_tray_icon_->setEnabled(on);
-}
-
-void BehaviourSettingsPage::MaxNumProcsTagClientsChanged(int value) {
-  ui_->max_numprocs_tagclients_value_label->setText(QString::number(value));
 }

--- a/src/ui/behavioursettingspage.ui
+++ b/src/ui/behavioursettingspage.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>516</width>
-    <height>1081</height>
+    <width>602</width>
+    <height>1395</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -335,48 +335,6 @@
          </size>
         </property>
        </spacer>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_max_tagclients">
-     <property name="title">
-      <string>Maximum number of child processes for tag handling (requires restart)</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_8">
-      <item>
-       <widget class="QLabel" name="numprocs_tagclients_label">
-        <property name="text">
-         <string>Number of processes:</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="max_numprocs_tagclients_value_label">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QSlider" name="max_numprocs_tagclients">
-        <property name="minimum">
-         <number>1</number>
-        </property>
-        <property name="maximum">
-         <number>32</number>
-        </property>
-        <property name="value">
-         <number>4</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="tickInterval">
-         <number>1</number>
-        </property>
-       </widget>
       </item>
      </layout>
     </widget>

--- a/src/ui/settingsdialog.cpp
+++ b/src/ui/settingsdialog.cpp
@@ -41,6 +41,7 @@
 #include "playlist/playlistview.h"
 #include "settingscategory.h"
 #include "songinfo/songinfosettingspage.h"
+#include "songmetadatasettingspage.h"
 #include "transcoder/transcodersettingspage.h"
 #include "ui_settingsdialog.h"
 #include "widgets/groupediconview.h"
@@ -108,6 +109,7 @@ SettingsDialog::SettingsDialog(Application* app, BackgroundStreams* streams,
   general->AddPage(Page_Playback, new PlaybackSettingsPage(this));
   general->AddPage(Page_Behaviour, new BehaviourSettingsPage(this));
   general->AddPage(Page_Library, new LibrarySettingsPage(this));
+  general->AddPage(Page_SongMetadata, new SongMetadataSettingsPage(this));
   general->AddPage(Page_BackgroundStreams,
                    new BackgroundStreamsSettingsPage(this));
   general->AddPage(Page_Proxy, new NetworkProxySettingsPage(this));

--- a/src/ui/settingsdialog.h
+++ b/src/ui/settingsdialog.h
@@ -64,6 +64,7 @@ class SettingsDialog : public QDialog {
     Page_Playback,
     Page_Behaviour,
     Page_Library,
+    Page_SongMetadata,
     Page_BackgroundStreams,
     Page_Proxy,
     Page_Transcoding,

--- a/src/ui/settingsdialog.h
+++ b/src/ui/settingsdialog.h
@@ -60,24 +60,29 @@ class SettingsDialog : public QDialog {
   ~SettingsDialog();
 
   enum Page {
+    // General
     Page_Playback,
     Page_Behaviour,
+    Page_Library,
+    Page_BackgroundStreams,
+    Page_Proxy,
+    Page_Transcoding,
+    Page_NetworkRemote,
+    Page_Wiimotedev,
+
+    // User interface
     Page_SongInformation,
     Page_GlobalShortcuts,
     Page_GlobalSearch,
     Page_Appearance,
-    Page_NetworkRemote,
     Page_Notifications,
-    Page_Library,
+
+    // Internet services
+    Page_InternetShow,
     Page_Lastfm,
     Page_Spotify,
     Page_Magnatune,
     Page_DigitallyImported,
-    Page_BackgroundStreams,
-    Page_Proxy,
-    Page_Transcoding,
-    Page_Remote,
-    Page_Wiimotedev,
     Page_Subsonic,
     Page_Podcasts,
     Page_GoogleDrive,
@@ -85,7 +90,6 @@ class SettingsDialog : public QDialog {
     Page_Skydrive,
     Page_Box,
     Page_Seafile,
-    Page_InternetShow,
     Page_AmazonCloudDrive,
     Page_RadioBrowser,
   };

--- a/src/ui/songmetadatasettingspage.cpp
+++ b/src/ui/songmetadatasettingspage.cpp
@@ -1,0 +1,68 @@
+/* This file is part of Clementine.
+   Copyright 2021, Jim Broadus <jbroadus@gmail.com>
+
+   Clementine is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Clementine is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "songmetadatasettingspage.h"
+
+#include <QSettings>
+#include <QThread>
+
+#include "core/player.h"
+#include "ui/iconloader.h"
+#include "ui_songmetadatasettingspage.h"
+
+SongMetadataSettingsPage::SongMetadataSettingsPage(SettingsDialog* dialog)
+    : SettingsPage(dialog), ui_(new Ui_SongMetadataSettingsPage) {
+  ui_->setupUi(this);
+  setWindowIcon(IconLoader::Load("view-media-lyrics", IconLoader::Base));
+
+  connect(ui_->max_numprocs_tagclients, SIGNAL(valueChanged(int)),
+          SLOT(MaxNumProcsTagClientsChanged(int)));
+  ui_->max_numprocs_tagclients_value_label->setMinimumWidth(
+      QFontMetrics(ui_->max_numprocs_tagclients_value_label->font())
+          .width("WWW"));
+
+  // Limit max tag clients to number of CPU cores.
+  ui_->max_numprocs_tagclients->setMaximum(QThread::idealThreadCount());
+}
+
+SongMetadataSettingsPage::~SongMetadataSettingsPage() { delete ui_; }
+
+void SongMetadataSettingsPage::Load() {
+  QSettings s;
+  s.beginGroup(Player::kSettingsGroup);
+
+  int max_numprocs_tagclients =
+      s.value("max_numprocs_tagclients", QThread::idealThreadCount()).toInt();
+  ui_->max_numprocs_tagclients->setValue(max_numprocs_tagclients);
+  ui_->max_numprocs_tagclients_value_label->setText(
+      QString::number(max_numprocs_tagclients));
+
+  s.endGroup();
+}
+
+void SongMetadataSettingsPage::Save() {
+  QSettings s;
+  s.beginGroup(Player::kSettingsGroup);
+
+  s.setValue("max_numprocs_tagclients", ui_->max_numprocs_tagclients->value());
+
+  s.endGroup();
+}
+
+void SongMetadataSettingsPage::MaxNumProcsTagClientsChanged(int value) {
+  ui_->max_numprocs_tagclients_value_label->setText(QString::number(value));
+}

--- a/src/ui/songmetadatasettingspage.cpp
+++ b/src/ui/songmetadatasettingspage.cpp
@@ -21,6 +21,8 @@
 #include <QThread>
 
 #include "core/player.h"
+#include "core/songpathparser.h"
+#include "core/tagreaderclient.h"
 #include "ui/iconloader.h"
 #include "ui_songmetadatasettingspage.h"
 
@@ -52,6 +54,14 @@ void SongMetadataSettingsPage::Load() {
       QString::number(max_numprocs_tagclients));
 
   s.endGroup();
+
+  s.beginGroup(SongPathParser::kSongMetadataSettingsGroup);
+  bool guess = s.value(SongPathParser::kGuessMetadataSetting,
+                       SongPathParser::kGuessMetadataSettingDefault)
+                   .toBool();
+  ui_->guess_metadata->setCheckState(guess ? Qt::Checked : Qt::Unchecked);
+
+  s.endGroup();
 }
 
 void SongMetadataSettingsPage::Save() {
@@ -61,6 +71,15 @@ void SongMetadataSettingsPage::Save() {
   s.setValue("max_numprocs_tagclients", ui_->max_numprocs_tagclients->value());
 
   s.endGroup();
+
+  s.beginGroup(SongPathParser::kSongMetadataSettingsGroup);
+
+  s.setValue(SongPathParser::kGuessMetadataSetting,
+             ui_->guess_metadata->checkState() != Qt::Unchecked);
+
+  s.endGroup();
+
+  TagReaderClient::Instance()->ReloadSettings();
 }
 
 void SongMetadataSettingsPage::MaxNumProcsTagClientsChanged(int value) {

--- a/src/ui/songmetadatasettingspage.h
+++ b/src/ui/songmetadatasettingspage.h
@@ -1,5 +1,5 @@
 /* This file is part of Clementine.
-   Copyright 2010, David Sansome <me@davidsansome.com>
+   Copyright 2021, Jim Broadus <jbroadus@gmail.com>
 
    Clementine is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -15,32 +15,28 @@
    along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef BEHAVIOURSETTINGSPAGE_H
-#define BEHAVIOURSETTINGSPAGE_H
-
-#include <QMap>
+#ifndef SONGMETADATASETTINGSPAGE_H
+#define SONGMETADATASETTINGSPAGE_H
 
 #include "settingspage.h"
 
-class Ui_BehaviourSettingsPage;
+class Ui_SongMetadataSettingsPage;
 
-class BehaviourSettingsPage : public SettingsPage {
+class SongMetadataSettingsPage : public SettingsPage {
   Q_OBJECT
 
  public:
-  BehaviourSettingsPage(SettingsDialog* dialog);
-  ~BehaviourSettingsPage();
+  SongMetadataSettingsPage(SettingsDialog* dialog);
+  ~SongMetadataSettingsPage();
 
   void Load();
   void Save();
 
  private slots:
-  void ShowTrayIconToggled(bool on);
+  void MaxNumProcsTagClientsChanged(int value);
 
  private:
-  Ui_BehaviourSettingsPage* ui_;
-
-  QMap<QString, QString> language_map_;
+  Ui_SongMetadataSettingsPage* ui_;
 };
 
-#endif  // BEHAVIOURSETTINGSPAGE_H
+#endif  // SONGMETADATASETTINGSPAGE_H

--- a/src/ui/songmetadatasettingspage.ui
+++ b/src/ui/songmetadatasettingspage.ui
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SongMetadataSettingsPage</class>
+ <widget class="QWidget" name="SongMetadataSettingsPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>602</width>
+    <height>1395</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Song Metadata</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="groupBox_max_tagclients">
+     <property name="title">
+      <string>Maximum number of child processes for tag handling (requires restart)</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_8">
+      <item>
+       <widget class="QLabel" name="numprocs_tagclients_label">
+        <property name="text">
+         <string>Number of processes:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="max_numprocs_tagclients_value_label">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QSlider" name="max_numprocs_tagclients">
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>32</number>
+        </property>
+        <property name="value">
+         <number>4</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="tickInterval">
+         <number>1</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>5</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/ui/songmetadatasettingspage.ui
+++ b/src/ui/songmetadatasettingspage.ui
@@ -57,6 +57,16 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="guess_metadata">
+     <property name="toolTip">
+      <string>Try to extract title, artist, and album from file path.</string>
+     </property>
+     <property name="text">
+      <string>Try to guess missing metadata</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>


### PR DESCRIPTION
Created a new Song Metadata settings page and move the and moved the tagreader settings here. Added the new "Try to guess missing metadata" setting here to control the setting added in 1309c76be.

I created the new settings page because the behavior page is really crowded and I think more settings can be added for the metadata guessing features, but I'm open to suggestions if "Song Metadata" doesn't feel right. I also used the song info icon for the new page. Maybe somebody who is better at GIMP than I am can come up with something new.

Partial fix for #6952
