### PR TITLE
Make git revision detection optional

### DIFF
--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -119,39 +119,41 @@ else(CLEMENTINE_VERSION_PRERELEASE)
 endif(CLEMENTINE_VERSION_PRERELEASE)
 
 # Add git revision
-if(FORCE_GIT_REVISION)
-  set(GIT_REV ${FORCE_GIT_REVISION})
-  set(GIT_INFO_RESULT 0)
-else(FORCE_GIT_REVISION)
-  find_program(GIT_EXECUTABLE git)
-  message(STATUS "Found git: ${GIT_EXECUTABLE}")
+if(INCLUDE_GIT_REVISION)
+  if(FORCE_GIT_REVISION)
+    set(GIT_REV ${FORCE_GIT_REVISION})
+    set(GIT_INFO_RESULT 0)
+  else(FORCE_GIT_REVISION)
+    find_program(GIT_EXECUTABLE git)
+    message(STATUS "Found git: ${GIT_EXECUTABLE}")
 
-  if(NOT GIT_EXECUTABLE-NOTFOUND)
-    execute_process(COMMAND ${GIT_EXECUTABLE} describe
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        RESULT_VARIABLE GIT_INFO_RESULT
-        OUTPUT_VARIABLE GIT_REV
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-    if(NOT ${GIT_INFO_RESULT} EQUAL 0)
-      message(SEND_ERROR "git describe failed with code ${GIT_INFO_RESULT}: ${GIT_REV}")
+    if(NOT GIT_EXECUTABLE-NOTFOUND)
+      execute_process(COMMAND ${GIT_EXECUTABLE} describe
+          WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+          RESULT_VARIABLE GIT_INFO_RESULT
+          OUTPUT_VARIABLE GIT_REV
+          OUTPUT_STRIP_TRAILING_WHITESPACE)
+      if(NOT ${GIT_INFO_RESULT} EQUAL 0)
+        message(SEND_ERROR "git describe failed with code ${GIT_INFO_RESULT}: ${GIT_REV}")
+      endif()
     endif()
   endif()
+
+  string(REGEX REPLACE "^(.+)-([0-9]+)-(g[a-f0-9]+)$" "\\1;\\2;\\3"
+        GIT_PARTS ${GIT_REV})
+
+  if(NOT GIT_PARTS)
+    message(FATAL_ERROR "Failed to parse git revision string '${GIT_REV}'")
+  endif(NOT GIT_PARTS)
+
+  list(LENGTH GIT_PARTS GIT_PARTS_LENGTH)
+  if(GIT_PARTS_LENGTH EQUAL 3)
+    list(GET GIT_PARTS 0 GIT_TAGNAME)
+    list(GET GIT_PARTS 1 GIT_COMMITCOUNT)
+    list(GET GIT_PARTS 2 GIT_SHA1)
+    set(HAS_GIT_REVISION ON)
+  endif(GIT_PARTS_LENGTH EQUAL 3)
 endif()
-
-string(REGEX REPLACE "^(.+)-([0-9]+)-(g[a-f0-9]+)$" "\\1;\\2;\\3"
-       GIT_PARTS ${GIT_REV})
-
-if(NOT GIT_PARTS)
-  message(FATAL_ERROR "Failed to parse git revision string '${GIT_REV}'")
-endif(NOT GIT_PARTS)
-
-list(LENGTH GIT_PARTS GIT_PARTS_LENGTH)
-if(GIT_PARTS_LENGTH EQUAL 3)
-  list(GET GIT_PARTS 0 GIT_TAGNAME)
-  list(GET GIT_PARTS 1 GIT_COMMITCOUNT)
-  list(GET GIT_PARTS 2 GIT_SHA1)
-  set(HAS_GIT_REVISION ON)
-endif(GIT_PARTS_LENGTH EQUAL 3)
 
 if(INCLUDE_GIT_REVISION AND HAS_GIT_REVISION)
   set(CLEMENTINE_VERSION_DISPLAY "${GIT_REV}")


### PR DESCRIPTION
With the [tagged 1.4.1](https://github.com/clementine-player/Clementine/releases/tag/1.4.1) source tarball downloaded from github, cmake fails due to forcing detection of a git revision, which doesn't exist from the github generated tarball.

This fix allows one to toggle that using the INCLUDE_GIT_REVISION variable at the top of cmake/Version.cmake, which if set to OFF will skip over git revision detection, allowing the user to complete cmake.

(Currently that INCLUDE_GIT_REVISION variable would need to be changed for a tagged release or have the user change it via sed or similar.)

Potentially fixes clementine-player/Clementine#7355