### PR TITLE
CMakeLists: use --stdlib=libc++ on macOS only with clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,10 +18,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "")
 if (CMAKE_CXX_COMPILER MATCHES ".*clang")
   set(CMAKE_COMPILER_IS_CLANGXX 1)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-uninitialized")
-endif ()
-
-if (APPLE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --stdlib=libc++")
+  if (APPLE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --stdlib=libc++")
+  endif ()
 endif ()
 
 find_program(CCACHE_EXECUTABLE NAMES ccache)


### PR DESCRIPTION
Do not hardcode C++ runtime regardless of compiler being used: only Clangs use `libc++` by default, not GCC.