### PR TITLE
WIP: Added system tray menu item to unhide the application

### DIFF
--- a/src/ui/macsystemtrayicon.h
+++ b/src/ui/macsystemtrayicon.h
@@ -33,7 +33,7 @@ class MacSystemTrayIcon : public SystemTrayIcon {
 
   void SetupMenu(QAction* previous, QAction* play, QAction* stop,
                  QAction* stop_after, QAction* next, QAction* mute,
-                 QAction* love, QAction* quit);
+                 QAction* show_hide, QAction* love, QAction* quit);
 
   void SetNowPlaying(const Song& song, const QString& image_path);
   void ClearNowPlaying();

--- a/src/ui/macsystemtrayicon.mm
+++ b/src/ui/macsystemtrayicon.mm
@@ -163,8 +163,8 @@ MacSystemTrayIcon::MacSystemTrayIcon(QObject* parent)
 MacSystemTrayIcon::~MacSystemTrayIcon() {}
 
 void MacSystemTrayIcon::SetupMenu(QAction* previous, QAction* play, QAction* stop,
-                                  QAction* stop_after, QAction* next, QAction* mute, QAction* love,
-                                  QAction* quit) {
+                                  QAction* stop_after, QAction* next, QAction* mute, 
+                                  QAction* show_hide, QAction* love, QAction* quit) {
   p_.reset(new MacSystemTrayIconPrivate());
   SetupMenuItem(previous);
   SetupMenuItem(play);
@@ -173,6 +173,7 @@ void MacSystemTrayIcon::SetupMenu(QAction* previous, QAction* play, QAction* sto
   SetupMenuItem(next);
   p_->AddSeparator();
   SetupMenuItem(mute);
+  SetupMenuItem(show_hide);
   p_->AddSeparator();
   SetupMenuItem(love);
   Q_UNUSED(quit);  // Mac already has a Quit item.

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -430,6 +430,8 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
   connect(ui_->action_stop_after_this_track, SIGNAL(triggered()),
           SLOT(StopAfterCurrent()));
   connect(ui_->action_mute, SIGNAL(triggered()), app_->player(), SLOT(Mute()));
+  connect(ui_->action_show_hide, SIGNAL(triggered()), SLOT(ToggleShowHide()));
+
 #ifdef HAVE_LIBLASTFM
   connect(ui_->action_love, SIGNAL(triggered()), SLOT(Love()));
   connect(ui_->action_toggle_scrobbling, SIGNAL(triggered()), app_->scrobbler(),
@@ -825,7 +827,7 @@ MainWindow::MainWindow(Application* app, SystemTrayIcon* tray_icon, OSD* osd,
     tray_icon_->SetupMenu(ui_->action_previous_track, ui_->action_play_pause,
                           ui_->action_stop, ui_->action_stop_after_this_track,
                           ui_->action_next_track, ui_->action_mute,
-                          ui_->action_love, ui_->action_quit);
+                          ui_->action_show_hide, ui_->action_love, ui_->action_quit);
     connect(tray_icon_, SIGNAL(PlayPause()), app_->player(), SLOT(PlayPause()));
     connect(tray_icon_, SIGNAL(SeekForward()), app_->player(),
             SLOT(SeekForward()));

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -565,6 +565,7 @@
     <addaction name="action_configure"/>
     <addaction name="separator"/>
     <addaction name="action_toggle_show_sidebar"/>
+    <addaction name="action_show_hide"/>
    </widget>
    <addaction name="menu_music"/>
    <addaction name="menu_playlist"/>
@@ -876,6 +877,14 @@
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+M</string>
+   </property>
+  </action>
+  <action name="action_show_hide">
+   <property name="checkable">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Show/Hide Clementine</string>
    </property>
   </action>
   <action name="action_full_library_scan">

--- a/src/ui/qtsystemtrayicon.cpp
+++ b/src/ui/qtsystemtrayicon.cpp
@@ -36,6 +36,7 @@ QtSystemTrayIcon::QtSystemTrayIcon(QObject* parent)
       action_stop_(nullptr),
       action_stop_after_this_track_(nullptr),
       action_mute_(nullptr),
+      action_show_hide_(nullptr),
       action_love_(nullptr) {
   QIcon theme_icon = IconLoader::Load("clementine-panel", IconLoader::Base);
   QIcon theme_icon_grey =
@@ -103,8 +104,8 @@ bool QtSystemTrayIcon::eventFilter(QObject* object, QEvent* event) {
 
 void QtSystemTrayIcon::SetupMenu(QAction* previous, QAction* play,
                                  QAction* stop, QAction* stop_after,
-                                 QAction* next, QAction* mute, QAction* love,
-                                 QAction* quit) {
+                                 QAction* next, QAction* mute, QAction* show_hide, 
+                                 QAction* love, QAction* quit) {
   // Creating new actions and connecting them to old ones. This allows us to
   // use old actions without displaying shortcuts that can not be used when
   // Clementine's window is hidden
@@ -123,6 +124,8 @@ void QtSystemTrayIcon::SetupMenu(QAction* previous, QAction* play,
       menu_->addAction(mute->icon(), mute->text(), mute, SLOT(trigger()));
   action_mute_->setCheckable(true);
   action_mute_->setChecked(mute->isChecked());
+  action_show_hide_ = 
+      menu_->addAction(show_hide->icon(), show_hide->text(), show_hide, SLOT(trigger()));
 
   menu_->addSeparator();
 #ifdef HAVE_LIBLASTFM

--- a/src/ui/qtsystemtrayicon.h
+++ b/src/ui/qtsystemtrayicon.h
@@ -32,7 +32,7 @@ class QtSystemTrayIcon : public SystemTrayIcon {
 
   void SetupMenu(QAction* previous, QAction* play, QAction* stop,
                  QAction* stop_after, QAction* next, QAction* mute,
-                 QAction* love, QAction* quit);
+                 QAction* show_hide, QAction* love, QAction* quit);
   bool IsVisible() const;
   void SetVisible(bool visible);
 
@@ -64,6 +64,7 @@ class QtSystemTrayIcon : public SystemTrayIcon {
   QAction* action_stop_;
   QAction* action_stop_after_this_track_;
   QAction* action_mute_;
+  QAction* action_show_hide_;
   QAction* action_love_;
 
   QPixmap orange_icon_;

--- a/src/ui/systemtrayicon.h
+++ b/src/ui/systemtrayicon.h
@@ -33,7 +33,7 @@ class SystemTrayIcon : public QObject {
   // Called once to create the icon's context menu
   virtual void SetupMenu(QAction* previous, QAction* play, QAction* stop,
                          QAction* stop_after, QAction* next, QAction* mute,
-                         QAction* love, QAction* quit) = 0;
+                         QAction* show_hide, QAction* love, QAction* quit) = 0;
 
   virtual bool IsVisible() const { return true; }
   virtual void SetVisible(bool visible) {}


### PR DESCRIPTION
Fix Clementine stuck in the Clementine system tray icon, without any option to unminimize after minimizing - Issue #3665

Note: There are several different "System Tray Icon" plugins that can be used with Linux and this should account for every one of them that displays the Clementine System Tray Icon, in a uniform presentation.

This is marked as a work in progress, while I attempt to locate, research, and reproduce the issue on several other platforms.

Current Status:
- 👷🏻 Investigated reproducibility for Ubuntu 22.04 LTS (Xubuntu) Xfce4
  - Issue: Proposed fix does not work for child windows. I would think ideally when you minimize something, it would minimize all child windows as well.
- 👷🏻 Investigating reproducibility with Arch + Fluxbox
- Investigate reproducibility with Arch + Xfce
- Investigate reproducibility with Ubuntu 22.04 + Gnome
- Investigate reproducibility with Ubuntu 23.04 + Gnome
- Investigate reproducibility with Ubuntu 23.04 + Unity
- Investigate reproducibility with Debian 12
- Investigate if OSx menu item is needed

Changelog:
- Added menu item to unhide the application from the Clementine system tray icon menu after being minimized.

