### PR TITLE
Fix potential vulnerable cloned functions

### DIFF
--- a/3rdparty/libprojectm/Renderer/SOIL/stb_image_aug.c
+++ b/3rdparty/libprojectm/Renderer/SOIL/stb_image_aug.c
@@ -1221,6 +1221,13 @@ static int process_frame_header(jpeg *z, int scan)
       if (z->img_comp[i].v > v_max) v_max = z->img_comp[i].v;
    }
 
+   // check that plane subsampling factors are integer ratios; our resamplers can't deal with fractional ratios
+   // and I've never seen a non-corrupted JPEG file actually use them
+   for (i=0; i < s->img_n; ++i) {
+      if (h_max % z->img_comp[i].h != 0) return stbi__err("bad H","Corrupt JPEG");
+      if (v_max % z->img_comp[i].v != 0) return stbi__err("bad V","Corrupt JPEG");
+   }
+
    // compute interleaved mcu info
    z->img_h_max = h_max;
    z->img_v_max = v_max;


### PR DESCRIPTION
Dear Development team,

I identified vulnerabilities in clone functions sourced from [nothings/stb](https://github.com/nothings/stb). These issues, originally reported in [CVE-2021-28021](https://nvd.nist.gov/vuln/detail/CVE-2021-28021), were resolved in the stb repository via this commit https://github.com/nothings/stb/commit/5ba0baaa269b3fd681828e0e3b3ac0f1472eaf40.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you for your time and attention!