### PR TITLE
Add error message mechanism to playlist parsers

### DIFF
--- a/src/playlist/playlistmanager.cpp
+++ b/src/playlist/playlistmanager.cpp
@@ -79,6 +79,7 @@ void PlaylistManager::Init(LibraryBackend* library_backend,
   connect(library_backend_, SIGNAL(SongsRatingChanged(SongList)),
           SLOT(SongsDiscovered(SongList)));
 
+  connect(parser_, SIGNAL(Error(QString)), this, SIGNAL(Error(QString)));
   for (const PlaylistBackend::Playlist& p :
        playlist_backend->GetAllOpenPlaylists()) {
     AddPlaylist(p.id, p.name, p.special_type, p.ui_path, p.favorite);

--- a/src/playlistparsers/cueparser.cpp
+++ b/src/playlistparsers/cueparser.cpp
@@ -348,7 +348,9 @@ qint64 CueParser::IndexToMarker(const QString& index) const {
 
 void CueParser::Save(const SongList& songs, QIODevice* device, const QDir& dir,
                      Playlist::Path path_type) const {
-  // TODO
+  // TODO: Not yet implemented. Cue files represent tracks within a single
+  //       file, so the song list would need to be composed properly.
+  emit Error(tr("Saving cue files is not yet supported."));
 }
 
 // Looks for a track starting with one of the .cue's keywords.

--- a/src/playlistparsers/parserbase.h
+++ b/src/playlistparsers/parserbase.h
@@ -55,6 +55,9 @@ class ParserBase : public QObject {
       const SongList& songs, QIODevice* device, const QDir& dir = QDir(),
       Playlist::Path path_type = Playlist::Path_Automatic) const = 0;
 
+ signals:
+  void Error(const QString& msg) const;
+
  protected:
   // Loads a song.  If filename_or_url is a URL (with a scheme other than
   // "file") then it is set on the song and the song marked as a stream.

--- a/src/playlistparsers/playlistparser.cpp
+++ b/src/playlistparsers/playlistparser.cpp
@@ -35,13 +35,18 @@ PlaylistParser::PlaylistParser(LibraryBackendInterface* library,
                                QObject* parent)
     : QObject(parent) {
   default_parser_ = new XSPFParser(library, this);
-  parsers_ << new M3UParser(library, this);
-  parsers_ << default_parser_;
-  parsers_ << new PLSParser(library, this);
-  parsers_ << new ASXParser(library, this);
-  parsers_ << new AsxIniParser(library, this);
-  parsers_ << new CueParser(library, this);
-  parsers_ << new WplParser(library, this);
+  AddParser(new M3UParser(library, this));
+  AddParser(default_parser_);
+  AddParser(new PLSParser(library, this));
+  AddParser(new ASXParser(library, this));
+  AddParser(new AsxIniParser(library, this));
+  AddParser(new CueParser(library, this));
+  AddParser(new WplParser(library, this));
+}
+
+void PlaylistParser::AddParser(ParserBase* parser) {
+  parsers_ << parser;
+  connect(parser, SIGNAL(Error(QString)), this, SIGNAL(Error(QString)));
 }
 
 QStringList PlaylistParser::file_extensions() const {

--- a/src/playlistparsers/playlistparser.cpp
+++ b/src/playlistparsers/playlistparser.cpp
@@ -129,6 +129,7 @@ SongList PlaylistParser::LoadFromFile(const QString& filename) const {
   // Find a parser that supports this file extension
   ParserBase* parser = ParserForExtension(info.suffix());
   if (!parser) {
+    emit Error(tr("Unknown filetype: %1").arg(filename));
     qLog(Warning) << "Unknown filetype:" << filename;
     return SongList();
   }
@@ -159,6 +160,7 @@ void PlaylistParser::Save(const SongList& songs, const QString& filename,
   // Find a parser that supports this file extension
   ParserBase* parser = ParserForExtension(info.suffix());
   if (!parser) {
+    emit Error(tr("Unknown filetype: %1").arg(filename));
     qLog(Warning) << "Unknown filetype:" << filename;
     return;
   }

--- a/src/playlistparsers/playlistparser.h
+++ b/src/playlistparsers/playlistparser.h
@@ -55,6 +55,9 @@ class PlaylistParser : public QObject {
   void Save(const SongList& songs, const QString& filename,
             Playlist::Path) const;
 
+ signals:
+  void Error(const QString& msg) const;
+
  private:
   QString FilterForParser(const ParserBase* parser,
                           QStringList* all_extensions = nullptr) const;

--- a/src/playlistparsers/playlistparser.h
+++ b/src/playlistparsers/playlistparser.h
@@ -59,6 +59,8 @@ class PlaylistParser : public QObject {
   void Error(const QString& msg) const;
 
  private:
+  void AddParser(ParserBase* parser);
+
   QString FilterForParser(const ParserBase* parser,
                           QStringList* all_extensions = nullptr) const;
 


### PR DESCRIPTION
Add an Error signal to PlayListParser and connect that to the PlayListManager::Error signal. This is eventually connected to the
Application::AddError. Add error messages in some cases where PlayListParser can fail silently.

Add a new Error signal to parser implementations as well. Display an error when user tries to use the unimplemented CueParser::Save.