### PR TITLE
Make background steams build-optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,6 +330,8 @@ optional_component(VISUALISATIONS ON "Visualisations"
   DEPENDS "opengl" OPENGL_FOUND
 )
 
+optional_component(BACKGROUND_STREAMS ON "Background streams")
+
 optional_component(TRANSLATIONS ON "Translations"
   DEPENDS "gettext" GETTEXT_XGETTEXT_EXECUTABLE
   DEPENDS "Qt5LinguistTools" Qt5LinguistTools_FOUND

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ find_library(PROTOBUF_STATIC_LIBRARY libprotobuf.a libprotobuf)
 
 pkg_check_modules(CDIO libcdio)
 pkg_check_modules(CHROMAPRINT REQUIRED libchromaprint)
-pkg_search_module(CRYPTOPP cryptopp libcrypto++)
+pkg_search_module(CRYPTOPP libcryptopp libcrypto++)
 pkg_check_modules(GIO gio-2.0)
 pkg_check_modules(GLIB REQUIRED glib-2.0)
 pkg_check_modules(GOBJECT REQUIRED gobject-2.0)

--- a/include/clementine-config.h.in
+++ b/include/clementine-config.h.in
@@ -48,6 +48,7 @@
 #cmakedefine HAVE_OPENGL
 #cmakedefine HAVE_TRANSLATIONS
 #cmakedefine HAVE_SPOTIFY
+#cmakedefine HAVE_BACKGROUND_STREAMS
 #cmakedefine TAGLIB_HAS_OPUS
 #cmakedefine USE_INSTALL_PREFIX
 #cmakedefine USE_SYSTEM_PROJECTM

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,7 +71,6 @@ set(SOURCES
 
   core/appearance.cpp
   core/application.cpp
-  core/backgroundstreams.cpp
   core/commandlineoptions.cpp
   core/crashreporting.cpp
   core/database.cpp
@@ -344,7 +343,6 @@ set(SOURCES
   ui/albumcovermanagerlist.cpp
   ui/albumcoversearcher.cpp
   ui/appearancesettingspage.cpp
-  ui/backgroundstreamssettingspage.cpp
   ui/behavioursettingspage.cpp
   ui/console.cpp
   ui/coverfromurldialog.cpp
@@ -390,7 +388,6 @@ set(SOURCES
   widgets/fileviewlist.cpp
   widgets/forcescrollperpixel.cpp
   widgets/freespacebar.cpp
-  widgets/fullscreenhypnotoad.cpp
   widgets/groupediconview.cpp
   widgets/lineedit.cpp
   widgets/linetextedit.cpp
@@ -425,7 +422,6 @@ set(HEADERS
   analyzers/turbine.h
 
   core/application.h
-  core/backgroundstreams.h
   core/crashreporting.h
   core/database.h
   core/deletefiles.h
@@ -647,7 +643,6 @@ set(HEADERS
   ui/albumcovermanagerlist.h
   ui/albumcoversearcher.h
   ui/appearancesettingspage.h
-  ui/backgroundstreamssettingspage.h
   ui/behavioursettingspage.h
   ui/console.h
   ui/coverfromurldialog.h
@@ -786,7 +781,6 @@ set(UI
   ui/albumcovermanager.ui
   ui/albumcoversearcher.ui
   ui/appearancesettingspage.ui
-  ui/backgroundstreamssettingspage.ui
   ui/behavioursettingspage.ui
   ui/console.ui
   ui/coverfromurldialog.ui
@@ -845,6 +839,20 @@ if (HAVE_TRANSLATIONS)
 endif(HAVE_TRANSLATIONS)
 
 option(USE_INSTALL_PREFIX "Look for data in CMAKE_INSTALL_PREFIX" ON)
+
+# Background streams
+optional_source(HAVE_BACKGROUND_STREAMS
+  SOURCES
+    core/backgroundstreams.cpp
+    ui/backgroundstreamssettingspage.cpp
+    widgets/fullscreenhypnotoad.cpp
+  HEADERS
+    core/backgroundstreams.h
+    ui/backgroundstreamssettingspage.h
+    widgets/fullscreenhypnotoad.h
+  UI
+    ui/backgroundstreamssettingspage.ui
+)
 
 # Visualisations
 optional_source(HAVE_VISUALISATIONS

--- a/src/engines/gstengine.h
+++ b/src/engines/gstengine.h
@@ -32,6 +32,7 @@
 #include <QTimerEvent>
 #include <memory>
 
+#include "config.h"
 #include "bufferconsumer.h"
 #include "core/timeconstants.h"
 #include "enginebase.h"
@@ -84,9 +85,11 @@ class GstEngine : public Engine::Base, public BufferConsumer {
   void EnsureInitialised() { initialising_.waitForFinished(); }
   void InitialiseGstreamer();
 
+#ifdef HAVE_BACKGROUND_STREAMS
   int AddBackgroundStream(const QUrl& url);
   void StopBackgroundStream(int id);
   void SetBackgroundStreamVolume(int id, int volume);
+#endif
 
   qint64 position_nanosec() const;
   qint64 length_nanosec() const;
@@ -152,8 +155,10 @@ class GstEngine : public Engine::Base, public BufferConsumer {
   void FadeoutFinished();
   void FadeoutPauseFinished();
   void SeekNow();
+#ifdef HAVE_BACKGROUND_STREAMS
   void BackgroundStreamFinished();
   void BackgroundStreamPlayDone(QFuture<GstStateChangeReturn>, int);
+#endif
   void PlayDone(QFuture<GstStateChangeReturn> future, const quint64, const int);
 
   void BufferingStarted();
@@ -182,7 +187,9 @@ class GstEngine : public Engine::Base, public BufferConsumer {
 
   void UpdateScope(int chunk_length);
 
+#ifdef HAVE_BACKGROUND_STREAMS
   int AddBackgroundStream(std::shared_ptr<GstEnginePipeline> pipeline);
+#endif
 
   bool IsCurrentPipeline(int id);
 
@@ -240,7 +247,9 @@ class GstEngine : public Engine::Base, public BufferConsumer {
   int timer_id_;
   int next_element_id_;
 
+#ifdef HAVE_BACKGROUND_STREAMS
   QHash<int, std::shared_ptr<GstEnginePipeline>> background_streams_;
+#endif
 
   bool is_fading_out_to_pause_;
   bool has_faded_out_;

--- a/src/ui/backgroundstreamssettingspage.cpp
+++ b/src/ui/backgroundstreamssettingspage.cpp
@@ -27,19 +27,24 @@
 
 BackgroundStreamsSettingsPage::BackgroundStreamsSettingsPage(
     SettingsDialog* dialog)
-    : SettingsPage(dialog), ui_(new Ui_BackgroundStreamsSettingsPage) {
+    : SettingsPage(dialog),
+      ui_(new Ui_BackgroundStreamsSettingsPage),
+      loaded_(false) {
   ui_->setupUi(this);
   setWindowIcon(
       IconLoader::Load("weather-showers-scattered", IconLoader::Base));
-
-  for (const QString& name : dialog->background_streams()->streams()) {
-    AddStream(name);
-  }
 }
 
 BackgroundStreamsSettingsPage::~BackgroundStreamsSettingsPage() { delete ui_; }
 
-void BackgroundStreamsSettingsPage::Load() {}
+void BackgroundStreamsSettingsPage::Load() {
+  if (!loaded_ and dialog()->background_streams()) {
+    for (const QString& name : dialog()->background_streams()->streams()) {
+      AddStream(name);
+    }
+    loaded_ = true;
+  }
+}
 
 void BackgroundStreamsSettingsPage::Save() {
   dialog()->background_streams()->SaveStreams();

--- a/src/ui/backgroundstreamssettingspage.h
+++ b/src/ui/backgroundstreamssettingspage.h
@@ -41,6 +41,7 @@ class BackgroundStreamsSettingsPage : public SettingsPage {
 
  private:
   Ui_BackgroundStreamsSettingsPage* ui_;
+  bool loaded_;
 };
 
 #endif  // BACKGROUNDSTREAMSSETTINGSPAGE_H

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -39,7 +39,9 @@
 
 #include "core/appearance.h"
 #include "core/application.h"
+#ifdef HAVE_BACKGROUND_STREAMS
 #include "core/backgroundstreams.h"
+#endif
 #include "core/commandlineoptions.h"
 #include "core/database.h"
 #include "core/deletefiles.h"
@@ -310,8 +312,10 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
   // Start initialising the player
   qLog(Debug) << "Initialising player";
   app_->player()->Init();
+#ifdef HAVE_BACKGROUND_STREAMS
   background_streams_ = new BackgroundStreams(app_->player()->engine(), this);
   background_streams_->LoadStreams();
+#endif
 
   // Models
   qLog(Debug) << "Creating models";
@@ -392,13 +396,15 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
       IconLoader::Load("document-save", IconLoader::Base));
   ui_->action_full_library_scan->setIcon(
       IconLoader::Load("view-refresh", IconLoader::Base));
+#ifdef HAVE_BACKGROUND_STREAMS
   ui_->action_rain->setIcon(
       IconLoader::Load("weather-showers-scattered", IconLoader::Base));
   ui_->action_hypnotoad->setIcon(
       IconLoader::Load("hypnotoad", IconLoader::Base));
-  ui_->action_kittens->setIcon(IconLoader::Load("kittens", IconLoader::Base));
   ui_->action_enterprise->setIcon(
-      IconLoader::Load("enterprise", IconLoader::Base));
+    IconLoader::Load("enterprise", IconLoader::Base));
+#endif
+  ui_->action_kittens->setIcon(IconLoader::Load("kittens", IconLoader::Base));
   ui_->action_love->setIcon(IconLoader::Load("love", IconLoader::Lastfm));
 
   // File view connections
@@ -495,9 +501,15 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
   connect(this, SIGNAL(NewDebugConsole(Console*)), app_,
           SIGNAL(NewDebugConsole(Console*)));
 
+#ifdef HAVE_BACKGROUND_STREAMS
   background_streams_->AddAction("Rain", ui_->action_rain);
   background_streams_->AddAction("Hypnotoad", ui_->action_hypnotoad);
   background_streams_->AddAction("Make it so!", ui_->action_enterprise);
+#else
+  ui_->action_rain->setVisible(false);
+  ui_->action_hypnotoad->setVisible(false);
+  ui_->action_enterprise->setVisible(false);
+#endif // HAVE_BACKGROUND_STREAMS
 
   // Playlist view actions
   ui_->action_next_playlist->setShortcuts(
@@ -938,8 +950,10 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
   connect(app_->player(), SIGNAL(Stopped()), ui_->now_playing, SLOT(Stopped()));
   connect(ui_->now_playing, SIGNAL(ShowAboveStatusBarChanged(bool)),
           SLOT(NowPlayingWidgetPositionChanged(bool)));
+#ifdef HAVE_BACKGROUND_STREAMS
   connect(ui_->action_hypnotoad, SIGNAL(toggled(bool)), ui_->now_playing,
           SLOT(AllHail(bool)));
+#endif
   connect(ui_->action_kittens, SIGNAL(toggled(bool)), ui_->now_playing,
           SLOT(EnableKittens(bool)));
   connect(ui_->action_kittens, SIGNAL(toggled(bool)), app_->network_remote(),
@@ -2714,10 +2728,12 @@ void MainWindow::ChangeLibraryQueryMode(QAction* action) {
 void MainWindow::ShowCoverManager() { cover_manager_->show(); }
 
 SettingsDialog* MainWindow::CreateSettingsDialog() {
-  SettingsDialog* settings_dialog =
-      new SettingsDialog(app_, background_streams_);
+  SettingsDialog* settings_dialog = new SettingsDialog(app_);
   settings_dialog->SetGlobalShortcutManager(global_shortcuts_);
   settings_dialog->SetSongInfoView(song_info_view_);
+#ifdef HAVE_BACKGROUND_STREAMS
+  settings_dialog->SetBackgroundStreams(background_streams_);
+#endif
 
   // Settings
   connect(settings_dialog, SIGNAL(accepted()), SLOT(ReloadAllSettings()));

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -396,14 +396,6 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
       IconLoader::Load("document-save", IconLoader::Base));
   ui_->action_full_library_scan->setIcon(
       IconLoader::Load("view-refresh", IconLoader::Base));
-#ifdef HAVE_BACKGROUND_STREAMS
-  ui_->action_rain->setIcon(
-      IconLoader::Load("weather-showers-scattered", IconLoader::Base));
-  ui_->action_hypnotoad->setIcon(
-      IconLoader::Load("hypnotoad", IconLoader::Base));
-  ui_->action_enterprise->setIcon(
-    IconLoader::Load("enterprise", IconLoader::Base));
-#endif
   ui_->action_kittens->setIcon(IconLoader::Load("kittens", IconLoader::Base));
   ui_->action_love->setIcon(IconLoader::Load("love", IconLoader::Lastfm));
 
@@ -501,15 +493,29 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
   connect(this, SIGNAL(NewDebugConsole(Console*)), app_,
           SIGNAL(NewDebugConsole(Console*)));
 
+  // Add menus for background streams
 #ifdef HAVE_BACKGROUND_STREAMS
-  background_streams_->AddAction("Rain", ui_->action_rain);
-  background_streams_->AddAction("Hypnotoad", ui_->action_hypnotoad);
-  background_streams_->AddAction("Make it so!", ui_->action_enterprise);
-#else
-  ui_->action_rain->setVisible(false);
-  ui_->action_hypnotoad->setVisible(false);
-  ui_->action_enterprise->setVisible(false);
-#endif // HAVE_BACKGROUND_STREAMS
+  QAction* action_rain =
+      ui_->menu_extras->addAction(tr("Rain"));
+  action_rain->setIcon(
+      IconLoader::Load("weather-showers-scattered", IconLoader::Base));
+  action_rain->setCheckable(true);
+  background_streams_->AddAction("Rain", action_rain);
+
+  QAction* action_hypnotoad =
+      ui_->menu_extras->addAction(tr("All Glory to the Hypnotoad!"));
+  action_hypnotoad->setIcon(
+      IconLoader::Load("hypnotoad", IconLoader::Base));
+  action_hypnotoad->setCheckable(true);
+  background_streams_->AddAction("Hypnotoad", action_hypnotoad);
+
+    QAction* action_enterprise =
+      ui_->menu_extras->addAction(tr("Make it so!"));
+  action_enterprise->setIcon(
+      IconLoader::Load("enterprise", IconLoader::Base));
+  action_enterprise->setCheckable(true);
+  background_streams_->AddAction("Make it so!", action_enterprise);
+#endif
 
   // Playlist view actions
   ui_->action_next_playlist->setShortcuts(
@@ -951,7 +957,7 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
   connect(ui_->now_playing, SIGNAL(ShowAboveStatusBarChanged(bool)),
           SLOT(NowPlayingWidgetPositionChanged(bool)));
 #ifdef HAVE_BACKGROUND_STREAMS
-  connect(ui_->action_hypnotoad, SIGNAL(toggled(bool)), ui_->now_playing,
+  connect(action_hypnotoad, SIGNAL(toggled(bool)), ui_->now_playing,
           SLOT(AllHail(bool)));
 #endif
   connect(ui_->action_kittens, SIGNAL(toggled(bool)), ui_->now_playing,

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -541,9 +541,6 @@
     <property name="title">
      <string>&amp;Extras</string>
     </property>
-    <addaction name="action_rain"/>
-    <addaction name="action_hypnotoad"/>
-    <addaction name="action_enterprise"/>
     <addaction name="action_kittens"/>
     <addaction name="action_console"/>
     <addaction name="separator"/>
@@ -733,30 +730,6 @@
   <action name="action_cover_manager">
    <property name="text">
     <string>Cover Manager</string>
-   </property>
-  </action>
-  <action name="action_rain">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string comment="Label for button to enable/disable rain background sound.">Rain</string>
-   </property>
-  </action>
-  <action name="action_hypnotoad">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string comment="Label for button to enable/disable Hypnotoad background sound.">All Glory to the Hypnotoad!</string>
-   </property>
-  </action>
-  <action name="action_enterprise">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string comment="Label for button to enable/disable Enterprise background sound.">Make it so!</string>
    </property>
   </action>
   <action name="action_kittens">

--- a/src/ui/settingsdialog.cpp
+++ b/src/ui/settingsdialog.cpp
@@ -18,11 +18,13 @@
 #include "settingsdialog.h"
 
 #include "appearancesettingspage.h"
+#ifdef HAVE_BACKGROUND_STREAMS
 #include "backgroundstreamssettingspage.h"
+#include "core/backgroundstreams.h"
+#endif
 #include "behavioursettingspage.h"
 #include "config.h"
 #include "core/application.h"
-#include "core/backgroundstreams.h"
 #include "core/logging.h"
 #include "core/networkproxyfactory.h"
 #include "core/player.h"
@@ -89,14 +91,13 @@ void SettingsItemDelegate::paint(QPainter* painter,
   }
 }
 
-SettingsDialog::SettingsDialog(Application* app, BackgroundStreams* streams,
-                               QWidget* parent)
+SettingsDialog::SettingsDialog(Application* app, QWidget* parent)
     : QDialog(parent),
       app_(app),
       model_(app_->directory_model()),
       gst_engine_(qobject_cast<GstEngine*>(app_->player()->engine())),
       song_info_view_(nullptr),
-      streams_(streams),
+      background_streams_(nullptr),
       global_search_(app_->global_search()),
       appearance_(app_->appearance()),
       ui_(new Ui_SettingsDialog),
@@ -110,8 +111,10 @@ SettingsDialog::SettingsDialog(Application* app, BackgroundStreams* streams,
   general->AddPage(Page_Behaviour, new BehaviourSettingsPage(this));
   general->AddPage(Page_Library, new LibrarySettingsPage(this));
   general->AddPage(Page_SongMetadata, new SongMetadataSettingsPage(this));
+#ifdef HAVE_BACKGROUND_STREAMS
   general->AddPage(Page_BackgroundStreams,
                    new BackgroundStreamsSettingsPage(this));
+#endif
   general->AddPage(Page_Proxy, new NetworkProxySettingsPage(this));
   general->AddPage(Page_Transcoding, new TranscoderSettingsPage(this));
   general->AddPage(Page_NetworkRemote, new NetworkRemoteSettingsPage(this));

--- a/src/ui/settingsdialog.h
+++ b/src/ui/settingsdialog.h
@@ -55,8 +55,7 @@ class SettingsDialog : public QDialog {
   Q_OBJECT
 
  public:
-  SettingsDialog(Application* app, BackgroundStreams* streams,
-                 QWidget* parent = nullptr);
+  SettingsDialog(Application* app, QWidget* parent = nullptr);
   ~SettingsDialog();
 
   enum Page {
@@ -101,6 +100,7 @@ class SettingsDialog : public QDialog {
     manager_ = manager;
   }
   void SetSongInfoView(SongInfoView* view) { song_info_view_ = view; }
+  void SetBackgroundStreams(BackgroundStreams* streams) { background_streams_ = streams; }
 
   bool is_loading_settings() const { return loading_settings_; }
 
@@ -109,7 +109,7 @@ class SettingsDialog : public QDialog {
   GlobalShortcuts* global_shortcuts_manager() const { return manager_; }
   const GstEngine* gst_engine() const { return gst_engine_; }
   SongInfoView* song_info_view() const { return song_info_view_; }
-  BackgroundStreams* background_streams() const { return streams_; }
+  BackgroundStreams* background_streams() const { return background_streams_; }
   GlobalSearch* global_search() const { return global_search_; }
   Appearance* appearance() const { return appearance_; }
 
@@ -149,7 +149,7 @@ class SettingsDialog : public QDialog {
   GlobalShortcuts* manager_;
   const GstEngine* gst_engine_;
   SongInfoView* song_info_view_;
-  BackgroundStreams* streams_;
+  BackgroundStreams* background_streams_;
   GlobalSearch* global_search_;
   Appearance* appearance_;
 

--- a/src/widgets/nowplayingwidget.cpp
+++ b/src/widgets/nowplayingwidget.cpp
@@ -35,7 +35,9 @@
 #include "covers/coverproviders.h"
 #include "covers/currentartloader.h"
 #include "covers/kittenloader.h"
+#ifdef HAVE_BACKGROUND_STREAMS
 #include "fullscreenhypnotoad.h"
+#endif
 #include "library/librarybackend.h"
 #include "networkremote/networkremote.h"
 #include "ui/albumcoverchoicecontroller.h"
@@ -43,7 +45,9 @@
 
 const char* NowPlayingWidget::kSettingsGroup = "NowPlayingWidget";
 
+#ifdef HAVE_BACKGROUND_STREAMS
 const char* NowPlayingWidget::kHypnotoadPath = ":/hypnotoad.gif";
+#endif
 
 // Space between the cover and the details in small mode
 const int NowPlayingWidget::kPadding = 2;
@@ -76,7 +80,9 @@ NowPlayingWidget::NowPlayingWidget(QWidget* parent)
       fade_animation_(new QTimeLine(1000, this)),
       details_(new QTextDocument(this)),
       previous_track_opacity_(0.0),
+#ifdef HAVE_BACKGROUND_STREAMS
       bask_in_his_glory_action_(nullptr),
+#endif
       downloading_covers_(false),
       aww_(false),
       kittens_(nullptr),
@@ -142,10 +148,12 @@ NowPlayingWidget::NowPlayingWidget(QWidget* parent)
   above_statusbar_action_->setChecked(
       s.value("above_status_bar", false).toBool());
 
+#ifdef HAVE_BACKGROUND_STREAMS
   bask_in_his_glory_action_ =
       menu_->addAction(tr("ALL GLORY TO THE HYPNOTOAD"));
   bask_in_his_glory_action_->setVisible(false);
   connect(bask_in_his_glory_action_, SIGNAL(triggered()), SLOT(Bask()));
+#endif // HAVE_BACKGROUND_STREAMS
 
   // Animations
   connect(show_hide_animation_, SIGNAL(frameChanged(int)),
@@ -377,10 +385,14 @@ void NowPlayingWidget::paintEvent(QPaintEvent* e) {
 void NowPlayingWidget::DrawContents(QPainter* p) {
   switch (mode_) {
     case SmallSongDetails:
+
+#ifdef HAVE_BACKGROUND_STREAMS
       if (hypnotoad_) {
         p->drawPixmap(0, 0, small_ideal_height_, small_ideal_height_,
                       hypnotoad_->currentPixmap());
-      } else {
+      } else 
+#endif
+      {
         // Draw the cover
         p->drawPixmap(0, 0, small_ideal_height_, small_ideal_height_, cover_);
         if (downloading_covers_) {
@@ -406,10 +418,13 @@ void NowPlayingWidget::DrawContents(QPainter* p) {
                   Qt::black);
 
       // Draw the cover
+#ifdef HAVE_BACKGROUND_STREAMS
       if (hypnotoad_) {
         p->drawPixmap(x_offset, kTopBorder, total_size, total_size,
                       hypnotoad_->currentPixmap());
-      } else {
+      } else 
+#endif
+      {
         p->drawPixmap(x_offset, kTopBorder, total_size, total_size, cover_);
         if (downloading_covers_) {
           p->drawPixmap(x_offset + 45, 35, 16, 16,
@@ -448,10 +463,13 @@ void NowPlayingWidget::DrawContents(QPainter* p) {
                   Qt::black);
 
       // Draw the cover
+#ifdef HAVE_BACKGROUND_STREAMS
       if (hypnotoad_) {
         p->drawPixmap(x_offset, kTopBorder, total_size, total_size,
                       hypnotoad_->currentPixmap());
-      } else {
+      } else 
+#endif
+      {
         p->drawPixmap(x_offset, kTopBorder, total_size, total_size, cover_);
         if (downloading_covers_) {
           p->drawPixmap(x_offset + 45, 35, 16, 16,
@@ -477,10 +495,13 @@ void NowPlayingWidget::DrawContents(QPainter* p) {
       }
 
       // Draw the cover
+#ifdef HAVE_BACKGROUND_STREAMS
       if (hypnotoad_) {
         p->drawPixmap(x_offset, kTopBorder, cover_size, cover_size,
                       hypnotoad_->currentPixmap());
-      } else {
+      } else 
+#endif
+      {
         p->drawPixmap(x_offset, kTopBorder, cover_size, cover_size, cover_);
         if (downloading_covers_) {
           p->drawPixmap(x_offset + 45, 35, 16, 16,
@@ -554,7 +575,9 @@ void NowPlayingWidget::contextMenuEvent(QContextMenuEvent* e) {
         !art_is_not_set);
   }
 
+#ifdef HAVE_BACKGROUND_STREAMS
   bask_in_his_glory_action_->setVisible(static_cast<bool>(hypnotoad_));
+#endif
 
   // show the menu
   menu_->popup(mapToGlobal(e->pos()));
@@ -562,7 +585,12 @@ void NowPlayingWidget::contextMenuEvent(QContextMenuEvent* e) {
 
 void NowPlayingWidget::mouseReleaseEvent(QMouseEvent* e) {
   // Same behaviour as right-click > Show Fullsize
-  if (e->button() == Qt::LeftButton && !aww_ && !hypnotoad_.get()) {
+  bool can_show_cover = true;
+  if (aww_) can_show_cover = false;
+#ifdef HAVE_BACKGROUND_STREAMS
+  if (hypnotoad_.get()) can_show_cover = false;
+#endif
+  if (e->button() == Qt::LeftButton && can_show_cover) {
     ShowCover();
   }
 }
@@ -589,6 +617,8 @@ void NowPlayingWidget::FitCoverWidth(bool fit) {
   s.setValue("fit_cover_width", fit_width_);
 }
 
+#ifdef HAVE_BACKGROUND_STREAMS
+
 void NowPlayingWidget::AllHail(bool hypnotoad) {
   if (hypnotoad) {
     hypnotoad_.reset(new QMovie(kHypnotoadPath, QByteArray(), this));
@@ -600,6 +630,8 @@ void NowPlayingWidget::AllHail(bool hypnotoad) {
     update();
   }
 }
+
+#endif // HAVE_BACKGROUND_STREAMS
 
 void NowPlayingWidget::EnableKittens(bool aww) {
   if (!kittens_ && aww) {
@@ -649,6 +681,8 @@ void NowPlayingWidget::SearchCoverAutomatically() {
   GetCoverAutomatically();
 }
 
+#ifdef HAVE_BACKGROUND_STREAMS
+
 void NowPlayingWidget::Bask() {
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   QScreen* screen = QWidget::screen();
@@ -661,6 +695,8 @@ void NowPlayingWidget::Bask() {
   if (screen) big_hypnotoad_->setGeometry(screen->availableGeometry());
   big_hypnotoad_->showFullScreen();
 }
+
+#endif // HAVE_BACKGROUND_STREAMS
 
 void NowPlayingWidget::dragEnterEvent(QDragEnterEvent* e) {
   if (AlbumCoverChoiceController::CanAcceptDrag(e)) {

--- a/src/widgets/nowplayingwidget.h
+++ b/src/widgets/nowplayingwidget.h
@@ -26,7 +26,9 @@
 
 class AlbumCoverChoiceController;
 class Application;
+#ifdef HAVE_BACKGROUND_STREAMS
 class FullscreenHypnotoad;
+#endif
 class KittenLoader;
 
 class QAction;
@@ -71,7 +73,10 @@ class NowPlayingWidget : public QWidget {
 
  public slots:
   void Stopped();
+
+#ifdef HAVE_BACKGROUND_STREAMS
   void AllHail(bool hypnotoad);
+#endif
   void EnableKittens(bool aww);
 
  protected:
@@ -104,7 +109,9 @@ class NowPlayingWidget : public QWidget {
   void ShowCover();
   void SearchCoverAutomatically();
 
+#ifdef HAVE_BACKGROUND_STREAMS
   void Bask();
+#endif
 
   void AutomaticCoverSearchDone();
 
@@ -147,10 +154,12 @@ class NowPlayingWidget : public QWidget {
   QPixmap previous_track_;
   qreal previous_track_opacity_;
 
+#ifdef HAVE_BACKGROUND_STREAMS
   static const char* kHypnotoadPath;
   QAction* bask_in_his_glory_action_;
   std::unique_ptr<QMovie> hypnotoad_;
   std::unique_ptr<FullscreenHypnotoad> big_hypnotoad_;
+#endif
 
   std::unique_ptr<QMovie> spinner_animation_;
   bool downloading_covers_;


### PR DESCRIPTION
Added a build option `ENABLE_BACKGROUND_STREAMS`. When disabled, removes background streams (hypnotoad, rain, enterprise) code from the UI and engine with a bunch of `#ifdef`. Stays enabled by default. Both option values have been tested.

This is simply to make it possible to remove these potentially unwanted features.