### PR TITLE
internet: Consolidate ShowConfig methods.

### DIFF
--- a/src/globalsearch/digitallyimportedsearchprovider.cpp
+++ b/src/globalsearch/digitallyimportedsearchprovider.cpp
@@ -52,6 +52,4 @@ void DigitallyImportedSearchProvider::RecreateItems() {
   SetItems(items);
 }
 
-void DigitallyImportedSearchProvider::ShowConfig() {
-  service_->ShowSettingsDialog();
-}
+void DigitallyImportedSearchProvider::ShowConfig() { service_->ShowConfig(); }

--- a/src/internet/core/cloudfilesearchprovider.cpp
+++ b/src/internet/core/cloudfilesearchprovider.cpp
@@ -34,7 +34,7 @@ bool CloudFileSearchProvider::IsLoggedIn() {
   return service_->has_credentials();
 }
 
-void CloudFileSearchProvider::ShowConfig() { service_->ShowSettingsDialog(); }
+void CloudFileSearchProvider::ShowConfig() { service_->ShowConfig(); }
 
 InternetService* CloudFileSearchProvider::internet_service() {
   return service_;

--- a/src/internet/core/cloudfileservice.cpp
+++ b/src/internet/core/cloudfileservice.cpp
@@ -84,7 +84,7 @@ void CloudFileService::LazyPopulate(QStandardItem* item) {
   switch (item->data(InternetModel::Role_Type).toInt()) {
     case InternetModel::Type_Service:
       if (!has_credentials()) {
-        ShowSettingsDialog();
+        ShowConfig();
       } else {
         Connect();
       }
@@ -103,8 +103,7 @@ void CloudFileService::PopulateContextMenu() {
                            tr("Cover Manager"), this, SLOT(ShowCoverManager()));
   context_menu_->addSeparator();
   context_menu_->addAction(IconLoader::Load("configure", IconLoader::Base),
-                           tr("Configure..."), this,
-                           SLOT(ShowSettingsDialog()));
+                           tr("Configure..."), this, SLOT(ShowConfig()));
 }
 
 void CloudFileService::ShowCoverManager() {
@@ -122,7 +121,7 @@ void CloudFileService::AddToPlaylist(QMimeData* mime) {
                                              QModelIndex());
 }
 
-void CloudFileService::ShowSettingsDialog() {
+void CloudFileService::ShowConfig() {
   app_->OpenSettingsDialogAtPage(settings_page_);
 }
 

--- a/src/internet/core/cloudfileservice.h
+++ b/src/internet/core/cloudfileservice.h
@@ -53,7 +53,7 @@ class CloudFileService : public InternetService {
   void AllIndexingTasksFinished();
 
  public slots:
-  void ShowSettingsDialog();
+  void ShowConfig() override;
 
  protected:
   virtual void Connect() = 0;

--- a/src/internet/digitally/digitallyimportedservicebase.cpp
+++ b/src/internet/digitally/digitallyimportedservicebase.cpp
@@ -127,7 +127,7 @@ void DigitallyImportedServiceBase::PopulateStreams() {
   if (root_->hasChildren()) root_->removeRows(0, root_->rowCount());
 
   if (!is_premium_account()) {
-    ShowSettingsDialog();
+    ShowConfig();
     return;
   }
 
@@ -180,8 +180,7 @@ void DigitallyImportedServiceBase::ShowContextMenu(const QPoint& global_pos) {
                              SLOT(ForceRefreshStreams()));
     context_menu_->addSeparator();
     context_menu_->addAction(IconLoader::Load("configure", IconLoader::Base),
-                             tr("Configure..."), this,
-                             SLOT(ShowSettingsDialog()));
+                             tr("Configure..."), this, SLOT(ShowConfig()));
   }
 
   context_menu_->popup(global_pos);
@@ -204,7 +203,7 @@ void DigitallyImportedServiceBase::LoadPlaylistFinished(QNetworkReply* reply) {
   }
 }
 
-void DigitallyImportedServiceBase::ShowSettingsDialog() {
+void DigitallyImportedServiceBase::ShowConfig() {
   app_->OpenSettingsDialogAtPage(SettingsDialog::Page_DigitallyImported);
 }
 

--- a/src/internet/digitally/digitallyimportedservicebase.h
+++ b/src/internet/digitally/digitallyimportedservicebase.h
@@ -65,7 +65,7 @@ class DigitallyImportedServiceBase : public InternetService {
                        Song* song) const;
 
  public slots:
-  void ShowSettingsDialog();
+  void ShowConfig() override;
 
  signals:
   void StreamsChanged();

--- a/src/internet/dropbox/dropboxservice.cpp
+++ b/src/internet/dropbox/dropboxservice.cpp
@@ -76,7 +76,7 @@ void DropboxService::Connect() {
   if (has_credentials()) {
     RequestFileList();
   } else {
-    ShowSettingsDialog();
+    ShowConfig();
   }
 }
 

--- a/src/internet/googledrive/googledriveservice.cpp
+++ b/src/internet/googledrive/googledriveservice.cpp
@@ -226,8 +226,7 @@ void GoogleDriveService::PopulateContextMenu() {
   context_menu_->addAction(IconLoader::Load("download", IconLoader::Base),
                            tr("Cover Manager"), this, SLOT(ShowCoverManager()));
   context_menu_->addAction(IconLoader::Load("configure", IconLoader::Base),
-                           tr("Configure..."), this,
-                           SLOT(ShowSettingsDialog()));
+                           tr("Configure..."), this, SLOT(ShowConfig()));
 }
 
 void GoogleDriveService::UpdateContextMenu() {

--- a/src/internet/seafile/seafileservice.cpp
+++ b/src/internet/seafile/seafileservice.cpp
@@ -218,7 +218,7 @@ void SeafileService::Connect() {
   if (has_credentials()) {
     UpdateLibraries();
   } else {
-    ShowSettingsDialog();
+    ShowConfig();
   }
 }
 

--- a/src/internet/skydrive/skydriveservice.cpp
+++ b/src/internet/skydrive/skydriveservice.cpp
@@ -219,8 +219,7 @@ void SkydriveService::PopulateContextMenu() {
                            tr("Cover Manager"), this, SLOT(ShowCoverManager()));
   context_menu_->addSeparator();
   context_menu_->addAction(IconLoader::Load("configure", IconLoader::Base),
-                           tr("Configure..."), this,
-                           SLOT(ShowSettingsDialog()));
+                           tr("Configure..."), this, SLOT(ShowConfig()));
 }
 
 void SkydriveService::UpdateContextMenu() {


### PR DESCRIPTION
InternetService::ShowConfig() and ShowSettingsPage() in various classes
were all used to show the settings page for a service. Consolidate these
to override the ShowConfig method in the base class.