### PR TITLE
Enable to build on systems lacking execinfo.h

### DIFF
--- a/ext/libclementine-common/CMakeLists.txt
+++ b/ext/libclementine-common/CMakeLists.txt
@@ -39,3 +39,6 @@ target_link_libraries(libclementine-common
   ${TAGLIB_LIBRARIES}
   ${CMAKE_THREAD_LIBS_INIT}
 )
+
+find_package(Backtrace)
+configure_file(core/conf_backtrace.h.in conf_backtrace.h)

--- a/ext/libclementine-common/core/conf_backtrace.h.in
+++ b/ext/libclementine-common/core/conf_backtrace.h.in
@@ -1,0 +1,4 @@
+#cmakedefine Backtrace_FOUND
+#ifdef Backtrace_FOUND
+#include <@Backtrace_HEADER@>
+#endif

--- a/ext/libclementine-common/core/logging.cpp
+++ b/ext/libclementine-common/core/logging.cpp
@@ -21,9 +21,7 @@
 #include <cxxabi.h>
 
 #include <QtGlobal>
-#ifdef Q_OS_UNIX
-#include <execinfo.h>
-#endif
+#include "conf_backtrace.h"
 
 #include <glib.h>
 
@@ -325,7 +323,7 @@ QString DemangleSymbol(const QString& symbol) {
 }
 
 void DumpStackTrace() {
-#ifdef Q_OS_UNIX
+#ifdef Backtrace_FOUND
   void* callstack[128];
   int callstack_size =
       backtrace(reinterpret_cast<void**>(&callstack), sizeof(callstack));


### PR DESCRIPTION
The Q_OS_UNIX macro is inappropriate for detection because many UNIX-like
platforms may lack backtrace support in the libc. E.g.: Darwin / Mac OS X,
Musl libc, OpenBSD, OpenIndiana.