### PR TITLE
Add a shortcut to go to next album

### DIFF
--- a/src/core/globalshortcuts.cpp
+++ b/src/core/globalshortcuts.cpp
@@ -58,6 +58,8 @@ GlobalShortcuts::GlobalShortcuts(QWidget* parent)
               SIGNAL(StopAfter()));
   AddShortcut("next_track", tr("Next track"), SIGNAL(Next()),
               QKeySequence(Qt::Key_MediaNext));
+  AddShortcut("next_album", tr("Next album"), SIGNAL(NextAlbum()),
+              QKeySequence(Qt::Key_MediaNext + Qt::SHIFT));
   AddShortcut("prev_track", tr("Previous track"), SIGNAL(Previous()),
               QKeySequence(Qt::Key_MediaPrevious));
   AddShortcut("inc_volume", tr("Increase volume"), SIGNAL(IncVolume()));

--- a/src/core/globalshortcuts.h
+++ b/src/core/globalshortcuts.h
@@ -66,6 +66,7 @@ class GlobalShortcuts : public QWidget {
   void Stop();
   void StopAfter();
   void Next();
+  void NextAlbum();
   void Previous();
   void IncVolume();
   void DecVolume();

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -862,6 +862,8 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
           ui_->action_stop_after_this_track, SLOT(trigger()));
   connect(global_shortcuts_, SIGNAL(Next()), ui_->action_next_track,
           SLOT(trigger()));
+  connect(global_shortcuts_, SIGNAL(NextAlbum()), ui_->action_next_album,
+          SLOT(trigger()));
   connect(global_shortcuts_, SIGNAL(Previous()), ui_->action_previous_track,
           SLOT(trigger()));
   connect(global_shortcuts_, SIGNAL(IncVolume()), app_->player(),


### PR DESCRIPTION
It was not possible to bind a global shortcut for skipping to the next album. This is easily fixed with some Qt signal plumbing.