### PR TITLE
Added option to remove/replace originals in transcoder dialog.

### DIFF
--- a/src/transcoder/transcodedialog.cpp
+++ b/src/transcoder/transcodedialog.cpp
@@ -211,13 +211,14 @@ void TranscodeDialog::JobComplete(const QString& input, const QString& output,
   UpdateProgress();
 
   bool overwrite_existing = ui_->remove_original->isChecked();
-  QFileInfo input_fileinfo(input);
-  QFileInfo output_fileinfo(output);
-  bool same_extension = input_fileinfo.suffix() == output_fileinfo.suffix();
-  bool same_path =
-      input_fileinfo.absolutePath() == output_fileinfo.absolutePath();
 
   if (success && overwrite_existing) {
+    QFileInfo input_fileinfo(input);
+    QFileInfo output_fileinfo(output);
+    bool same_extension = input_fileinfo.suffix() == output_fileinfo.suffix();
+    bool same_path =
+        input_fileinfo.absolutePath() == output_fileinfo.absolutePath();
+
     QFile(input).remove();
     if (same_path && same_extension) {
       QFile(output).rename(input);

--- a/src/transcoder/transcodedialog.ui
+++ b/src/transcoder/transcodedialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>499</width>
-    <height>448</height>
+    <height>482</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -162,6 +162,16 @@
        <widget class="QPushButton" name="select">
         <property name="text">
          <string>Select...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QCheckBox" name="remove_original">
+        <property name="toolTip">
+         <string>If enabled the original files will be removed. If transcoded files have the same file extension and the destination is the same directory as the original files, the original files will be replaced.</string>
+        </property>
+        <property name="text">
+         <string>Remove or replace original files </string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This behavior is enabled via a new checkbox in the transcoder dialog.
When enabled, transcoding will replace original files if the transcoded file would end up with the same path name (same format/extension and destination "alongside the originals"). In all other cases, the original files will simply be deleted after successful transcoding.
If transcoding of a file fails for any reason, the original will not be deleted/replaced.

Requested in #7110 .