### PR TITLE
Remove unused build-time requirement to sha2-devel

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -243,7 +243,6 @@ jobs:
           qtsingleapplication-qt5-devel
           qtsinglecoreapplication-qt5-devel
           rpmdevtools
-          sha2-devel
           sparsehash-devel
           sqlite-devel
           taglib-devel
@@ -318,7 +317,6 @@ jobs:
           qtsingleapplication-qt5-devel
           qtsinglecoreapplication-qt5-devel
           rpmdevtools
-          sha2-devel
           sparsehash-devel
           sqlite-devel
           taglib-devel


### PR DESCRIPTION
As of writing, Clementine has a build-time requirement in the GitHub Action to sha2-devel (but only for Fedora), but there is no source code in Clementine (anymore?) that actually includes `sha2.h` provided by sha2-devel.

I'm suggesting the same change downstream: https://src.fedoraproject.org/rpms/clementine/pull-request/4