### PR TITLE
Fix: GstEnginePipeline BusCallback erroneously returned false.

### DIFF
--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -613,7 +613,7 @@ gboolean GstEnginePipeline::BusCallback(GstBus*, GstMessage* msg,
       break;
   }
 
-  return FALSE;
+  return TRUE;
 }
 
 GstBusSyncReply GstEnginePipeline::BusCallbackSync(GstBus*, GstMessage* msg,


### PR DESCRIPTION
@jonaski reported in PR #7101 of getting an error for removal of the bus callback there (see the [direct link](https://github.com/clementine-player/Clementine/pull/7101#issuecomment-950403314) to that post for details ).

The cause was the following: Since the callback as it was implemented returned false, it was removed from the bus after its first invocation (cf. "The watch can be removed using gst_bus_remove_watch or by returning FALSE from func.", [Gstreamer docs](https://gstreamer.freedesktop.org/documentation/gstreamer/gstbus.html?gi-language=c#gst_bus_add_watch)), which is not what we want there.

Fixed in this PR by making the callback return true instead.