### PR TITLE
Revert "Fix: GstEnginePipeline BusCallback erroneously returned false."

### DIFF
--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -613,7 +613,7 @@ gboolean GstEnginePipeline::BusCallback(GstBus*, GstMessage* msg,
       break;
   }
 
-  return TRUE;
+  return FALSE;
 }
 
 GstBusSyncReply GstEnginePipeline::BusCallbackSync(GstBus*, GstMessage* msg,


### PR DESCRIPTION
Reverts clementine-player/Clementine#7112

See https://github.com/clementine-player/Clementine/issues/7115