### PR TITLE
File formatting options in CD ripping dialog now consistent with organise files dialog

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -385,6 +385,7 @@ set(SOURCES
   widgets/errordialog.cpp
   widgets/fancytabwidget.cpp
   widgets/favoritewidget.cpp
+  widgets/filenameformatwidget.cpp
   widgets/fileview.cpp
   widgets/fileviewlist.cpp
   widgets/forcescrollperpixel.cpp
@@ -683,6 +684,7 @@ set(HEADERS
   widgets/errordialog.h
   widgets/fancytabwidget.h
   widgets/favoritewidget.h
+  widgets/filenameformatwidget.h
   widgets/fileview.h
   widgets/fileviewlist.h
   widgets/freespacebar.h
@@ -807,6 +809,7 @@ set(UI
 
   widgets/equalizerslider.ui
   widgets/errordialog.ui
+  widgets/filenameformatwidget.ui
   widgets/fileview.ui
   widgets/loginstatewidget.ui
   widgets/osdpretty.ui

--- a/src/core/organiseformat.cpp
+++ b/src/core/organiseformat.cpp
@@ -31,6 +31,7 @@
 #include "core/arraysize.h"
 #include "core/timeconstants.h"
 #include "core/utilities.h"
+#include "transcoder/transcoder.h"
 
 const char* OrganiseFormat::kTagPattern = "\\%([a-zA-Z]*)";
 const char* OrganiseFormat::kBlockPattern = "\\{([^{}]+)\\}";
@@ -97,7 +98,8 @@ bool OrganiseFormat::IsValid() const {
   return v.validate(format_copy, pos) == QValidator::Acceptable;
 }
 
-QString OrganiseFormat::GetFilenameForSong(const Song& song) const {
+QString OrganiseFormat::GetFilenameForSong(const Song& song,
+                                           QString prefix_path) const {
   QString filename = ParseBlock(format_, song);
 
   if (QFileInfo(filename).completeBaseName().isEmpty()) {
@@ -141,7 +143,18 @@ QString OrganiseFormat::GetFilenameForSong(const Song& song) const {
     }
   }
 
+  if (!prefix_path.isEmpty()) parts.insert(0, prefix_path);
+
   return parts.join("/");
+}
+
+QString OrganiseFormat::GetFilenameForSong(
+    const Song& song, const TranscoderPreset& transcoder_preset,
+    QString prefix_path) const {
+  OrganiseFormat format(*this);
+  format.add_tag_override("extension", transcoder_preset.extension_);
+
+  return format.GetFilenameForSong(song, prefix_path);
 }
 
 QStringList OrganiseFormat::GetFilenamesForSongs(const SongList& songs) const {

--- a/src/core/organiseformat.cpp
+++ b/src/core/organiseformat.cpp
@@ -24,6 +24,7 @@
 
 #include <QApplication>
 #include <QFileInfo>
+#include <QHash>
 #include <QPalette>
 #include <QUrl>
 
@@ -141,6 +142,27 @@ QString OrganiseFormat::GetFilenameForSong(const Song& song) const {
   }
 
   return parts.join("/");
+}
+
+QStringList OrganiseFormat::GetFilenamesForSongs(const SongList& songs) const {
+  // Check if we will have multiple files with the same name.
+  // If so, they will erase each other if the overwrite flag is set.
+  // Better to rename them: e.g. foo.bar -> foo(2).bar
+  QHash<QString, int> filenames;
+  QStringList new_filenames;
+
+  for (const Song& song : songs) {
+    QString new_filename = GetFilenameForSong(song);
+    if (filenames.contains(new_filename)) {
+      QString song_number = QString::number(++filenames[new_filename]);
+      new_filename = Utilities::PathWithoutFilenameExtension(new_filename) +
+                     "(" + song_number + ")." +
+                     QFileInfo(new_filename).suffix();
+    }
+    filenames.insert(new_filename, 1);
+    new_filenames << new_filename;
+  }
+  return new_filenames;
 }
 
 QString OrganiseFormat::ParseBlock(QString block, const Song& song,

--- a/src/core/organiseformat.h
+++ b/src/core/organiseformat.h
@@ -27,9 +27,12 @@
 
 #include "core/song.h"
 
+class TranscoderPreset;
+
 class OrganiseFormat {
  public:
   explicit OrganiseFormat(const QString& format = QString());
+  OrganiseFormat(const OrganiseFormat& format) = default;
 
   static const char* kTagPattern;
   static const char* kBlockPattern;
@@ -55,7 +58,10 @@ class OrganiseFormat {
   void reset_tag_overrides() { tag_overrides_.clear(); }
 
   bool IsValid() const;
-  QString GetFilenameForSong(const Song& song) const;
+  QString GetFilenameForSong(const Song& song, QString prefix_path = "") const;
+  QString GetFilenameForSong(const Song& song,
+                             const TranscoderPreset& transcoder_preset,
+                             QString prefix_path = "") const;
   QStringList GetFilenamesForSongs(const SongList& songs) const;
 
   class Validator : public QValidator {

--- a/src/core/organiseformat.h
+++ b/src/core/organiseformat.h
@@ -20,6 +20,7 @@
 #ifndef CORE_ORGANISEFORMAT_H_
 #define CORE_ORGANISEFORMAT_H_
 
+#include <QStringList>
 #include <QSyntaxHighlighter>
 #include <QTextEdit>
 #include <QValidator>
@@ -55,6 +56,7 @@ class OrganiseFormat {
 
   bool IsValid() const;
   QString GetFilenameForSong(const Song& song) const;
+  QStringList GetFilenamesForSongs(const SongList& songs) const;
 
   class Validator : public QValidator {
    public:

--- a/src/ripper/ripcddialog.cpp
+++ b/src/ripper/ripcddialog.cpp
@@ -129,10 +129,12 @@ RipCDDialog::RipCDDialog(DeviceManager* device_manager, QWidget* parent)
   s.beginGroup(kSettingsGroup);
   last_add_dir_ = s.value("last_add_dir", QDir::homePath()).toString();
 
-  QString last_output_format = s.value("last_output_format", "ogg").toString();
+  QString last_output_format =
+      s.value("last_output_format", "audio/x-vorbis").toString();
+  qLog(Debug) << "last_output_format loaded: " << last_output_format;
   for (int i = 0; i < ui_->format->count(); ++i) {
     if (last_output_format ==
-        ui_->format->itemData(i).value<TranscoderPreset>().extension_) {
+        ui_->format->itemData(i).value<TranscoderPreset>().codec_mimetype_) {
       ui_->format->setCurrentIndex(i);
       break;
     }
@@ -194,8 +196,6 @@ void RipCDDialog::ClickedRipButton() {
   OrganiseFormat format = ui_->naming_group->format();
   Q_ASSERT(format.IsValid());
 
-  ui_->naming_group->StoreSettings();
-
   QFileInfo path(
       ui_->destination->itemData(ui_->destination->currentIndex()).toString());
 
@@ -233,6 +233,14 @@ void RipCDDialog::ClickedRipButton() {
 
   SetWorking(true);
   ripper->Start();
+
+  // store settings
+  QSettings s;
+  s.beginGroup(kSettingsGroup);
+  s.setValue("last_output_format", preset.codec_mimetype_);
+  qLog(Debug) << "last_output_format stored: " << preset.codec_mimetype_;
+
+  ui_->naming_group->StoreSettings();
 }
 
 void RipCDDialog::Options() {

--- a/src/ripper/ripcddialog.h
+++ b/src/ripper/ripcddialog.h
@@ -65,6 +65,7 @@ class RipCDDialog : public QDialog {
   void AddAlbumMetadataFromMusicBrainz(const SongList& songs);
   void DiscChanged();
   void FormatStringUpdated();
+  void UpdateFileNamePreviews();
 
  private:
   static const char* kSettingsGroup;

--- a/src/ripper/ripcddialog.h
+++ b/src/ripper/ripcddialog.h
@@ -60,31 +60,24 @@ class RipCDDialog : public QDialog {
   void Cancelled(Ripper* ripper);
   void SetupProgressBarLimits(int min, int max);
   void UpdateProgressBar(int progress);
-  // Initializes track list table based on preliminary song list with durations
-  // but without metadata.
-  void BuildTrackListTable(const SongList& songs);
-  // Update track list based on metadata.
-  void UpdateTrackListTable(const SongList& songs);
+  void UpdateTrackList(const SongList& songs);
   // Update album information with metadata.
   void AddAlbumMetadataFromMusicBrainz(const SongList& songs);
   void DiscChanged();
+  void FormatStringUpdated();
 
  private:
   static const char* kSettingsGroup;
   static const int kMaxDestinationItems;
 
-  // Constructs a filename from the given base name with a path taken
-  // from the ui dialog and an extension that corresponds to the audio
-  // format chosen in the ui.
   void AddDestinationDirectory(QString dir);
-  QString GetOutputFileName(const QString& basename) const;
-  QString ParseFileFormatString(const QString& file_format, int track_no) const;
   void SetWorking(bool working);
   void ResetDialog();
   void InitializeDevices();
+  void EnableIfPossible();
+  void UpdateTrackListTable();
 
   QList<QCheckBox*> checkboxes_;
-  QList<QLineEdit*> track_names_;
   QString last_add_dir_;
   QPushButton* cancel_button_;
   QPushButton* close_button_;
@@ -95,5 +88,6 @@ class RipCDDialog : public QDialog {
   bool working_;
   std::shared_ptr<CddaDevice> cdda_device_;
   CddaSongLoader* loader_;
+  SongList songs_;
 };
 #endif  // SRC_RIPPER_RIPCDDIALOG_H_

--- a/src/ripper/ripcddialog.ui
+++ b/src/ripper/ripcddialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>522</width>
-    <height>575</height>
+    <height>800</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -122,7 +122,7 @@
            <number>4</number>
           </property>
           <attribute name="horizontalHeaderVisible">
-           <bool>true</bool>
+           <bool>false</bool>
           </attribute>
           <attribute name="horizontalHeaderMinimumSectionSize">
            <number>10</number>
@@ -225,50 +225,29 @@
     </widget>
    </item>
    <item>
+    <widget class="FileNameFormatWidget" name="naming_group" native="true"/>
+   </item>
+   <item>
     <widget class="QGroupBox" name="output_group">
      <property name="title">
       <string>Output options</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="2" column="2">
-       <widget class="QPushButton" name="select">
-        <property name="text">
-         <string>Select...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>File Format</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1" colspan="2">
-       <widget class="QLineEdit" name="format_filename">
-        <property name="text">
-         <string notr="true">%track - %artist - %title</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
+      <item row="1" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
          <string>Destination</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="format">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Audio format</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="1" column="1">
        <widget class="QComboBox" name="destination">
         <property name="enabled">
          <bool>true</bool>
@@ -281,17 +260,27 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
-       <widget class="QPushButton" name="options">
-        <property name="text">
-         <string>Options...</string>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="format">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label">
+      <item row="1" column="2">
+       <widget class="QPushButton" name="select">
         <property name="text">
-         <string>Audio format</string>
+         <string>Select...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QPushButton" name="options">
+        <property name="text">
+         <string>Options...</string>
         </property>
        </widget>
       </item>
@@ -322,6 +311,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>FileNameFormatWidget</class>
+   <extends>QWidget</extends>
+   <header>widgets/filenameformatwidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>tableWidget</tabstop>
   <tabstop>select_all_button</tabstop>
@@ -332,7 +329,6 @@
   <tabstop>genreLineEdit</tabstop>
   <tabstop>yearLineEdit</tabstop>
   <tabstop>discLineEdit</tabstop>
-  <tabstop>format_filename</tabstop>
   <tabstop>format</tabstop>
   <tabstop>options</tabstop>
   <tabstop>destination</tabstop>

--- a/src/ripper/ripcddialog.ui
+++ b/src/ripper/ripcddialog.ui
@@ -9,7 +9,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>522</width>
+    <width>600</width>
     <height>800</height>
    </rect>
   </property>
@@ -119,13 +119,16 @@
            </sizepolicy>
           </property>
           <property name="columnCount">
-           <number>4</number>
+           <number>5</number>
           </property>
           <attribute name="horizontalHeaderVisible">
            <bool>false</bool>
           </attribute>
           <attribute name="horizontalHeaderMinimumSectionSize">
-           <number>10</number>
+           <number>4</number>
+          </attribute>
+          <attribute name="horizontalHeaderDefaultSectionSize">
+           <number>20</number>
           </attribute>
           <attribute name="verticalHeaderVisible">
            <bool>false</bool>
@@ -151,6 +154,11 @@
           <column>
            <property name="text">
             <string>Duration</string>
+           </property>
+          </column>
+          <column>
+           <property name="text">
+            <string>Filename Preview</string>
            </property>
           </column>
          </widget>

--- a/src/ripper/ripper.cpp
+++ b/src/ripper/ripper.cpp
@@ -58,12 +58,13 @@ Ripper::~Ripper() {}
 
 void Ripper::AddTrack(int track_number, const QString& title,
                       const QString& transcoded_filename,
-                      const TranscoderPreset& preset) {
+                      const TranscoderPreset& preset, bool overwrite_existing) {
   if (track_number < 1 || track_number > TracksOnDisc()) {
     qLog(Warning) << "Invalid track number:" << track_number << "Ignoring";
     return;
   }
-  TrackInformation track(track_number, title, transcoded_filename, preset);
+  TrackInformation track(track_number, title, transcoded_filename, preset,
+                         overwrite_existing);
   tracks_.append(track);
 }
 
@@ -232,7 +233,7 @@ void Ripper::Rip() {
 
     it->temporary_filename = filename;
     transcoder_->AddJob(it->temporary_filename, it->preset,
-                        it->transcoded_filename);
+                        it->transcoded_filename, it->overwrite_existing);
   }
   transcoder_->Start();
   emit RippingComplete();

--- a/src/ripper/ripper.h
+++ b/src/ripper/ripper.h
@@ -48,7 +48,7 @@ class Ripper : public QObject {
   // chosen TranscoderPreset.
   void AddTrack(int track_number, const QString& title,
                 const QString& transcoded_filename,
-                const TranscoderPreset& preset);
+                const TranscoderPreset& preset, bool overwrite_existing);
   // Sets album metadata. This information is used when tagging the
   // final files.
   void SetAlbumInformation(const QString& album, const QString& artist,
@@ -83,17 +83,19 @@ class Ripper : public QObject {
   struct TrackInformation {
     TrackInformation(int track_number, const QString& title,
                      const QString& transcoded_filename,
-                     const TranscoderPreset& preset)
+                     const TranscoderPreset& preset, bool overwrite_existing)
         : track_number(track_number),
           title(title),
           transcoded_filename(transcoded_filename),
-          preset(preset) {}
+          preset(preset),
+          overwrite_existing(overwrite_existing) {}
 
     int track_number;
     QString title;
     QString transcoded_filename;
     TranscoderPreset preset;
     QString temporary_filename;
+    bool overwrite_existing;
   };
 
   struct AlbumInformation {

--- a/src/transcoder/transcoder.cpp
+++ b/src/transcoder/transcoder.cpp
@@ -319,7 +319,7 @@ Song::FileType Transcoder::PickBestFormat(QList<Song::FileType> supported) {
 }
 
 void Transcoder::AddJob(const QString& input, const TranscoderPreset& preset,
-                        const QString& output) {
+                        const QString& output, bool overwrite_existing) {
   Job job;
   job.input = input;
   job.preset = preset;
@@ -331,8 +331,8 @@ void Transcoder::AddJob(const QString& input, const TranscoderPreset& preset,
   else
     job.output = input.section('.', 0, -2) + '.' + preset.extension_;
 
-  // Never overwrite existing files
-  if (QFile::exists(job.output)) {
+  // Don't overwrite existing files if overwrite_existing is not set
+  if (!overwrite_existing && QFile::exists(job.output)) {
     for (int i = 0;; ++i) {
       QString new_filename = QString("%1.%2.%3")
                                  .arg(job.output.section('.', 0, -2))

--- a/src/transcoder/transcoder.cpp
+++ b/src/transcoder/transcoder.cpp
@@ -488,6 +488,10 @@ bool Transcoder::StartJob(const Job& job) {
   g_object_set(src, "location", job.input.toUtf8().constData(), nullptr);
   g_object_set(sink, "location", job.output.toUtf8().constData(), nullptr);
 
+  // Create target directory, if it does not exist
+  QFileInfo output_file_path(job.output);
+  output_file_path.dir().mkpath(".");
+
   // Set callbacks
   state->convert_element_ = convert;
 

--- a/src/transcoder/transcoder.h
+++ b/src/transcoder/transcoder.h
@@ -71,7 +71,8 @@ class Transcoder : public QObject {
   void set_max_threads(int count) { max_threads_ = count; }
 
   void AddJob(const QString& input, const TranscoderPreset& preset,
-              const QString& output = QString());
+              const QString& output = QString(),
+              bool overwrite_existing = false);
   void AddTemporaryJob(const QString& input, const TranscoderPreset& preset);
 
   QMap<QString, float> GetProgress() const;

--- a/src/ui/organisedialog.h
+++ b/src/ui/organisedialog.h
@@ -25,7 +25,6 @@
 #include <memory>
 
 #include "core/organise.h"
-#include "core/organiseformat.h"
 #include "core/song.h"
 #include "gtest/gtest_prod.h"
 #include "library/librarybackend.h"
@@ -75,7 +74,6 @@ class OrganiseDialog : public QDialog {
  private slots:
   void Reset();
 
-  void InsertTag(const QString& tag);
   void UpdatePreviews();
 
   void DestDataChanged(const QModelIndex& begin, const QModelIndex& end);
@@ -94,8 +92,6 @@ class OrganiseDialog : public QDialog {
   LibraryBackend* backend_;
 
   QMetaObject::Connection model_connection_;
-
-  OrganiseFormat format_;
 
   QFuture<SongList> songs_future_;
   SongList songs_;

--- a/src/ui/organisedialog.ui
+++ b/src/ui/organisedialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>588</width>
-    <height>525</height>
+    <height>596</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -64,77 +64,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="naming_group">
-     <property name="title">
-      <string>Naming options</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="LineTextEdit" name="naming">
-          <property name="toolTip">
-           <string>&lt;p&gt;Tokens start with %, for example: %artist %album %title &lt;/p&gt;
-
-&lt;p&gt;If you surround sections of text that contain a token with curly-braces, that section will be hidden if the token is empty.&lt;/p&gt;</string>
-          </property>
-          <property name="lineWrapMode">
-           <enum>QTextEdit::NoWrap</enum>
-          </property>
-          <property name="acceptRichText">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="insert">
-          <property name="text">
-           <string>Insert...</string>
-          </property>
-          <property name="popupMode">
-           <enum>QToolButton::InstantPopup</enum>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="replace_the">
-        <property name="text">
-         <string>Ignore &quot;The&quot; in artist names</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="replace_spaces">
-        <property name="text">
-         <string>Replaces spaces with underscores</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="replace_ascii">
-        <property name="text">
-         <string>Restrict to ASCII characters</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="overwrite">
-        <property name="text">
-         <string>Overwrite existing files</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="mark_as_listened">
-        <property name="text">
-         <string>Mark as listened</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
+    <widget class="FileNameFormatWidget" name="naming_group" native="true"/>
    </item>
    <item>
     <widget class="QGroupBox" name="preview_group">
@@ -152,7 +82,16 @@
           <property name="spacing">
            <number>0</number>
           </property>
-          <property name="margin">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
            <number>0</number>
           </property>
           <item>
@@ -165,7 +104,16 @@
           <property name="spacing">
            <number>0</number>
           </property>
-          <property name="margin">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
            <number>0</number>
           </property>
           <item>
@@ -228,14 +176,15 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>LineTextEdit</class>
-   <extends>QTextEdit</extends>
-   <header>widgets/linetextedit.h</header>
-  </customwidget>
-  <customwidget>
    <class>BusyIndicator</class>
    <extends>QWidget</extends>
    <header>widgets/busyindicator.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>FileNameFormatWidget</class>
+   <extends>QWidget</extends>
+   <header>widgets/filenameformatwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
@@ -243,12 +192,6 @@
   <tabstop>destination</tabstop>
   <tabstop>aftercopying</tabstop>
   <tabstop>eject_after</tabstop>
-  <tabstop>naming</tabstop>
-  <tabstop>insert</tabstop>
-  <tabstop>replace_the</tabstop>
-  <tabstop>replace_spaces</tabstop>
-  <tabstop>replace_ascii</tabstop>
-  <tabstop>overwrite</tabstop>
   <tabstop>button_box</tabstop>
  </tabstops>
  <resources>

--- a/src/widgets/filenameformatwidget.cpp
+++ b/src/widgets/filenameformatwidget.cpp
@@ -1,0 +1,166 @@
+/* This file is part of Clementine.
+   Copyright 2010, David Sansome <me@davidsansome.com>
+   Copyright 2021, Lukas Prediger <lumip@lumip.de>
+
+   Clementine is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Clementine is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "filenameformatwidget.h"
+
+#include <QDebug>
+#include <QMap>
+#include <QMenu>
+#include <QSettings>
+#include <QString>
+#include <QStringList>
+
+#include "core/organise.h"
+#include "ui/organisedialog.h"
+#include "ui_filenameformatwidget.h"
+
+const char* FileNameFormatWidget::kDefaultFormat =
+    "%artist/%album{ (Disc %disc)}/{%track - }%title.%extension";
+const char* FileNameFormatWidget::kSettingsGroup = "FileNameFormatWidget";
+
+FileNameFormatWidget::FileNameFormatWidget(QWidget* parent)
+    : QWidget(parent), ui_(new Ui_FileNameFormatWidget) {
+  setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
+  ui_->setupUi(this);
+
+  // Syntax highlighting for naming scheme input field.
+  // attaches as child to ui_->naming, which transfers ownership
+  new OrganiseFormat::SyntaxHighlighter(ui_->naming);
+
+  // Valid tags
+  QMap<QString, QString> tags;
+  tags[tr("Title")] = "title";
+  tags[tr("Album")] = "album";
+  tags[tr("Artist")] = "artist";
+  tags[tr("Artist's initial")] = "artistinitial";
+  tags[tr("Album artist")] = "albumartist";
+  tags[tr("Composer")] = "composer";
+  tags[tr("Performer")] = "performer";
+  tags[tr("Grouping")] = "grouping";
+  tags[tr("Lyrics")] = "lyrics";
+  tags[tr("Track")] = "track";
+  tags[tr("Disc")] = "disc";
+  tags[tr("BPM")] = "bpm";
+  tags[tr("Year")] = "year";
+  tags[tr("Original year")] = "originalyear";
+  tags[tr("Genre")] = "genre";
+  tags[tr("Comment")] = "comment";
+  tags[tr("Length")] = "length";
+  tags[tr("Bitrate", "Refers to bitrate in file organise dialog.")] = "bitrate";
+  tags[tr("Samplerate")] = "samplerate";
+  tags[tr("File extension")] = "extension";
+
+  // Get the titles of the tags to put in the insert menu
+  QStringList tag_titles = tags.keys();
+  std::stable_sort(tag_titles.begin(), tag_titles.end());
+
+  // Build the insert menu
+  QMenu* tag_menu = new QMenu(this);
+  for (const QString& title : tag_titles) {
+    QAction* action = tag_menu->addAction(title);
+    QString tag = tags[title];
+    connect(action, &QAction::triggered, [this, tag]() { InsertTag(tag); });
+  }
+
+  ui_->insert->setMenu(tag_menu);
+
+  connect(ui_->naming, SIGNAL(textChanged()), SIGNAL(FormatStringChanged()));
+  connect(ui_->replace_ascii, SIGNAL(toggled(bool)), SIGNAL(OptionChanged()));
+  connect(ui_->replace_spaces, SIGNAL(toggled(bool)), SIGNAL(OptionChanged()));
+  connect(ui_->replace_the, SIGNAL(toggled(bool)), SIGNAL(OptionChanged()));
+  connect(ui_->overwrite, SIGNAL(toggled(bool)), SIGNAL(OptionChanged()));
+  connect(ui_->mark_as_listened, SIGNAL(toggled(bool)),
+          SIGNAL(OptionChanged()));
+
+  LoadSettings();
+}
+
+void FileNameFormatWidget::Reset() {
+  ui_->naming->setPlainText(kDefaultFormat);
+  ui_->replace_ascii->setChecked(false);
+  ui_->replace_spaces->setChecked(false);
+  ui_->replace_the->setChecked(false);
+  ui_->overwrite->setChecked(false);
+  ui_->mark_as_listened->setChecked(false);
+}
+
+bool FileNameFormatWidget::ignore_the() const {
+  return ui_->replace_the->isChecked();
+}
+
+bool FileNameFormatWidget::replace_spaces() const {
+  return ui_->replace_spaces->isChecked();
+}
+
+bool FileNameFormatWidget::restrict_to_ascii() const {
+  return ui_->replace_ascii->isChecked();
+}
+
+bool FileNameFormatWidget::overwrite_existing() const {
+  return ui_->overwrite->isChecked();
+}
+
+bool FileNameFormatWidget::mark_as_listened() const {
+  return ui_->mark_as_listened->isChecked();
+}
+
+OrganiseFormat FileNameFormatWidget::format() const {
+  OrganiseFormat format;
+  format.set_format(ui_->naming->toPlainText());
+  format.set_replace_non_ascii(ui_->replace_ascii->isChecked());
+  format.set_replace_spaces(ui_->replace_spaces->isChecked());
+  format.set_replace_the(ui_->replace_the->isChecked());
+  return format;
+}
+
+void FileNameFormatWidget::InsertTag(const QString& tag) {
+  ui_->naming->insertPlainText("%" + tag);
+}
+
+void FileNameFormatWidget::LoadSettings() {
+  QSettings s;
+
+  // transitional fallback: if the new kSettingsGroup for FileNameFormatWidget
+  // is not present, try loading from OrganiseDialog::kSettingsGroup, where
+  // these settings where previously held.
+  if (!s.childGroups().contains(kSettingsGroup) &&
+      s.childGroups().contains(OrganiseDialog::kSettingsGroup)) {
+    s.beginGroup(OrganiseDialog::kSettingsGroup);
+  } else {
+    s.beginGroup(kSettingsGroup);
+  }
+
+  ui_->naming->setPlainText(s.value("format", kDefaultFormat).toString());
+  ui_->replace_ascii->setChecked(s.value("replace_ascii", false).toBool());
+  ui_->replace_spaces->setChecked(s.value("replace_spaces", false).toBool());
+  ui_->replace_the->setChecked(s.value("replace_the", false).toBool());
+  ui_->overwrite->setChecked(s.value("overwrite", false).toBool());
+  ui_->mark_as_listened->setChecked(
+      s.value("mark_as_listened", false).toBool());
+}
+
+void FileNameFormatWidget::StoreSettings() {
+  QSettings s;
+  s.beginGroup(kSettingsGroup);
+  s.setValue("format", ui_->naming->toPlainText());
+  s.setValue("replace_ascii", ui_->replace_ascii->isChecked());
+  s.setValue("replace_spaces", ui_->replace_spaces->isChecked());
+  s.setValue("replace_the", ui_->replace_the->isChecked());
+  s.setValue("overwrite", ui_->overwrite->isChecked());
+  s.setValue("mark_as_listened", ui_->overwrite->isChecked());
+}

--- a/src/widgets/filenameformatwidget.h
+++ b/src/widgets/filenameformatwidget.h
@@ -1,0 +1,59 @@
+/* This file is part of Clementine.
+   Copyright 2010, David Sansome <me@davidsansome.com>
+   Copyright 2021, Lukas Prediger <lumip@lumip.de>
+
+   Clementine is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Clementine is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Clementine.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef FILENAMEFORMATWIDGET_H
+#define FILENAMEFORMATWIDGET_H
+
+#include <QWidget>
+#include <memory>
+
+#include "core/organiseformat.h"
+#include "ui_filenameformatwidget.h"
+
+class FileNameFormatWidget : public QWidget {
+  Q_OBJECT
+ public:
+  static const char* kDefaultFormat;
+  static const char* kSettingsGroup;
+
+ signals:
+  void OptionChanged();
+  void FormatStringChanged();
+
+ private slots:
+  void InsertTag(const QString& tag);
+
+ public:
+  FileNameFormatWidget(QWidget* parent);
+  void Reset();
+  void StoreSettings();
+
+  bool ignore_the() const;
+  bool replace_spaces() const;
+  bool restrict_to_ascii() const;
+  bool overwrite_existing() const;
+  bool mark_as_listened() const;
+  OrganiseFormat format() const;
+
+ private:
+  void LoadSettings();
+
+  std::unique_ptr<Ui_FileNameFormatWidget> ui_;
+};
+
+#endif  // FILENAMEFORMATWIDGET_H

--- a/src/widgets/filenameformatwidget.ui
+++ b/src/widgets/filenameformatwidget.ui
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>FileNameFormatWidget</class>
+ <widget class="QWidget" name="FileNameFormatWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>361</width>
+    <height>283</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="naming_group">
+     <property name="title">
+      <string>Naming options</string>
+     </property>
+     <layout class="QVBoxLayout" name="innerVerticalLayout">
+      <item>
+       <layout class="QHBoxLayout" name="innerHorizontalLayout">
+        <item>
+         <widget class="LineTextEdit" name="naming">
+          <property name="toolTip">
+           <string>&lt;p&gt;Tokens start with %, for example: %artist %album %title &lt;/p&gt;
+
+&lt;p&gt;If you surround sections of text that contain a token with curly-braces, that section will be hidden if the token is empty.&lt;/p&gt;</string>
+          </property>
+          <property name="lineWrapMode">
+           <enum>QTextEdit::NoWrap</enum>
+          </property>
+          <property name="acceptRichText">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolButton" name="insert">
+          <property name="text">
+           <string>Insert...</string>
+          </property>
+          <property name="popupMode">
+           <enum>QToolButton::InstantPopup</enum>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="replace_the">
+        <property name="text">
+         <string>Ignore &quot;The&quot; in artist names</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="replace_spaces">
+        <property name="text">
+         <string>Replaces spaces with underscores</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="replace_ascii">
+        <property name="text">
+         <string>Restrict to ASCII characters</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="overwrite">
+        <property name="text">
+         <string>Overwrite existing files</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="mark_as_listened">
+        <property name="text">
+         <string>Mark as listened</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>LineTextEdit</class>
+   <extends>QTextEdit</extends>
+   <header>widgets/linetextedit.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>naming</tabstop>
+  <tabstop>insert</tabstop>
+  <tabstop>replace_the</tabstop>
+  <tabstop>replace_spaces</tabstop>
+  <tabstop>replace_ascii</tabstop>
+  <tabstop>overwrite</tabstop>
+  <tabstop>mark_as_listened</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/widgets/filenameformatwidget.ui
+++ b/src/widgets/filenameformatwidget.ui
@@ -21,6 +21,12 @@
        <layout class="QHBoxLayout" name="innerHorizontalLayout">
         <item>
          <widget class="LineTextEdit" name="naming">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="toolTip">
            <string>&lt;p&gt;Tokens start with %, for example: %artist %album %title &lt;/p&gt;
 


### PR DESCRIPTION
Previously we had very different UI and inconsistent logic for file name formatting in the CD ripping dialog compared to the organise files dialog window. This change set unifies the UI by moving the file formatting UI elements of the organise files dialog into a distinct widget that is then re-used in the CD ripping dalog.

Further changes:
- filename preview in CD ripping dialog
- Transcoder now creates folders along the output paths if they don't already exist
- Transcoder::AddJob now accepts an optional flag to overwrite existing files (defaults to `false`)
- CD ripping dialog was not correctly loading (and not at all storing) the chosen transcoder preset