### PR TITLE
Cd ripper file formatting fixes

### DIFF
--- a/src/musicbrainz/musicbrainzclient.cpp
+++ b/src/musicbrainz/musicbrainzclient.cpp
@@ -113,7 +113,7 @@ void MusicBrainzClient::DiscIdRequestFinished(const QString& discid,
         << "Error:"
         << reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt()
         << "http status code received";
-    qLog(Error) << reply->readAll();
+    if (reply->isOpen()) qLog(Error) << reply->readAll();
     emit Finished(artist, album, ret);
     return;
   }

--- a/src/ripper/ripcddialog.h
+++ b/src/ripper/ripcddialog.h
@@ -60,12 +60,14 @@ class RipCDDialog : public QDialog {
   void Cancelled(Ripper* ripper);
   void SetupProgressBarLimits(int min, int max);
   void UpdateProgressBar(int progress);
-  void UpdateTrackList(const SongList& songs);
-  // Update album information with metadata.
-  void AddAlbumMetadataFromMusicBrainz(const SongList& songs);
+  void SongsLoaded(const SongList& songs);
   void DiscChanged();
   void FormatStringUpdated();
   void UpdateFileNamePreviews();
+  void DiscEditChanged(const QString& disc_string);
+  void YearEditChanged(const QString& year_string);
+  void UpdateMetadataEdits();
+  void UpdateMetadataFromGUI();
 
  private:
   static const char* kSettingsGroup;


### PR DESCRIPTION
This amends/fixes PR #7078 : Editing the values in the album metadata edits previously did affect the tags of the transcoded files, but was not reflected in file names/paths and the file name prefix. This is now fixed.

As an additional small fix: MusicBrainzClient was producing an IO error when the connection timed out (while trying to read an error response, which in this case did not exist).