### PR TITLE
Update Compile Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Compile and install:
 
     cd bin
     cmake ..
-    make -j8
+    make -jd$(proc)
     sudo make install
 
 See the Wiki for more instructions and a list of dependencies:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Compile and install:
 
     cd bin
     cmake ..
-    make -jd$(proc)
+    make -j$(nproc)
     sudo make install
 
 See the Wiki for more instructions and a list of dependencies:


### PR DESCRIPTION
uses `nproc` instead of assuming 8 cores