### PR TITLE
Radiobrowser.info: use the url_resolved field for radio stations

### DIFF
--- a/src/internet/radiobrowser/radiobrowserservice.cpp
+++ b/src/internet/radiobrowser/radiobrowserservice.cpp
@@ -433,7 +433,7 @@ void RadioBrowserService::ResolveStationUrl(const QUrl& original_url) {
     Song ret;
     ret.set_valid(true);
     ret.set_title(item["name"].toString());
-    QUrl url(item["url"].toString());
+    QUrl url(item["url_resolved"].toString());
     ret.set_url(url);
     ret.set_art_automatic(item["favicon"].toString());
 

--- a/src/internet/radiobrowser/radiobrowserservice.cpp
+++ b/src/internet/radiobrowser/radiobrowserservice.cpp
@@ -434,6 +434,7 @@ void RadioBrowserService::ResolveStationUrl(const QUrl& original_url) {
     ret.set_valid(true);
     ret.set_title(item["name"].toString());
     QUrl url(item["url_resolved"].toString());
+    if (url.isEmpty()) url.setUrl(item["url"].toString());
     ret.set_url(url);
     ret.set_art_automatic(item["favicon"].toString());
 


### PR DESCRIPTION
Some radio stations on radiobrowser.info contain a playlist address in the "url" field.
The radiobrowser API is so kind to provide also a url_resolved field containing the resolved url of the audio stream.
This PR switches from the "url" to the "url_resolved" field to fix playback of those stations.

Fix #6988 