### PR TITLE
CMake: Re-enable usability of system QtSingleApplication

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -231,6 +231,7 @@ jobs:
           qt5-qtbase-devel
           qt5-qtx11extras-devel
           qt5-rpm-macros
+          qtsingleapplication-qt5-devel
           rpmdevtools
           sha2-devel
           sparsehash-devel
@@ -242,7 +243,7 @@ jobs:
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
       - name: cmake
         working-directory: bin
-        run: cmake ..
+        run: cmake -DUSE_SYSTEM_QTSINGLEAPPLICATION=On ..
       - name: Build source tarball
         working-directory: bin
         run: ../dist/maketarball.sh
@@ -303,6 +304,7 @@ jobs:
           qt5-qtbase-devel
           qt5-qtx11extras-devel
           qt5-rpm-macros
+          qtsingleapplication-qt5-devel
           rpmdevtools
           sha2-devel
           sparsehash-devel
@@ -314,7 +316,7 @@ jobs:
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
       - name: cmake
         working-directory: bin
-        run: cmake ..
+        run: cmake -DUSE_SYSTEM_QTSINGLEAPPLICATION=On ..
       - name: Build source tarball
         working-directory: bin
         run: ../dist/maketarball.sh
@@ -375,6 +377,7 @@ jobs:
           qt5-qtbase-devel
           qt5-qtx11extras-devel
           qt5-rpm-macros
+          qtsingleapplication-qt5-devel
           rpmdevtools
           sha2-devel
           sparsehash-devel
@@ -386,7 +389,7 @@ jobs:
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
       - name: cmake
         working-directory: bin
-        run: cmake ..
+        run: cmake -DUSE_SYSTEM_QTSINGLEAPPLICATION=On ..
       - name: Build source tarball
         working-directory: bin
         run: ../dist/maketarball.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,11 +347,13 @@ include_directories("3rdparty/qsqlite")
 
 # When/if upstream accepts our patches then these options can be used to link
 # to system installed qtsingleapplication instead.
-option(USE_SYSTEM_QTSINGLEAPPLICATION "Don't set this option unless your system QtSingleApplication library has been compiled with the Clementine patches in 3rdparty" OFF)
+option(USE_SYSTEM_QTSINGLEAPPLICATION "Use the system-provided QtSingleApplication library (needs to have clementine patches, but these seem to be in Qt5)" OFF)
 if(USE_SYSTEM_QTSINGLEAPPLICATION)
-  find_path(QTSINGLEAPPLICATION_INCLUDE_DIRS qtsingleapplication.h PATH_SUFFIXES qt5/QtSolutions)
-  find_library(QTSINGLEAPPLICATION_LIBRARIES Qt5Solutions_SingleApplication-2.6)
-  find_library(QTSINGLECOREAPPLICATION_LIBRARIES Qt5Solutions_SingleCoreApplication-2.6)
+  find_path(QTSINGLEAPPLICATION_INCLUDE_DIRS qtsingleapplication.h PATH_SUFFIXES qt5/QtSolutions REQUIRED)
+  find_library(QTSINGLEAPPLICATION_LIBRARIES Qt5Solutions_SingleApplication-2.6 REQUIRED)
+  add_library(qtsingleapplication INTERFACE)
+  target_link_libraries(qtsingleapplication INTERFACE QTSINGLEAPPLICATION_LIBRARIES)
+  target_include_directories(qtsingleapplication INTERFACE QTSINGLEAPPLICATION_INCLUDE_DIRS)
 else(USE_SYSTEM_QTSINGLEAPPLICATION)
   add_subdirectory(3rdparty/qtsingleapplication)
   set(QTSINGLEAPPLICATION_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/qtsingleapplication)

--- a/dist/clementine.spec.in
+++ b/dist/clementine.spec.in
@@ -18,6 +18,7 @@ BuildRequires:  liblastfm-qt5-devel
 BuildRequires:  desktop-file-utils
 BuildRequires:  hicolor-icon-theme
 BuildRequires:  libappstream-glib
+BuildRequires:  qtsingleapplication-qt5-devel
 BuildRequires:  pkgconfig
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(gio-2.0)


### PR DESCRIPTION
This seem to have gone broken over time.
As far as I can tell, upstream QtSingleApplication works fine!

Signed-off-by: Marcus Müller <marcus_clementine@baseband.digital>
