### PR TITLE
Fix: Detaching bus callback in ~GstEnginePipeline

### DIFF
--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -499,7 +499,7 @@ bool GstEnginePipeline::InitAudioBin() {
   gst_object_unref(pad);
   GstBus* bus = gst_pipeline_get_bus(GST_PIPELINE(pipeline_));
   gst_bus_set_sync_handler(bus, BusCallbackSync, this, nullptr);
-  bus_cb_id_ = gst_bus_add_watch(bus, BusCallback, this);
+  gst_bus_add_watch(bus, BusCallback, this);
   gst_object_unref(bus);
 
   return true;
@@ -567,10 +567,11 @@ bool GstEnginePipeline::InitFromReq(const MediaPlaybackRequest& req,
 GstEnginePipeline::~GstEnginePipeline() {
   if (pipeline_) {
     GstBus* bus = gst_pipeline_get_bus(GST_PIPELINE(pipeline_));
+    gst_bus_remove_watch(bus);
+
     gst_bus_set_sync_handler(bus, nullptr, nullptr, nullptr);
     gst_object_unref(bus);
 
-    g_source_remove(bus_cb_id_);
     gst_element_set_state(pipeline_, GST_STATE_NULL);
 
     if (tee_) {

--- a/src/engines/gstenginepipeline.h
+++ b/src/engines/gstenginepipeline.h
@@ -294,8 +294,6 @@ class GstEnginePipeline : public GstPipelineBase {
   GstPad* tee_probe_pad_;
   GstPad* tee_audio_pad_;
 
-  uint bus_cb_id_;
-
   QThreadPool set_state_threadpool_;
 
   GstSegment last_decodebin_segment_;


### PR DESCRIPTION
Stopping a playing track (or switching to a next one, whether manual or automatically) caused the following error to be issued from `GstEnginePipeline`'s destructor:
```
ERROR logging:64(GLib)                 Source ID xy was not found when attempting to remove it
```
This was caused by an apparently faulty detaching/clearing of a callback from the gstreamer pipeline which is fixed in this pull request.