### PR TITLE
Replace Q_ENUMS with Q_ENUM

### DIFF
--- a/src/internet/subsonic/subsonicservice.h
+++ b/src/internet/subsonic/subsonicservice.h
@@ -39,8 +39,6 @@ class SubsonicLibraryScanner;
 
 class SubsonicService : public InternetService {
   Q_OBJECT
-  Q_ENUMS(LoginState)
-  Q_ENUMS(ApiError)
 
  public:
   SubsonicService(Application* app, InternetModel* parent);
@@ -63,6 +61,7 @@ class SubsonicService : public InternetService {
     LoginState_RedirectLimitExceeded,
     LoginState_RedirectNoUrl,
   };
+  Q_ENUM(LoginState)
 
   enum ApiError {
     ApiError_Generic = 0,
@@ -74,6 +73,7 @@ class SubsonicService : public InternetService {
     ApiError_Unlicensed = 60,
     ApiError_NotFound = 70,
   };
+  Q_ENUM(ApiError)
 
   enum Type {
     Type_Artist = InternetModel::TypeCount,

--- a/src/library/librarymodel.h
+++ b/src/library/librarymodel.h
@@ -46,7 +46,6 @@ class QSettings;
 
 class LibraryModel : public SimpleTreeModel<LibraryItem> {
   Q_OBJECT
-  Q_ENUMS(GroupBy)
 
  public:
   LibraryModel(std::shared_ptr<LibraryBackend> backend, Application* app,
@@ -91,6 +90,7 @@ class LibraryModel : public SimpleTreeModel<LibraryItem> {
     GroupBy_OriginalYearAlbum = 13,
     GroupBy_OriginalYear = 14,
   };
+  Q_ENUM(GroupBy)
 
   struct Grouping {
     Grouping(GroupBy f = GroupBy_None, GroupBy s = GroupBy_None,


### PR DESCRIPTION
Q_ENUMS is obsolete. See: https://doc.qt.io/qt-5/qobject-obsolete.html
The replacement is Q_ENUM which was introduced in Qt 5.5, and Clementine
requires Qt 5.6.