### PR TITLE
Remove the out-of-place Easter Egg

### DIFF
--- a/src/playlist/playlistcontainer.cpp
+++ b/src/playlist/playlistcontainer.cpp
@@ -397,15 +397,9 @@ void PlaylistContainer::UpdateNoMatchesLabel() {
 
   QString text;
   if (has_rows && !has_results) {
-    if (ui_->filter->text().trimmed().compare("the answer to life the universe "
-                                              "and everything",
-                                              Qt::CaseInsensitive) == 0) {
-      text = "42";
-    } else {
-      text = tr(
-          "No matches found.  Clear the search box to show the whole playlist "
-          "again.");
-    }
+    text =
+        tr("No matches found.  Clear the search box to show the whole playlist "
+           "again.");
   }
 
   if (!text.isEmpty()) {


### PR DESCRIPTION
Discovered while trying to understand how the filtering components are interconnected, this felt a bit surprising. Removing for the sake of clarity - unless it's used for testing or something?