### PR TITLE
Fix ClassicalRadio.com and ROCKRADIO.com #5616

### DIFF
--- a/src/internet/digitally/digitallyimportedservicebase.cpp
+++ b/src/internet/digitally/digitallyimportedservicebase.cpp
@@ -259,7 +259,7 @@ RockRadioService::RockRadioService(Application* app, InternetModel* model,
     : DigitallyImportedServiceBase(
           "RockRadio", "ROCKRADIO.com", QUrl("http://www.rockradio.com"),
           IconLoader::Load("rockradio", IconLoader::Provider), "rockradio", app,
-          model, false, parent) {}
+          model, true, parent) {}
 
 ClassicalRadioService::ClassicalRadioService(Application* app,
                                              InternetModel* model,
@@ -268,4 +268,4 @@ ClassicalRadioService::ClassicalRadioService(Application* app,
           "ClassicalRadio", "ClassicalRadio.com",
           QUrl("http://www.classicalradio.com"),
           IconLoader::Load("digitallyimported", IconLoader::Provider),
-          "classicalradio", app, model, false, parent) {}
+          "classicalradio", app, model, true, parent) {}


### PR DESCRIPTION
These two audio addict feeds do support premium -- Perhaps they didn't previously. This changes fixes the playlist not loading for me on a local build.

This was changed in https://github.com/clementine-player/Clementine/issues/4582