### PR TITLE
Rewrite the Block Analyzer to improve performance.

### DIFF
--- a/src/analyzers/analyzerbase.cpp
+++ b/src/analyzers/analyzerbase.cpp
@@ -65,13 +65,15 @@ Analyzer::Base::Base(QWidget* parent, uint scopeSize)
       timeout_(40),  // msec
       fht_(new FHT(scopeSize)),
       engine_(nullptr),
-      lastScope_(512),
+      lastScope_(),
       new_frame_(false),
       is_playing_(false),
       barkband_table_(),
       prev_color_index_(0),
       bands_(0),
-      psychedelic_enabled_(false) {}
+      psychedelic_enabled_(false) {
+  lastScope_.resize(fht_->size());
+}
 
 void Analyzer::Base::hideEvent(QHideEvent*) { timer_.stop(); }
 

--- a/src/analyzers/blockanalyzer.h
+++ b/src/analyzers/blockanalyzer.h
@@ -4,6 +4,7 @@
    Copyright 2010, 2014, John Maguire <john.maguire@gmail.com>
    Copyright 2014-2015, Mark Furneaux <mark@furneaux.ca>
    Copyright 2014, Krzysztof A. Sobiecki <sobkas@gmail.com>
+   Copyright 2022, Andrew Reading <andrew@areading.me>
 
    Clementine is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -43,9 +44,11 @@ class BlockAnalyzer : public Analyzer::Base {
   static const uint kHeight;
   static const uint kWidth;
   static const uint kMinRows;
+  static const uint kMaxRows;
   static const uint kMinColumns;
   static const uint kMaxColumns;
   static const uint kFadeSize;
+  static const uint kFadeInitial;
 
   static const char* kName;
 
@@ -57,27 +60,58 @@ class BlockAnalyzer : public Analyzer::Base {
   virtual void framerateChanged();
   virtual void psychedelicModeChanged(bool);
 
-  void drawBackground();
   void determineStep();
 
  private:
-  QPixmap* bar() { return &barPixmap_; }
+  struct FHTBand {
+    FHTBand()
+        : height(0.f),
+          row(0),
+          fade_row(0),
+          fade_coloridx(kMaxRows),
+          fade_intensity(kFadeInitial) {}
 
-  uint columns_, rows_;  // number of rows and columns of blocks
-  uint y_;               // y-offset from top of widget
-  QPixmap barPixmap_;
-  QPixmap topBarPixmap_;
-  QPixmap background_;
-  QPixmap canvas_;
-  Analyzer::Scope scope_;  // so we don't create a vector every frame
-  QVector<float> store_;   // current bar kHeights
-  QVector<float> yscale_;
+    // Top of the spectral activity bar.
+    float height;  // Foreground-Background transition row.
+    uint row;      // Integer floor of the height value.
 
-  QVector<QPixmap> fade_bars_;
-  QVector<uint> fade_pos_;
-  QVector<int> fade_intensity_;
+    // Vertical color fade effect (a sort of hysteresis).
+    uint fade_row;       // Row in which to begin showing BG gradient.
+    uint fade_coloridx;  // Current fade_bars_[] offset.
+    int fade_intensity;  // Current intensity frame counter value.
+  };
 
-  float step_;  // rows to fall per frame
+  inline quint32 colorFromRowAndBand(uint cur_r, const FHTBand& band);
+
+  Analyzer::Scope scope_;
+
+  uint columns_;  // Number of columns of blocks.
+  uint rows_;     // Number of rows of blocks.
+  uint y_;        // y-offset from top of widget.
+  float step_;    // Rows to fall per frame (during inactivity).
+
+  QColor fg_color_;   // Foreground/Active block color.
+  QColor bg_color_;   // Background/Inactive block color.
+  QColor pad_color_;  // Color of 'lines' dividing the blocks.
+  QImage canvas_;     // Drawable canvas of widget.
+
+  QVector<float> rthresh_;      // [rows_+1] Rowwise intensity thresholds.
+  QVector<quint32> bg_grad_;    // [rows_+1] Vertical background gradient.
+  QVector<quint32> fade_bars_;  // [kFadeSize] Block colors per fade level.
+  QVector<FHTBand> bandinfo_;   // [columns_] FHT band info.
 };
+
+inline quint32 BlockAnalyzer::colorFromRowAndBand(uint r, const FHTBand& band) {
+  // Calculate the block color given band info and the current row.
+  // Note: 0 <= r <= rows_.
+  if (r == band.row)
+    return fg_color_.rgba();
+  else if (r > band.row)
+    return bg_grad_[r];
+  else if ((band.fade_intensity > 0) && (r >= band.fade_row))
+    return fade_bars_[band.fade_coloridx];
+  else
+    return bg_color_.rgba();
+}
 
 #endif  // ANALYZERS_BLOCKANALYZER_H_


### PR DESCRIPTION
The block analyzer was doing lots of repeated, out-of-order blits to the
widget's canvas. To improve performance and reduce CPU usage, this has
been rewritten to generate the canvas contents using only a single buffer.
Cache thrashing has been greatly reduced by writing to memory only
sequentially and in one single write pass. Further, the raw format is
now guaranteed to be in a format efficient for Qt.

The results are visually identical to what they were previously, but
result in a CPU usage reduction between 2 and 6 percent depending on refresh
rate and Psychadelic Mode value. In particular, there used to be a ~3 percent
overhead for Psychadelic Mode, and this has been eliminated.

The specific details of the block analyzer and explanations for how it works
(and used to work) have been documented via fairly extensive comments
in blockanalyzer.cpp.