### PR TITLE
build: Fix translations

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -58,14 +58,14 @@ jobs:
           libtag1-dev
           pkg-config
           protobuf-compiler
-          python-pip
+          python3-pip
           qtbase5-dev
           qttools5-dev-tools
           qttools5-dev
           libsparsehash-dev
           ssh
       - name: Install tx
-        run: pip install transifex-client==0.13.9
+        run: pip3 install transifex-client==0.13.9
       - name: Checkout
         uses: actions/checkout@v1.2.0
       - name: tx init

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -16,10 +16,10 @@ jobs:
         run: >
           apt-get update && apt-get install -y
           git
-          python-pip
+          python3-pip
           ssh
       - name: Install tx
-        run: pip install transifex-client==0.13.9
+        run: pip3 install transifex-client==0.13.9
       - name: Checkout
         uses: actions/checkout@v1.2.0
       - name: Switch to master


### PR DESCRIPTION
transifex-client indirectly requires Unidecode>=0.04.16. As of version
1.3.2, Unidecode no longer supports Python 2. Its setup shebang points
to /usr/bin/python, which it assumes is python3. To correct the issue,
install pip3 instead of pip, avoiding the installation of Python 2.

If running transifex-client with python3 is undesirable, manually installing Unidecode==1.2.0 should also be a workable solution.