### PR TITLE
Remove all hardcoded API keys and secrets from code

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -187,6 +187,16 @@ jobs:
       image: fedora:34
     env:
       RPM_BUILD_NCPUS: "2"
+      BOX_SERVICE_CLIENT_SECRET: ${{ secrets.BOX_SERVICE_CLIENT_SECRET }}
+      DISCOGS_API_ACCESS_KEY: ${{ secrets.DISCOGS_API_ACCESS_KEY }}
+      DISCOGS_API_SECRET_KEY: ${{ secrets.DISCOGS_API_SECRET_KEY }}
+      DROPBOX_CLIENT_SECRET: ${{ secrets.DROPBOX_CLIENT_SECRET }}
+      FLICKR_API_KEY: ${{ secrets.FLICKR_API_KEY }}
+      GOOGLE_DRIVE_CLIENT_SECRET: ${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
+      LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY }}
+      LASTFM_API_SECRET: ${{ secrets.LASTFM_API_SECRET }}
+      SONGKICK_API_KEY: ${{ secrets.SONGKICK_API_KEY }}
+      SPOTIFY_API_KEY: ${{ secrets.SPOTIFY_API_KEY }}
     steps:
       - name: Install dependencies
         run: >
@@ -257,6 +267,16 @@ jobs:
       image: fedora:33
     env:
       RPM_BUILD_NCPUS: "2"
+      BOX_SERVICE_CLIENT_SECRET: ${{ secrets.BOX_SERVICE_CLIENT_SECRET }}
+      DISCOGS_API_ACCESS_KEY: ${{ secrets.DISCOGS_API_ACCESS_KEY }}
+      DISCOGS_API_SECRET_KEY: ${{ secrets.DISCOGS_API_SECRET_KEY }}
+      DROPBOX_CLIENT_SECRET: ${{ secrets.DROPBOX_CLIENT_SECRET }}
+      FLICKR_API_KEY: ${{ secrets.FLICKR_API_KEY }}
+      GOOGLE_DRIVE_CLIENT_SECRET: ${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
+      LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY }}
+      LASTFM_API_SECRET: ${{ secrets.LASTFM_API_SECRET }}
+      SONGKICK_API_KEY: ${{ secrets.SONGKICK_API_KEY }}
+      SPOTIFY_API_KEY: ${{ secrets.SPOTIFY_API_KEY }}
     steps:
       - name: Install dependencies
         run: >
@@ -327,6 +347,16 @@ jobs:
       image: eu.gcr.io/clementine-data/mingw-w64:latest
     env:
       PKG_CONFIG_PATH: /target/lib/pkgconfig
+      BOX_SERVICE_CLIENT_SECRET: ${{ secrets.BOX_SERVICE_CLIENT_SECRET }}
+      DISCOGS_API_ACCESS_KEY: ${{ secrets.DISCOGS_API_ACCESS_KEY }}
+      DISCOGS_API_SECRET_KEY: ${{ secrets.DISCOGS_API_SECRET_KEY }}
+      DROPBOX_CLIENT_SECRET: ${{ secrets.DROPBOX_CLIENT_SECRET }}
+      FLICKR_API_KEY: ${{ secrets.FLICKR_API_KEY }}
+      GOOGLE_DRIVE_CLIENT_SECRET: ${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
+      LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY }}
+      LASTFM_API_SECRET: ${{ secrets.LASTFM_API_SECRET }}
+      SONGKICK_API_KEY: ${{ secrets.SONGKICK_API_KEY }}
+      SPOTIFY_API_KEY: ${{ secrets.SPOTIFY_API_KEY }}
     steps:
       - name: Fix liblastfm includes
         run: ln -s /target/include/lastfm /target/include/lastfm5
@@ -516,6 +546,17 @@ jobs:
     runs-on: ubuntu-18.04
     container:
       image: debian:stretch
+    env:
+      BOX_SERVICE_CLIENT_SECRET: ${{ secrets.BOX_SERVICE_CLIENT_SECRET }}
+      DISCOGS_API_ACCESS_KEY: ${{ secrets.DISCOGS_API_ACCESS_KEY }}
+      DISCOGS_API_SECRET_KEY: ${{ secrets.DISCOGS_API_SECRET_KEY }}
+      DROPBOX_CLIENT_SECRET: ${{ secrets.DROPBOX_CLIENT_SECRET }}
+      FLICKR_API_KEY: ${{ secrets.FLICKR_API_KEY }}
+      GOOGLE_DRIVE_CLIENT_SECRET: ${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
+      LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY }}
+      LASTFM_API_SECRET: ${{ secrets.LASTFM_API_SECRET }}
+      SONGKICK_API_KEY: ${{ secrets.SONGKICK_API_KEY }}
+      SPOTIFY_API_KEY: ${{ secrets.SPOTIFY_API_KEY }}
     steps:
       - name: Install dependencies
         run: >
@@ -574,6 +615,17 @@ jobs:
     runs-on: ubuntu-18.04
     container:
       image: ubuntu:bionic
+    env:
+      BOX_SERVICE_CLIENT_SECRET: ${{ secrets.BOX_SERVICE_CLIENT_SECRET }}
+      DISCOGS_API_ACCESS_KEY: ${{ secrets.DISCOGS_API_ACCESS_KEY }}
+      DISCOGS_API_SECRET_KEY: ${{ secrets.DISCOGS_API_SECRET_KEY }}
+      DROPBOX_CLIENT_SECRET: ${{ secrets.DROPBOX_CLIENT_SECRET }}
+      FLICKR_API_KEY: ${{ secrets.FLICKR_API_KEY }}
+      GOOGLE_DRIVE_CLIENT_SECRET: ${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
+      LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY }}
+      LASTFM_API_SECRET: ${{ secrets.LASTFM_API_SECRET }}
+      SONGKICK_API_KEY: ${{ secrets.SONGKICK_API_KEY }}
+      SPOTIFY_API_KEY: ${{ secrets.SPOTIFY_API_KEY }}
     steps:
       - name: Install dependencies
         env:
@@ -632,6 +684,17 @@ jobs:
     runs-on: ubuntu-18.04
     container:
       image: debian:buster
+    env:
+      BOX_SERVICE_CLIENT_SECRET: ${{ secrets.BOX_SERVICE_CLIENT_SECRET }}
+      DISCOGS_API_ACCESS_KEY: ${{ secrets.DISCOGS_API_ACCESS_KEY }}
+      DISCOGS_API_SECRET_KEY: ${{ secrets.DISCOGS_API_SECRET_KEY }}
+      DROPBOX_CLIENT_SECRET: ${{ secrets.DROPBOX_CLIENT_SECRET }}
+      FLICKR_API_KEY: ${{ secrets.FLICKR_API_KEY }}
+      GOOGLE_DRIVE_CLIENT_SECRET: ${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
+      LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY }}
+      LASTFM_API_SECRET: ${{ secrets.LASTFM_API_SECRET }}
+      SONGKICK_API_KEY: ${{ secrets.SONGKICK_API_KEY }}
+      SPOTIFY_API_KEY: ${{ secrets.SPOTIFY_API_KEY }}
     steps:
       - name: Install dependencies
         run: >
@@ -690,6 +753,17 @@ jobs:
     runs-on: ubuntu-18.04
     container:
       image: ubuntu:focal
+    env:
+      BOX_SERVICE_CLIENT_SECRET: ${{ secrets.BOX_SERVICE_CLIENT_SECRET }}
+      DISCOGS_API_ACCESS_KEY: ${{ secrets.DISCOGS_API_ACCESS_KEY }}
+      DISCOGS_API_SECRET_KEY: ${{ secrets.DISCOGS_API_SECRET_KEY }}
+      DROPBOX_CLIENT_SECRET: ${{ secrets.DROPBOX_CLIENT_SECRET }}
+      FLICKR_API_KEY: ${{ secrets.FLICKR_API_KEY }}
+      GOOGLE_DRIVE_CLIENT_SECRET: ${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
+      LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY }}
+      LASTFM_API_SECRET: ${{ secrets.LASTFM_API_SECRET }}
+      SONGKICK_API_KEY: ${{ secrets.SONGKICK_API_KEY }}
+      SPOTIFY_API_KEY: ${{ secrets.SPOTIFY_API_KEY }}
     steps:
       - name: Install dependencies
         env:
@@ -754,6 +828,17 @@ jobs:
     runs-on: ubuntu-18.04
     container:
       image: ubuntu:groovy
+    env:
+      BOX_SERVICE_CLIENT_SECRET: ${{ secrets.BOX_SERVICE_CLIENT_SECRET }}
+      DISCOGS_API_ACCESS_KEY: ${{ secrets.DISCOGS_API_ACCESS_KEY }}
+      DISCOGS_API_SECRET_KEY: ${{ secrets.DISCOGS_API_SECRET_KEY }}
+      DROPBOX_CLIENT_SECRET: ${{ secrets.DROPBOX_CLIENT_SECRET }}
+      FLICKR_API_KEY: ${{ secrets.FLICKR_API_KEY }}
+      GOOGLE_DRIVE_CLIENT_SECRET: ${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
+      LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY }}
+      LASTFM_API_SECRET: ${{ secrets.LASTFM_API_SECRET }}
+      SONGKICK_API_KEY: ${{ secrets.SONGKICK_API_KEY }}
+      SPOTIFY_API_KEY: ${{ secrets.SPOTIFY_API_KEY }}
     steps:
       - name: Install dependencies
         env:
@@ -821,6 +906,17 @@ jobs:
     runs-on: ubuntu-18.04
     container:
       image: ubuntu:hirsute
+    env:
+      BOX_SERVICE_CLIENT_SECRET: ${{ secrets.BOX_SERVICE_CLIENT_SECRET }}
+      DISCOGS_API_ACCESS_KEY: ${{ secrets.DISCOGS_API_ACCESS_KEY }}
+      DISCOGS_API_SECRET_KEY: ${{ secrets.DISCOGS_API_SECRET_KEY }}
+      DROPBOX_CLIENT_SECRET: ${{ secrets.DROPBOX_CLIENT_SECRET }}
+      FLICKR_API_KEY: ${{ secrets.FLICKR_API_KEY }}
+      GOOGLE_DRIVE_CLIENT_SECRET: ${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
+      LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY }}
+      LASTFM_API_SECRET: ${{ secrets.LASTFM_API_SECRET }}
+      SONGKICK_API_KEY: ${{ secrets.SONGKICK_API_KEY }}
+      SPOTIFY_API_KEY: ${{ secrets.SPOTIFY_API_KEY }}
     steps:
       - name: Install dependencies
         env:
@@ -886,6 +982,17 @@ jobs:
   build_mac:
     name: Build Mac DMG
     runs-on: macos-10.15
+    env:
+      BOX_SERVICE_CLIENT_SECRET: ${{ secrets.BOX_SERVICE_CLIENT_SECRET }}
+      DISCOGS_API_ACCESS_KEY: ${{ secrets.DISCOGS_API_ACCESS_KEY }}
+      DISCOGS_API_SECRET_KEY: ${{ secrets.DISCOGS_API_SECRET_KEY }}
+      DROPBOX_CLIENT_SECRET: ${{ secrets.DROPBOX_CLIENT_SECRET }}
+      FLICKR_API_KEY: ${{ secrets.FLICKR_API_KEY }}
+      GOOGLE_DRIVE_CLIENT_SECRET: ${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
+      LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY }}
+      LASTFM_API_SECRET: ${{ secrets.LASTFM_API_SECRET }}
+      SONGKICK_API_KEY: ${{ secrets.SONGKICK_API_KEY }}
+      SPOTIFY_API_KEY: ${{ secrets.SPOTIFY_API_KEY }}
     steps:
       - uses: actions/checkout@v1.2.0
       - name: Install dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -478,6 +478,8 @@ endif()
 # Global configuration
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/clementine-config.h.in
                ${CMAKE_CURRENT_BINARY_DIR}/include/clementine-config.h)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/api-keys.h.in
+               ${CMAKE_CURRENT_BINARY_DIR}/src/api-keys.h)
 
 # Uninstall support
 configure_file(

--- a/ext/clementine-spotifyblob/CMakeLists.txt
+++ b/ext/clementine-spotifyblob/CMakeLists.txt
@@ -6,6 +6,9 @@ include_directories(${CMAKE_BINARY_DIR}/ext/libclementine-spotifyblob)
 include_directories(${CMAKE_SOURCE_DIR}/ext/libclementine-spotifyblob)
 include_directories(${CMAKE_SOURCE_DIR}/ext/libclementine-common)
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/spotifykey.h.in
+               ${CMAKE_CURRENT_BINARY_DIR}/spotifykey.h)
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Woverloaded-virtual -Wall -Wno-sign-compare -Wno-deprecated-declarations -Wno-unused-local-typedefs -Wno-unused-private-field -Wno-unknown-warning-option")
 
 link_directories(${LIBSPOTIFY_LIBRARY_DIRS})

--- a/ext/clementine-spotifyblob/spotifykey.h.in
+++ b/ext/clementine-spotifyblob/spotifykey.h.in
@@ -19,19 +19,11 @@
 // compatible.
 
 // The Spotify terms of service require that application keys are not
-// accessible to third parties.  Therefore this application key is heavily
-// encrypted here in the source to prevent third parties from viewing it.
-// It is most definitely not base64 encoded.
+// accessible to third parties. Therefore the API key is held as a Github
+// secret and inserted here during the build process. If you need
+// to supply a custom API key for local testing, set it as the SPOTIFY_API_KEY
+// environment variable during cmake configuration and it will be imported here.
 
-static const char* kSpotifyApiKey =
-    "AVlOrvJkKx8T+LEsCk+Kyl24I0MSsjohZAtMFzm2O5Lms1bmAWFWgdZaHkpypzSJPmSd+"
-    "Wi50wwg"
-    "JwVCU0sq4Lep1zB4t6Z8h26NK6+z8gmkHVkV9DRPkRgebcUkWTDTflwVPKWF4+"
-    "gdRjUwprsqBw6O"
-    "iofRLJzeKaxbmaUGqkSkxVLOiXC9lxylNq6ju7Q7uY8u8XkDUsVM3YIxiWy2+EM7I/"
-    "lhatzT9xrq"
-    "rxHe2lg7CzOwF5kuFdwgmi8MQ72xTYXIKnNlOry/"
-    "hJDlN9lKxkbUBLh+pzbYvO92S2fYKK5PAHvX"
-    "5+SmSBGbh6dlpHeCGqb8MPdaeZ5I1YxMcDkxa2+tbLA/Muat7gKA9u57TFCtYjun/u/i/"
-    "ONwdBIQ"
-    "rePzXZjipO32kYmQAiCkN1p8sgQEcF43QxaVwXGo2X0rRnJf";
+#define SPOTIFY_API_KEY_BASE64 "$ENV{SPOTIFY_API_KEY}"
+
+static const char* kSpotifyApiKey = SPOTIFY_API_KEY_BASE64;

--- a/src/api-keys.h.in
+++ b/src/api-keys.h.in
@@ -1,0 +1,35 @@
+/* This file is part of Clementine.
+
+   Clementine is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Clementine is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef API_KEYS_H
+#define API_KEYS_H
+
+// API keys must not be included in the plain. Therefore the API keys are held as 
+// Github secrets and inserted here during the build process. If you need
+// to supply a custom API key for local testing, set it as the corresponding
+// environment variable during cmake configuration and it will be imported here.
+
+#define BOX_SERVICE_CLIENT_SECRET "$ENV{BOX_SERVICE_CLIENT_SECRET}"
+#define DISCOGS_API_ACCESS_KEY_BASE64 "$ENV{DISCOGS_API_ACCESS_KEY}"
+#define DISCOGS_API_SECRET_KEY_BASE64 "$ENV{DISCOGS_API_SECRET_KEY}"
+#define DROPBOX_CLIENT_SECRET "$ENV{DROPBOX_CLIENT_SECRET}"
+#define FLICKR_API_KEY "$ENV{FLICKR_API_KEY}"
+#define GOOGLE_DRIVE_CLIENT_SECRET "$ENV{GOOGLE_DRIVE_CLIENT_SECRET}"
+#define LASTFM_API_KEY "$ENV{LASTFM_API_KEY}"
+#define LASTFM_API_SECRET "$ENV{LASTFM_API_SECRET}"
+#define SONGKICK_API_KEY "$ENV{SONGKICK_API_KEY}"
+
+#endif // API_KEYS_H

--- a/src/covers/discogscoverprovider.cpp
+++ b/src/covers/discogscoverprovider.cpp
@@ -30,6 +30,7 @@
 #include <QUrlQuery>
 #include <QVariant>
 
+#include "api-keys.h"
 #include "core/closure.h"
 #include "core/logging.h"
 #include "core/network.h"
@@ -40,10 +41,8 @@ const char* DiscogsCoverProvider::kUrlSearch =
 const char* DiscogsCoverProvider::kUrlReleases =
     "https://api.discogs.com/releases";
 
-const char* DiscogsCoverProvider::kAccessKeyB64 =
-    "YVR4Yk5JTnlmUkhFY0pTaldid2c=";
-const char* DiscogsCoverProvider::kSecretKeyB64 =
-    "QkJNb2tMVXVUVFhSRWRUVmZDc0ZGamZmSWRjdHZRVno=";
+const char* DiscogsCoverProvider::kAccessKeyB64 = DISCOGS_API_ACCESS_KEY_BASE64;
+const char* DiscogsCoverProvider::kSecretKeyB64 = DISCOGS_API_SECRET_KEY_BASE64;
 
 DiscogsCoverProvider::DiscogsCoverProvider(QObject* parent)
     : CoverProvider("Discogs", false, parent),

--- a/src/covers/kittenloader.cpp
+++ b/src/covers/kittenloader.cpp
@@ -24,13 +24,16 @@
 #include <QNetworkRequest>
 #include <QXmlStreamReader>
 
+#include "api-keys.h"
 #include "core/closure.h"
 #include "core/network.h"
+
+const char* FlickrApiKey = FLICKR_API_KEY;
 
 const char* KittenLoader::kFlickrKittenUrl =
     "https://api.flickr.com/services/rest/"
     "?method=flickr.photos.search"
-    "&api_key=808b52887b3cc7fe098abd62f6ed1745"
+    "&api_key=%1"
     "&group_id=99442622@N00"
     "&sort=random"
     "&safe_search=1"
@@ -62,7 +65,8 @@ quint64 KittenLoader::LoadKitten(const AlbumCoverLoaderOptions& options) {
 }
 
 void KittenLoader::FetchMoreKittens() {
-  QNetworkRequest req = QNetworkRequest(QUrl(kFlickrKittenUrl));
+  QNetworkRequest req =
+      QNetworkRequest(QUrl(QString(kFlickrKittenUrl).arg(FlickrApiKey)));
   QNetworkReply* reply = network_->get(req);
   NewClosure(reply, SIGNAL(finished()), this,
              SLOT(KittensRetrieved(QNetworkReply*)), reply);

--- a/src/covers/kittenloader.h
+++ b/src/covers/kittenloader.h
@@ -39,6 +39,7 @@ class KittenLoader : public AlbumCoverLoader {
   void FetchMoreKittens();
 
  private:
+  static const char* kFlickrApiKey;
   static const char* kFlickrKittenUrl;
   static const char* kFlickrPhotoUrl;
 

--- a/src/internet/box/boxservice.cpp
+++ b/src/internet/box/boxservice.cpp
@@ -23,6 +23,7 @@
 #include <QJsonObject>
 #include <QUrlQuery>
 
+#include "api-keys.h"
 #include "core/application.h"
 #include "core/player.h"
 #include "core/waitforsignal.h"
@@ -37,7 +38,7 @@ const char* BoxService::kSettingsGroup = "Box";
 namespace {
 
 static const char* kClientId = "gbswb9wp7gjyldc3qrw68h2rk68jaf4h";
-static const char* kClientSecret = "pZ6cUCQz5X0xaWoPVbCDg6GpmfTtz73s";
+static const char* kClientSecret = BOX_SERVICE_CLIENT_SECRET;
 
 static const char* kOAuthEndpoint = "https://api.box.com/oauth2/authorize";
 static const char* kOAuthTokenEndpoint = "https://api.box.com/oauth2/token";

--- a/src/internet/dropbox/dropboxsettingspage.cpp
+++ b/src/internet/dropbox/dropboxsettingspage.cpp
@@ -18,6 +18,7 @@
 
 #include "dropboxsettingspage.h"
 
+#include "api-keys.h"
 #include "core/application.h"
 #include "internet/core/internetmodel.h"
 #include "internet/core/oauthenticator.h"
@@ -30,7 +31,7 @@ namespace {
 static const char* kOAuthEndpoint =
     "https://www.dropbox.com/1/oauth2/authorize";
 static const char* kOAuthClientId = "qh6ca27eclt9p2k";
-static const char* kOAuthClientSecret = "pg7y68h5efap8r6";
+static const char* kOAuthClientSecret = DROPBOX_CLIENT_SECRET;
 static const char* kOAuthTokenEndpoint =
     "https://api.dropboxapi.com/1/oauth2/token";
 static const char* kOAuthScope = "";

--- a/src/internet/googledrive/googledriveclient.cpp
+++ b/src/internet/googledrive/googledriveclient.cpp
@@ -26,6 +26,7 @@
 #include <QJsonValue>
 #include <QUrlQuery>
 
+#include "api-keys.h"
 #include "core/closure.h"
 #include "core/logging.h"
 #include "core/network.h"
@@ -50,7 +51,7 @@ static const char* kOAuthScope =
     "https://www.googleapis.com/auth/drive.readonly "
     "https://www.googleapis.com/auth/userinfo.email";
 static const char* kClientId = "679260893280.apps.googleusercontent.com";
-static const char* kClientSecret = "l3cWb8efUZsrBI4wmY3uKl6i";
+static const char* kClientSecret = GOOGLE_DRIVE_CLIENT_SECRET;
 }  // namespace
 
 QStringList File::parent_ids() const {

--- a/src/internet/lastfm/lastfmservice.cpp
+++ b/src/internet/lastfm/lastfmservice.cpp
@@ -46,6 +46,7 @@
 #include <lastfm5/RadioStation>
 #endif
 
+#include "api-keys.h"
 #include "core/application.h"
 #include "core/closure.h"
 #include "core/logging.h"
@@ -72,8 +73,8 @@ uint qHash(const lastfm::Track& track) {
 const char* LastFMService::kServiceName = "Last.fm";
 const char* LastFMService::kSettingsGroup = "Last.fm";
 const char* LastFMService::kAudioscrobblerClientId = "tng";
-const char* LastFMService::kApiKey = "75d20fb472be99275392aefa2760ea09";
-const char* LastFMService::kSecret = "d3072b60ae626be12be69448f5c46e70";
+const char* LastFMService::kApiKey = LASTFM_API_KEY;
+const char* LastFMService::kSecret = LASTFM_API_SECRET;
 const char* LastFMService::kAuthLoginUrl =
     "https://www.last.fm/api/auth/?api_key=%1&token=%2";
 

--- a/src/songinfo/songkickconcerts.cpp
+++ b/src/songinfo/songkickconcerts.cpp
@@ -26,6 +26,7 @@
 #include <QVBoxLayout>
 #include <QXmlStreamWriter>
 
+#include "api-keys.h"
 #include "core/logging.h"
 #include "songkickconcertwidget.h"
 #include "ui/iconloader.h"
@@ -35,7 +36,7 @@ const char* kSongkickArtistCalendarUrl =
     "https://api.songkick.com/api/3.0/artists/%1/calendar.json";
 const char* kSongkickArtistSearchUrl =
     "https://api.songkick.com/api/3.0/search/artists.json";
-const char* kSongkickApiKey = "8rgKfy1WU6IlJFfN";
+const char* kSongkickApiKey = SONGKICK_API_KEY;
 }  // namespace
 
 SongkickConcerts::SongkickConcerts() {


### PR DESCRIPTION
And have them be re-injected into builds via github secrets. 
As API keys are supposed to be kept secret, they should not be publicly visible in code on github.

Accepting this PR means that the api keys need to be added as the following Github Secrets (and ideally new ones should be generated before that as the current ones have been exposes for a while now):
- BOX_SERVICE_CLIENT_SECRET
- DISCOGS_API_ACCESS_KEY
- DISCOGS_API_SECRET_KEY
- DROPBOX_CLIENT_SECRET
- FLICKR_API_KEY
- GOOGLE_DRIVE_CLIENT_SECRET
- LASTFM_API_KEY
- LASTFM_API_SECRET
- SONGKICK_API_KEY
- SPOTIFY_API_KEY

I believe this fixes the security issue alluded to by #7034 (based on checking past vulnerability reports from that user on that vulnerability hunting page).