### PR TITLE
Update KGlobalAccel shortcut backend for Plasma 6.5

### DIFF
--- a/src/core/kglobalaccelglobalshortcutbackend.cpp
+++ b/src/core/kglobalaccelglobalshortcutbackend.cpp
@@ -85,6 +85,11 @@ bool KGlobalAccelShortcutBackend::DoRegister() {
                    this, &KGlobalAccelShortcutBackend::OnShortcutPressed,
                    Qt::UniqueConnection);
 
+  QObject::connect(component_,
+                   &OrgKdeKglobalaccelComponentInterface::globalShortcutRepeated,
+                   this, &KGlobalAccelShortcutBackend::OnShortcutPressed,
+                   Qt::UniqueConnection);
+
   return complete;
 #else   // HAVE_DBUS
   qLog(Warning) << "dbus not available";
@@ -104,6 +109,9 @@ void KGlobalAccelShortcutBackend::DoUnregister() {
   QObject::disconnect(
       component_, &OrgKdeKglobalaccelComponentInterface::globalShortcutPressed,
       this, &KGlobalAccelShortcutBackend::OnShortcutPressed);
+  QObject::disconnect(
+        component_, &OrgKdeKglobalaccelComponentInterface::globalShortcutRepeated,
+        this, &KGlobalAccelShortcutBackend::OnShortcutPressed);
 #endif  // HAVE_DBUS
 }
 

--- a/src/dbus/org.kde.kglobalaccel.Component.xml
+++ b/src/dbus/org.kde.kglobalaccel.Component.xml
@@ -9,6 +9,11 @@
             <arg name="actionUnique" type="s" direction="out"/>
             <arg name="timestamp" type="x" direction="out"/>
         </signal>
+        <signal name="globalShortcutRepeated">
+            <arg name="componentUnique" type="s" direction="out"/>
+            <arg name="actionUnique" type="s" direction="out"/>
+            <arg name="timestamp" type="x" direction="out"/>
+        </signal>
         <method name="cleanUp">
             <arg type="b" direction="out"/>
         </method>


### PR DESCRIPTION
Hi. First time ever contributing here, bear with me!

This PR fixes a bug I'd seen reported on KDE's Bugzilla. Turns out, when we updated kglobalaccel in Frameworks 6.19.0 and kwin in Plasma 6.5, my code may have broken Clementine unintentionally... :(

I've updated the project's D-Bus interface to deal with us separating key repeat from key press events. In most cases, you shouldn't need to do anything special on a key repeat, and since I'm not familiar enough with Clementine's code yet, I opted to just emulate the old behaviour of kglobalaccel from before Frameworks 6.19. 

This should have zero effect on older Plasma/kglobalaccel versions.

See also: https://bugs.kde.org/show_bug.cgi?id=511041