### PR TITLE
Added option to remove/replace originals in transcoder dialog (fixed).

### DIFF
--- a/src/transcoder/transcodedialog.ui
+++ b/src/transcoder/transcodedialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>499</width>
-    <height>448</height>
+    <height>482</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -162,6 +162,16 @@
        <widget class="QPushButton" name="select">
         <property name="text">
          <string>Select...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QCheckBox" name="remove_original">
+        <property name="toolTip">
+         <string>If enabled the original files will be removed. If transcoded files have the same file extension and the destination is the same directory as the original files, the original files will be replaced.</string>
+        </property>
+        <property name="text">
+         <string>Remove or replace original files </string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This is a squashed and fixed version of previous commits
6b6547095ac60b6e4c9113fffdfa9b5e945bb9b0
dd1393ea3ab5ae58aff8f8cc444aee3c8e4830fb

from previously merged PR #7118 which failed to build due to incompatible changes made to master between opening and merging the PR. Sorry for that @hatstand 