### PR TITLE
Fix sentinels in variadic function calls

### DIFF
--- a/src/devices/cddasongloader.cpp
+++ b/src/devices/cddasongloader.cpp
@@ -79,7 +79,7 @@ void CddaSongLoader::LoadSongsFromCdda() {
   }
   if (g_object_class_find_property(G_OBJECT_GET_CLASS(cdda_),
                                    "paranoia-mode")) {
-    g_object_set(cdda_, "paranoia-mode", 0, NULL);
+    g_object_set(cdda_, "paranoia-mode", 0, nullptr);
   }
 
   // Change the element's state to ready and paused, to be able to query it
@@ -121,7 +121,7 @@ void CddaSongLoader::LoadSongsFromCdda() {
 
   GstElement* pipeline = gst_pipeline_new("pipeline");
   GstElement* sink = gst_element_factory_make("fakesink", NULL);
-  gst_bin_add_many(GST_BIN(pipeline), cdda_, sink, NULL);
+  gst_bin_add_many(GST_BIN(pipeline), cdda_, sink, nullptr);
   gst_element_link(cdda_, sink);
   gst_element_set_state(pipeline, GST_STATE_READY);
   gst_element_set_state(pipeline, GST_STATE_PAUSED);

--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -440,7 +440,7 @@ bool GstEnginePipeline::InitAudioBin() {
   gst_element_link(queue_, audioconvert_);
 
   GstCaps* caps16 = gst_caps_new_simple("audio/x-raw", "format", G_TYPE_STRING,
-                                        "S16LE", NULL);
+                                        "S16LE", nullptr);
   gst_element_link_filtered(probe_converter, probe_sink, caps16);
   gst_caps_unref(caps16);
 

--- a/src/musicbrainz/chromaprinter.cpp
+++ b/src/musicbrainz/chromaprinter.cpp
@@ -82,7 +82,7 @@ QString Chromaprinter::CreateFingerprint() {
   // Chromaprint expects mono 16-bit ints at a sample rate of 11025Hz.
   GstCaps* caps = gst_caps_new_simple(
       "audio/x-raw", "format", G_TYPE_STRING, "S16LE", "channels", G_TYPE_INT,
-      kDecodeChannels, "rate", G_TYPE_INT, kDecodeRate, NULL);
+      kDecodeChannels, "rate", G_TYPE_INT, kDecodeRate, nullptr);
   gst_element_link_filtered(resample, sink, caps);
   gst_caps_unref(caps);
 


### PR DESCRIPTION
Replace sentinel NULL with nullptr, guaranteed to be correctly expanded.

NULL may be defined as plain 0 in C++; which may lead to undefined upper
bits passed in variadic function arguments, causing crashes.

See: https://ewontfix.com/11/