### PR TITLE
Allow developer to use clang for the compilation

### DIFF
--- a/src/devices/cddadevice.h
+++ b/src/devices/cddadevice.h
@@ -45,7 +45,9 @@ class CddaDevice : public ConnectedDevice {
 
   bool Init() override;
   bool CopyToStorage(const MusicStorage::CopyJob&) override { return false; }
-  bool DeleteFromStorage(const MusicStorage::DeleteJob&) override { return false; }
+  bool DeleteFromStorage(const MusicStorage::DeleteJob&) override {
+    return false;
+  }
   CddaSongLoader* loader();
   // Access to the raw cdio device handle.
   CdIo_t* raw_cdio();  // TODO: not ideal, but Ripper needs this currently

--- a/src/devices/cddadevice.h
+++ b/src/devices/cddadevice.h
@@ -44,8 +44,8 @@ class CddaDevice : public ConnectedDevice {
   ~CddaDevice();
 
   bool Init() override;
-  bool CopyToStorage(const MusicStorage::CopyJob&) { return false; }
-  bool DeleteFromStorage(const MusicStorage::DeleteJob&) { return false; }
+  bool CopyToStorage(const MusicStorage::CopyJob&) override { return false; }
+  bool DeleteFromStorage(const MusicStorage::DeleteJob&) override { return false; }
   CddaSongLoader* loader();
   // Access to the raw cdio device handle.
   CdIo_t* raw_cdio();  // TODO: not ideal, but Ripper needs this currently

--- a/src/devices/gpoddevice.h
+++ b/src/devices/gpoddevice.h
@@ -41,15 +41,15 @@ class GPodDevice : public ConnectedDevice, public virtual MusicStorage {
 
   static QStringList url_schemes() { return QStringList() << "ipod"; }
 
-  bool GetSupportedFiletypes(QList<Song::FileType>* ret);
+  bool GetSupportedFiletypes(QList<Song::FileType>* ret) override;
 
-  bool StartCopy(QList<Song::FileType>* supported_types);
-  bool CopyToStorage(const CopyJob& job);
-  void FinishCopy(bool success);
+  bool StartCopy(QList<Song::FileType>* supported_types) override;
+  bool CopyToStorage(const CopyJob& job) override;
+  void FinishCopy(bool success) override;
 
-  void StartDelete();
-  bool DeleteFromStorage(const DeleteJob& job);
-  void FinishDelete(bool success);
+  void StartDelete() override;
+  bool DeleteFromStorage(const DeleteJob& job) override;
+  void FinishDelete(bool success) override;
 
  protected slots:
   void LoadFinished(Itdb_iTunesDB* db);

--- a/src/devices/mtpdevice.h
+++ b/src/devices/mtpdevice.h
@@ -44,19 +44,19 @@ class MtpDevice : public ConnectedDevice {
   }
 
   bool Init() override;
-  void ConnectAsync();
+  void ConnectAsync() override;
 
-  bool GetSupportedFiletypes(QList<Song::FileType>* ret);
+  bool GetSupportedFiletypes(QList<Song::FileType>* ret) override;
   int GetFreeSpace();
   int GetCapacity();
 
-  bool StartCopy(QList<Song::FileType>* supported_types);
-  bool CopyToStorage(const CopyJob& job);
-  void FinishCopy(bool success);
+  bool StartCopy(QList<Song::FileType>* supported_types) override;
+  bool CopyToStorage(const CopyJob& job) override;
+  void FinishCopy(bool success) override;
 
-  void StartDelete();
-  bool DeleteFromStorage(const DeleteJob& job);
-  void FinishDelete(bool success);
+  void StartDelete() override;
+  bool DeleteFromStorage(const DeleteJob& job) override;
+  void FinishDelete(bool success) override;
 
  private slots:
   void LoadFinished(bool success);

--- a/src/internet/core/cloudfileservice.h
+++ b/src/internet/core/cloudfileservice.h
@@ -43,8 +43,8 @@ class CloudFileService : public InternetService {
                    const QIcon& icon, SettingsDialog::Page settings_page);
 
   // InternetService
-  virtual QStandardItem* CreateRootItem();
-  virtual void LazyPopulate(QStandardItem* item);
+  virtual QStandardItem* CreateRootItem() override;
+  virtual void LazyPopulate(QStandardItem* item) override;
 
   virtual bool has_credentials() const = 0;
   bool is_indexing() const { return indexing_task_id_ != -1; }

--- a/src/internet/googledrive/googledriveservice.h
+++ b/src/internet/googledrive/googledriveservice.h
@@ -39,7 +39,7 @@ class GoogleDriveService : public CloudFileService {
   static const char* kServiceName;
   static const char* kSettingsGroup;
 
-  virtual bool has_credentials() const;
+  virtual bool has_credentials() const override;
 
   google_drive::Client* client() const { return client_; }
   QString refresh_token() const;
@@ -47,7 +47,7 @@ class GoogleDriveService : public CloudFileService {
   QUrl GetStreamingUrlFromSongId(const QString& file_id);
 
  public slots:
-  void Connect();
+  void Connect() override;
   void ForgetCredentials();
 
  signals:

--- a/src/internet/skydrive/skydriveservice.h
+++ b/src/internet/skydrive/skydriveservice.h
@@ -37,13 +37,13 @@ class SkydriveService : public CloudFileService {
   static const char* kServiceName;
   static const char* kSettingsGroup;
 
-  virtual bool has_credentials() const;
+  virtual bool has_credentials() const override;
   QUrl GetStreamingUrlFromSongId(const QString& song_id);
 
   QString GetScheme() const { return "onedrive"; }
 
  public slots:
-  virtual void Connect();
+  virtual void Connect() override;
   void ForgetCredentials();
 
  private slots:


### PR DESCRIPTION
The existing master cannot be built by clang, because it enforces all overrided virtual functions are specified with the "override" keyword.

The problem is now fixed after adding all those missing keywords