### PR TITLE
Fixing gst bus watch issues

### DIFF
--- a/src/engines/gstelementdeleter.cpp
+++ b/src/engines/gstelementdeleter.cpp
@@ -28,4 +28,5 @@ void GstElementDeleter::DeleteElementLater(GstElement* element) {
 
 void GstElementDeleter::DeleteElement(GstElement* element) {
   gst_element_set_state(element, GST_STATE_NULL);
+  gst_object_unref(element);
 }

--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -613,7 +613,7 @@ gboolean GstEnginePipeline::BusCallback(GstBus*, GstMessage* msg,
       break;
   }
 
-  return FALSE;
+  return TRUE;
 }
 
 GstBusSyncReply GstEnginePipeline::BusCallbackSync(GstBus*, GstMessage* msg,

--- a/src/engines/gstenginepipeline.cpp
+++ b/src/engines/gstenginepipeline.cpp
@@ -1146,6 +1146,7 @@ void GstEnginePipeline::SourceSetupCallback(GstURIDecodeBin* bin,
 
 void GstEnginePipeline::TransitionToNext() {
   GstElement* old_decode_bin = uridecodebin_;
+  gst_object_ref(old_decode_bin);
 
   ignore_tags_ = true;
 


### PR DESCRIPTION
Second attempt for fixing #7120 (after the initial PR addressing that was reverted) while also addressing the issue of #7115 .

I did some digging and the problem that arose from the initial pull request seems to have been caused by replacing the uridecodebin in `GstEnginePipeline::TransitionToNext`. After removing the old uridecodebin from the pipeline, its reference count dropped to zero before its state was set to `GST_STATE_NULL`, which resulted in the crash reported in #7115.
This behavior is documented in the [docs for `gst_bin_remove`](https://gstreamer.freedesktop.org/documentation/gstreamer/gstbin.html?gi-language=c#gst_bin_remove): "Removes the element from the bin, unparenting it as well. Unparenting the element means that the element will be dereferenced, so if the bin holds the only reference to the element, the element will be freed in the process of removing it from the bin. If you want the element to still exist after removing, you need to call gst_object_ref before removing it from the bin."

I added a fix for this that increments the reference count on the old decodebin before removing it from the pipeline and accordingly modified `GstElementDeleter::DeleteElement` to decrement the reference count after setting its state to `GST_STATE_NULL`.

Now, the real question is why this was not a problem earlier. I have monitored the reference counts of all decodebins and noticed that previously they were never reaching zero. The change of the return value of `BusCallback` changed this. I'm not sure why this is but the current new behavior seems to be the correct one. I haven't had the opportunity to look into this in more depth, so if someone could verify that there was a memory leak of decodebins earlier and give an intuition why changing the return value of `BusCallback` might have solved this, that would be very helpful.