### PR TITLE
Fix Compile Warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.0.0)
 project(clementine)
 
-cmake_minimum_required(VERSION 3.0.0)
 cmake_policy(SET CMP0053 OLD)
 
 include(CheckCXXCompilerFlag)

--- a/src/core/organiseformat.h
+++ b/src/core/organiseformat.h
@@ -27,7 +27,7 @@
 
 #include "core/song.h"
 
-class TranscoderPreset;
+struct TranscoderPreset;
 
 class OrganiseFormat {
  public:

--- a/src/internet/digitally/digitallyimportedservicebase.h
+++ b/src/internet/digitally/digitallyimportedservicebase.h
@@ -41,16 +41,16 @@ class DigitallyImportedServiceBase : public InternetService {
                                const QString& api_service_name,
                                Application* app, InternetModel* model,
                                bool has_premium, QObject* parent = nullptr);
-  ~DigitallyImportedServiceBase();
+  ~DigitallyImportedServiceBase() override;
 
   static const char* kSettingsGroup;
   static const int kStreamsCacheDurationSecs;
 
-  QStandardItem* CreateRootItem();
-  void LazyPopulate(QStandardItem* parent);
-  void ShowContextMenu(const QPoint& global_pos);
+  QStandardItem* CreateRootItem() override;
+  void LazyPopulate(QStandardItem* parent) override;
+  void ShowContextMenu(const QPoint& global_pos) override;
 
-  void ReloadSettings();
+  void ReloadSettings() override;
 
   bool is_premium_account() const;
 

--- a/src/internet/icecast/icecastservice.h
+++ b/src/internet/icecast/icecastservice.h
@@ -40,7 +40,7 @@ class IcecastService : public InternetService {
 
  public:
   IcecastService(Application* app, InternetModel* parent);
-  ~IcecastService();
+  ~IcecastService() override;
 
   static const char* kServiceName;
   static const char* kDirectoryUrl;
@@ -51,12 +51,12 @@ class IcecastService : public InternetService {
     Type_Genre,
   };
 
-  QStandardItem* CreateRootItem();
-  void LazyPopulate(QStandardItem* item);
+  QStandardItem* CreateRootItem() override;
+  void LazyPopulate(QStandardItem* item) override;
 
-  void ShowContextMenu(const QPoint& global_pos);
+  void ShowContextMenu(const QPoint& global_pos) override;
 
-  QWidget* HeaderWidget() const;
+  QWidget* HeaderWidget() const override;
 
  private slots:
   void LoadDirectory();

--- a/src/internet/intergalacticfm/intergalacticfmservice.h
+++ b/src/internet/intergalacticfm/intergalacticfmservice.h
@@ -39,7 +39,7 @@ class IntergalacticFMServiceBase : public InternetService {
                              const QString& name, const QUrl& channel_list_url,
                              const QUrl& homepage_url,
                              const QUrl& donate_page_url, const QIcon& icon);
-  ~IntergalacticFMServiceBase();
+  ~IntergalacticFMServiceBase() override;
 
   enum ItemType {
     Type_Stream = 2000,
@@ -59,14 +59,14 @@ class IntergalacticFMServiceBase : public InternetService {
   const QString& url_scheme() const { return url_scheme_; }
   const QIcon& icon() const { return icon_; }
 
-  QStandardItem* CreateRootItem();
-  void LazyPopulate(QStandardItem* item);
-  void ShowContextMenu(const QPoint& global_pos);
+  QStandardItem* CreateRootItem() override;
+  void LazyPopulate(QStandardItem* item) override;
+  void ShowContextMenu(const QPoint& global_pos) override;
 
-  PlaylistItem::Options playlistitem_options() const;
+  PlaylistItem::Options playlistitem_options() const override;
   QNetworkAccessManager* network() const { return network_; }
 
-  void ReloadSettings();
+  void ReloadSettings() override;
 
   bool IsStreamListStale() const { return streams_.IsStale(); }
   StreamList Streams();

--- a/src/internet/internetradio/savedradio.h
+++ b/src/internet/internetradio/savedradio.h
@@ -34,7 +34,7 @@ class SavedRadio : public InternetService {
 
  public:
   SavedRadio(Application* app, InternetModel* parent);
-  ~SavedRadio();
+  ~SavedRadio() override;
 
   enum ItemType {
     Type_Stream = 2000,
@@ -57,10 +57,10 @@ class SavedRadio : public InternetService {
   static const char* kServiceName;
   static const char* kSettingsGroup;
 
-  QStandardItem* CreateRootItem();
-  void LazyPopulate(QStandardItem* item);
+  QStandardItem* CreateRootItem() override;
+  void LazyPopulate(QStandardItem* item) override;
 
-  void ShowContextMenu(const QPoint& global_pos);
+  void ShowContextMenu(const QPoint& global_pos) override;
 
   void Add(const QUrl& url, const QString& name = QString(),
            const QUrl& url_logo = QUrl());

--- a/src/internet/jamendo/jamendoservice.h
+++ b/src/internet/jamendo/jamendoservice.h
@@ -43,14 +43,14 @@ class JamendoService : public InternetService {
 
  public:
   JamendoService(Application* app, InternetModel* parent);
-  ~JamendoService();
+  ~JamendoService() override;
 
-  QStandardItem* CreateRootItem();
-  void LazyPopulate(QStandardItem* item);
+  QStandardItem* CreateRootItem() override;
+  void LazyPopulate(QStandardItem* item) override;
 
-  void ShowContextMenu(const QPoint& global_pos);
+  void ShowContextMenu(const QPoint& global_pos) override;
 
-  QWidget* HeaderWidget() const;
+  QWidget* HeaderWidget() const override;
 
   LibraryBackend* library_backend() const { return library_backend_.get(); }
 

--- a/src/internet/magnatune/magnatuneservice.h
+++ b/src/internet/magnatune/magnatuneservice.h
@@ -38,7 +38,7 @@ class MagnatuneService : public InternetService {
 
  public:
   MagnatuneService(Application* app, InternetModel* parent);
-  ~MagnatuneService();
+  ~MagnatuneService() override;
 
   // Values are saved in QSettings and are indices into the combo box in
   // MagnatuneConfig
@@ -71,14 +71,14 @@ class MagnatuneService : public InternetService {
 
   static QString ReadElementText(QXmlStreamReader& reader);
 
-  QStandardItem* CreateRootItem();
-  void LazyPopulate(QStandardItem* item);
+  QStandardItem* CreateRootItem() override;
+  void LazyPopulate(QStandardItem* item) override;
 
-  void ShowContextMenu(const QPoint& global_pos);
+  void ShowContextMenu(const QPoint& global_pos) override;
 
-  QWidget* HeaderWidget() const;
+  QWidget* HeaderWidget() const override;
 
-  void ReloadSettings();
+  void ReloadSettings() override;
 
   // Magnatune specific stuff
   MembershipType membership_type() const { return membership_; }
@@ -99,7 +99,7 @@ class MagnatuneService : public InternetService {
 
   void Download();
   void Homepage();
-  void ShowConfig();
+  void ShowConfig() override;
 
  private:
   void EnsureMenuCreated();

--- a/src/internet/podcasts/podcastservice.h
+++ b/src/internet/podcasts/podcastservice.h
@@ -44,7 +44,7 @@ class PodcastService : public InternetService {
 
  public:
   PodcastService(Application* app, InternetModel* parent);
-  ~PodcastService();
+  ~PodcastService() override;
 
   static const char* kServiceName;
   static const char* kSettingsGroup;
@@ -57,12 +57,12 @@ class PodcastService : public InternetService {
 
   enum Role { Role_Podcast = InternetModel::RoleCount, Role_Episode };
 
-  QStandardItem* CreateRootItem();
-  void LazyPopulate(QStandardItem* parent);
-  bool has_initial_load_settings() const { return true; }
-  void ShowContextMenu(const QPoint& global_pos);
-  void ReloadSettings();
-  void InitialLoadSettings();
+  QStandardItem* CreateRootItem() override;
+  void LazyPopulate(QStandardItem* parent) override;
+  bool has_initial_load_settings() const override { return true; }
+  void ShowContextMenu(const QPoint& global_pos) override;
+  void ReloadSettings() override;
+  void InitialLoadSettings() override;
   // Called by SongLoader when the user adds a Podcast URL directly.  Adds a
   // subscription to the podcast and displays it in the UI.  If the QVariant
   // contains an OPML file then this displays it in the Add Podcast dialog.
@@ -81,7 +81,7 @@ class PodcastService : public InternetService {
   void DeleteDownloadedData();
   void SetNew();
   void SetListened();
-  void ShowConfig();
+  void ShowConfig() override;
 
   void SubscriptionAdded(const Podcast& podcast);
   void SubscriptionRemoved(const Podcast& podcast);

--- a/src/internet/radiobrowser/radiobrowserservice.h
+++ b/src/internet/radiobrowser/radiobrowserservice.h
@@ -35,7 +35,7 @@ class RadioBrowserService : public InternetService {
 
  public:
   RadioBrowserService(Application* app, InternetModel* parent);
-  ~RadioBrowserService(){};
+  ~RadioBrowserService() override{};
 
   enum ItemType {
     Type_Stream = 2000,

--- a/src/internet/somafm/somafmservice.h
+++ b/src/internet/somafm/somafmservice.h
@@ -39,7 +39,7 @@ class SomaFMServiceBase : public InternetService {
                     const QString& name, const QUrl& channel_list_url,
                     const QUrl& homepage_url, const QUrl& donate_page_url,
                     const QIcon& icon);
-  ~SomaFMServiceBase();
+  ~SomaFMServiceBase() override;
 
   enum ItemType {
     Type_Stream = 2000,
@@ -59,14 +59,14 @@ class SomaFMServiceBase : public InternetService {
   const QString& url_scheme() const { return url_scheme_; }
   const QIcon& icon() const { return icon_; }
 
-  QStandardItem* CreateRootItem();
-  void LazyPopulate(QStandardItem* item);
-  void ShowContextMenu(const QPoint& global_pos);
+  QStandardItem* CreateRootItem() override;
+  void LazyPopulate(QStandardItem* item) override;
+  void ShowContextMenu(const QPoint& global_pos) override;
 
-  PlaylistItem::Options playlistitem_options() const;
+  PlaylistItem::Options playlistitem_options() const override;
   QNetworkAccessManager* network() const { return network_; }
 
-  void ReloadSettings();
+  void ReloadSettings() override;
 
   bool IsStreamListStale() const { return streams_.IsStale(); }
   StreamList Streams();

--- a/src/internet/subsonic/subsonicservice.h
+++ b/src/internet/subsonic/subsonicservice.h
@@ -42,7 +42,7 @@ class SubsonicService : public InternetService {
 
  public:
   SubsonicService(Application* app, InternetModel* parent);
-  ~SubsonicService();
+  ~SubsonicService() override;
 
   enum LoginState {
     LoginState_Loggedin,
@@ -90,11 +90,11 @@ class SubsonicService : public InternetService {
   bool IsConfigured() const;
   bool IsAmpache() const;
 
-  QStandardItem* CreateRootItem();
-  void LazyPopulate(QStandardItem* item);
-  void ShowContextMenu(const QPoint& global_pos);
-  QWidget* HeaderWidget() const;
-  void ReloadSettings();
+  QStandardItem* CreateRootItem() override;
+  void LazyPopulate(QStandardItem* item) override;
+  void ShowContextMenu(const QPoint& global_pos) override;
+  QWidget* HeaderWidget() const override;
+  void ReloadSettings() override;
 
   void Login();
   void Login(const QString& server, const QString& username,
@@ -175,7 +175,7 @@ class SubsonicService : public InternetService {
   void OnLoginStateChanged(SubsonicService::LoginState newstate);
   void OnPingFinished(QNetworkReply* reply);
 
-  void ShowConfig();
+  void ShowConfig() override;
 };
 
 class SubsonicLibraryScanner : public QObject {
@@ -184,7 +184,7 @@ class SubsonicLibraryScanner : public QObject {
  public:
   explicit SubsonicLibraryScanner(SubsonicService* service,
                                   QObject* parent = nullptr);
-  ~SubsonicLibraryScanner();
+  ~SubsonicLibraryScanner() override;
 
   void Scan();
   const SongList& GetSongs() const { return songs_; }

--- a/src/library/librarybackend.cpp
+++ b/src/library/librarybackend.cpp
@@ -896,7 +896,7 @@ LibraryBackend::AlbumList LibraryBackend::GetAlbums(const QString& artist,
   QString last_artist;
   QString last_album_artist;
   while (query.Next()) {
-    bool compilation = query.Value(3).toBool() | query.Value(4).toBool();
+    bool compilation = query.Value(3).toBool() || query.Value(4).toBool();
 
     Album info;
     info.artist = compilation ? QString() : query.Value(1).toString();

--- a/src/moodbar/moodbarbuilder.cpp
+++ b/src/moodbar/moodbarbuilder.cpp
@@ -92,12 +92,10 @@ void MoodbarBuilder::Normalize(QList<Rgb>* vals, double Rgb::*member) {
   }
 
   double avg = 0;
-  int t = 0;
   for (const Rgb& rgb : *vals) {
     const double value = rgb.*member;
     if (value != mini && value != maxi) {
       avg += value / vals->count();
-      t++;
     }
   }
 

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -1729,13 +1729,11 @@ PlaylistItemList Playlist::RemoveItemsWithoutUndo(int row, int count) {
   endRemoveRows();
 
   QList<int>::iterator it = virtual_items_.begin();
-  int i = 0;
   while (it != virtual_items_.end()) {
     if (*it >= items_.count())
       it = virtual_items_.erase(it);
     else
       ++it;
-    ++i;
   }
 
   // Reset current_virtual_index_

--- a/src/ripper/ripper.cpp
+++ b/src/ripper/ripper.cpp
@@ -34,12 +34,6 @@
 #undef AddJob
 #endif
 
-namespace {
-const char kWavHeaderRiffMarker[] = "RIFF";
-const char kWavFileTypeFormatChunk[] = "WAVEfmt ";
-const char kWavDataString[] = "data";
-}  // namespace
-
 Ripper::Ripper(int track_count, QObject* parent)
     : QObject(parent),
       track_count_(track_count),


### PR DESCRIPTION
I had to disable `-Werror` in the default compiler settings for `-DCMAKE_BUILD_TYPE=RelWithDebInfo` to build with clang16, and I disliked that. So, I fixed all the showstoppers. None of them were critical, but overall, they increase readability, reduce probability of future bugs. The struct vs class fwd declaration *might* be problematic on MSVC, anyways, fixed that, no reason not to.

Also, moved the CMake version check in front of the project definition.

- CMake: Check for minimum version before setting the project name
- core/organisefmt: use same visibility for fwd decl as in def
- internet services: consistently use 'override'
- library: use boolean, not bitwise, operator on bools
- src: remove unused variable
