### PR TITLE
Count song skips if song listened to for >5 seconds

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1262,10 +1262,14 @@ void MainWindow::TrackSkipped(PlaylistItemPtr item) {
 
     const qint64 seconds_left = (length - position) / kNsecPerSec;
     const qint64 seconds_total = length / kNsecPerSec;
+    const qint64 seconds_listened = position / kNsecPerSec;
 
     if (((0.05 * seconds_total > 60 && percentage < 0.98) ||
          percentage < 0.95) &&
-        seconds_left > 5) {  // Never count the skip if under 5 seconds left
+        (seconds_left > 5 &&
+         5 < seconds_listened)) {  // Never count the skip if under 5 seconds
+                                   // left. Or we haven't listened for more than
+                                   // 5 seconds.
       app_->library_backend()->IncrementSkipCountAsync(song.id(), percentage);
     }
   }


### PR DESCRIPTION
I believe that skipping through playlists to find a song unfairly increments a song's skip counter and negatively impacts the score. This feature would help eliminate this issue.