### PR TITLE
internet/podcasts: Fix crash when updating podcasts.

### DIFF
--- a/src/internet/podcasts/podcastservice.h
+++ b/src/internet/podcasts/podcastservice.h
@@ -119,6 +119,7 @@ class PodcastService : public InternetService {
 
   QStandardItem* CreatePodcastItem(const Podcast& podcast);
   QStandardItem* CreatePodcastEpisodeItem(const PodcastEpisode& episode);
+  void RemovePodcastItem(QStandardItem* item);
 
   QModelIndex MapToMergedModel(const QModelIndex& index) const;
 


### PR DESCRIPTION
When a podcast is updated and the number of visible items is set in the
podcast settings, child items that disappear from the view, and are
deleted, are still referenced by the database id map.

Move the removal code from SubscriptionRemoved to a common method and
use that for this case.