### PR TITLE
Compatibility with TagLib 2.0

### DIFF
--- a/ext/libclementine-tagreader/cloudstream.cpp
+++ b/ext/libclementine-tagreader/cloudstream.cpp
@@ -91,7 +91,7 @@ void CloudStream::Precache() {
   clear();
 }
 
-TagLib::ByteVector CloudStream::readBlock(ulong length) {
+TagLib::ByteVector CloudStream::readBlock(size_t length) {
   const uint start = cursor_;
   const uint end = qMin(cursor_ + length - 1, length_ - 1);
 
@@ -144,11 +144,11 @@ void CloudStream::writeBlock(const TagLib::ByteVector&) {
   qLog(Debug) << Q_FUNC_INFO << "not implemented";
 }
 
-void CloudStream::insert(const TagLib::ByteVector&, ulong, ulong) {
+void CloudStream::insert(const TagLib::ByteVector&, TagLib::offset_t, size_t) {
   qLog(Debug) << Q_FUNC_INFO << "not implemented";
 }
 
-void CloudStream::removeBlock(ulong, ulong) {
+void CloudStream::removeBlock(TagLib::offset_t, size_t) {
   qLog(Debug) << Q_FUNC_INFO << "not implemented";
 }
 
@@ -159,7 +159,7 @@ bool CloudStream::readOnly() const {
 
 bool CloudStream::isOpen() const { return true; }
 
-void CloudStream::seek(long offset, TagLib::IOStream::Position p) {
+void CloudStream::seek(TagLib::offset_t offset, TagLib::IOStream::Position p) {
   switch (p) {
     case TagLib::IOStream::Beginning:
       cursor_ = offset;
@@ -178,11 +178,11 @@ void CloudStream::seek(long offset, TagLib::IOStream::Position p) {
 
 void CloudStream::clear() { cursor_ = 0; }
 
-long CloudStream::tell() const { return cursor_; }
+TagLib::offset_t CloudStream::tell() const { return cursor_; }
 
-long CloudStream::length() { return length_; }
+TagLib::offset_t CloudStream::length() { return length_; }
 
-void CloudStream::truncate(long) {
+void CloudStream::truncate(TagLib::offset_t) {
   qLog(Debug) << Q_FUNC_INFO << "not implemented";
 }
 

--- a/ext/libclementine-tagreader/cloudstream.h
+++ b/ext/libclementine-tagreader/cloudstream.h
@@ -35,17 +35,17 @@ class CloudStream : public QObject, public TagLib::IOStream {
 
   // Taglib::IOStream
   virtual TagLib::FileName name() const;
-  virtual TagLib::ByteVector readBlock(ulong length);
+  virtual TagLib::ByteVector readBlock(size_t length);
   virtual void writeBlock(const TagLib::ByteVector&);
-  virtual void insert(const TagLib::ByteVector&, ulong, ulong);
-  virtual void removeBlock(ulong, ulong);
+  virtual void insert(const TagLib::ByteVector&, TagLib::offset_t, size_t);
+  virtual void removeBlock(TagLib::offset_t, size_t);
   virtual bool readOnly() const;
   virtual bool isOpen() const;
-  virtual void seek(long offset, TagLib::IOStream::Position p);
+  virtual void seek(TagLib::offset_t offset, TagLib::IOStream::Position p);
   virtual void clear();
-  virtual long tell() const;
-  virtual long length();
-  virtual void truncate(long);
+  virtual TagLib::offset_t tell() const;
+  virtual TagLib::offset_t length();
+  virtual void truncate(TagLib::offset_t);
 
   google::sparsetable<char>::size_type cached_bytes() const {
     return cache_.num_nonempty();


### PR DESCRIPTION
TagLib recently updated to version 2.0 and introduced breaking changes due to function deprecations and type changes. This patch updates Clementine to be compatible with TagLib 2.0.

I can confirm that this builds and works on my Arch Linux machine with TagLib 2.0, but I haven't tested it with TagLib 1.x. More testing may be warranted if support for TagLib 1.x is desired.

Fixes #7313.