### PR TITLE
Skip subsonic multi-genre tags

### DIFF
--- a/src/internet/subsonic/subsonicservice.cpp
+++ b/src/internet/subsonic/subsonicservice.cpp
@@ -530,6 +530,11 @@ void SubsonicLibraryScanner::OnGetAlbumFinished(QNetworkReply* reply) {
 
   // Read song information
   while (reader.readNextStartElement()) {
+    // skip multi-artist and multi-genre tags
+    if ((reader.name() == "artists") || (reader.name() == "genres")) {
+      reader.skipCurrentElement();
+      continue;
+    }
     if (reader.name() != "song") {
       ParsingError("song tag expected. Aborting scan.");
       return;


### PR DESCRIPTION
Subsonic API supports multi-genre and multi-artist tags for an album.

These tags are currently not expected by Clementine Subsonic service parser and will cause abort of the library scan if present.

This patch simply skips them, allowing the scan to continue.