### PR TITLE
transcoder: Add options avenc_aac element.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -323,6 +323,7 @@ set(SOURCES
   transcoder/transcodedialog.cpp
   transcoder/transcoder.cpp
   transcoder/transcoderoptionsaac.cpp
+  transcoder/transcoderoptionsavaac.cpp
   transcoder/transcoderoptionsdialog.cpp
   transcoder/transcoderoptionserror.cpp
   transcoder/transcoderoptionsfdkaac.cpp
@@ -630,6 +631,7 @@ set(HEADERS
 
   transcoder/transcodedialog.h
   transcoder/transcoder.h
+  transcoder/transcoderoptionsavaac.h
   transcoder/transcoderoptionsdialog.h
   transcoder/transcoderoptionsmp3.h
   transcoder/transcoderoptionsfdkaac.h
@@ -763,6 +765,7 @@ set(UI
   transcoder/transcodedialog.ui
   transcoder/transcodelogdialog.ui
   transcoder/transcoderoptionsaac.ui
+  transcoder/transcoderoptionsavaac.ui
   transcoder/transcoderoptionsdialog.ui
   transcoder/transcoderoptionserror.ui
   transcoder/transcoderoptionsfdkaac.ui

--- a/src/transcoder/transcoderoptionsavaac.cpp
+++ b/src/transcoder/transcoderoptionsavaac.cpp
@@ -1,0 +1,100 @@
+/* This file is part of Clementine.
+   Copyright 2021, Jim Broadus <jbroadus@gmail.com>
+
+   Clementine is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Clementine is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*
+ Settings for the avenc_aac gstreamer element.
+ https://gstreamer.freedesktop.org/documentation/libav/avenc_aac.html
+*/
+
+#include "transcoderoptionsavaac.h"
+
+#include <QSettings>
+
+#include "core/logging.h"
+#include "ui_transcoderoptionsavaac.h"
+
+const char* TranscoderOptionsAvAAC::kSettingsGroup = "Transcoder/avenc_aac";
+
+TranscoderOptionsAvAAC::TranscoderOptionsAvAAC(QWidget* parent)
+    : TranscoderOptionsInterface(parent), ui_(new Ui_TranscoderOptionsAvAAC) {
+  ui_->setupUi(this);
+  connect(ui_->bitrate_target, SIGNAL(toggled(bool)),
+          SLOT(TargetBitrateToggle(bool)));
+}
+
+TranscoderOptionsAvAAC::~TranscoderOptionsAvAAC() { delete ui_; }
+
+void TranscoderOptionsAvAAC::Load() {
+  QSettings s;
+  s.beginGroup(kSettingsGroup + settings_postfix_);
+
+  // The gst-libav defaults to "fast". ffmpeg's default is twoloop.
+  int encoder = s.value("aac-coder", 2).toInt();
+  switch (encoder) {
+    case 0:
+      ui_->encoder_anmr->setChecked(true);
+      break;
+    case 1:
+      ui_->encoder_twoloop->setChecked(true);
+      break;
+    default:
+      qLog(Warning) << "Unknown encoder setting" << encoder;
+      // Fall through.
+    case 2:
+      ui_->encoder_fast->setChecked(true);
+      break;
+  }
+
+  // If bitrate is set to 0 (default), then the codec default.
+  int bitrate = s.value("bitrate", 0).toInt();
+  if (bitrate == 0) {
+    ui_->bitrate_default->setChecked(true);
+    ui_->bitrate_group->setEnabled(false);
+  } else {
+    ui_->bitrate_target->setChecked(true);
+    ui_->bitrate_slider->setValue(bitrate / 1000);
+  }
+}
+
+void TranscoderOptionsAvAAC::Save() {
+  QSettings s;
+  s.beginGroup(kSettingsGroup + settings_postfix_);
+
+  int encoder;
+  int strict = 0;
+  if (ui_->encoder_anmr->isChecked()) {
+    encoder = 0;
+    // Allow experimental
+    strict = -2;
+  } else if (ui_->encoder_twoloop->isChecked()) {
+    encoder = 1;
+  } else {
+    encoder = 2;
+  }
+  s.setValue("aac-coder", encoder);
+  s.setValue("strict", strict);
+
+  if (ui_->bitrate_target->isChecked()) {
+    s.setValue("bitrate", ui_->bitrate_slider->value() * 1000);
+  } else {
+    s.setValue("bitrate", 0);
+  }
+}
+
+void TranscoderOptionsAvAAC::TargetBitrateToggle(bool checked) {
+  ui_->bitrate_group->setEnabled(checked);
+}

--- a/src/transcoder/transcoderoptionsavaac.h
+++ b/src/transcoder/transcoderoptionsavaac.h
@@ -1,0 +1,44 @@
+/* This file is part of Clementine.
+   Copyright 2021, Jim Broadus <jbroadus@gmail.com>
+
+   Clementine is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Clementine is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef TRANSCODEROPTIONSAVAAC_H
+#define TRANSCODEROPTIONSAVAAC_H
+
+#include "transcoderoptionsinterface.h"
+
+class Ui_TranscoderOptionsAvAAC;
+
+class TranscoderOptionsAvAAC : public TranscoderOptionsInterface {
+  Q_OBJECT
+
+ public:
+  TranscoderOptionsAvAAC(QWidget* parent = nullptr);
+  ~TranscoderOptionsAvAAC();
+
+  void Load();
+  void Save();
+
+ private slots:
+  void TargetBitrateToggle(bool checked);
+
+ private:
+  static const char* kSettingsGroup;
+
+  Ui_TranscoderOptionsAvAAC* ui_;
+};
+
+#endif  // TRANSCODEROPTIONSAVAAC_H

--- a/src/transcoder/transcoderoptionsavaac.ui
+++ b/src/transcoder/transcoderoptionsavaac.ui
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TranscoderOptionsAvAAC</class>
+ <widget class="QWidget" name="TranscoderOptionsAvAAC">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>480</width>
+    <height>344</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="encoder_group">
+     <property name="title">
+      <string>Encoder</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <widget class="QRadioButton" name="encoder_fast">
+        <property name="text">
+         <string>Fast search</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="encoder_twoloop">
+        <property name="text">
+         <string>Two loop searching method</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="encoder_anmr">
+        <property name="text">
+         <string> ANMR method (experimental)</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="bitrateGroup">
+     <property name="title">
+      <string>Bitrate</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QRadioButton" name="bitrate_default">
+        <property name="text">
+         <string>Use default bitrate</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="bitrate_target">
+        <property name="text">
+         <string>Set target rate</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="bitrate_group">
+        <property name="title">
+         <string/>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QSpinBox" name="bitrate_spinbox">
+           <property name="suffix">
+            <string> kbps</string>
+           </property>
+           <property name="minimum">
+            <number>8</number>
+           </property>
+           <property name="maximum">
+            <number>320</number>
+           </property>
+           <property name="singleStep">
+            <number>8</number>
+           </property>
+           <property name="value">
+            <number>128</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSlider" name="bitrate_slider">
+           <property name="minimum">
+            <number>8</number>
+           </property>
+           <property name="maximum">
+            <number>320</number>
+           </property>
+           <property name="value">
+            <number>128</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>bitrate_slider</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>bitrate_spinbox</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>170</x>
+     <y>29</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>445</x>
+     <y>24</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>bitrate_spinbox</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>bitrate_slider</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>407</x>
+     <y>18</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>191</x>
+     <y>29</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/transcoder/transcoderoptionsdialog.cpp
+++ b/src/transcoder/transcoderoptionsdialog.cpp
@@ -21,6 +21,7 @@
 #include "core/utilities.h"
 #include "transcoder.h"
 #include "transcoderoptionsaac.h"
+#include "transcoderoptionsavaac.h"
 #include "transcoderoptionserror.h"
 #include "transcoderoptionsfdkaac.h"
 #include "transcoderoptionsflac.h"
@@ -76,7 +77,9 @@ TranscoderOptionsInterface* TranscoderOptionsDialog::MakeOptionsPage(
   QString element = Transcoder::GetEncoderFactoryForMimeType(mime_type);
 
   qLog(Debug) << "Options for element" << element;
-  if (element == "flacenc") {
+  if (element == "avenc_aac") {
+    return new TranscoderOptionsAvAAC(parent);
+  } else if (element == "flacenc") {
     return new TranscoderOptionsFlac(parent);
   } else if (element == "faac") {
     return new TranscoderOptionsAAC(parent);


### PR DESCRIPTION
Initially adding encoder and bitrate settings, but the gstreamer
element exposes a lot of ffmpeg options that can be added as needed.

Reference: https://gstreamer.freedesktop.org/documentation/libav/avenc_aac.html

Fix for #7049