### PR TITLE
cueparser: Be more lenient when parsing indexes.

### DIFF
--- a/src/playlistparsers/cueparser.cpp
+++ b/src/playlistparsers/cueparser.cpp
@@ -31,7 +31,8 @@
 
 const char* CueParser::kFileLineRegExp =
     "(\\S+)\\s+(?:\"([^\"]+)\"|(\\S+))\\s*(?:\"([^\"]+)\"|(\\S+))?";
-const char* CueParser::kIndexRegExp = "(\\d{2,3}):(\\d{2}):(\\d{2})";
+// Most cue specs specify mm:ss:ff, but we can be more flexible here.
+const char* CueParser::kIndexRegExp = "(\\d{1,3}):(\\d{2}):(\\d{2})";
 
 const char* CueParser::kPerformer = "performer";
 const char* CueParser::kTitle = "title";
@@ -336,6 +337,7 @@ bool CueParser::UpdateLastSong(const CueEntry& entry, Song* song) const {
 qint64 CueParser::IndexToMarker(const QString& index) const {
   QRegExp index_regexp(kIndexRegExp);
   if (!index_regexp.exactMatch(index)) {
+    qLog(Warning) << "Could not parse index" << index;
     return -1;
   }
 


### PR DESCRIPTION
Most specs have mm:ss:ff as the index time format, but cue files have
been found with single digit minutes. e.g. 0:00:00 instead of 00:00:00

Reference: https://www.gnu.org/software/ccd2cue/manual/html_node/CUE-sheet-format.html

This is a fix for #7042