### PR TITLE
Fix setting task blocking library scans

### DIFF
--- a/src/core/deletefiles.cpp
+++ b/src/core/deletefiles.cpp
@@ -48,7 +48,7 @@ void DeleteFiles::Start(const SongList& songs) {
   songs_ = songs;
 
   task_id_ = task_manager_->StartTask(tr("Deleting files"));
-  task_manager_->SetTaskBlocksLibraryScans(true);
+  task_manager_->SetTaskBlocksLibraryScans(task_id_);
 
   thread_ = new QThread;
   connect(thread_, SIGNAL(started()), SLOT(ProcessSomeFiles()));

--- a/src/core/organise.cpp
+++ b/src/core/organise.cpp
@@ -70,7 +70,7 @@ void Organise::Start() {
   if (thread_) return;
 
   task_id_ = task_manager_->StartTask(tr("Organising files"));
-  task_manager_->SetTaskBlocksLibraryScans(true);
+  task_manager_->SetTaskBlocksLibraryScans(task_id_);
 
   thread_ = new QThread;
   connect(thread_, SIGNAL(started()), SLOT(ProcessSomeFiles()));


### PR DESCRIPTION
TaskManager::SetTaskBlocksLibraryScans() takes the ID of the task.