### PR TITLE
Correct time computation for seekbar tooltip.

### DIFF
--- a/src/widgets/tracksliderslider.cpp
+++ b/src/widgets/tracksliderslider.cpp
@@ -85,10 +85,11 @@ void TrackSliderSlider::mouseMoveEvent(QMouseEvent* e) {
   int slider_min = gr.x();
   int slider_max = gr.right() - slider_length + 1;
 
-  mouse_hover_seconds_ = QStyle::sliderValueFromPosition(
-      minimum(), maximum(),
-      e->x() - slider_length / 2 - slider_min, slider_max - slider_min)
-      / kMsecPerSec;
+  mouse_hover_seconds_ =
+      QStyle::sliderValueFromPosition(minimum(), maximum(),
+                                      e->x() - slider_length / 2 - slider_min,
+                                      slider_max - slider_min) /
+      kMsecPerSec;
 
   popup_->SetText(Utilities::PrettyTime(mouse_hover_seconds_));
   UpdateDeltaTime();

--- a/src/widgets/tracksliderslider.cpp
+++ b/src/widgets/tracksliderslider.cpp
@@ -86,8 +86,9 @@ void TrackSliderSlider::mouseMoveEvent(QMouseEvent* e) {
   int slider_max = gr.right() - slider_length + 1;
 
   mouse_hover_seconds_ = QStyle::sliderValueFromPosition(
-      minimum() / kMsecPerSec, maximum() / kMsecPerSec,
-      e->x() - slider_length / 2 - slider_min + 1, slider_max - slider_min);
+      minimum(), maximum(),
+      e->x() - slider_length / 2 - slider_min, slider_max - slider_min)
+      / kMsecPerSec;
 
   popup_->SetText(Utilities::PrettyTime(mouse_hover_seconds_));
   UpdateDeltaTime();


### PR DESCRIPTION
This fixes [this bug I reported to the Debian bug tracker](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=981225) where the tooltip when hovering over the seekbar isn't *quite* right. I thought it was exactly one pixel off, but once I fixed that, there was also a rounding error that went away when I moved the `/ kMsecPerSec` to outside the call to `QStyle::sliderValueFromPosition`.

The code says it's based on [QSliderPrivate::pixelPosToRangeValue](https://github.com/qt/qtbase/blob/9db7cc79a26ced4997277b5c206ca15949133240/src/widgets/widgets/qslider.cpp#L100), so I looked at that code and [its callsite used to process a mouse click](https://github.com/qt/qtbase/blob/9db7cc79a26ced4997277b5c206ca15949133240/src/widgets/widgets/qslider.cpp#L377) to adjust the code to match that logic more closely. 62e21d64f3328ce74a5149adbd90f53e9df1a385 added the `+ 1` as part of fixing an older issue in that code; it's unclear why from that change.

My test that this actually does the right thing was to manually click and drag on the seekbar and confirm that while dragging the delta display is always "+0:00" as well as clicking on a bunch of places on the seekbar and checking the same.